### PR TITLE
fix: add allocate/deallocate support to lazy Fortran parser (fixes #35)

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -34,10 +34,12 @@ This document lists all open GitHub issues prioritized by architectural impact a
 
 ## 🟠 High-Impact Parser & AST Enhancements
 
-### #35 - Add allocate/deallocate support to lazy Fortran parser
+### ✅ #35 - Add allocate/deallocate support to lazy Fortran parser
 **Priority: High** | **Impact: Parser Architecture** | **Effort: Medium**
+- **Status**: ✅ **COMPLETED** - allocate/deallocate keywords added to lexer, tests passing (PR #40)
 - **Description**: Integrate existing allocate/deallocate parsing with lazy parser
-- **Status**: Implementation exists but not integrated
+- **Root Cause**: Missing lexer keyword recognition, not parser dispatcher integration
+- **⚠️ PENDING**: Awaiting qodo merge feedback and code coverage analysis before final closure
 
 ### #13 - Missing AST Traversal and Visitor Pattern Implementation
 **Priority: High** | **Impact: Architectural** | **Effort: Medium**

--- a/README.md
+++ b/README.md
@@ -97,3 +97,4 @@ end if
 ## License
 
 MIT License - see LICENSE file for details.
+

--- a/src/lexer/lexer_core.f90
+++ b/src/lexer/lexer_core.f90
@@ -30,7 +30,7 @@ module lexer_core
     public :: token_type_name
 
     ! Keywords list
-    character(len=20), dimension(49) :: keywords = [ &
+    character(len=20), dimension(51) :: keywords = [ &
                        "program     ", "end         ", "function    ", "subroutine  ", &
                        "if          ", "then        ", "else        ", "endif       ", &
                        "do          ", "while       ", "implicit    ", "none        ", &
@@ -45,7 +45,7 @@ module lexer_core
                                         "return      ", "cycle       ", "exit        ", &
                                         "where       ", "elsewhere   ", "optional    ", &
                                         "present     ", "open        ", "close       ", &
-                                        "parameter   " &
+                                        "parameter   ", "allocate    ", "deallocate  " &
                                         ]
 
 contains


### PR DESCRIPTION
### **User description**
## Summary
- ✅ Add 'allocate' and 'deallocate' to lexer keywords list 
- ✅ Enable proper recognition of allocate/deallocate statements in lazy parser
- ✅ Update allocate/deallocate tests to use lazy Fortran format
- ✅ All allocate/deallocate parsing tests now pass

## Root Cause
The issue was **not** missing parser dispatcher integration (which already existed), but missing **lexer keyword recognition**. The tokens `allocate` and `deallocate` were being treated as identifiers instead of keywords, preventing the parser dispatcher from recognizing them.

## Test Results
All allocate/deallocate parsing tests now pass:
- ✅ Simple allocate statement: `allocate(arr)`  
- ✅ Allocate with shape: `allocate(matrix(10, 20))`
- ✅ Allocate with stat: `allocate(arr(100), stat=ierr)`
- ✅ Simple deallocate: `deallocate(arr)`
- ✅ Deallocate with stat: `deallocate(arr, stat=ierr)`

## Test plan
- [x] All 133 existing tests continue to pass
- [x] All 5 allocate/deallocate parsing tests now pass
- [x] Verified lexer now correctly identifies allocate/deallocate as keywords (kind=5)
- [x] Verified parser dispatcher correctly processes allocate/deallocate statements
- [x] Verified lazy Fortran parser includes statements in program body

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add `allocate` and `deallocate` keywords to lexer

- Enable lazy parser recognition of memory management statements

- Update tests to use simplified lazy parsing format

- Fix lexer treating allocate/deallocate as identifiers instead of keywords


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Lexer Keywords"] -- "Add allocate/deallocate" --> B["Token Recognition"]
  B -- "Keywords instead of identifiers" --> C["Parser Dispatcher"]
  C -- "Recognize statements" --> D["AST Generation"]
  E["Test Cases"] -- "Simplify to lazy format" --> F["Validation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>lexer_core.f90</strong><dd><code>Add allocate/deallocate keywords to lexer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lexer/lexer_core.f90

<ul><li>Add <code>allocate</code> and <code>deallocate</code> to keywords array<br> <li> Increase keywords array size from 49 to 51 elements</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/40/files#diff-187e0e820afd77752d741df078d243ab3c6f2a01d297db7accda31afc22a3cb2">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_allocate_deallocate_parsing.f90</strong><dd><code>Update tests for lazy parser format</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/parser/test_allocate_deallocate_parsing.f90

<ul><li>Remove full program structure from test cases<br> <li> Simplify test sources to single statement format<br> <li> Enable actual test execution instead of skipping<br> <li> Remove debug output and program wrapper code</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/40/files#diff-c3baed148ac6e194595e0ec6f6ef837ae4a90da1b0e00638eff57b80fdac62b5">+21/-43</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

