### PR TITLE
fix: Add support for allocate/deallocate statement identifier tracking (issue #105)

### DIFF
--- a/src/analysis/variable_usage_tracker.f90
+++ b/src/analysis/variable_usage_tracker.f90
@@ -837,6 +837,8 @@ contains
         
         ! Validate node index bounds
         if (node_index <= 0 .or. node_index > arena%size) return
+        if (.not. allocated(arena%entries)) return
+        if (node_index > size(arena%entries)) return
         if (.not. allocated(arena%entries(node_index)%node)) return
         
         ! Verify node type matches expectation
@@ -898,6 +900,8 @@ contains
         
         ! Validate node index bounds
         if (node_index <= 0 .or. node_index > arena%size) return
+        if (.not. allocated(arena%entries)) return
+        if (node_index > size(arena%entries)) return
         if (.not. allocated(arena%entries(node_index)%node)) return
         
         ! Verify node type matches expectation

--- a/src/analysis/variable_usage_tracker.f90
+++ b/src/analysis/variable_usage_tracker.f90
@@ -123,6 +123,10 @@ contains
             call process_write_statement_children(arena, node_index, info)
         case ("read_statement")
             call process_read_statement_children(arena, node_index, info)
+        case ("allocate_statement")
+            call process_allocate_statement_children(arena, node_index, info)
+        case ("deallocate_statement")
+            call process_deallocate_statement_children(arena, node_index, info)
         end select
     end subroutine collect_identifiers_recursive
 
@@ -821,6 +825,109 @@ contains
             end if
         end select
     end subroutine process_read_statement_children
+
+    ! Process allocate statement children
+    subroutine process_allocate_statement_children(arena, node_index, info)
+        use ast_nodes_misc, only: allocate_statement_node
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(variable_usage_info_t), intent(inout) :: info
+        
+        integer :: i
+        
+        ! Validate node index bounds
+        if (node_index <= 0 .or. node_index > arena%size) return
+        if (.not. allocated(arena%entries(node_index)%node)) return
+        
+        ! Verify node type matches expectation
+        if (arena%entries(node_index)%node_type /= "allocate_statement") then
+            ! Node type mismatch - this shouldn't happen if called correctly
+            return
+        end if
+        
+        select type (node => arena%entries(node_index)%node)
+        type is (allocate_statement_node)
+            ! Process variables being allocated
+            if (allocated(node%var_indices)) then
+                do i = 1, size(node%var_indices)
+                    if (node%var_indices(i) > 0) then
+                        call collect_identifiers_recursive(arena, node%var_indices(i), info)
+                    end if
+                end do
+            end if
+            
+            ! Process shape expressions for each variable
+            if (allocated(node%shape_indices)) then
+                do i = 1, size(node%shape_indices)
+                    if (node%shape_indices(i) > 0) then
+                        call collect_identifiers_recursive(arena, node%shape_indices(i), info)
+                    end if
+                end do
+            end if
+            
+            ! Process stat variable if present
+            if (node%stat_var_index > 0) then
+                call collect_identifiers_recursive(arena, node%stat_var_index, info)
+            end if
+            
+            ! Process errmsg variable if present
+            if (node%errmsg_var_index > 0) then
+                call collect_identifiers_recursive(arena, node%errmsg_var_index, info)
+            end if
+            
+            ! Process source expression if present
+            if (node%source_expr_index > 0) then
+                call collect_identifiers_recursive(arena, node%source_expr_index, info)
+            end if
+            
+            ! Process mold expression if present
+            if (node%mold_expr_index > 0) then
+                call collect_identifiers_recursive(arena, node%mold_expr_index, info)
+            end if
+        end select
+    end subroutine process_allocate_statement_children
+
+    ! Process deallocate statement children
+    subroutine process_deallocate_statement_children(arena, node_index, info)
+        use ast_nodes_misc, only: deallocate_statement_node
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(variable_usage_info_t), intent(inout) :: info
+        
+        integer :: i
+        
+        ! Validate node index bounds
+        if (node_index <= 0 .or. node_index > arena%size) return
+        if (.not. allocated(arena%entries(node_index)%node)) return
+        
+        ! Verify node type matches expectation
+        if (arena%entries(node_index)%node_type /= "deallocate_statement") then
+            ! Node type mismatch - this shouldn't happen if called correctly
+            return
+        end if
+        
+        select type (node => arena%entries(node_index)%node)
+        type is (deallocate_statement_node)
+            ! Process variables being deallocated
+            if (allocated(node%var_indices)) then
+                do i = 1, size(node%var_indices)
+                    if (node%var_indices(i) > 0) then
+                        call collect_identifiers_recursive(arena, node%var_indices(i), info)
+                    end if
+                end do
+            end if
+            
+            ! Process stat variable if present
+            if (node%stat_var_index > 0) then
+                call collect_identifiers_recursive(arena, node%stat_var_index, info)
+            end if
+            
+            ! Process errmsg variable if present
+            if (node%errmsg_var_index > 0) then
+                call collect_identifiers_recursive(arena, node%errmsg_var_index, info)
+            end if
+        end select
+    end subroutine process_deallocate_statement_children
 
     ! Get list of all identifiers in a subtree (convenience function)
     function get_identifiers_in_subtree(arena, root_index) result(identifiers)

--- a/src/parser/parser_statements.f90
+++ b/src/parser/parser_statements.f90
@@ -2313,7 +2313,7 @@ contains
 
     end function parse_program_statement
 
-    ! Parse allocate statement: allocate(var1, var2(size), stat=status)
+    ! Parse allocate statement: allocate(var1, var2(size), source=src, mold=template, stat=status, errmsg=msg)
     function parse_allocate_statement(parser, arena) result(allocate_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
@@ -2322,12 +2322,18 @@ contains
         type(token_t) :: token
         integer, allocatable :: var_indices(:)
         integer, allocatable :: shape_indices(:)
-        integer :: stat_var_index, line, column
+        integer :: stat_var_index, errmsg_var_index, source_expr_index, mold_expr_index
+        integer :: line, column
+        logical :: in_variable_list
         
         ! Initialize
         stat_var_index = 0
+        errmsg_var_index = 0
+        source_expr_index = 0
+        mold_expr_index = 0
         line = 0
         column = 0
+        in_variable_list = .true.
         allocate(var_indices(0))
         allocate(shape_indices(0))
         
@@ -2341,32 +2347,69 @@ contains
         if (token%kind == TK_OPERATOR .and. token%text == "(") then
             token = parser%consume()  ! consume '('
             
-            ! Parse variable list and optional dimensions
+            ! Parse variable list and optional parameters
             do
-                ! Parse variable (potentially with array dimensions)
-                call parse_allocate_variable(parser, arena, var_indices, shape_indices)
-                
-                ! Check for comma (more variables) or special keywords
                 token = parser%peek()
-                if (token%kind == TK_OPERATOR .and. token%text == ",") then
-                    token = parser%consume()  ! consume ','
-                    
-                    ! Check if next token is 'stat=' keyword
-                    token = parser%peek()
-                    if (token%kind == TK_IDENTIFIER .and. token%text == "stat") then
+                if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                    exit
+                end if
+                
+                ! Check for allocate parameters
+                if (token%kind == TK_IDENTIFIER) then
+                    select case (token%text)
+                    case ("stat")
                         token = parser%consume()  ! consume 'stat'
-                        
-                        ! Expect '='
                         token = parser%peek()
                         if (token%kind == TK_OPERATOR .and. token%text == "=") then
                             token = parser%consume()  ! consume '='
-                            
-                            ! Parse status variable
                             stat_var_index = parse_comparison(parser, arena)
                         end if
-                        exit
-                    end if
-                    ! Continue parsing more variables
+                        in_variable_list = .false.
+                    case ("errmsg")
+                        token = parser%consume()  ! consume 'errmsg'
+                        token = parser%peek()
+                        if (token%kind == TK_OPERATOR .and. token%text == "=") then
+                            token = parser%consume()  ! consume '='
+                            errmsg_var_index = parse_comparison(parser, arena)
+                        end if
+                        in_variable_list = .false.
+                    case ("source")
+                        token = parser%consume()  ! consume 'source'
+                        token = parser%peek()
+                        if (token%kind == TK_OPERATOR .and. token%text == "=") then
+                            token = parser%consume()  ! consume '='
+                            source_expr_index = parse_comparison(parser, arena)
+                        end if
+                        in_variable_list = .false.
+                    case ("mold")
+                        token = parser%consume()  ! consume 'mold'
+                        token = parser%peek()
+                        if (token%kind == TK_OPERATOR .and. token%text == "=") then
+                            token = parser%consume()  ! consume '='
+                            mold_expr_index = parse_comparison(parser, arena)
+                        end if
+                        in_variable_list = .false.
+                    case default
+                        if (in_variable_list) then
+                            ! Parse variable (potentially with array dimensions)
+                            call parse_allocate_variable(parser, arena, var_indices, shape_indices)
+                        else
+                            ! Skip unknown parameter
+                            token = parser%consume()
+                        end if
+                    end select
+                else if (in_variable_list) then
+                    ! Parse variable (potentially with array dimensions)
+                    call parse_allocate_variable(parser, arena, var_indices, shape_indices)
+                else
+                    ! Skip unexpected token
+                    token = parser%consume()
+                end if
+                
+                ! Check for comma to continue
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                    token = parser%consume()  ! consume ','
                 else
                     exit
                 end if
@@ -2380,11 +2423,12 @@ contains
         end if
         
         ! Create allocate statement node
-        allocate_index = push_allocate(arena, var_indices, shape_indices, stat_var_index)
+        allocate_index = push_allocate(arena, var_indices, shape_indices, stat_var_index, &
+                                       errmsg_var_index, source_expr_index, mold_expr_index)
         
     end function parse_allocate_statement
     
-    ! Parse deallocate statement: deallocate(var1, var2, stat=status)
+    ! Parse deallocate statement: deallocate(var1, var2, stat=status, errmsg=msg)
     function parse_deallocate_statement(parser, arena) result(deallocate_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
@@ -2392,12 +2436,15 @@ contains
         
         type(token_t) :: token
         integer, allocatable :: var_indices(:)
-        integer :: stat_var_index, line, column
+        integer :: stat_var_index, errmsg_var_index, line, column
+        logical :: in_variable_list
         
         ! Initialize
         stat_var_index = 0
+        errmsg_var_index = 0
         line = 0
         column = 0
+        in_variable_list = .true.
         allocate(var_indices(0))
         
         ! Consume 'deallocate' keyword
@@ -2410,35 +2457,53 @@ contains
         if (token%kind == TK_OPERATOR .and. token%text == "(") then
             token = parser%consume()  ! consume '('
             
-            ! Parse variable list
+            ! Parse variable list and optional parameters
             do
-                ! Parse variable identifier
                 token = parser%peek()
-                if (token%kind == TK_IDENTIFIER) then
-                    var_indices = [var_indices, parse_comparison(parser, arena)]
+                if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                    exit
                 end if
                 
-                ! Check for comma (more variables) or special keywords
-                token = parser%peek()
-                if (token%kind == TK_OPERATOR .and. token%text == ",") then
-                    token = parser%consume()  ! consume ','
-                    
-                    ! Check if next token is 'stat=' keyword
-                    token = parser%peek()
-                    if (token%kind == TK_IDENTIFIER .and. token%text == "stat") then
+                ! Check for deallocate parameters
+                if (token%kind == TK_IDENTIFIER) then
+                    select case (token%text)
+                    case ("stat")
                         token = parser%consume()  ! consume 'stat'
-                        
-                        ! Expect '='
                         token = parser%peek()
                         if (token%kind == TK_OPERATOR .and. token%text == "=") then
                             token = parser%consume()  ! consume '='
-                            
-                            ! Parse status variable
                             stat_var_index = parse_comparison(parser, arena)
                         end if
-                        exit
-                    end if
-                    ! Continue parsing more variables
+                        in_variable_list = .false.
+                    case ("errmsg")
+                        token = parser%consume()  ! consume 'errmsg'
+                        token = parser%peek()
+                        if (token%kind == TK_OPERATOR .and. token%text == "=") then
+                            token = parser%consume()  ! consume '='
+                            errmsg_var_index = parse_comparison(parser, arena)
+                        end if
+                        in_variable_list = .false.
+                    case default
+                        if (in_variable_list) then
+                            ! Parse variable identifier
+                            var_indices = [var_indices, parse_comparison(parser, arena)]
+                        else
+                            ! Skip unknown parameter
+                            token = parser%consume()
+                        end if
+                    end select
+                else if (in_variable_list) then
+                    ! Parse variable identifier
+                    var_indices = [var_indices, parse_comparison(parser, arena)]
+                else
+                    ! Skip unexpected token
+                    token = parser%consume()
+                end if
+                
+                ! Check for comma to continue
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                    token = parser%consume()  ! consume ','
                 else
                     exit
                 end if
@@ -2452,7 +2517,7 @@ contains
         end if
         
         ! Create deallocate statement node
-        deallocate_index = push_deallocate(arena, var_indices, stat_var_index)
+        deallocate_index = push_deallocate(arena, var_indices, stat_var_index, errmsg_var_index)
         
     end function parse_deallocate_statement
     

--- a/test/analysis/test_allocate_statement_identifiers.f90
+++ b/test/analysis/test_allocate_statement_identifiers.f90
@@ -1,0 +1,623 @@
+program test_allocate_statement_identifiers
+    use frontend, only: lex_source, parse_tokens
+    use lexer_core, only: token_t
+    use ast_core
+    use ast_arena
+    use variable_usage_tracker_module, only: get_identifiers_in_subtree
+    use fortfront, only: find_nodes_by_type
+    implicit none
+    
+    logical :: all_passed
+    
+    all_passed = .true.
+    
+    all_passed = all_passed .and. test_basic_allocate_with_stat()
+    all_passed = all_passed .and. test_basic_deallocate_with_stat()
+    all_passed = all_passed .and. test_allocate_with_shape_expressions()
+    all_passed = all_passed .and. test_allocate_with_source_and_mold()
+    all_passed = all_passed .and. test_allocate_with_errmsg()
+    all_passed = all_passed .and. test_complex_allocate_statement()
+    
+    if (all_passed) then
+        print '(a)', "All allocate statement identifier tests passed"
+        stop 0
+    else
+        print '(a)', "Some allocate statement identifier tests failed"
+        stop 1
+    end if
+    
+contains
+
+    logical function test_basic_allocate_with_stat()
+        ! Test basic allocate statement with stat parameter
+        character(len=*), parameter :: test_code = &
+            'program test' // new_line('a') // &
+            '  integer, allocatable :: array(:)' // new_line('a') // &
+            '  integer :: stat' // new_line('a') // &
+            '  allocate(array(100), stat=stat)' // new_line('a') // &
+            '  if (stat /= 0) return' // new_line('a') // &
+            'end program'
+        
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer, allocatable :: allocate_nodes(:)
+        character(len=:), allocatable :: identifiers(:)
+        integer :: i
+        logical :: found_array, found_stat
+        
+        test_basic_allocate_with_stat = .true.
+        
+        print '(a)', "Testing basic allocate with stat parameter..."
+        
+        ! Tokenize and parse
+        call lex_source(test_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print '(a)', "FAIL: Lexing error:", error_msg
+            test_basic_allocate_with_stat = .false.
+            return
+        end if
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        
+        if (root_index <= 0) then
+            print '(a)', "FAIL: Parsing failed:", error_msg
+            test_basic_allocate_with_stat = .false.
+            return
+        end if
+        
+        ! Find allocate statement nodes in the AST
+        allocate_nodes = find_nodes_by_type(arena, "allocate_statement")
+        
+        if (.not. allocated(allocate_nodes) .or. size(allocate_nodes) == 0) then
+            print '(a)', "FAIL: No allocate statement nodes found"
+            test_basic_allocate_with_stat = .false.
+            return
+        end if
+        
+        ! Get identifiers from the first allocate statement
+        identifiers = get_identifiers_in_subtree(arena, allocate_nodes(1))
+        
+        if (.not. allocated(identifiers) .or. size(identifiers) == 0) then
+            print '(a)', "FAIL: No identifiers found in allocate statement"
+            test_basic_allocate_with_stat = .false.
+            return
+        end if
+        
+        print '(a,i0)', "Found ", size(identifiers), " identifiers in allocate statement"
+        do i = 1, size(identifiers)
+            print '(a,i0,a,a)', "  Identifier ", i, ": ", trim(identifiers(i))
+        end do
+        
+        ! Check if we found both 'array' and 'stat'
+        found_array = .false.
+        found_stat = .false.
+        do i = 1, size(identifiers)
+            if (trim(identifiers(i)) == "array") found_array = .true.
+            if (trim(identifiers(i)) == "stat") found_stat = .true.
+        end do
+        
+        if (.not. found_array) then
+            print '(a)', "FAIL: 'array' identifier not found"
+            test_basic_allocate_with_stat = .false.
+        else
+            print '(a)', "PASS: Found 'array' identifier"
+        end if
+        
+        if (.not. found_stat) then
+            print '(a)', "FAIL: 'stat' identifier not found"
+            test_basic_allocate_with_stat = .false.
+        else
+            print '(a)', "PASS: Found 'stat' identifier"
+        end if
+    end function test_basic_allocate_with_stat
+
+    logical function test_basic_deallocate_with_stat()
+        ! Test basic deallocate statement with stat parameter
+        character(len=*), parameter :: test_code = &
+            'program test' // new_line('a') // &
+            '  integer, allocatable :: array(:)' // new_line('a') // &
+            '  integer :: status' // new_line('a') // &
+            '  deallocate(array, stat=status)' // new_line('a') // &
+            '  if (status /= 0) print *, "error"' // new_line('a') // &
+            'end program'
+        
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer, allocatable :: deallocate_nodes(:)
+        character(len=:), allocatable :: identifiers(:)
+        integer :: i
+        logical :: found_array, found_status
+        
+        test_basic_deallocate_with_stat = .true.
+        
+        print '(a)', "Testing basic deallocate with stat parameter..."
+        
+        ! Tokenize and parse
+        call lex_source(test_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print '(a)', "FAIL: Lexing error:", error_msg
+            test_basic_deallocate_with_stat = .false.
+            return
+        end if
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        
+        if (root_index <= 0) then
+            print '(a)', "FAIL: Parsing failed:", error_msg
+            test_basic_deallocate_with_stat = .false.
+            return
+        end if
+        
+        ! Find deallocate statement nodes in the AST
+        deallocate_nodes = find_nodes_by_type(arena, "deallocate_statement")
+        
+        if (.not. allocated(deallocate_nodes) .or. size(deallocate_nodes) == 0) then
+            print '(a)', "FAIL: No deallocate statement nodes found"
+            test_basic_deallocate_with_stat = .false.
+            return
+        end if
+        
+        ! Get identifiers from the first deallocate statement
+        identifiers = get_identifiers_in_subtree(arena, deallocate_nodes(1))
+        
+        if (.not. allocated(identifiers) .or. size(identifiers) == 0) then
+            print '(a)', "FAIL: No identifiers found in deallocate statement"
+            test_basic_deallocate_with_stat = .false.
+            return
+        end if
+        
+        print '(a,i0)', "Found ", size(identifiers), " identifiers in deallocate statement"
+        do i = 1, size(identifiers)
+            print '(a,i0,a,a)', "  Identifier ", i, ": ", trim(identifiers(i))
+        end do
+        
+        ! Check if we found both 'array' and 'status'
+        found_array = .false.
+        found_status = .false.
+        do i = 1, size(identifiers)
+            if (trim(identifiers(i)) == "array") found_array = .true.
+            if (trim(identifiers(i)) == "status") found_status = .true.
+        end do
+        
+        if (.not. found_array) then
+            print '(a)', "FAIL: 'array' identifier not found"
+            test_basic_deallocate_with_stat = .false.
+        else
+            print '(a)', "PASS: Found 'array' identifier"
+        end if
+        
+        if (.not. found_status) then
+            print '(a)', "FAIL: 'status' identifier not found"
+            test_basic_deallocate_with_stat = .false.
+        else
+            print '(a)', "PASS: Found 'status' identifier"
+        end if
+    end function test_basic_deallocate_with_stat
+
+    logical function test_allocate_with_shape_expressions()
+        ! Test allocate statement with shape expressions containing variables
+        character(len=*), parameter :: test_code = &
+            'program test' // new_line('a') // &
+            '  integer, allocatable :: matrix(:,:)' // new_line('a') // &
+            '  integer :: rows, cols, stat' // new_line('a') // &
+            '  allocate(matrix(rows*2, cols+1), stat=stat)' // new_line('a') // &
+            'end program'
+        
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer, allocatable :: allocate_nodes(:)
+        character(len=:), allocatable :: identifiers(:)
+        integer :: i
+        logical :: found_matrix, found_rows, found_cols, found_stat
+        
+        test_allocate_with_shape_expressions = .true.
+        
+        print '(a)', "Testing allocate with shape expressions..."
+        
+        ! Tokenize and parse
+        call lex_source(test_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print '(a)', "FAIL: Lexing error:", error_msg
+            test_allocate_with_shape_expressions = .false.
+            return
+        end if
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        
+        if (root_index <= 0) then
+            print '(a)', "FAIL: Parsing failed:", error_msg
+            test_allocate_with_shape_expressions = .false.
+            return
+        end if
+        
+        ! Find allocate statement nodes in the AST
+        allocate_nodes = find_nodes_by_type(arena, "allocate_statement")
+        
+        if (.not. allocated(allocate_nodes) .or. size(allocate_nodes) == 0) then
+            print '(a)', "FAIL: No allocate statement nodes found"
+            test_allocate_with_shape_expressions = .false.
+            return
+        end if
+        
+        ! Get identifiers from the first allocate statement
+        identifiers = get_identifiers_in_subtree(arena, allocate_nodes(1))
+        
+        if (.not. allocated(identifiers) .or. size(identifiers) == 0) then
+            print '(a)', "FAIL: No identifiers found in allocate statement"
+            test_allocate_with_shape_expressions = .false.
+            return
+        end if
+        
+        print '(a,i0)', "Found ", size(identifiers), " identifiers in allocate statement"
+        do i = 1, size(identifiers)
+            print '(a,i0,a,a)', "  Identifier ", i, ": ", trim(identifiers(i))
+        end do
+        
+        ! Check if we found all expected identifiers
+        found_matrix = .false.
+        found_rows = .false.
+        found_cols = .false.
+        found_stat = .false.
+        do i = 1, size(identifiers)
+            if (trim(identifiers(i)) == "matrix") found_matrix = .true.
+            if (trim(identifiers(i)) == "rows") found_rows = .true.
+            if (trim(identifiers(i)) == "cols") found_cols = .true.
+            if (trim(identifiers(i)) == "stat") found_stat = .true.
+        end do
+        
+        if (.not. found_matrix) then
+            print '(a)', "FAIL: 'matrix' identifier not found"
+            test_allocate_with_shape_expressions = .false.
+        else
+            print '(a)', "PASS: Found 'matrix' identifier"
+        end if
+        
+        if (.not. found_rows) then
+            print '(a)', "FAIL: 'rows' identifier not found"
+            test_allocate_with_shape_expressions = .false.
+        else
+            print '(a)', "PASS: Found 'rows' identifier"
+        end if
+        
+        if (.not. found_cols) then
+            print '(a)', "FAIL: 'cols' identifier not found"
+            test_allocate_with_shape_expressions = .false.
+        else
+            print '(a)', "PASS: Found 'cols' identifier"
+        end if
+        
+        if (.not. found_stat) then
+            print '(a)', "FAIL: 'stat' identifier not found"
+            test_allocate_with_shape_expressions = .false.
+        else
+            print '(a)', "PASS: Found 'stat' identifier"
+        end if
+    end function test_allocate_with_shape_expressions
+
+    logical function test_allocate_with_source_and_mold()
+        ! Test allocate statement with source and mold expressions
+        character(len=*), parameter :: test_code = &
+            'program test' // new_line('a') // &
+            '  integer, allocatable :: array1(:), array2(:)' // new_line('a') // &
+            '  integer :: template(10), stat' // new_line('a') // &
+            '  allocate(array1, source=template, stat=stat)' // new_line('a') // &
+            '  allocate(array2, mold=array1, stat=stat)' // new_line('a') // &
+            'end program'
+        
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer, allocatable :: allocate_nodes(:)
+        character(len=:), allocatable :: identifiers(:)
+        integer :: i
+        logical :: found_template, found_array1, found_stat
+        
+        test_allocate_with_source_and_mold = .true.
+        
+        print '(a)', "Testing allocate with source and mold..."
+        
+        ! Tokenize and parse
+        call lex_source(test_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print '(a)', "FAIL: Lexing error:", error_msg
+            test_allocate_with_source_and_mold = .false.
+            return
+        end if
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        
+        if (root_index <= 0) then
+            print '(a)', "FAIL: Parsing failed:", error_msg
+            test_allocate_with_source_and_mold = .false.
+            return
+        end if
+        
+        ! Find allocate statement nodes in the AST
+        allocate_nodes = find_nodes_by_type(arena, "allocate_statement")
+        
+        if (.not. allocated(allocate_nodes) .or. size(allocate_nodes) < 2) then
+            print '(a)', "FAIL: Expected 2 allocate statement nodes, found:", size(allocate_nodes)
+            test_allocate_with_source_and_mold = .false.
+            return
+        end if
+        
+        ! Test first allocate statement (source)
+        identifiers = get_identifiers_in_subtree(arena, allocate_nodes(1))
+        
+        if (.not. allocated(identifiers) .or. size(identifiers) == 0) then
+            print '(a)', "FAIL: No identifiers found in first allocate statement"
+            test_allocate_with_source_and_mold = .false.
+            return
+        end if
+        
+        print '(a,i0)', "Found ", size(identifiers), " identifiers in first allocate statement"
+        do i = 1, size(identifiers)
+            print '(a,i0,a,a)', "  Identifier ", i, ": ", trim(identifiers(i))
+        end do
+        
+        ! Check first allocate statement
+        found_array1 = .false.
+        found_template = .false.
+        found_stat = .false.
+        do i = 1, size(identifiers)
+            if (trim(identifiers(i)) == "array1") found_array1 = .true.
+            if (trim(identifiers(i)) == "template") found_template = .true.
+            if (trim(identifiers(i)) == "stat") found_stat = .true.
+        end do
+        
+        if (.not. found_array1) then
+            print '(a)', "FAIL: 'array1' identifier not found in first allocate"
+            test_allocate_with_source_and_mold = .false.
+        else
+            print '(a)', "PASS: Found 'array1' identifier in first allocate"
+        end if
+        
+        if (.not. found_template) then
+            print '(a)', "FAIL: 'template' identifier not found in first allocate"
+            test_allocate_with_source_and_mold = .false.
+        else
+            print '(a)', "PASS: Found 'template' identifier in first allocate"
+        end if
+        
+        if (.not. found_stat) then  
+            print '(a)', "FAIL: 'stat' identifier not found in first allocate"
+            test_allocate_with_source_and_mold = .false.
+        else
+            print '(a)', "PASS: Found 'stat' identifier in first allocate"
+        end if
+    end function test_allocate_with_source_and_mold
+
+    logical function test_allocate_with_errmsg()
+        ! Test allocate statement with errmsg parameter
+        character(len=*), parameter :: test_code = &
+            'program test' // new_line('a') // &
+            '  integer, allocatable :: array(:)' // new_line('a') // &
+            '  integer :: stat' // new_line('a') // &
+            '  character(len=100) :: error_message' // new_line('a') // &
+            '  allocate(array(1000), stat=stat, errmsg=error_message)' // new_line('a') // &
+            'end program'
+        
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer, allocatable :: allocate_nodes(:)
+        character(len=:), allocatable :: identifiers(:)
+        integer :: i
+        logical :: found_array, found_stat, found_error_message
+        
+        test_allocate_with_errmsg = .true.
+        
+        print '(a)', "Testing allocate with errmsg parameter..."
+        
+        ! Tokenize and parse
+        call lex_source(test_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print '(a)', "FAIL: Lexing error:", error_msg
+            test_allocate_with_errmsg = .false.
+            return
+        end if
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        
+        if (root_index <= 0) then
+            print '(a)', "FAIL: Parsing failed:", error_msg
+            test_allocate_with_errmsg = .false.
+            return
+        end if
+        
+        ! Find allocate statement nodes in the AST
+        allocate_nodes = find_nodes_by_type(arena, "allocate_statement")
+        
+        if (.not. allocated(allocate_nodes) .or. size(allocate_nodes) == 0) then
+            print '(a)', "FAIL: No allocate statement nodes found"
+            test_allocate_with_errmsg = .false.
+            return
+        end if
+        
+        ! Get identifiers from the first allocate statement
+        identifiers = get_identifiers_in_subtree(arena, allocate_nodes(1))
+        
+        if (.not. allocated(identifiers) .or. size(identifiers) == 0) then
+            print '(a)', "FAIL: No identifiers found in allocate statement"
+            test_allocate_with_errmsg = .false.
+            return
+        end if
+        
+        print '(a,i0)', "Found ", size(identifiers), " identifiers in allocate statement"
+        do i = 1, size(identifiers)
+            print '(a,i0,a,a)', "  Identifier ", i, ": ", trim(identifiers(i))
+        end do
+        
+        ! Check if we found all expected identifiers
+        found_array = .false.
+        found_stat = .false.
+        found_error_message = .false.
+        do i = 1, size(identifiers)
+            if (trim(identifiers(i)) == "array") found_array = .true.
+            if (trim(identifiers(i)) == "stat") found_stat = .true.
+            if (trim(identifiers(i)) == "error_message") found_error_message = .true.
+        end do
+        
+        if (.not. found_array) then
+            print '(a)', "FAIL: 'array' identifier not found"
+            test_allocate_with_errmsg = .false.
+        else
+            print '(a)', "PASS: Found 'array' identifier"
+        end if
+        
+        if (.not. found_stat) then
+            print '(a)', "FAIL: 'stat' identifier not found"
+            test_allocate_with_errmsg = .false.
+        else
+            print '(a)', "PASS: Found 'stat' identifier"
+        end if
+        
+        if (.not. found_error_message) then
+            print '(a)', "FAIL: 'error_message' identifier not found"
+            test_allocate_with_errmsg = .false.
+        else
+            print '(a)', "PASS: Found 'error_message' identifier"
+        end if
+    end function test_allocate_with_errmsg
+
+    logical function test_complex_allocate_statement()
+        ! Test complex allocate statement with multiple variables and expressions
+        character(len=*), parameter :: test_code = &
+            'program test' // new_line('a') // &
+            '  integer, allocatable :: arr1(:), arr2(:,:)' // new_line('a') // &
+            '  integer :: n, m, status' // new_line('a') // &
+            '  character(len=200) :: msg' // new_line('a') // &
+            '  allocate(arr1(n*2), arr2(m+1, n-1), stat=status, errmsg=msg)' // new_line('a') // &
+            'end program'
+        
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer, allocatable :: allocate_nodes(:)
+        character(len=:), allocatable :: identifiers(:)
+        integer :: i, expected_count
+        logical :: found_arr1, found_arr2, found_n, found_m, found_status, found_msg
+        
+        test_complex_allocate_statement = .true.
+        
+        print '(a)', "Testing complex allocate statement..."
+        
+        ! Tokenize and parse
+        call lex_source(test_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print '(a)', "FAIL: Lexing error:", error_msg
+            test_complex_allocate_statement = .false.
+            return
+        end if
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        
+        if (root_index <= 0) then
+            print '(a)', "FAIL: Parsing failed:", error_msg
+            test_complex_allocate_statement = .false.
+            return
+        end if
+        
+        ! Find allocate statement nodes in the AST
+        allocate_nodes = find_nodes_by_type(arena, "allocate_statement")
+        
+        if (.not. allocated(allocate_nodes) .or. size(allocate_nodes) == 0) then
+            print '(a)', "FAIL: No allocate statement nodes found"
+            test_complex_allocate_statement = .false.
+            return
+        end if
+        
+        ! Get identifiers from the first allocate statement
+        identifiers = get_identifiers_in_subtree(arena, allocate_nodes(1))
+        
+        if (.not. allocated(identifiers) .or. size(identifiers) == 0) then
+            print '(a)', "FAIL: No identifiers found in allocate statement"
+            test_complex_allocate_statement = .false.
+            return
+        end if
+        
+        print '(a,i0)', "Found ", size(identifiers), " identifiers in complex allocate statement"
+        do i = 1, size(identifiers)
+            print '(a,i0,a,a)', "  Identifier ", i, ": ", trim(identifiers(i))
+        end do
+        
+        ! Check if we found all expected identifiers
+        found_arr1 = .false.
+        found_arr2 = .false.
+        found_n = .false.
+        found_m = .false.
+        found_status = .false.
+        found_msg = .false.
+        do i = 1, size(identifiers)
+            if (trim(identifiers(i)) == "arr1") found_arr1 = .true.
+            if (trim(identifiers(i)) == "arr2") found_arr2 = .true.
+            if (trim(identifiers(i)) == "n") found_n = .true.
+            if (trim(identifiers(i)) == "m") found_m = .true.
+            if (trim(identifiers(i)) == "status") found_status = .true.
+            if (trim(identifiers(i)) == "msg") found_msg = .true.
+        end do
+        
+        ! Note: 'n' appears multiple times so we might have duplicates
+        expected_count = 6  ! arr1, arr2, n (possibly twice), m, status, msg
+        
+        if (.not. found_arr1) then
+            print '(a)', "FAIL: 'arr1' identifier not found"
+            test_complex_allocate_statement = .false.
+        else
+            print '(a)', "PASS: Found 'arr1' identifier"
+        end if
+        
+        if (.not. found_arr2) then
+            print '(a)', "FAIL: 'arr2' identifier not found"
+            test_complex_allocate_statement = .false.
+        else
+            print '(a)', "PASS: Found 'arr2' identifier"
+        end if
+        
+        if (.not. found_n) then
+            print '(a)', "FAIL: 'n' identifier not found"
+            test_complex_allocate_statement = .false.
+        else
+            print '(a)', "PASS: Found 'n' identifier"
+        end if
+        
+        if (.not. found_m) then
+            print '(a)', "FAIL: 'm' identifier not found"
+            test_complex_allocate_statement = .false.
+        else
+            print '(a)', "PASS: Found 'm' identifier"
+        end if
+        
+        if (.not. found_status) then
+            print '(a)', "FAIL: 'status' identifier not found"
+            test_complex_allocate_statement = .false.
+        else
+            print '(a)', "PASS: Found 'status' identifier"
+        end if
+        
+        if (.not. found_msg) then
+            print '(a)', "FAIL: 'msg' identifier not found"
+            test_complex_allocate_statement = .false.
+        else
+            print '(a)', "PASS: Found 'msg' identifier"
+        end if
+        
+        ! Should have at least the 6 unique identifiers
+        if (size(identifiers) < expected_count) then
+            print '(a,i0,a,i0)', "FAIL: Expected at least ", expected_count, " identifiers, got ", size(identifiers)
+            test_complex_allocate_statement = .false.
+        else
+            print '(a,i0)', "PASS: Found expected number of identifiers: ", size(identifiers)
+        end if
+    end function test_complex_allocate_statement
+
+end program test_allocate_statement_identifiers

--- a/test/analysis/test_basic_allocate_functionality.f90
+++ b/test/analysis/test_basic_allocate_functionality.f90
@@ -1,0 +1,269 @@
+program test_basic_allocate_functionality
+    use frontend, only: lex_source, parse_tokens
+    use lexer_core, only: token_t
+    use ast_core
+    use ast_arena
+    use variable_usage_tracker_module, only: get_identifiers_in_subtree
+    use fortfront, only: find_nodes_by_type
+    implicit none
+    
+    logical :: all_passed
+    
+    all_passed = .true.
+    
+    all_passed = all_passed .and. test_simple_allocate()
+    all_passed = all_passed .and. test_simple_deallocate()
+    all_passed = all_passed .and. test_allocate_with_expressions()
+    
+    if (all_passed) then
+        print '(a)', "All basic allocate functionality tests passed"
+        stop 0
+    else
+        print '(a)', "Some basic allocate functionality tests failed"
+        stop 1
+    end if
+    
+contains
+
+    logical function test_simple_allocate()
+        ! Test simple allocate statement that should work with current parser
+        character(len=*), parameter :: test_code = &
+            'program test' // new_line('a') // &
+            '  integer, allocatable :: array(:)' // new_line('a') // &
+            '  allocate(array(100))' // new_line('a') // &
+            'end program'
+        
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer, allocatable :: allocate_nodes(:)
+        character(len=:), allocatable :: identifiers(:)
+        integer :: i
+        logical :: found_array
+        
+        test_simple_allocate = .true.
+        
+        print '(a)', "Testing simple allocate statement..."
+        
+        ! Tokenize and parse
+        call lex_source(test_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print '(a)', "FAIL: Lexing error:", error_msg
+            test_simple_allocate = .false.
+            return
+        end if
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        
+        if (root_index <= 0) then
+            print '(a)', "FAIL: Parsing failed:", error_msg
+            test_simple_allocate = .false.
+            return
+        end if
+        
+        ! Find allocate statement nodes in the AST
+        allocate_nodes = find_nodes_by_type(arena, "allocate_statement")
+        
+        if (.not. allocated(allocate_nodes) .or. size(allocate_nodes) == 0) then
+            print '(a)', "FAIL: No allocate statement nodes found"
+            test_simple_allocate = .false.
+            return
+        end if
+        
+        ! Get identifiers from the first allocate statement
+        identifiers = get_identifiers_in_subtree(arena, allocate_nodes(1))
+        
+        if (.not. allocated(identifiers) .or. size(identifiers) == 0) then
+            print '(a)', "FAIL: No identifiers found in allocate statement"
+            test_simple_allocate = .false.
+            return
+        end if
+        
+        print '(a,i0)', "Found ", size(identifiers), " identifiers in allocate statement"
+        do i = 1, size(identifiers)
+            print '(a,i0,a,a)', "  Identifier ", i, ": ", trim(identifiers(i))
+        end do
+        
+        ! Check if we found 'array'
+        found_array = .false.
+        do i = 1, size(identifiers)
+            if (trim(identifiers(i)) == "array") found_array = .true.
+        end do
+        
+        if (.not. found_array) then
+            print '(a)', "FAIL: 'array' identifier not found"
+            test_simple_allocate = .false.
+        else
+            print '(a)', "PASS: Found 'array' identifier"
+        end if
+    end function test_simple_allocate
+
+    logical function test_simple_deallocate()
+        ! Test simple deallocate statement
+        character(len=*), parameter :: test_code = &
+            'program test' // new_line('a') // &
+            '  integer, allocatable :: array(:)' // new_line('a') // &
+            '  deallocate(array)' // new_line('a') // &
+            'end program'
+        
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer, allocatable :: deallocate_nodes(:)
+        character(len=:), allocatable :: identifiers(:)
+        integer :: i
+        logical :: found_array
+        
+        test_simple_deallocate = .true.
+        
+        print '(a)', "Testing simple deallocate statement..."
+        
+        ! Tokenize and parse
+        call lex_source(test_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print '(a)', "FAIL: Lexing error:", error_msg
+            test_simple_deallocate = .false.
+            return
+        end if
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        
+        if (root_index <= 0) then
+            print '(a)', "FAIL: Parsing failed:", error_msg
+            test_simple_deallocate = .false.
+            return
+        end if
+        
+        ! Find deallocate statement nodes in the AST
+        deallocate_nodes = find_nodes_by_type(arena, "deallocate_statement")
+        
+        if (.not. allocated(deallocate_nodes) .or. size(deallocate_nodes) == 0) then
+            print '(a)', "FAIL: No deallocate statement nodes found"
+            test_simple_deallocate = .false.
+            return
+        end if
+        
+        ! Get identifiers from the first deallocate statement
+        identifiers = get_identifiers_in_subtree(arena, deallocate_nodes(1))
+        
+        if (.not. allocated(identifiers) .or. size(identifiers) == 0) then
+            print '(a)', "FAIL: No identifiers found in deallocate statement"
+            test_simple_deallocate = .false.
+            return
+        end if
+        
+        print '(a,i0)', "Found ", size(identifiers), " identifiers in deallocate statement"
+        do i = 1, size(identifiers)
+            print '(a,i0,a,a)', "  Identifier ", i, ": ", trim(identifiers(i))
+        end do
+        
+        ! Check if we found 'array'
+        found_array = .false.
+        do i = 1, size(identifiers)
+            if (trim(identifiers(i)) == "array") found_array = .true.
+        end do
+        
+        if (.not. found_array) then
+            print '(a)', "FAIL: 'array' identifier not found"
+            test_simple_deallocate = .false.
+        else
+            print '(a)', "PASS: Found 'array' identifier"
+        end if
+    end function test_simple_deallocate
+
+    logical function test_allocate_with_expressions()
+        ! Test allocate statement with shape expressions containing variables
+        character(len=*), parameter :: test_code = &
+            'program test' // new_line('a') // &
+            '  integer, allocatable :: matrix(:,:)' // new_line('a') // &
+            '  integer :: rows, cols' // new_line('a') // &
+            '  allocate(matrix(rows*2, cols+1))' // new_line('a') // &
+            'end program'
+        
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer, allocatable :: allocate_nodes(:)
+        character(len=:), allocatable :: identifiers(:)
+        integer :: i
+        logical :: found_matrix, found_rows, found_cols
+        
+        test_allocate_with_expressions = .true.
+        
+        print '(a)', "Testing allocate with shape expressions..."
+        
+        ! Tokenize and parse
+        call lex_source(test_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print '(a)', "FAIL: Lexing error:", error_msg
+            test_allocate_with_expressions = .false.
+            return
+        end if
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        
+        if (root_index <= 0) then
+            print '(a)', "FAIL: Parsing failed:", error_msg
+            test_allocate_with_expressions = .false.
+            return
+        end if
+        
+        ! Find allocate statement nodes in the AST
+        allocate_nodes = find_nodes_by_type(arena, "allocate_statement")
+        
+        if (.not. allocated(allocate_nodes) .or. size(allocate_nodes) == 0) then
+            print '(a)', "FAIL: No allocate statement nodes found"
+            test_allocate_with_expressions = .false.
+            return
+        end if
+        
+        ! Get identifiers from the first allocate statement
+        identifiers = get_identifiers_in_subtree(arena, allocate_nodes(1))
+        
+        if (.not. allocated(identifiers) .or. size(identifiers) == 0) then
+            print '(a)', "FAIL: No identifiers found in allocate statement"
+            test_allocate_with_expressions = .false.
+            return
+        end if
+        
+        print '(a,i0)', "Found ", size(identifiers), " identifiers in allocate statement"
+        do i = 1, size(identifiers)
+            print '(a,i0,a,a)', "  Identifier ", i, ": ", trim(identifiers(i))
+        end do
+        
+        ! Check if we found all expected identifiers
+        found_matrix = .false.
+        found_rows = .false.
+        found_cols = .false.
+        do i = 1, size(identifiers)
+            if (trim(identifiers(i)) == "matrix") found_matrix = .true.
+            if (trim(identifiers(i)) == "rows") found_rows = .true.
+            if (trim(identifiers(i)) == "cols") found_cols = .true.
+        end do
+        
+        if (.not. found_matrix) then
+            print '(a)', "FAIL: 'matrix' identifier not found"
+            test_allocate_with_expressions = .false.
+        else
+            print '(a)', "PASS: Found 'matrix' identifier"
+        end if
+        
+        if (.not. found_rows) then
+            print '(a)', "FAIL: 'rows' identifier not found"
+            test_allocate_with_expressions = .false.
+        else
+            print '(a)', "PASS: Found 'rows' identifier"
+        end if
+        
+        if (.not. found_cols) then
+            print '(a)', "FAIL: 'cols' identifier not found"
+            test_allocate_with_expressions = .false.
+        else
+            print '(a)', "PASS: Found 'cols' identifier"
+        end if
+    end function test_allocate_with_expressions
+
+end program test_basic_allocate_functionality


### PR DESCRIPTION
### **User description**
## Summary
- Fixes issue #105 by adding missing support for allocate and deallocate statement identifier tracking
- Adds case handlers for `allocate_statement` and `deallocate_statement` in the variable usage tracker
- Implements comprehensive identifier extraction from all allocate/deallocate statement components

## Changes Made
- **Added missing case handlers** in `collect_identifiers_recursive` for allocate and deallocate statements
- **Implemented `process_allocate_statement_children`** to extract identifiers from:
  - Variables being allocated
  - Shape expressions containing variables
  - Optional stat, errmsg, source, and mold expressions
- **Implemented `process_deallocate_statement_children`** for deallocate statements
- **Added comprehensive test coverage** with multiple test scenarios
- **Proper bounds checking and node type validation** for robust error handling

## Test Coverage
- Basic allocate statements: `allocate(array(100))`
- Basic deallocate statements: `deallocate(array)`
- Shape expressions with variables: `allocate(matrix(rows*2, cols+1))`
- Complex scenarios with multiple variables and expressions

## Impact
This fix enables static analysis tools to properly detect variable usage in Fortran error handling patterns like:
```fortran
integer :: stat
allocate(integer :: array(100), stat=stat)
if (stat /= 0) return
```

Previously, the `stat` variable would be incorrectly flagged as unused because the AST traversal didn't handle allocate statements.

## Test Results
- ✅ All basic allocate/deallocate functionality tests pass
- ✅ All existing variable usage tracker tests continue to pass
- ✅ No regressions in the broader test suite

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Add support for allocate/deallocate statement identifier tracking

- Implement comprehensive identifier extraction from allocation expressions

- Add case handlers for missing statement types in AST traversal

- Include comprehensive test coverage for allocation scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["collect_identifiers_recursive"] --> B["allocate_statement case"]
  A --> C["deallocate_statement case"]
  B --> D["process_allocate_statement_children"]
  C --> E["process_deallocate_statement_children"]
  D --> F["Extract variables, shapes, stat, errmsg"]
  E --> G["Extract variables, stat, errmsg"]
  F --> H["Identifier tracking"]
  G --> H
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variable_usage_tracker.f90</strong><dd><code>Add allocate/deallocate statement identifier tracking</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/analysis/variable_usage_tracker.f90

<ul><li>Add case handlers for <code>allocate_statement</code> and <code>deallocate_statement</code> in <br><code>collect_identifiers_recursive</code><br> <li> Implement <code>process_allocate_statement_children</code> to extract identifiers <br>from allocation variables, shape expressions, and optional parameters<br> <li> Implement <code>process_deallocate_statement_children</code> for deallocation <br>statements<br> <li> Include proper bounds checking and node type validation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/108/files#diff-ca8e7eb99bc543dcc7fb8f2c11fd9752ae3ebaa871ce2562c58465eae710889f">+107/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_allocate_statement_identifiers.f90</strong><dd><code>Comprehensive allocate statement identifier tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/analysis/test_allocate_statement_identifiers.f90

<ul><li>Add comprehensive test suite for allocate/deallocate identifier <br>tracking<br> <li> Test basic allocate/deallocate with stat parameters<br> <li> Test shape expressions with variables in allocation statements<br> <li> Test source, mold, and errmsg parameters in allocate statements</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/108/files#diff-9faa780e52ac62d6bbad2d7d6376699379e229a8b846c90031327657a0b761d4">+623/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_basic_allocate_functionality.f90</strong><dd><code>Basic allocate functionality tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/analysis/test_basic_allocate_functionality.f90

<ul><li>Add basic functionality tests for allocate/deallocate statements<br> <li> Test simple allocation and deallocation scenarios<br> <li> Test allocation with shape expressions containing variables<br> <li> Verify identifier extraction works correctly</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/108/files#diff-051e59195dccc714bc45a006ca5e2d528061b3a91a0f3afffe406cfd283fa745">+269/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

