### PR TITLE
feat: resolve function/subroutine interface inconsistencies in AST API

### DIFF
--- a/src/ast/ast_core.f90
+++ b/src/ast/ast_core.f90
@@ -36,7 +36,10 @@ module ast_core
                                  create_select_case
     use ast_nodes_procedure, only: function_def_node, subroutine_def_node, &
                                    subroutine_call_node, &
-                                   create_function_def, create_subroutine_def
+                                   create_function_def, create_subroutine_def, &
+                                   is_procedure_node, get_procedure_name, get_procedure_params, &
+                                   get_procedure_body, procedure_has_return_type, &
+                                   get_procedure_return_type
     use ast_nodes_data, only: declaration_node, parameter_declaration_node, &
                                module_node, derived_type_node, &
                                create_declaration, create_derived_type
@@ -95,6 +98,9 @@ module ast_core
               create_print_statement, create_declaration, create_do_loop, &
               create_do_while, create_if, &
               create_select_case, create_derived_type
+    ! Procedure helper functions for consistent interface
+    public :: is_procedure_node, get_procedure_name, get_procedure_params, &
+              get_procedure_body, procedure_has_return_type, get_procedure_return_type
     ! Factory functions in this module
     public :: create_identifier, create_literal, create_binary_op, &
               create_call_or_subscript, &

--- a/src/ast/ast_nodes_procedure.f90
+++ b/src/ast/ast_nodes_procedure.f90
@@ -6,6 +6,10 @@ module ast_nodes_procedure
 
     ! Public factory functions
     public :: create_function_def, create_subroutine_def
+    
+    ! Public interface helpers
+    public :: is_procedure_node, get_procedure_name, get_procedure_params, get_procedure_body
+    public :: procedure_has_return_type, get_procedure_return_type
 
     ! Procedure-related AST nodes
 
@@ -161,5 +165,119 @@ contains
         if (present(line)) node%line = line
         if (present(column)) node%column = column
     end function create_subroutine_def
+
+    ! Helper functions for unified procedure interface
+
+    ! Check if a node is a procedure definition (function or subroutine)
+    function is_procedure_node(node) result(is_proc)
+        class(ast_node), intent(in) :: node
+        logical :: is_proc
+        
+        is_proc = .false.
+        select type (n => node)
+        type is (function_def_node)
+            is_proc = .true.
+        type is (subroutine_def_node)
+            is_proc = .true.
+        end select
+    end function is_procedure_node
+
+    ! Get procedure name (works for both functions and subroutines)
+    function get_procedure_name(node) result(name)
+        class(ast_node), intent(in) :: node
+        character(len=:), allocatable :: name
+        
+        select type (n => node)
+        type is (function_def_node)
+            if (allocated(n%name)) then
+                name = n%name
+            else
+                name = ""
+            end if
+        type is (subroutine_def_node)
+            if (allocated(n%name)) then
+                name = n%name
+            else
+                name = ""
+            end if
+        class default
+            name = ""
+        end select
+    end function get_procedure_name
+
+    ! Get procedure parameters (works for both functions and subroutines)
+    function get_procedure_params(node) result(param_indices)
+        class(ast_node), intent(in) :: node
+        integer, allocatable :: param_indices(:)
+        
+        select type (n => node)
+        type is (function_def_node)
+            if (allocated(n%param_indices)) then
+                param_indices = n%param_indices
+            else
+                allocate(param_indices(0))
+            end if
+        type is (subroutine_def_node)
+            if (allocated(n%param_indices)) then
+                param_indices = n%param_indices
+            else
+                allocate(param_indices(0))
+            end if
+        class default
+            allocate(param_indices(0))
+        end select
+    end function get_procedure_params
+
+    ! Get procedure body (works for both functions and subroutines)
+    function get_procedure_body(node) result(body_indices)
+        class(ast_node), intent(in) :: node
+        integer, allocatable :: body_indices(:)
+        
+        select type (n => node)
+        type is (function_def_node)
+            if (allocated(n%body_indices)) then
+                body_indices = n%body_indices
+            else
+                allocate(body_indices(0))
+            end if
+        type is (subroutine_def_node)
+            if (allocated(n%body_indices)) then
+                body_indices = n%body_indices
+            else
+                allocate(body_indices(0))
+            end if
+        class default
+            allocate(body_indices(0))
+        end select
+    end function get_procedure_body
+
+    ! Check if procedure has a return type (only functions do)
+    function procedure_has_return_type(node) result(has_return)
+        class(ast_node), intent(in) :: node
+        logical :: has_return
+        
+        has_return = .false.
+        select type (n => node)
+        type is (function_def_node)
+            has_return = .true.
+        end select
+    end function procedure_has_return_type
+
+    ! Get procedure return type (only for functions)
+    function get_procedure_return_type(node) result(return_type)
+        class(ast_node), intent(in) :: node
+        character(len=:), allocatable :: return_type
+        
+        select type (n => node)
+        type is (function_def_node)
+            if (allocated(n%return_type)) then
+                return_type = n%return_type
+            else
+                return_type = ""
+            end if
+        class default
+            return_type = ""
+        end select
+    end function get_procedure_return_type
 
 end module ast_nodes_procedure

--- a/src/fortfront.f90
+++ b/src/fortfront.f90
@@ -51,7 +51,10 @@ module fortfront
                         comment_node, contains_node, &
                         LITERAL_INTEGER, LITERAL_REAL, LITERAL_STRING, &
                         LITERAL_LOGICAL, LITERAL_ARRAY, LITERAL_COMPLEX, &
-                        create_ast_arena, ast_arena_stats_t
+                        create_ast_arena, ast_arena_stats_t, &
+                        create_function_def, create_subroutine_def, &
+                        is_procedure_node, get_procedure_name, get_procedure_params, &
+                        get_procedure_body, procedure_has_return_type, get_procedure_return_type
     
     ! Re-export AST node data utilities  
     use ast_nodes_data, only: intent_type_to_string, INTENT_NONE, INTENT_IN, &

--- a/test/ast/test_procedure_interface_consistency.f90
+++ b/test/ast/test_procedure_interface_consistency.f90
@@ -1,0 +1,226 @@
+program test_procedure_interface_consistency
+    ! Test for issue #74: Function/subroutine interface inconsistencies in AST API
+    ! This test verifies that the unified procedure interface works correctly
+    use fortfront
+    implicit none
+    
+    logical :: all_tests_passed
+    
+    all_tests_passed = .true.
+    
+    call test_unified_procedure_interface()
+    call test_interface_block_with_procedures()
+    call test_procedure_helper_functions()
+    
+    if (all_tests_passed) then
+        print *, "All procedure interface consistency tests PASSED!"
+    else
+        error stop "Some procedure interface consistency tests FAILED!"
+    end if
+    
+contains
+
+    subroutine test_unified_procedure_interface()
+        type(ast_arena_t) :: arena
+        type(function_def_node) :: func_node
+        type(subroutine_def_node) :: sub_node
+        integer :: func_index, sub_index
+        character(len=:), allocatable :: name
+        integer, allocatable :: params(:), body(:)
+        logical :: has_return
+        
+        print *, "Testing unified procedure interface..."
+        
+        ! Create test arena
+        arena = create_ast_arena()
+        
+        ! Create function node
+        func_node = create_function_def("test_func", [1,2], "real", [3,4])
+        call arena%push(func_node, "function_def", 0)
+        func_index = arena%size
+        
+        ! Create subroutine node  
+        sub_node = create_subroutine_def("test_sub", [5,6], [7,8])
+        call arena%push(sub_node, "subroutine_def", 0)
+        sub_index = arena%size
+        
+        ! Test unified interface with function
+        if (is_procedure_node(arena%entries(func_index)%node)) then
+            name = get_procedure_name(arena%entries(func_index)%node)
+            if (name /= "test_func") then
+                print *, "FAILED: Function name mismatch:", name
+                all_tests_passed = .false.
+                return
+            end if
+            
+            params = get_procedure_params(arena%entries(func_index)%node)
+            if (size(params) /= 2 .or. params(1) /= 1 .or. params(2) /= 2) then
+                print *, "FAILED: Function params mismatch"
+                all_tests_passed = .false.
+                return
+            end if
+            
+            body = get_procedure_body(arena%entries(func_index)%node)
+            if (size(body) /= 2 .or. body(1) /= 3 .or. body(2) /= 4) then
+                print *, "FAILED: Function body mismatch"
+                all_tests_passed = .false.
+                return
+            end if
+            
+            has_return = procedure_has_return_type(arena%entries(func_index)%node)
+            if (.not. has_return) then
+                print *, "FAILED: Function should have return type"
+                all_tests_passed = .false.
+                return
+            end if
+            
+            name = get_procedure_return_type(arena%entries(func_index)%node)
+            if (name /= "real") then
+                print *, "FAILED: Function return type mismatch:", name
+                all_tests_passed = .false.
+                return
+            end if
+        else
+            print *, "FAILED: Function not recognized as procedure"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        ! Test unified interface with subroutine
+        if (is_procedure_node(arena%entries(sub_index)%node)) then
+            name = get_procedure_name(arena%entries(sub_index)%node)
+            if (name /= "test_sub") then
+                print *, "FAILED: Subroutine name mismatch:", name
+                all_tests_passed = .false.
+                return
+            end if
+            
+            params = get_procedure_params(arena%entries(sub_index)%node)
+            if (size(params) /= 2 .or. params(1) /= 5 .or. params(2) /= 6) then
+                print *, "FAILED: Subroutine params mismatch"
+                all_tests_passed = .false.
+                return
+            end if
+            
+            body = get_procedure_body(arena%entries(sub_index)%node)
+            if (size(body) /= 2 .or. body(1) /= 7 .or. body(2) /= 8) then
+                print *, "FAILED: Subroutine body mismatch"
+                all_tests_passed = .false.
+                return
+            end if
+            
+            has_return = procedure_has_return_type(arena%entries(sub_index)%node)
+            if (has_return) then
+                print *, "FAILED: Subroutine should not have return type"
+                all_tests_passed = .false.
+                return
+            end if
+            
+            name = get_procedure_return_type(arena%entries(sub_index)%node)
+            if (name /= "") then
+                print *, "FAILED: Subroutine should have empty return type"
+                all_tests_passed = .false.
+                return
+            end if
+        else
+            print *, "FAILED: Subroutine not recognized as procedure"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        print *, "PASSED: Unified procedure interface"
+    end subroutine test_unified_procedure_interface
+
+    subroutine test_interface_block_with_procedures()
+        type(ast_arena_t) :: arena
+        type(interface_block_node) :: iface_node
+        integer :: iface_index
+        
+        print *, "Testing interface block with procedures..."
+        
+        ! Create test arena
+        arena = create_ast_arena()
+        
+        ! Create interface block node
+        iface_node%name = "test_interface"
+        iface_node%kind = "interface"
+        ! Procedures would be referenced by indices in procedure_indices array
+        allocate(iface_node%procedure_indices(2))
+        iface_node%procedure_indices = [100, 200]  ! Mock indices
+        
+        call arena%push(iface_node, "interface_block", 0)
+        iface_index = arena%size
+        
+        ! Test interface block structure
+        select type (n => arena%entries(iface_index)%node)
+        type is (interface_block_node)
+            if (.not. allocated(n%procedure_indices)) then
+                print *, "FAILED: Interface block procedure_indices not allocated"
+                all_tests_passed = .false.
+                return
+            end if
+            
+            if (size(n%procedure_indices) /= 2) then
+                print *, "FAILED: Interface block procedure count mismatch"
+                all_tests_passed = .false.
+                return
+            end if
+            
+            if (n%procedure_indices(1) /= 100 .or. n%procedure_indices(2) /= 200) then
+                print *, "FAILED: Interface block procedure indices mismatch"
+                all_tests_passed = .false.
+                return
+            end if
+        class default
+            print *, "FAILED: Interface block node type mismatch"
+            all_tests_passed = .false.
+            return
+        end select
+        
+        print *, "PASSED: Interface block with procedures"
+    end subroutine test_interface_block_with_procedures
+
+    subroutine test_procedure_helper_functions()
+        type(ast_arena_t) :: arena
+        type(identifier_node) :: id_node
+        integer :: id_index
+        character(len=:), allocatable :: name
+        integer, allocatable :: params(:)
+        logical :: is_proc
+        
+        print *, "Testing procedure helper functions with non-procedure..."
+        
+        ! Create test arena
+        arena = create_ast_arena()
+        
+        ! Create identifier node (not a procedure)
+        id_node%name = "not_a_procedure"
+        call arena%push(id_node, "identifier", 0)
+        id_index = arena%size
+        
+        ! Test that non-procedures are handled correctly
+        is_proc = is_procedure_node(arena%entries(id_index)%node)
+        if (is_proc) then
+            print *, "FAILED: Identifier incorrectly identified as procedure"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        name = get_procedure_name(arena%entries(id_index)%node)
+        if (name /= "") then
+            print *, "FAILED: Non-procedure should return empty name"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        params = get_procedure_params(arena%entries(id_index)%node)
+        if (size(params) /= 0) then
+            print *, "FAILED: Non-procedure should return empty params"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        print *, "PASSED: Procedure helper functions with non-procedure"
+    end subroutine test_procedure_helper_functions
+
+end program test_procedure_interface_consistency


### PR DESCRIPTION
### **User description**
## Summary
- Resolves function/subroutine interface inconsistencies in the AST API
- Provides unified interface for working with both function and subroutine definitions
- Maintains full backward compatibility while adding cleaner abstractions

## Problem
The AST API had inconsistencies when working with procedure definitions:

1. **No unified interface**: Functions and subroutines required different handling patterns
2. **Interface block limitations**: `interface_block_node` could reference procedures but lacked unified access methods
3. **Code duplication**: Users had to write separate handling code for functions vs subroutines
4. **API complexity**: No consistent way to query procedure properties across different node types

## Solution
**Added unified procedure helper functions:**
- `is_procedure_node()` - Check if a node is a procedure (function or subroutine)
- `get_procedure_name()` - Get procedure name (works for both functions and subroutines)
- `get_procedure_params()` - Get parameter indices uniformly
- `get_procedure_body()` - Get body indices uniformly  
- `procedure_has_return_type()` - Check if procedure has return type (functions only)
- `get_procedure_return_type()` - Get return type (functions only, empty for subroutines)

**Key features:**
- **Polymorphic**: All functions work with `class(ast_node)`
- **Safe**: Handle both function and subroutine node types gracefully
- **Consistent**: Same interface regardless of procedure type
- **Backward compatible**: Existing code continues to work unchanged

## Changes
- `src/ast/ast_nodes_procedure.f90`: Added 6 new helper functions with proper error handling
- `src/ast/ast_core.f90`: Export helper functions through main AST interface  
- `src/fortfront.f90`: Make helper functions available through main API
- `test/ast/test_procedure_interface_consistency.f90`: Comprehensive test coverage

## Testing
- ✅ All 6 helper functions tested with both function and subroutine nodes
- ✅ Interface block compatibility verified
- ✅ Error handling tested with non-procedure nodes
- ✅ All existing tests continue to pass (no regressions)

## Example Usage
```fortran
\! Before (inconsistent):
select type (node => arena%entries(index)%node)
type is (function_def_node)
    name = node%name
    params = node%param_indices
type is (subroutine_def_node) 
    name = node%name
    params = node%param_indices
end select

\! After (unified):
if (is_procedure_node(arena%entries(index)%node)) then
    name = get_procedure_name(arena%entries(index)%node)
    params = get_procedure_params(arena%entries(index)%node)
end if
```

Resolves #74

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Enhancement


___

### **Description**
- Add unified procedure interface helper functions for consistent AST API access

- Implement 6 new helper functions for both functions and subroutines

- Export helpers through main fortfront API for easy access

- Add comprehensive test suite for interface consistency verification


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ast_nodes_procedure.f90"] --> B["6 Helper Functions"]
  B --> C["ast_core.f90"]
  C --> D["fortfront.f90"]
  D --> E["Unified API"]
  F["test_procedure_interface_consistency.f90"] --> G["Test Coverage"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ast_nodes_procedure.f90</strong><dd><code>Add unified procedure interface helper functions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/ast_nodes_procedure.f90

<ul><li>Add 6 new helper functions for unified procedure interface<br> <li> Implement <code>is_procedure_node</code>, <code>get_procedure_name</code>, <code>get_procedure_params</code><br> <li> Add <code>get_procedure_body</code>, <code>procedure_has_return_type</code>, <br><code>get_procedure_return_type</code><br> <li> Handle both function and subroutine nodes with proper error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/77/files#diff-901b66964b494ddbb6b56afd2dd54d3b49390ba33c3cc5f976c94d78e30a9280">+118/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_core.f90</strong><dd><code>Export procedure helper functions through AST core</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/ast_core.f90

<ul><li>Import 6 new helper functions from <code>ast_nodes_procedure</code> module<br> <li> Export helper functions through public interface for external access</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/77/files#diff-cc1dea1e746de8af0c8624e56c1d9d94912a160a0c1792f522ffe33541e4ae0d">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fortfront.f90</strong><dd><code>Expose procedure helpers through main API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/fortfront.f90

<ul><li>Import and re-export procedure helper functions and factory functions<br> <li> Make unified interface available through main fortfront API</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/77/files#diff-fad5ae7216bd4521420bbf4c38f2968d1241c3a6518f877ff7d92fe318945c23">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_procedure_interface_consistency.f90</strong><dd><code>Add comprehensive procedure interface consistency tests</code>&nbsp; &nbsp; </dd></summary>
<hr>

test/ast/test_procedure_interface_consistency.f90

<ul><li>Add comprehensive test suite for unified procedure interface<br> <li> Test all 6 helper functions with function and subroutine nodes<br> <li> Verify interface block compatibility and error handling<br> <li> Test non-procedure nodes for proper error handling</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/77/files#diff-b27549f34ece318b28ab0e47c7c4070b14d1ea9ab5c405fc66fe2f15133ead1f">+226/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

