### PR TITLE
feat: Add ASSOCIATE construct AST node support

### DIFF
--- a/ISSUES.md
+++ b/ISSUES.md
@@ -99,15 +99,18 @@ This document lists all open GitHub issues prioritized by architectural impact a
 - **Description**: Specific node type for derived type component access
 - **⚠️ PENDING**: Awaiting qodo merge feedback and code coverage analysis before final closure
 
-### 🚧 #25 - Add character substring AST node support
+### ✅ #25 - Add character substring AST node support
 **Priority: Medium** | **Impact: AST Design** | **Effort: Low**
-- **Status**: 🚧 **IN PROGRESS** - Working on character substring AST node
+- **Status**: ✅ **COMPLETED** - Character substring support implemented using range_subscript_node (PR #51)
 - **Description**: Handle character substring operations
-- **Branch**: feature/25-character-substring-node
+- **Implementation**: Created range_subscript_node for parse-time ambiguity, added is_character_substring flag
+- **⚠️ PENDING**: Awaiting qodo merge feedback and code coverage analysis before final closure
 
-### #23 - Add ASSOCIATE construct AST node support
+### 🚧 #23 - Add ASSOCIATE construct AST node support
 **Priority: Medium** | **Impact: AST Design** | **Effort: Medium**
+- **Status**: 🚧 **IN PROGRESS** - Working on ASSOCIATE construct AST node
 - **Description**: Support ASSOCIATE construct parsing
+- **Branch**: feature/23-associate-construct-ast
 
 ## 🟢 API and Documentation Improvements
 

--- a/src/ast/ast_factory.f90
+++ b/src/ast/ast_factory.f90
@@ -10,6 +10,7 @@ module ast_factory
     public :: push_derived_type, push_declaration, push_multi_declaration, &
               push_parameter_declaration
     public :: push_if, push_do_loop, push_do_while, push_forall, push_select_case
+    public :: push_associate
     public :: push_case_block, push_case_range, push_case_default, &
               push_select_case_with_default
     public :: push_use_statement, push_include_statement, push_print_statement, &
@@ -557,6 +558,36 @@ contains
         while_index = arena%size
 
     end function push_do_while
+
+    ! Create ASSOCIATE construct node and add to stack
+    function push_associate(arena, associations, body_indices, line, column, &
+                           parent_index) result(assoc_index)
+        use ast_nodes_control, only: associate_node, association_t
+        type(ast_arena_t), intent(inout) :: arena
+        type(association_t), intent(in) :: associations(:)
+        integer, intent(in), optional :: body_indices(:)
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: assoc_index
+        type(associate_node) :: assoc
+
+        ! Set associations
+        if (size(associations) > 0) then
+            assoc%associations = associations
+        end if
+
+        ! Set body indices
+        if (present(body_indices)) then
+            if (size(body_indices) > 0) then
+                assoc%body_indices = body_indices
+            end if
+        end if
+
+        if (present(line)) assoc%line = line
+        if (present(column)) assoc%column = column
+
+        call arena%push(assoc, "associate", parent_index)
+        assoc_index = arena%size
+    end function push_associate
 
     ! Create forall construct node and add to stack
     function push_forall(arena, index_var, start_index, end_index, step_index, &

--- a/src/lexer/lexer_core.f90
+++ b/src/lexer/lexer_core.f90
@@ -30,7 +30,7 @@ module lexer_core
     public :: token_type_name
 
     ! Keywords list
-    character(len=20), dimension(52) :: keywords = [ &
+    character(len=20), dimension(53) :: keywords = [ &
                        "program     ", "end         ", "function    ", "subroutine  ", &
                        "if          ", "then        ", "else        ", "endif       ", &
                        "do          ", "while       ", "implicit    ", "none        ", &
@@ -46,7 +46,7 @@ module lexer_core
                                         "where       ", "elsewhere   ", "optional    ", &
                                         "present     ", "open        ", "close       ", &
                                         "parameter   ", "allocate    ", "deallocate  ", &
-                                        "forall      " &
+                                        "forall      ", "associate   " &
                                         ]
 
 contains
@@ -350,7 +350,7 @@ contains
             if (two_char == "==" .or. two_char == "/=" .or. &
                 two_char == "<=" .or. two_char == ">=" .or. &
                 two_char == "::" .or. two_char == "**" .or. &
-                two_char == "//") then
+                two_char == "//" .or. two_char == "=>") then
 
                 token_count = token_count + 1
                 if (token_count > size(tokens)) then

--- a/src/parser/parser_dispatcher.f90
+++ b/src/parser/parser_dispatcher.f90
@@ -13,7 +13,8 @@ module parser_dispatcher_module
                                         parse_stop_statement, parse_return_statement, &
                                         parse_cycle_statement, parse_exit_statement, &
                                         parse_allocate_statement, parse_deallocate_statement
-    use parser_control_flow_module
+    use parser_control_flow_module, only: parse_if, parse_do_loop, parse_select_case, &
+                                         parse_where_construct, parse_associate
     use ast_core
     use ast_factory
     use parser_expressions_module, only: parse_expression, parse_range
@@ -86,6 +87,8 @@ contains
                 stmt_index = parse_cycle_statement(parser, arena)
             case ("exit")
                 stmt_index = parse_exit_statement(parser, arena)
+            case ("associate")
+                stmt_index = parse_associate(parser, arena)
             case default
                 stmt_index = parse_as_expression(tokens, arena)
             end select

--- a/test/ast/test_associate_node.f90
+++ b/test/ast/test_associate_node.f90
@@ -1,0 +1,219 @@
+program test_associate_node
+    use iso_fortran_env, only: error_unit
+    use ast_core
+    use ast_nodes_control, only: associate_node, association_t, create_associate
+    use ast_factory, only: push_associate, push_identifier, push_binary_op
+    use json_module
+    implicit none
+
+    integer :: total_tests, passed_tests
+    
+    total_tests = 0
+    passed_tests = 0
+    
+    ! Run all tests
+    call test_associate_node_creation()
+    call test_associate_node_assignment()
+    call test_associate_node_json()
+    call test_associate_factory()
+    call test_associate_arena_push()
+    
+    ! Report results
+    write (*, '(A)') ''
+    write (*, '(A,I0,A,I0,A)') 'Passed ', passed_tests, ' out of ', total_tests, ' tests'
+    if (passed_tests /= total_tests) then
+        stop 1
+    end if
+
+contains
+
+    subroutine test_associate_node_creation()
+        character(len=*), parameter :: test_name = "test_associate_node_creation"
+        type(associate_node) :: node
+        type(association_t) :: associations(2)
+        integer :: body_indices(3)
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Create associations
+        associations(1)%name = "x"
+        associations(1)%expr_index = 10
+        associations(2)%name = "y"
+        associations(2)%expr_index = 20
+        
+        ! Create body indices
+        body_indices = [30, 40, 50]
+        
+        ! Create node using factory function
+        node = create_associate(associations, body_indices, line=5, column=10)
+        
+        ! Verify node properties
+        if (allocated(node%associations) .and. &
+            size(node%associations) == 2 .and. &
+            node%associations(1)%name == "x" .and. &
+            node%associations(1)%expr_index == 10 .and. &
+            node%associations(2)%name == "y" .and. &
+            node%associations(2)%expr_index == 20 .and. &
+            allocated(node%body_indices) .and. &
+            size(node%body_indices) == 3 .and. &
+            all(node%body_indices == [30, 40, 50]) .and. &
+            node%line == 5 .and. &
+            node%column == 10) then
+            write (*, '(A)') 'PASS'
+            passed_tests = passed_tests + 1
+        else
+            write (*, '(A)') 'FAIL - Node properties incorrect'
+        end if
+    end subroutine test_associate_node_creation
+
+    subroutine test_associate_node_assignment()
+        character(len=*), parameter :: test_name = "test_associate_node_assignment"
+        type(associate_node) :: node1, node2
+        type(association_t) :: associations(1)
+        integer :: body_indices(2)
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Create first node
+        associations(1)%name = "z"
+        associations(1)%expr_index = 100
+        body_indices = [200, 300]
+        
+        node1 = create_associate(associations, body_indices, line=10, column=20)
+        
+        ! Test assignment
+        node2 = node1
+        
+        ! Verify deep copy
+        if (allocated(node2%associations) .and. &
+            size(node2%associations) == 1 .and. &
+            node2%associations(1)%name == "z" .and. &
+            node2%associations(1)%expr_index == 100 .and. &
+            allocated(node2%body_indices) .and. &
+            size(node2%body_indices) == 2 .and. &
+            all(node2%body_indices == [200, 300]) .and. &
+            node2%line == 10 .and. &
+            node2%column == 20) then
+            write (*, '(A)') 'PASS'
+            passed_tests = passed_tests + 1
+        else
+            write (*, '(A)') 'FAIL - Assignment did not create proper copy'
+        end if
+    end subroutine test_associate_node_assignment
+
+    subroutine test_associate_node_json()
+        character(len=*), parameter :: test_name = "test_associate_node_json"
+        type(associate_node) :: node
+        type(association_t) :: associations(2)
+        integer :: body_indices(1)
+        type(json_core) :: json
+        type(json_value), pointer :: root, obj
+        character(len=:), allocatable :: json_str
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Create node
+        associations(1)%name = "a"
+        associations(1)%expr_index = 1
+        associations(2)%name = "b"
+        associations(2)%expr_index = 2
+        body_indices = [3]
+        
+        node = create_associate(associations, body_indices, line=1, column=1)
+        
+        ! Convert to JSON
+        call json%create_object(root, '')
+        call node%to_json(json, root)
+        call json%print_to_string(root, json_str)
+        
+        ! Check JSON contains required fields
+        if (index(json_str, '"type":"associate"') > 0 .and. &
+            index(json_str, '"associations"') > 0 .and. &
+            index(json_str, '"name":"a"') > 0 .and. &
+            index(json_str, '"name":"b"') > 0 .and. &
+            index(json_str, '"expr_index":1') > 0 .and. &
+            index(json_str, '"expr_index":2') > 0 .and. &
+            index(json_str, '"body_indices"') > 0 .and. &
+            index(json_str, '"line":1') > 0 .and. &
+            index(json_str, '"column":1') > 0) then
+            write (*, '(A)') 'PASS'
+            passed_tests = passed_tests + 1
+        else
+            write (*, '(A)') 'FAIL - JSON missing required fields'
+            write (error_unit, '(A)') 'JSON output:'
+            write (error_unit, '(A)') json_str
+        end if
+        
+        call json%destroy(root)
+    end subroutine test_associate_node_json
+
+    subroutine test_associate_factory()
+        character(len=*), parameter :: test_name = "test_associate_factory"
+        type(association_t) :: empty_assocs(0)
+        type(associate_node) :: node
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Test with empty associations (should fail in real usage but factory should handle it)
+        node = create_associate(empty_assocs)
+        
+        ! Since the factory checks size > 0, associations won't be allocated for empty array
+        if (.not. allocated(node%associations) .and. &
+            .not. allocated(node%body_indices)) then
+            write (*, '(A)') 'PASS'
+            passed_tests = passed_tests + 1
+        else
+            write (*, '(A)') 'FAIL - Empty associations should not allocate arrays'
+        end if
+    end subroutine test_associate_factory
+
+    subroutine test_associate_arena_push()
+        character(len=*), parameter :: test_name = "test_associate_arena_push"
+        type(ast_arena_t) :: arena
+        type(association_t) :: associations(1)
+        integer :: body_indices(2)
+        integer :: id_index, bin_index, assoc_index
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Create expression nodes in arena
+        id_index = push_identifier(arena, "x", 1, 1)
+        bin_index = push_binary_op(arena, id_index, id_index, "+", 1, 1)
+        
+        ! Create association
+        associations(1)%name = "sum"
+        associations(1)%expr_index = bin_index
+        
+        ! Create body indices (using the same nodes for simplicity)
+        body_indices = [id_index, bin_index]
+        
+        ! Push associate node to arena
+        assoc_index = push_associate(arena, associations, body_indices, 1, 1)
+        
+        ! Verify node was added
+        if (assoc_index > 0 .and. assoc_index <= arena%size) then
+            select type (node => arena%entries(assoc_index)%node)
+            type is (associate_node)
+                if (allocated(node%associations) .and. &
+                    size(node%associations) == 1 .and. &
+                    node%associations(1)%name == "sum" .and. &
+                    node%associations(1)%expr_index == bin_index) then
+                    write (*, '(A)') 'PASS'
+                    passed_tests = passed_tests + 1
+                else
+                    write (*, '(A)') 'FAIL - Arena node has incorrect properties'
+                end if
+            class default
+                write (*, '(A)') 'FAIL - Wrong node type in arena'
+            end select
+        else
+            write (*, '(A)') 'FAIL - Invalid index returned'
+        end if
+    end subroutine test_associate_arena_push
+
+end program test_associate_node

--- a/test/parser/test_associate_construct.f90
+++ b/test/parser/test_associate_construct.f90
@@ -1,0 +1,381 @@
+program test_associate_construct
+    use iso_fortran_env, only: error_unit
+    use lexer_core, only: token_t, tokenize_core
+    use parser_dispatcher_module, only: parse_statement_dispatcher
+    use parser_control_flow_module, only: parse_associate
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use ast_core, only: create_ast_arena
+    use ast_core
+    use ast_nodes_control, only: associate_node
+    use codegen_core, only: generate_code_from_arena
+    implicit none
+
+    integer :: total_tests, passed_tests
+    
+    total_tests = 0
+    passed_tests = 0
+    
+    ! Run all tests
+    call test_simple_associate()
+    call test_multiple_associations()
+    call test_associate_with_expressions()
+    call test_associate_with_body()
+    call test_nested_associate()
+    call test_associate_codegen()
+    call test_associate_integration()
+    
+    ! Report results
+    write (*, '(A)') ''
+    write (*, '(A,I0,A,I0,A)') 'Passed ', passed_tests, ' out of ', total_tests, ' tests'
+    if (passed_tests /= total_tests) then
+        stop 1
+    end if
+
+contains
+
+    subroutine test_simple_associate()
+        character(len=*), parameter :: test_name = "test_simple_associate"
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        logical :: found_associate
+        integer :: i
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Test simple ASSOCIATE with one association
+        source = 'associate (x => a + b)' // new_line('a') // &
+                'end associate'
+        
+        call tokenize_core(source, tokens)
+        
+        ! Debug: check tokens
+        write (error_unit, '(A,I0)') 'DEBUG: Number of tokens: ', size(tokens)
+        do i = 1, min(5, size(tokens))
+            write (error_unit, '(A,I0,A,A)') 'Token ', i, ': ', trim(tokens(i)%text)
+        end do
+        
+        arena = create_ast_arena()
+        
+        ! Parse just the associate statement
+        block
+            type(parser_state_t) :: parser
+            parser = create_parser_state(tokens)
+            root_index = parse_associate(parser, arena)
+        end block
+        
+        write (error_unit, '(A,I0)') 'DEBUG: root_index = ', root_index
+        write (error_unit, '(A,I0)') 'DEBUG: arena%size = ', arena%size
+        
+        ! Debug: print all nodes
+        do i = 1, arena%size
+            write (error_unit, '(A,I0,A,A)') 'Node ', i, ': ', arena%entries(i)%node_type
+        end do
+        
+        ! Check if ASSOCIATE node was created
+        found_associate = .false.
+        do i = 1, arena%size
+            select type (node => arena%entries(i)%node)
+            type is (associate_node)
+                found_associate = .true.
+                if (allocated(node%associations)) then
+                    if (size(node%associations) == 1) then
+                        if (node%associations(1)%name == "x") then
+                            write (*, '(A)') 'PASS'
+                            passed_tests = passed_tests + 1
+                        else
+                            write (*, '(A)') 'FAIL - Wrong association name'
+                        end if
+                    else
+                        write (*, '(A)') 'FAIL - Wrong number of associations'
+                    end if
+                else
+                    write (*, '(A)') 'FAIL - No associations allocated'
+                end if
+            end select
+        end do
+        
+        if (.not. found_associate) then
+            write (*, '(A)') 'FAIL - No ASSOCIATE node found'
+        end if
+    end subroutine test_simple_associate
+
+    subroutine test_multiple_associations()
+        character(len=*), parameter :: test_name = "test_multiple_associations"
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        logical :: found_associate
+        integer :: i
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Test ASSOCIATE with multiple associations
+        source = 'associate (x => a + b, y => c * d, z => e / f)' // new_line('a') // &
+                'end associate'
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        root_index = parse_statement_dispatcher(tokens, arena)
+        
+        ! Check if ASSOCIATE node was created with correct associations
+        found_associate = .false.
+        do i = 1, arena%size
+            select type (node => arena%entries(i)%node)
+            type is (associate_node)
+                found_associate = .true.
+                if (allocated(node%associations)) then
+                    if (size(node%associations) == 3) then
+                        if (node%associations(1)%name == "x" .and. &
+                            node%associations(2)%name == "y" .and. &
+                            node%associations(3)%name == "z") then
+                            write (*, '(A)') 'PASS'
+                            passed_tests = passed_tests + 1
+                        else
+                            write (*, '(A)') 'FAIL - Wrong association names'
+                        end if
+                    else
+                        write (*, '(A,I0)') 'FAIL - Wrong number of associations: ', &
+                                           size(node%associations)
+                    end if
+                else
+                    write (*, '(A)') 'FAIL - No associations allocated'
+                end if
+            end select
+        end do
+        
+        if (.not. found_associate) then
+            write (*, '(A)') 'FAIL - No ASSOCIATE node found'
+        end if
+    end subroutine test_multiple_associations
+
+    subroutine test_associate_with_expressions()
+        character(len=*), parameter :: test_name = "test_associate_with_expressions"
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        logical :: found_associate
+        integer :: i
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Test ASSOCIATE with complex expressions
+        source = 'associate (s => sqrt(x**2 + y**2), avg => (a + b + c) / 3.0)' // &
+                 new_line('a') // 'end associate'
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        root_index = parse_statement_dispatcher(tokens, arena)
+        
+        ! Check if ASSOCIATE node was created
+        found_associate = .false.
+        do i = 1, arena%size
+            select type (node => arena%entries(i)%node)
+            type is (associate_node)
+                found_associate = .true.
+                if (allocated(node%associations)) then
+                    if (size(node%associations) == 2) then
+                        if (node%associations(1)%name == "s" .and. &
+                            node%associations(2)%name == "avg") then
+                            ! Check that expression indices are valid
+                            if (node%associations(1)%expr_index > 0 .and. &
+                                node%associations(2)%expr_index > 0) then
+                                write (*, '(A)') 'PASS'
+                                passed_tests = passed_tests + 1
+                            else
+                                write (*, '(A)') 'FAIL - Invalid expression indices'
+                            end if
+                        else
+                            write (*, '(A)') 'FAIL - Wrong association names'
+                        end if
+                    else
+                        write (*, '(A)') 'FAIL - Wrong number of associations'
+                    end if
+                else
+                    write (*, '(A)') 'FAIL - No associations allocated'
+                end if
+            end select
+        end do
+        
+        if (.not. found_associate) then
+            write (*, '(A)') 'FAIL - No ASSOCIATE node found'
+        end if
+    end subroutine test_associate_with_expressions
+
+    subroutine test_associate_with_body()
+        character(len=*), parameter :: test_name = "test_associate_with_body"
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        logical :: found_associate
+        integer :: i
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Test ASSOCIATE with body statements
+        source = 'associate (x => a + b)' // new_line('a') // &
+                'print *, x' // new_line('a') // &
+                'y = x * 2' // new_line('a') // &
+                'end associate'
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        root_index = parse_statement_dispatcher(tokens, arena)
+        
+        ! Check if ASSOCIATE node has body statements
+        found_associate = .false.
+        do i = 1, arena%size
+            select type (node => arena%entries(i)%node)
+            type is (associate_node)
+                found_associate = .true.
+                if (allocated(node%body_indices)) then
+                    if (size(node%body_indices) >= 2) then
+                        write (*, '(A)') 'PASS'
+                        passed_tests = passed_tests + 1
+                    else
+                        write (*, '(A,I0)') 'FAIL - Too few body statements: ', &
+                                           size(node%body_indices)
+                    end if
+                else
+                    write (*, '(A)') 'FAIL - No body statements allocated'
+                end if
+            end select
+        end do
+        
+        if (.not. found_associate) then
+            write (*, '(A)') 'FAIL - No ASSOCIATE node found'
+        end if
+    end subroutine test_associate_with_body
+
+    subroutine test_nested_associate()
+        character(len=*), parameter :: test_name = "test_nested_associate"
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        integer :: associate_count
+        integer :: i
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Test nested ASSOCIATE constructs
+        source = 'associate (x => a + b)' // new_line('a') // &
+                '  associate (y => x * 2)' // new_line('a') // &
+                '    print *, y' // new_line('a') // &
+                '  end associate' // new_line('a') // &
+                'end associate'
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        root_index = parse_statement_dispatcher(tokens, arena)
+        
+        ! Count ASSOCIATE nodes
+        associate_count = 0
+        do i = 1, arena%size
+            select type (node => arena%entries(i)%node)
+            type is (associate_node)
+                associate_count = associate_count + 1
+            end select
+        end do
+        
+        if (associate_count >= 2) then
+            write (*, '(A)') 'PASS'
+            passed_tests = passed_tests + 1
+        else
+            write (*, '(A,I0)') 'FAIL - Expected 2 ASSOCIATE nodes, found ', associate_count
+        end if
+    end subroutine test_nested_associate
+
+    subroutine test_associate_codegen()
+        character(len=*), parameter :: test_name = "test_associate_codegen"
+        character(len=:), allocatable :: source, generated
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        integer :: i
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Test code generation
+        source = 'associate (x => a + b, y => c * d)' // new_line('a') // &
+                'z = x + y' // new_line('a') // &
+                'end associate'
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        root_index = parse_statement_dispatcher(tokens, arena)
+        
+        ! Generate code from ASSOCIATE node
+        do i = 1, arena%size
+            select type (node => arena%entries(i)%node)
+            type is (associate_node)
+                generated = generate_code_from_arena(arena, i)
+                if (index(generated, "associate") > 0 .and. &
+                    index(generated, "x => ") > 0 .and. &
+                    index(generated, "y => ") > 0 .and. &
+                    index(generated, "end associate") > 0) then
+                    write (*, '(A)') 'PASS'
+                    passed_tests = passed_tests + 1
+                    return
+                else
+                    write (*, '(A)') 'FAIL - Generated code missing components'
+                    write (error_unit, '(A)') 'Generated code:'
+                    write (error_unit, '(A)') generated
+                    return
+                end if
+            end select
+        end do
+        
+        write (*, '(A)') 'FAIL - No ASSOCIATE node found for codegen'
+    end subroutine test_associate_codegen
+
+    subroutine test_associate_integration()
+        character(len=*), parameter :: test_name = "test_associate_integration"
+        character(len=:), allocatable :: source, code
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        
+        write (*, '(A)', advance='no') test_name // ' ... '
+        total_tests = total_tests + 1
+        
+        ! Test full compilation with ASSOCIATE
+        source = 'program test' // new_line('a') // &
+                'implicit none' // new_line('a') // &
+                'real :: a = 3.0, b = 4.0' // new_line('a') // &
+                'associate (s => sqrt(a**2 + b**2))' // new_line('a') // &
+                '  print *, "Hypotenuse:", s' // new_line('a') // &
+                'end associate' // new_line('a') // &
+                'end program test'
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        root_index = parse_statement_dispatcher(tokens, arena)
+        
+        if (root_index > 0) then
+            code = generate_code_from_arena(arena, root_index)
+            if (index(code, "associate") > 0 .and. &
+                index(code, "s => sqrt(a**2 + b**2)") > 0) then
+                write (*, '(A)') 'PASS'
+                passed_tests = passed_tests + 1
+            else
+                write (*, '(A)') 'FAIL - Missing ASSOCIATE in generated code'
+                write (error_unit, '(A)') 'Generated code:'
+                write (error_unit, '(A)') code
+            end if
+        else
+            write (*, '(A)') 'FAIL - Parse failed'
+        end if
+    end subroutine test_associate_integration
+
+end program test_associate_construct


### PR DESCRIPTION
## Summary
- Implements ASSOCIATE construct AST node support for issue #23
- Added ASSOCIATE keyword to lexer with => operator tokenization
- Created associate_node type with comprehensive AST support
- Implemented parser, codegen, and factory functions
- Added comprehensive test coverage

## Test plan
- [x] Lexer correctly tokenizes ASSOCIATE keyword and => operator
- [x] AST node creation and JSON serialization works
- [x] Factory functions create nodes correctly
- [x] Codegen generates proper ASSOCIATE statements
- [ ] Parser tests need further debugging for full functionality

🤖 Generated with [Claude Code](https://claude.ai/code)