### PR TITLE
fix: correct array stride parsing in range expressions (#22)

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -81,8 +81,9 @@ This document lists all open GitHub issues prioritized by architectural impact a
 
 ### ✅ #22 - Add explicit array section/slice AST nodes
 **Priority: Medium** | **Impact: AST Design** | **Effort: Medium**
-- **Status**: ✅ **COMPLETED** - Array slice nodes already implemented, fixed stride parsing
+- **Status**: ✅ **COMPLETED** - Array slice nodes already implemented, fixed stride parsing (PR #48)
 - **Description**: Dedicated nodes for array slicing operations
+- **Note**: Array slice infrastructure (array_slice_node, array_bounds_node) was already present; this PR fixed stride parsing
 - **⚠️ PENDING**: Awaiting qodo merge feedback and code coverage analysis before final closure
 
 ### #21 - Disambiguate array indexing from function calls in call_or_subscript_node

--- a/test/parser/test_array_stride.f90
+++ b/test/parser/test_array_stride.f90
@@ -57,6 +57,18 @@ contains
                         print *, '  PASS: Stride parsed as range_expression_node'
                         if (node%stride_index > 0) then
                             print *, '  PASS: Stride index is non-zero'
+                            ! Verify stride value
+                            if (allocated(arena%entries(node%stride_index)%node)) then
+                                select type (stride_node => arena%entries(node%stride_index)%node)
+                                type is (literal_node)
+                                    if (stride_node%value == "2") then
+                                        print *, '  PASS: Stride value correctly parsed as 2'
+                                    else
+                                        print *, '  FAIL: Stride value mismatch'
+                                        test_simple_stride = .false.
+                                    end if
+                                end select
+                            end if
                         else
                             print *, '  FAIL: Stride index is zero'
                             test_simple_stride = .false.
@@ -93,7 +105,22 @@ contains
                         print *, '  PASS: Empty lower bound with stride parsed'
                         if (node%start_index == 0 .and. node%end_index > 0 .and. &
                             node%stride_index > 0) then
-                            print *, '  PASS: Correct bounds and stride indices'
+                            ! Verify stride value is correctly parsed
+                            if (allocated(arena%entries(node%stride_index)%node)) then
+                                select type (stride_node => arena%entries(node%stride_index)%node)
+                                type is (literal_node)
+                                    if (stride_node%value == "2") then
+                                        print *, '  PASS: Correct bounds and stride indices with value 2'
+                                    else
+                                        print *, '  FAIL: Stride value mismatch, got: ', stride_node%value
+                                        test_empty_bounds_with_stride = .false.
+                                    end if
+                                class default
+                                    print *, '  PASS: Correct bounds and stride indices'
+                                end select
+                            else
+                                print *, '  PASS: Correct bounds and stride indices'
+                            end if
                         else
                             print *, '  FAIL: Incorrect indices for empty lower bound with stride'
                             test_empty_bounds_with_stride = .false.


### PR DESCRIPTION
### **User description**
## Summary
- Fixed stride parsing in the `parse_range` function to properly handle the third component of array slices (e.g., `arr(1:10:2)`)
- Added comprehensive test coverage for array stride parsing
- Updated ISSUES.md to reflect completion of issues #22, #27, and #28

## Details

This PR addresses issue #22 by ensuring that array slice expressions with stride are properly parsed. The existing array slice node infrastructure was already in place, but the parser was not correctly handling the stride component.

### Changes:
1. **Parser fix**: Modified `parse_range` function in `parser_expressions.f90` to detect and parse the second colon for stride
2. **Test coverage**: Added `test_array_stride.f90` with tests for:
   - Simple stride expressions (1:10:2)
   - Empty lower bound with stride (:5:2)
   - Array expressions with stride (arr(1:20:3))
3. **Documentation**: Updated ISSUES.md to mark completed issues

## Test plan
- [x] All existing tests pass
- [x] New stride parsing tests pass
- [x] Manual testing confirms stride is correctly generated in output

Fixes #22

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed array stride parsing in range expressions for syntax like `arr(1:10:2)`

- Added comprehensive test coverage for stride parsing scenarios

- Updated documentation to mark issues #22, #27, #28 as completed


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["parse_range function"] --> B["Check for second colon"]
  B --> C["Parse stride component"]
  C --> D["Create range_expression_node with stride"]
  E["Test cases"] --> F["Validate stride parsing"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser_expressions.f90</strong><dd><code>Enhanced range parsing with stride support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_expressions.f90

<ul><li>Added stride detection logic for second colon in range expressions<br> <li> Enhanced <code>parse_range</code> function to handle stride component parsing<br> <li> Updated <code>push_range_expression</code> calls to include stride_index parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/48/files#diff-3840ac8e1ba949344a6d9bb928875718aaa4ed437ffbe93f1a8458377286b1aa">+56/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_array_stride.f90</strong><dd><code>Added array stride parsing test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/parser/test_array_stride.f90

<ul><li>Added comprehensive test suite for array stride parsing<br> <li> Tests simple stride expressions like <code>1:10:2</code><br> <li> Tests empty bounds with stride like <code>:5:2</code><br> <li> Tests nested array expressions with stride like <code>arr(1:20:3)</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/48/files#diff-2464f09c7d640a243ebf4067dbaeb3ea074a4d1e704adc6c1289014fd6df51bb">+162/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ISSUES.md</strong><dd><code>Updated issue tracking documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ISSUES.md

<ul><li>Marked issues #22, #27, and #28 as completed<br> <li> Updated issue status with completion details<br> <li> Reduced total open issues count from 25 to 16</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/48/files#diff-ccf25e28bb6b96800a92313dfceb6c1a89d7ab1d932606565f2921bdeed08864">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

