### PR TITLE
feat: implement full Fortran implicit statement support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
           
           // Extract overall project coverage
           const coverageMatch = xml.match(/line-rate="([0-9.]+)"/);
-          const projectCoverage = coverageMatch ? Math.round(parseFloat(coverageMatch[1]) * 100).toString() : '0';
+          const projectCoverage = coverageMatch ? (parseFloat(coverageMatch[1]) * 100).toFixed(2) : '0.00';
           
           // For patch coverage, we'll use a simplified approach for now
           // In a full implementation, this would analyze only changed lines
@@ -165,9 +165,9 @@ jobs:
             output: {
               title: projectPassed ? `OK - ${projectCoverage}%` : `FAIL - ${projectCoverage}%`,
               summary: projectPassed 
-                ? `✅ Project coverage ${projectCoverage}% meets the ${projectThreshold}% threshold`
-                : `❌ Project coverage ${projectCoverage}% is below the ${projectThreshold}% threshold`,
-              text: `Current project coverage: ${projectCoverage}%\nRequired threshold: ${projectThreshold}%`
+                ? `✅ Project coverage ${projectCoverage}% meets the ${projectThreshold}.00% threshold`
+                : `❌ Project coverage ${projectCoverage}% is below the ${projectThreshold}.00% threshold`,
+              text: `Current project coverage: ${projectCoverage}%\nRequired threshold: ${projectThreshold}.00%`
             }
           });
           
@@ -182,9 +182,9 @@ jobs:
             output: {
               title: patchPassed ? `OK - ${patchCoverage}%` : `FAIL - ${patchCoverage}%`,
               summary: patchPassed 
-                ? `✅ Patch coverage ${patchCoverage}% meets the ${patchThreshold}% threshold`
-                : `❌ Patch coverage ${patchCoverage}% is below the ${patchThreshold}% threshold`,
-              text: `Current patch coverage: ${patchCoverage}%\nRequired threshold: ${patchThreshold}%\n\nNote: Patch coverage analyzes only the lines changed in this PR.`
+                ? `✅ Patch coverage ${patchCoverage}% meets the ${patchThreshold}.00% threshold`
+                : `❌ Patch coverage ${patchCoverage}% is below the ${patchThreshold}.00% threshold`,
+              text: `Current patch coverage: ${patchCoverage}%\nRequired threshold: ${patchThreshold}.00%\n\nNote: Patch coverage analyzes only the lines changed in this PR.`
             }
           });
 

--- a/src/ast/ast_factory.f90
+++ b/src/ast/ast_factory.f90
@@ -14,7 +14,7 @@ module ast_factory
     public :: push_associate
     public :: push_case_block, push_case_range, push_case_default, &
               push_select_case_with_default
-    public :: push_use_statement, push_include_statement, push_print_statement, &
+    public :: push_use_statement, push_implicit_statement, push_include_statement, push_print_statement, &
               push_write_statement, push_read_statement, push_read_statement_with_err, &
               push_read_statement_with_end, push_read_statement_with_all_specifiers, &
               push_write_statement_with_iostat, push_write_statement_with_format, &
@@ -926,6 +926,29 @@ contains
         use_index = arena%size
 
     end function push_use_statement
+
+    ! Create implicit statement node and add to stack
+    function push_implicit_statement(arena, is_none, type_name, kind_value, has_kind, &
+                                     length_value, has_length, letter_ranges, &
+                                     line, column, parent_index) result(implicit_index)
+        type(ast_arena_t), intent(inout) :: arena
+        logical, intent(in) :: is_none
+        character(len=*), intent(in), optional :: type_name
+        integer, intent(in), optional :: kind_value
+        logical, intent(in), optional :: has_kind
+        integer, intent(in), optional :: length_value
+        logical, intent(in), optional :: has_length
+        character(len=*), intent(in), optional :: letter_ranges(:)
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: implicit_index
+        type(implicit_statement_node) :: implicit_stmt
+
+        implicit_stmt = create_implicit_statement(is_none, type_name, kind_value, &
+                                                  has_kind, length_value, has_length, &
+                                                  letter_ranges, line, column)
+        call arena%push(implicit_stmt, "implicit_statement", parent_index)
+        implicit_index = arena%size
+    end function push_implicit_statement
 
     ! Create include statement node and add to stack
     function push_include_statement(arena, filename, line, column, &

--- a/src/parser/parser_statements.f90
+++ b/src/parser/parser_statements.f90
@@ -10,7 +10,7 @@ module parser_statements_module
     implicit none
     private
 
-    public :: parse_use_statement, parse_include_statement, parse_print_statement
+    public :: parse_use_statement, parse_implicit_statement, parse_include_statement, parse_print_statement
     public :: parse_write_statement, parse_read_statement
     public :: parse_function_definition, parse_subroutine_definition
     public :: parse_interface_block, parse_module, parse_program_statement
@@ -80,6 +80,218 @@ contains
                                         has_only, line, column, parent_index=0)
 
     end function parse_use_statement
+
+    ! Parse implicit statement: implicit none | implicit type-spec (letter-spec-list)
+    function parse_implicit_statement(parser, arena) result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer :: stmt_index
+        type(token_t) :: token
+        character(len=:), allocatable :: type_name
+        integer :: kind_value, length_value
+        logical :: has_kind, has_length, is_none
+        character(len=64), allocatable :: letter_ranges(:)
+        integer :: line, column, range_count, saved_pos
+        logical :: is_type_spec
+        
+        ! Consume 'implicit' keyword
+        token = parser%consume()
+        line = token%line
+        column = token%column
+        
+        ! Check for 'none'
+        token = parser%peek()
+        if (token%kind == TK_KEYWORD .and. token%text == "none") then
+            token = parser%consume()  ! consume 'none'
+            is_none = .true.
+            stmt_index = push_implicit_statement(arena, is_none, &
+                                                line=line, column=column, parent_index=0)
+            return
+        end if
+        
+        ! Parse type specification
+        is_none = .false.
+        has_kind = .false.
+        has_length = .false.
+        kind_value = 0
+        length_value = 0
+        range_count = 0
+        
+        ! Get type name
+        if (token%kind == TK_KEYWORD) then
+            type_name = token%text
+            token = parser%consume()
+            
+            ! Check for kind or length specification - but be careful to distinguish 
+            ! from letter specification parentheses
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == "(") then
+                ! Peek ahead to see if this looks like a type spec or letter spec
+                ! Save parser position to backtrack if needed
+                saved_pos = parser%current_token
+                
+                token = parser%consume()  ! consume '('
+                token = parser%peek()
+                
+                is_type_spec = .false.
+                
+                if (type_name == "character") then
+                    ! For character: check for "len" keyword or number
+                    if ((token%kind == TK_KEYWORD .and. token%text == "len") .or. &
+                        token%kind == TK_NUMBER) then
+                        is_type_spec = .true.
+                    end if
+                else
+                    ! For other types: check for number (kind specification)
+                    if (token%kind == TK_NUMBER) then
+                        is_type_spec = .true.
+                    end if
+                end if
+                
+                if (is_type_spec) then
+                    ! Parse as type specification
+                    if (type_name == "character") then
+                        ! Handle character length: character(len=10) or character*10
+                        if (token%kind == TK_KEYWORD .and. token%text == "len") then
+                            token = parser%consume()  ! consume 'len'
+                            token = parser%peek()
+                            if (token%kind == TK_OPERATOR .and. token%text == "=") then
+                                token = parser%consume()  ! consume '='
+                                token = parser%peek()
+                            end if
+                        end if
+                        if (token%kind == TK_NUMBER) then
+                            read(token%text, *) length_value
+                            has_length = .true.
+                            token = parser%consume()
+                        end if
+                    else
+                        ! Handle kind specification for other types
+                        if (token%kind == TK_NUMBER) then
+                            read(token%text, *) kind_value
+                            has_kind = .true.
+                            token = parser%consume()
+                        end if
+                    end if
+                    
+                    token = parser%peek()
+                    if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                        token = parser%consume()  ! consume ')'
+                    end if
+                else
+                    ! This is not a type specification, backtrack
+                    parser%current_token = saved_pos
+                end if
+            end if
+        end if
+        
+        ! Parse letter specification list in parentheses
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. token%text == "(") then
+            token = parser%consume()  ! consume '('
+            
+            ! Count letter ranges first
+            call count_letter_ranges(parser, range_count)
+            
+            if (range_count > 0) then
+                allocate(letter_ranges(range_count))
+                call parse_letter_ranges(parser, letter_ranges)
+            end if
+            
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                token = parser%consume()  ! consume ')'
+            end if
+        end if
+        
+        ! Create implicit statement node
+        stmt_index = push_implicit_statement(arena, is_none, type_name, kind_value, &
+                                           has_kind, length_value, has_length, &
+                                           letter_ranges, line, column, parent_index=0)
+                                           
+    end function parse_implicit_statement
+    
+    ! Helper to count letter ranges for allocation
+    subroutine count_letter_ranges(parser, count)
+        type(parser_state_t), intent(inout) :: parser
+        integer, intent(out) :: count
+        type(token_t) :: token
+        integer :: saved_pos
+        
+        count = 0
+        saved_pos = parser%current_token
+        
+        do
+            token = parser%peek()
+            if (token%kind == TK_IDENTIFIER .and. len(token%text) == 1) then
+                count = count + 1
+                token = parser%consume()
+                
+                ! Check for range (a-h)
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. token%text == "-") then
+                    token = parser%consume()  ! consume '-'
+                    token = parser%peek()
+                    if (token%kind == TK_IDENTIFIER .and. len(token%text) == 1) then
+                        token = parser%consume()  ! consume end letter
+                    end if
+                end if
+                
+                ! Check for comma
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                    token = parser%consume()  ! consume ','
+                else
+                    exit
+                end if
+            else
+                exit
+            end if
+        end do
+        
+        ! Restore parser position
+        parser%current_token = saved_pos
+    end subroutine count_letter_ranges
+    
+    ! Helper to parse letter ranges into array
+    subroutine parse_letter_ranges(parser, letter_ranges)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=64), intent(out) :: letter_ranges(:)
+        type(token_t) :: token
+        integer :: i
+        
+        i = 1
+        do while (i <= size(letter_ranges))
+            token = parser%peek()
+            if (token%kind == TK_IDENTIFIER .and. len(token%text) == 1) then
+                letter_ranges(i) = token%text
+                token = parser%consume()
+                
+                ! Check for range (a-h)  
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. token%text == "-") then
+                    token = parser%consume()  ! consume '-'
+                    token = parser%peek()
+                    if (token%kind == TK_IDENTIFIER .and. len(token%text) == 1) then
+                        letter_ranges(i) = trim(letter_ranges(i)) // "-" // token%text
+                        token = parser%consume()  ! consume end letter
+                    end if
+                end if
+                
+                i = i + 1
+                
+                ! Check for comma
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. token%text == ",") then  
+                    token = parser%consume()  ! consume ','
+                else
+                    exit
+                end if
+            else
+                exit
+            end if
+        end do
+    end subroutine parse_letter_ranges
 
     ! Parse include statement: include 'filename'
     function parse_include_statement(parser, arena) result(stmt_index)
@@ -1737,13 +1949,8 @@ contains
                 integer :: stmt_index
                 
                 if (token%kind == TK_KEYWORD .and. token%text == "implicit") then
-                    token = parser%consume()  ! consume 'implicit'
-                    token = parser%peek()
-                    if (token%kind == TK_KEYWORD .and. token%text == "none") then
-                        token = parser%consume()  ! consume 'none'
-                        stmt_index = push_literal(arena, "implicit none", &
-                                                   LITERAL_STRING, token%line, &
-                                                   token%column)
+                    stmt_index = parse_implicit_statement(parser, arena)
+                    if (stmt_index > 0) then
                         declaration_indices = [declaration_indices, stmt_index]
                     end if
                 else if (token%kind == TK_KEYWORD .and. &
@@ -1977,13 +2184,7 @@ contains
                     case ("use")
                         stmt_index = parse_use_statement(parser, arena)
                     case ("implicit")
-                        ! Skip implicit none - already handled by codegen
-                        token = parser%consume()  ! implicit
-                        token = parser%peek()
-                        if (token%text == "none") then
-                            token = parser%consume()  ! none
-                        end if
-                        stmt_index = 0  ! Don't add to AST
+                        stmt_index = parse_implicit_statement(parser, arena)
                     case ("integer", "real", "logical", "character", "complex")
                         ! Check if this is a single declaration with initializer
                         ! If so, use parse_declaration for proper initializer handling

--- a/src/standardizer.f90
+++ b/src/standardizer.f90
@@ -296,7 +296,6 @@ contains
         integer :: implicit_none_index
         integer, allocatable :: declaration_indices(:)
         integer :: i, j, insert_pos, n_declarations
-        type(literal_node) :: implicit_none_node
 
         if (.not. allocated(prog%body_indices)) return
 
@@ -306,13 +305,9 @@ contains
 
         ! Check if implicit none already exists
         if (.not. has_implicit_none(arena, prog)) then
-            ! Create implicit none node
-            implicit_none_node%value = "implicit none"
-            implicit_none_node%literal_kind = LITERAL_STRING
-            implicit_none_node%line = 1
-            implicit_none_node%column = 1
-            call arena%push(implicit_none_node, "implicit_none", prog_index)
-            implicit_none_index = arena%size
+            ! Create implicit none statement node
+            implicit_none_index = push_implicit_statement(arena, .true., &
+                                                         line=1, column=1, parent_index=prog_index)
         else
             implicit_none_index = 0  ! Don't add duplicate
         end if
@@ -1135,7 +1130,6 @@ contains
         integer, intent(in) :: func_index
         integer, allocatable :: new_body_indices(:)
         integer :: implicit_none_index, i, j
-        type(literal_node) :: implicit_none_node
         character(len=:), allocatable :: return_type_str
 
         ! Standardize return type
@@ -1150,13 +1144,9 @@ contains
 
         ! Add implicit none at the beginning of function body
         if (allocated(func_def%body_indices)) then
-            ! Create implicit none node
-            implicit_none_node%value = "implicit none"
-            implicit_none_node%literal_kind = LITERAL_STRING
-            implicit_none_node%line = 1
-            implicit_none_node%column = 1
-            call arena%push(implicit_none_node, "implicit_none", func_index)
-            implicit_none_index = arena%size
+            ! Create implicit none statement node
+            implicit_none_index = push_implicit_statement(arena, .true., &
+                                                         line=1, column=1, parent_index=func_index)
 
             ! Create new body with implicit none at the beginning
             allocate (new_body_indices(size(func_def%body_indices) + 1))
@@ -1306,7 +1296,6 @@ contains
         integer, intent(in) :: sub_index
         integer, allocatable :: new_body_indices(:)
         integer :: implicit_none_index, i, j
-        type(literal_node) :: implicit_none_node
         logical :: has_implicit_none
 
         ! Check if implicit none already exists
@@ -1331,13 +1320,9 @@ contains
 
         ! Add implicit none at the beginning of subroutine body if not present
         if (allocated(sub_def%body_indices) .and. .not. has_implicit_none) then
-            ! Create implicit none node
-            implicit_none_node%value = "implicit none"
-            implicit_none_node%literal_kind = LITERAL_STRING
-            implicit_none_node%line = 1
-            implicit_none_node%column = 1
-            call arena%push(implicit_none_node, "implicit_none", sub_index)
-            implicit_none_index = arena%size
+            ! Create implicit none statement node
+            implicit_none_index = push_implicit_statement(arena, .true., &
+                                                         line=1, column=1, parent_index=sub_index)
 
             ! Create new body with implicit none at the beginning
             allocate (new_body_indices(size(sub_def%body_indices) + 1))
@@ -1351,12 +1336,8 @@ contains
             arena%entries(implicit_none_index)%parent_index = sub_index
         else if (.not. allocated(sub_def%body_indices)) then
             ! For empty body, just add implicit none
-            implicit_none_node%value = "implicit none"
-            implicit_none_node%literal_kind = LITERAL_STRING
-            implicit_none_node%line = 1
-            implicit_none_node%column = 1
-            call arena%push(implicit_none_node, "implicit_none", sub_index)
-            implicit_none_index = arena%size
+            implicit_none_index = push_implicit_statement(arena, .true., &
+                                                         line=1, column=1, parent_index=sub_index)
             
             allocate(sub_def%body_indices(1))
             sub_def%body_indices(1) = implicit_none_index
@@ -1546,7 +1527,6 @@ contains
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(inout) :: func_index
         type(program_node) :: prog
-        type(literal_node) :: implicit_none_node
         type(contains_node) :: contains_stmt
         integer :: prog_index, implicit_none_index, contains_index
         integer, allocatable :: body_indices(:)
@@ -1557,12 +1537,8 @@ contains
         prog%column = 1
 
         ! Create implicit none
-        implicit_none_node%value = "implicit none"
-        implicit_none_node%literal_kind = LITERAL_STRING
-        implicit_none_node%line = 1
-        implicit_none_node%column = 1
-        call arena%push(implicit_none_node, "implicit_none", 0)
-        implicit_none_index = arena%size
+        implicit_none_index = push_implicit_statement(arena, .true., &
+                                                     line=1, column=1, parent_index=0)
 
         ! Create contains statement
         contains_stmt%line = 1
@@ -1601,7 +1577,6 @@ contains
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(inout) :: sub_index
         type(program_node) :: prog
-        type(literal_node) :: implicit_none_node
         type(contains_node) :: contains_stmt
         integer :: prog_index, implicit_none_index, contains_index
         integer, allocatable :: body_indices(:)
@@ -1612,12 +1587,8 @@ contains
         prog%column = 1
 
         ! Create implicit none
-        implicit_none_node%value = "implicit none"
-        implicit_none_node%literal_kind = LITERAL_STRING
-        implicit_none_node%line = 1
-        implicit_none_node%column = 1
-        call arena%push(implicit_none_node, "implicit_none", 0)
-        implicit_none_index = arena%size
+        implicit_none_index = push_implicit_statement(arena, .true., &
+                                                     line=1, column=1, parent_index=0)
 
         ! Create contains statement
         contains_stmt%line = 1

--- a/test/parser/test_implicit_statement_parsing.f90
+++ b/test/parser/test_implicit_statement_parsing.f90
@@ -1,0 +1,565 @@
+program test_implicit_statement_parsing
+    use ast_core
+    use ast_factory
+    use parser_statements_module, only: parse_implicit_statement
+    use parser_state_module
+    use lexer_core
+    use codegen_core, only: generate_code_from_arena
+    implicit none
+    
+    logical :: all_tests_passed
+    
+    print *, "=== Implicit Statement Parsing Tests ==="
+    
+    all_tests_passed = .true.
+    
+    ! Test implicit none
+    if (.not. test_implicit_none()) all_tests_passed = .false.
+    
+    ! Test implicit type with letter ranges
+    if (.not. test_implicit_real_range()) all_tests_passed = .false.
+    if (.not. test_implicit_integer_range()) all_tests_passed = .false.
+    
+    ! Test implicit type with kind specification
+    if (.not. test_implicit_real_with_kind()) all_tests_passed = .false.
+    
+    ! Test implicit character with length
+    if (.not. test_implicit_character_with_length()) all_tests_passed = .false.
+    
+    ! Test implicit type with multiple letter ranges
+    if (.not. test_implicit_multiple_ranges()) all_tests_passed = .false.
+    
+    if (all_tests_passed) then
+        print *, "All implicit statement parsing tests passed!"
+        stop 0
+    else
+        print *, "Some implicit statement parsing tests failed!"
+        stop 1
+    end if
+
+contains
+
+    function test_implicit_none() result(passed)
+        logical :: passed
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(token_t), allocatable :: tokens(:)
+        integer :: stmt_index
+        character(len=:), allocatable :: code_result
+        
+        passed = .true.
+        
+        ! Create arena
+        arena = create_ast_arena()
+        
+        ! Create tokens for "implicit none"
+        allocate(tokens(3))
+        tokens(1)%kind = TK_KEYWORD
+        tokens(1)%text = "implicit"
+        tokens(1)%line = 1
+        tokens(1)%column = 1
+        
+        tokens(2)%kind = TK_KEYWORD
+        tokens(2)%text = "none"
+        tokens(2)%line = 1
+        tokens(2)%column = 10
+        
+        tokens(3)%kind = TK_EOF
+        tokens(3)%text = ""
+        tokens(3)%line = 1
+        tokens(3)%column = 15
+        
+        ! Create parser
+        parser = create_parser_state(tokens)
+        
+        ! Parse implicit statement
+        stmt_index = parse_implicit_statement(parser, arena)
+        
+        ! Generate code to verify
+        code_result = generate_code_from_arena(arena, stmt_index)
+        
+        ! Check result
+        if (trim(code_result) /= "implicit none") then
+            passed = .false.
+            print *, "FAIL: Expected 'implicit none', got '", trim(code_result), "'"
+        end if
+        
+        if (passed) then
+            print *, "PASS: test_implicit_none"
+        else
+            print *, "FAIL: test_implicit_none"
+        end if
+        
+        call arena%clear()
+    end function test_implicit_none
+    
+    function test_implicit_real_range() result(passed)
+        logical :: passed
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(token_t), allocatable :: tokens(:)
+        integer :: stmt_index
+        character(len=:), allocatable :: code_result
+        
+        passed = .true.
+        
+        ! Create arena
+        arena = create_ast_arena()
+        
+        ! Create tokens for "implicit real (a-h,o-z)"
+        allocate(tokens(11))
+        tokens(1)%kind = TK_KEYWORD
+        tokens(1)%text = "implicit"
+        tokens(1)%line = 1
+        tokens(1)%column = 1
+        
+        tokens(2)%kind = TK_KEYWORD
+        tokens(2)%text = "real"
+        tokens(2)%line = 1
+        tokens(2)%column = 10
+        
+        tokens(3)%kind = TK_OPERATOR
+        tokens(3)%text = "("
+        tokens(3)%line = 1
+        tokens(3)%column = 15
+        
+        tokens(4)%kind = TK_IDENTIFIER
+        tokens(4)%text = "a"
+        tokens(4)%line = 1
+        tokens(4)%column = 16
+        
+        tokens(5)%kind = TK_OPERATOR
+        tokens(5)%text = "-"
+        tokens(5)%line = 1
+        tokens(5)%column = 17
+        
+        tokens(6)%kind = TK_IDENTIFIER
+        tokens(6)%text = "h"
+        tokens(6)%line = 1
+        tokens(6)%column = 18
+        
+        tokens(7)%kind = TK_OPERATOR
+        tokens(7)%text = ","
+        tokens(7)%line = 1
+        tokens(7)%column = 19
+        
+        tokens(8)%kind = TK_IDENTIFIER
+        tokens(8)%text = "o"
+        tokens(8)%line = 1
+        tokens(8)%column = 20
+        
+        tokens(9)%kind = TK_OPERATOR
+        tokens(9)%text = "-"
+        tokens(9)%line = 1
+        tokens(9)%column = 21
+        
+        tokens(10)%kind = TK_IDENTIFIER
+        tokens(10)%text = "z"
+        tokens(10)%line = 1
+        tokens(10)%column = 22
+        
+        tokens(11)%kind = TK_OPERATOR
+        tokens(11)%text = ")"
+        tokens(11)%line = 1
+        tokens(11)%column = 23
+        
+        ! Create parser
+        parser = create_parser_state(tokens)
+        
+        ! Parse implicit statement
+        stmt_index = parse_implicit_statement(parser, arena)
+        
+        ! Generate code to verify
+        code_result = generate_code_from_arena(arena, stmt_index)
+        
+        ! Check result contains expected elements
+        if (index(code_result, "implicit") == 0 .or. &
+            index(code_result, "real") == 0 .or. &
+            index(code_result, "a-h") == 0 .or. &
+            index(code_result, "o-z") == 0) then
+            passed = .false.
+            print *, "FAIL: Expected implicit real statement with ranges, got '", trim(code_result), "'"
+        end if
+        
+        if (passed) then
+            print *, "PASS: test_implicit_real_range"
+        else
+            print *, "FAIL: test_implicit_real_range"
+        end if
+        
+        call arena%clear()
+    end function test_implicit_real_range
+    
+    function test_implicit_integer_range() result(passed)
+        logical :: passed
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(token_t), allocatable :: tokens(:)
+        integer :: stmt_index
+        character(len=:), allocatable :: code_result
+        
+        passed = .true.
+        
+        ! Create arena
+        arena = create_ast_arena()
+        
+        ! Create tokens for "implicit integer (i-n)"
+        allocate(tokens(8))
+        tokens(1)%kind = TK_KEYWORD
+        tokens(1)%text = "implicit"
+        tokens(1)%line = 1
+        tokens(1)%column = 1
+        
+        tokens(2)%kind = TK_KEYWORD
+        tokens(2)%text = "integer"
+        tokens(2)%line = 1
+        tokens(2)%column = 10
+        
+        tokens(3)%kind = TK_OPERATOR
+        tokens(3)%text = "("
+        tokens(3)%line = 1
+        tokens(3)%column = 18
+        
+        tokens(4)%kind = TK_IDENTIFIER
+        tokens(4)%text = "i"
+        tokens(4)%line = 1
+        tokens(4)%column = 19
+        
+        tokens(5)%kind = TK_OPERATOR
+        tokens(5)%text = "-"
+        tokens(5)%line = 1
+        tokens(5)%column = 20
+        
+        tokens(6)%kind = TK_IDENTIFIER
+        tokens(6)%text = "n"
+        tokens(6)%line = 1
+        tokens(6)%column = 21
+        
+        tokens(7)%kind = TK_OPERATOR
+        tokens(7)%text = ")"
+        tokens(7)%line = 1
+        tokens(7)%column = 22
+        
+        tokens(8)%kind = TK_EOF
+        tokens(8)%text = ""
+        tokens(8)%line = 1
+        tokens(8)%column = 23
+        
+        ! Create parser
+        parser = create_parser_state(tokens)
+        
+        ! Parse implicit statement
+        stmt_index = parse_implicit_statement(parser, arena)
+        
+        ! Generate code to verify
+        code_result = generate_code_from_arena(arena, stmt_index)
+        
+        ! Check result
+        if (index(code_result, "implicit") == 0 .or. &
+            index(code_result, "integer") == 0 .or. &
+            index(code_result, "i-n") == 0) then
+            passed = .false.
+            print *, "FAIL: Expected implicit integer(i-n), got '", trim(code_result), "'"
+        end if
+        
+        if (passed) then
+            print *, "PASS: test_implicit_integer_range"
+        else
+            print *, "FAIL: test_implicit_integer_range"
+        end if
+        
+        call arena%clear()
+    end function test_implicit_integer_range
+    
+    function test_implicit_real_with_kind() result(passed)
+        logical :: passed
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(token_t), allocatable :: tokens(:)
+        integer :: stmt_index
+        character(len=:), allocatable :: code_result
+        
+        passed = .true.
+        
+        ! Create arena
+        arena = create_ast_arena()
+        
+        ! Create tokens for "implicit real(8) (a-h)"
+        allocate(tokens(10))
+        tokens(1)%kind = TK_KEYWORD
+        tokens(1)%text = "implicit"
+        tokens(1)%line = 1
+        tokens(1)%column = 1
+        
+        tokens(2)%kind = TK_KEYWORD
+        tokens(2)%text = "real"
+        tokens(2)%line = 1
+        tokens(2)%column = 10
+        
+        tokens(3)%kind = TK_OPERATOR
+        tokens(3)%text = "("
+        tokens(3)%line = 1
+        tokens(3)%column = 14
+        
+        tokens(4)%kind = TK_NUMBER
+        tokens(4)%text = "8"
+        tokens(4)%line = 1
+        tokens(4)%column = 15
+        
+        tokens(5)%kind = TK_OPERATOR
+        tokens(5)%text = ")"
+        tokens(5)%line = 1
+        tokens(5)%column = 16
+        
+        tokens(6)%kind = TK_OPERATOR
+        tokens(6)%text = "("
+        tokens(6)%line = 1
+        tokens(6)%column = 18
+        
+        tokens(7)%kind = TK_IDENTIFIER
+        tokens(7)%text = "a"
+        tokens(7)%line = 1
+        tokens(7)%column = 19
+        
+        tokens(8)%kind = TK_OPERATOR
+        tokens(8)%text = "-"
+        tokens(8)%line = 1
+        tokens(8)%column = 20
+        
+        tokens(9)%kind = TK_IDENTIFIER
+        tokens(9)%text = "h"
+        tokens(9)%line = 1
+        tokens(9)%column = 21
+        
+        tokens(10)%kind = TK_OPERATOR
+        tokens(10)%text = ")"
+        tokens(10)%line = 1
+        tokens(10)%column = 22
+        
+        ! Create parser
+        parser = create_parser_state(tokens)
+        
+        ! Parse implicit statement
+        stmt_index = parse_implicit_statement(parser, arena)
+        
+        ! Generate code to verify
+        code_result = generate_code_from_arena(arena, stmt_index)
+        
+        ! Check result
+        if (index(code_result, "implicit") == 0 .or. &
+            index(code_result, "real(8)") == 0 .or. &
+            index(code_result, "a-h") == 0) then
+            passed = .false.
+            print *, "FAIL: Expected implicit real(8)(a-h), got '", trim(code_result), "'"
+        end if
+        
+        if (passed) then
+            print *, "PASS: test_implicit_real_with_kind"
+        else
+            print *, "FAIL: test_implicit_real_with_kind"
+        end if
+        
+        call arena%clear()
+    end function test_implicit_real_with_kind
+    
+    function test_implicit_character_with_length() result(passed)
+        logical :: passed
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(token_t), allocatable :: tokens(:)
+        integer :: stmt_index
+        character(len=:), allocatable :: code_result
+        
+        passed = .true.
+        
+        ! Create arena
+        arena = create_ast_arena()
+        
+        ! Create tokens for "implicit character(len=10) (s-z)"
+        allocate(tokens(12))
+        tokens(1)%kind = TK_KEYWORD
+        tokens(1)%text = "implicit"
+        tokens(1)%line = 1
+        tokens(1)%column = 1
+        
+        tokens(2)%kind = TK_KEYWORD
+        tokens(2)%text = "character"
+        tokens(2)%line = 1
+        tokens(2)%column = 10
+        
+        tokens(3)%kind = TK_OPERATOR
+        tokens(3)%text = "("
+        tokens(3)%line = 1
+        tokens(3)%column = 19
+        
+        tokens(4)%kind = TK_KEYWORD
+        tokens(4)%text = "len"
+        tokens(4)%line = 1
+        tokens(4)%column = 20
+        
+        tokens(5)%kind = TK_OPERATOR
+        tokens(5)%text = "="
+        tokens(5)%line = 1
+        tokens(5)%column = 23
+        
+        tokens(6)%kind = TK_NUMBER
+        tokens(6)%text = "10"
+        tokens(6)%line = 1
+        tokens(6)%column = 24
+        
+        tokens(7)%kind = TK_OPERATOR
+        tokens(7)%text = ")"
+        tokens(7)%line = 1
+        tokens(7)%column = 26
+        
+        tokens(8)%kind = TK_OPERATOR
+        tokens(8)%text = "("
+        tokens(8)%line = 1
+        tokens(8)%column = 28
+        
+        tokens(9)%kind = TK_IDENTIFIER
+        tokens(9)%text = "s"
+        tokens(9)%line = 1
+        tokens(9)%column = 29
+        
+        tokens(10)%kind = TK_OPERATOR
+        tokens(10)%text = "-"
+        tokens(10)%line = 1
+        tokens(10)%column = 30
+        
+        tokens(11)%kind = TK_IDENTIFIER
+        tokens(11)%text = "z"
+        tokens(11)%line = 1
+        tokens(11)%column = 31
+        
+        tokens(12)%kind = TK_OPERATOR
+        tokens(12)%text = ")"
+        tokens(12)%line = 1
+        tokens(12)%column = 32
+        
+        ! Create parser
+        parser = create_parser_state(tokens)
+        
+        ! Parse implicit statement
+        stmt_index = parse_implicit_statement(parser, arena)
+        
+        ! Generate code to verify
+        code_result = generate_code_from_arena(arena, stmt_index)
+        
+        ! Check result
+        if (index(code_result, "implicit") == 0 .or. &
+            index(code_result, "character") == 0 .or. &
+            index(code_result, "len=10") == 0 .or. &
+            index(code_result, "s-z") == 0) then
+            passed = .false.
+            print *, "FAIL: Expected implicit character(len=10)(s-z), got '", trim(code_result), "'"
+        end if
+        
+        if (passed) then
+            print *, "PASS: test_implicit_character_with_length"
+        else
+            print *, "FAIL: test_implicit_character_with_length"
+        end if
+        
+        call arena%clear()
+    end function test_implicit_character_with_length
+    
+    function test_implicit_multiple_ranges() result(passed)
+        logical :: passed
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(token_t), allocatable :: tokens(:)
+        integer :: stmt_index
+        character(len=:), allocatable :: code_result
+        
+        passed = .true.
+        
+        ! Create arena
+        arena = create_ast_arena()
+        
+        ! Create tokens for "implicit real (a,d-f,z)"
+        allocate(tokens(11))
+        tokens(1)%kind = TK_KEYWORD
+        tokens(1)%text = "implicit"
+        tokens(1)%line = 1
+        tokens(1)%column = 1
+        
+        tokens(2)%kind = TK_KEYWORD
+        tokens(2)%text = "real"
+        tokens(2)%line = 1
+        tokens(2)%column = 10
+        
+        tokens(3)%kind = TK_OPERATOR
+        tokens(3)%text = "("
+        tokens(3)%line = 1
+        tokens(3)%column = 15
+        
+        tokens(4)%kind = TK_IDENTIFIER
+        tokens(4)%text = "a"
+        tokens(4)%line = 1
+        tokens(4)%column = 16
+        
+        tokens(5)%kind = TK_OPERATOR
+        tokens(5)%text = ","
+        tokens(5)%line = 1
+        tokens(5)%column = 17
+        
+        tokens(6)%kind = TK_IDENTIFIER
+        tokens(6)%text = "d"
+        tokens(6)%line = 1
+        tokens(6)%column = 18
+        
+        tokens(7)%kind = TK_OPERATOR
+        tokens(7)%text = "-"
+        tokens(7)%line = 1
+        tokens(7)%column = 19
+        
+        tokens(8)%kind = TK_IDENTIFIER
+        tokens(8)%text = "f"
+        tokens(8)%line = 1
+        tokens(8)%column = 20
+        
+        tokens(9)%kind = TK_OPERATOR
+        tokens(9)%text = ","
+        tokens(9)%line = 1
+        tokens(9)%column = 21
+        
+        tokens(10)%kind = TK_IDENTIFIER
+        tokens(10)%text = "z"
+        tokens(10)%line = 1
+        tokens(10)%column = 22
+        
+        tokens(11)%kind = TK_OPERATOR
+        tokens(11)%text = ")"
+        tokens(11)%line = 1
+        tokens(11)%column = 23
+        
+        ! Create parser
+        parser = create_parser_state(tokens)
+        
+        ! Parse implicit statement
+        stmt_index = parse_implicit_statement(parser, arena)
+        
+        ! Generate code to verify
+        code_result = generate_code_from_arena(arena, stmt_index)
+        
+        ! Check result
+        if (index(code_result, "implicit") == 0 .or. &
+            index(code_result, "real") == 0 .or. &
+            index(code_result, "a") == 0 .or. &
+            index(code_result, "d-f") == 0 .or. &
+            index(code_result, "z") == 0) then
+            passed = .false.
+            print *, "FAIL: Expected implicit real(a,d-f,z), got '", trim(code_result), "'"
+        end if
+        
+        if (passed) then
+            print *, "PASS: test_implicit_multiple_ranges"
+        else
+            print *, "FAIL: test_implicit_multiple_ranges"
+        end if
+        
+        call arena%clear()
+    end function test_implicit_multiple_ranges
+
+end program test_implicit_statement_parsing


### PR DESCRIPTION
### **User description**
## Summary
- Implements complete Fortran implicit statement support according to the Fortran standard
- Replaces literal_node usage for implicit statements with proper AST nodes
- Adds support for legacy implicit typing beyond just "implicit none"

## Key Features
- **Full implicit syntax support**: `implicit none`, `implicit type-spec (letter-spec-list)`
- **Type specifications**: Support for kind parameters (`real(8)`) and character lengths (`character(len=10)`)
- **Letter ranges**: Support for ranges like `a-h`, `i-n`, `o-z` and individual letters
- **Complex combinations**: `implicit real(8)(a-h,o-z)`, `implicit character(len=10)(s-z)`
- **Proper AST representation**: Uses `implicit_statement_node` instead of `literal_node`
- **Code generation**: Emits clean, standard-compliant implicit statements

## Technical Implementation
- Created new AST node types: `implicit_statement_node`, `implicit_type_spec_t`, `implicit_letter_spec_t`
- Updated parser to distinguish type specification parentheses from letter specification parentheses
- Enhanced code generation to handle all implicit statement variants
- Updated standardizer to use proper AST nodes for language constructs
- Added comprehensive test suite with 6 different implicit statement patterns

## Test Coverage
- ✅ `implicit none`
- ✅ `implicit real (a-h,o-z)` 
- ✅ `implicit integer (i-n)`
- ✅ `implicit real(8) (a-h)`
- ✅ `implicit character(len=10) (s-z)`
- ✅ `implicit real (a,d-f,z)`

## Addresses
- Resolves issue #69
- Addresses Qodo review feedback about proper AST nodes for language constructs
- Maintains backward compatibility while improving semantic correctness

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Implement complete Fortran implicit statement support with proper AST nodes

- Add support for type specifications with kind parameters and character lengths

- Support letter ranges and complex implicit statement combinations

- Replace literal_node usage with dedicated implicit_statement_node


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parser"] --> B["implicit_statement_node"]
  B --> C["Type Specification"]
  B --> D["Letter Ranges"]
  C --> E["Kind/Length Parameters"]
  D --> F["Single Letters & Ranges"]
  B --> G["Code Generation"]
  G --> H["Standard Fortran Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ast_core.f90</strong><dd><code>Add implicit statement factory function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/ast_core.f90

<ul><li>Add imports for new implicit statement AST node types<br> <li> Export <code>create_implicit_statement</code> factory function<br> <li> Implement factory function with type specs and letter range parsing</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/70/files#diff-cc1dea1e746de8af0c8624e56c1d9d94912a160a0c1792f522ffe33541e4ae0d">+47/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_factory.f90</strong><dd><code>Add implicit statement arena support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/ast_factory.f90

<ul><li>Export <code>push_implicit_statement</code> function for AST arena<br> <li> Implement arena push function for implicit statement nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/70/files#diff-6becc5eaf1593a79f5383f4852686e99967045ef857a8ff8d5e2407f91f62f79">+24/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_nodes_misc.f90</strong><dd><code>Define implicit statement AST node types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/ast_nodes_misc.f90

<ul><li>Define <code>implicit_letter_spec_t</code> for letter range specifications<br> <li> Define <code>implicit_type_spec_t</code> for type specifications with kind/length<br> <li> Define <code>implicit_statement_node</code> extending base AST node<br> <li> Implement JSON serialization and assignment methods</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/70/files#diff-eff6e456fbd5667753afbf5381fc351bbbf3939da89121c3f1cd3e4a54f61079">+113/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codegen_core.f90</strong><dd><code>Add implicit statement code generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_core.f90

<ul><li>Add case for <code>implicit_statement_node</code> in code generation dispatch<br> <li> Implement <code>generate_code_implicit_statement</code> function<br> <li> Support all implicit variants: none, type specs, kind/length, letter <br>ranges</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/70/files#diff-c81dee672bc2729fc6591078149f41c001c1860248a5c6fc86294fb9dac68b15">+58/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_statements.f90</strong><dd><code>Implement comprehensive implicit statement parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_statements.f90

<ul><li>Export <code>parse_implicit_statement</code> function<br> <li> Implement full implicit statement parser with type/letter spec <br>disambiguation<br> <li> Add helper functions for counting and parsing letter ranges<br> <li> Update module and program parsers to use new implicit parser</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/70/files#diff-3b8f0e50d97c2b33fb2385b4522a393e2a1c62df0c84a838da279f354c66f2df">+216/-15</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>standardizer.f90</strong><dd><code>Replace literal nodes with proper implicit statements</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/standardizer.f90

<ul><li>Replace <code>literal_node</code> usage with <code>push_implicit_statement</code> calls<br> <li> Update all implicit none insertions to use proper AST nodes<br> <li> Maintain functionality while improving semantic correctness</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/70/files#diff-e7d434f9761267d5fd2c23cebef4b5fce5ed0da37e745ee10d947bbc508efbbf">+15/-44</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_implicit_statement_parsing.f90</strong><dd><code>Add comprehensive implicit statement test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/parser/test_implicit_statement_parsing.f90

<ul><li>Add comprehensive test suite for all implicit statement variants<br> <li> Test implicit none, type specifications, kind parameters, character <br>lengths<br> <li> Test letter ranges and complex combinations<br> <li> Verify code generation produces correct output</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/70/files#diff-a0814e4797a2c1d9be1eea8fae8a3b6574033faeb8b856b0d73597177278e3f6">+565/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

