### PR TITLE
Fix issue #135: Enable print statement variable tracking

### DIFF
--- a/src/parser/parser_statements.f90
+++ b/src/parser/parser_statements.f90
@@ -2189,6 +2189,10 @@ contains
                 ! Parse print statement
                 allocate (stmt_indices(1))
                 stmt_indices(1) = parse_print_statement(parser, arena)
+                if (stmt_indices(1) <= 0) then
+                    deallocate(stmt_indices)
+                    allocate (stmt_indices(0))  ! Return empty array on failure
+                end if
                 return
             end if
         end if

--- a/src/parser/parser_statements.f90
+++ b/src/parser/parser_statements.f90
@@ -2185,6 +2185,11 @@ contains
                 allocate (stmt_indices(1))
                 stmt_indices(1) = parse_if_simple(parser, arena)
                 return
+            else if (first_token%text == "print") then
+                ! Parse print statement
+                allocate (stmt_indices(1))
+                stmt_indices(1) = parse_print_statement(parser, arena)
+                return
             end if
         end if
 

--- a/test/analysis/test_print_variable_tracking.f90
+++ b/test/analysis/test_print_variable_tracking.f90
@@ -46,7 +46,7 @@ contains
         sub_index = parse_subroutine_definition(parser, arena)
         
         if (sub_index <= 0) then
-            print *, "FAILED: Could not parse subroutine"
+            write(error_unit, *) "FAILED: Could not parse subroutine"
             all_tests_passed = .false.
             return
         end if
@@ -55,7 +55,7 @@ contains
         print_node_index = find_print_statement_in_arena(arena)
         
         if (print_node_index <= 0) then
-            print *, "FAILED: Could not find print statement node in AST"
+            write(error_unit, *) "FAILED: Could not find print statement node in AST"
             all_tests_passed = .false.
             return
         end if
@@ -77,8 +77,8 @@ contains
         if (found_arg) then
             print *, "PASSED: Found 'arg' in print statement"
         else
-            print *, "FAILED: 'arg' not found in print statement"
-            print *, "  Found identifiers:", size(identifiers)
+            write(error_unit, *) "FAILED: 'arg' not found in print statement"
+            write(error_unit, *) "  Found identifiers:", size(identifiers)
             if (allocated(identifiers)) then
                 do i = 1, size(identifiers)
                     print *, "    ", trim(identifiers(i))
@@ -112,7 +112,7 @@ contains
         sub_index = parse_subroutine_definition(parser, arena)
         
         if (sub_index <= 0) then
-            print *, "FAILED: Could not parse subroutine"
+            write(error_unit, *) "FAILED: Could not parse subroutine"
             all_tests_passed = .false.
             return
         end if
@@ -120,7 +120,7 @@ contains
         print_node_index = find_print_statement_in_arena(arena)
         
         if (print_node_index <= 0) then
-            print *, "FAILED: Could not find print statement node in AST"
+            write(error_unit, *) "FAILED: Could not find print statement node in AST"
             all_tests_passed = .false.
             return
         end if
@@ -140,8 +140,8 @@ contains
         if (found_x .and. found_y) then
             print *, "PASSED: Found both 'x' and 'y' in print statement"
         else
-            print *, "FAILED: Missing variables in print statement"
-            print *, "  Found x:", found_x, " Found y:", found_y
+            write(error_unit, *) "FAILED: Missing variables in print statement"
+            write(error_unit, *) "  Found x:", found_x, " Found y:", found_y
             all_tests_passed = .false.
         end if
         
@@ -170,7 +170,7 @@ contains
         sub_index = parse_subroutine_definition(parser, arena)
         
         if (sub_index <= 0) then
-            print *, "FAILED: Could not parse subroutine"
+            write(error_unit, *) "FAILED: Could not parse subroutine"
             all_tests_passed = .false.
             return
         end if
@@ -178,7 +178,7 @@ contains
         print_node_index = find_print_statement_in_arena(arena)
         
         if (print_node_index <= 0) then
-            print *, "FAILED: Could not find print statement node in AST"
+            write(error_unit, *) "FAILED: Could not find print statement node in AST"
             all_tests_passed = .false.
             return
         end if
@@ -198,8 +198,8 @@ contains
         if (found_a .and. found_b) then
             print *, "PASSED: Found both 'a' and 'b' in print expression"
         else
-            print *, "FAILED: Missing variables in print expression"
-            print *, "  Found a:", found_a, " Found b:", found_b
+            write(error_unit, *) "FAILED: Missing variables in print expression"
+            write(error_unit, *) "  Found a:", found_a, " Found b:", found_b
             all_tests_passed = .false.
         end if
         

--- a/test/analysis/test_print_variable_tracking.f90
+++ b/test/analysis/test_print_variable_tracking.f90
@@ -1,0 +1,225 @@
+program test_print_variable_tracking
+    use iso_fortran_env, only: error_unit
+    use lexer_core, only: tokenize_core, token_t
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_statements_module, only: parse_subroutine_definition
+    use ast_core, only: ast_arena_t, create_ast_arena
+    use variable_usage_tracker_module, only: get_identifiers_in_subtree
+    implicit none
+
+    logical :: all_tests_passed
+    all_tests_passed = .true.
+
+    call test_print_statement_variable_usage()
+    call test_print_with_multiple_variables()
+    call test_print_with_expression()
+
+    if (all_tests_passed) then
+        print *, "All print variable tracking tests PASSED!"
+    else
+        error stop "Some print variable tracking tests FAILED!"
+    end if
+
+contains
+
+    subroutine test_print_statement_variable_usage()
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        integer :: sub_index, print_node_index
+        character(len=:), allocatable :: identifiers(:)
+        logical :: found_arg
+        integer :: i
+        
+        print *, "Testing variable usage in simple print statement..."
+        
+        ! Test case from issue #135
+        source = "subroutine test_sub(arg)" // new_line('a') // &
+                "  integer :: arg" // new_line('a') // &
+                "  print *, arg" // new_line('a') // &
+                "end subroutine"
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        parser = create_parser_state(tokens)
+        sub_index = parse_subroutine_definition(parser, arena)
+        
+        if (sub_index <= 0) then
+            print *, "FAILED: Could not parse subroutine"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        ! Find the print statement node in the AST
+        print_node_index = find_print_statement_in_arena(arena)
+        
+        if (print_node_index <= 0) then
+            print *, "FAILED: Could not find print statement node in AST"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        ! Test get_identifiers_in_subtree on the print statement
+        identifiers = get_identifiers_in_subtree(arena, print_node_index)
+        
+        ! Check if 'arg' was found
+        found_arg = .false.
+        if (allocated(identifiers)) then
+            do i = 1, size(identifiers)
+                if (identifiers(i) == "arg") then
+                    found_arg = .true.
+                    exit
+                end if
+            end do
+        end if
+        
+        if (found_arg) then
+            print *, "PASSED: Found 'arg' in print statement"
+        else
+            print *, "FAILED: 'arg' not found in print statement"
+            print *, "  Found identifiers:", size(identifiers)
+            if (allocated(identifiers)) then
+                do i = 1, size(identifiers)
+                    print *, "    ", trim(identifiers(i))
+                end do
+            end if
+            all_tests_passed = .false.
+        end if
+        
+    end subroutine test_print_statement_variable_usage
+
+    subroutine test_print_with_multiple_variables()
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        integer :: sub_index, print_node_index
+        character(len=:), allocatable :: identifiers(:)
+        logical :: found_x, found_y
+        integer :: i
+        
+        print *, "Testing variable usage in print with multiple variables..."
+        
+        source = "subroutine test_multi(x, y)" // new_line('a') // &
+                "  integer :: x, y" // new_line('a') // &
+                "  print *, x, y" // new_line('a') // &
+                "end subroutine"
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        parser = create_parser_state(tokens)
+        sub_index = parse_subroutine_definition(parser, arena)
+        
+        if (sub_index <= 0) then
+            print *, "FAILED: Could not parse subroutine"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        print_node_index = find_print_statement_in_arena(arena)
+        
+        if (print_node_index <= 0) then
+            print *, "FAILED: Could not find print statement node in AST"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        identifiers = get_identifiers_in_subtree(arena, print_node_index)
+        
+        ! Check if both 'x' and 'y' were found
+        found_x = .false.
+        found_y = .false.
+        if (allocated(identifiers)) then
+            do i = 1, size(identifiers)
+                if (identifiers(i) == "x") found_x = .true.
+                if (identifiers(i) == "y") found_y = .true.
+            end do
+        end if
+        
+        if (found_x .and. found_y) then
+            print *, "PASSED: Found both 'x' and 'y' in print statement"
+        else
+            print *, "FAILED: Missing variables in print statement"
+            print *, "  Found x:", found_x, " Found y:", found_y
+            all_tests_passed = .false.
+        end if
+        
+    end subroutine test_print_with_multiple_variables
+
+    subroutine test_print_with_expression()
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        integer :: sub_index, print_node_index
+        character(len=:), allocatable :: identifiers(:)
+        logical :: found_a, found_b
+        integer :: i
+        
+        print *, "Testing variable usage in print with expression..."
+        
+        source = "subroutine test_expr(a, b)" // new_line('a') // &
+                "  integer :: a, b" // new_line('a') // &
+                "  print *, a + b" // new_line('a') // &
+                "end subroutine"
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        parser = create_parser_state(tokens)
+        sub_index = parse_subroutine_definition(parser, arena)
+        
+        if (sub_index <= 0) then
+            print *, "FAILED: Could not parse subroutine"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        print_node_index = find_print_statement_in_arena(arena)
+        
+        if (print_node_index <= 0) then
+            print *, "FAILED: Could not find print statement node in AST"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        identifiers = get_identifiers_in_subtree(arena, print_node_index)
+        
+        ! Check if both 'a' and 'b' were found in the expression
+        found_a = .false.
+        found_b = .false.
+        if (allocated(identifiers)) then
+            do i = 1, size(identifiers)
+                if (identifiers(i) == "a") found_a = .true.
+                if (identifiers(i) == "b") found_b = .true.
+            end do
+        end if
+        
+        if (found_a .and. found_b) then
+            print *, "PASSED: Found both 'a' and 'b' in print expression"
+        else
+            print *, "FAILED: Missing variables in print expression"
+            print *, "  Found a:", found_a, " Found b:", found_b
+            all_tests_passed = .false.
+        end if
+        
+    end subroutine test_print_with_expression
+
+    ! Helper function to find print_statement node in the arena
+    function find_print_statement_in_arena(arena) result(node_index)
+        use ast_core, only: ast_arena_t
+        type(ast_arena_t), intent(in) :: arena
+        integer :: node_index
+        integer :: i
+        
+        node_index = 0
+        
+        do i = 1, arena%size
+            if (arena%entries(i)%node_type == "print_statement") then
+                node_index = i
+                return
+            end if
+        end do
+    end function find_print_statement_in_arena
+
+end program test_print_variable_tracking


### PR DESCRIPTION
### **User description**
## Summary
This PR resolves issue #135 where `get_identifiers_in_subtree` failed to find variable usage in print statements, causing variables to be incorrectly flagged as unused during dead code analysis.

## Root Cause Analysis
Print statements in function/subroutine bodies were being parsed as `literal` nodes instead of proper `print_statement` nodes due to a parser limitation in `parse_basic_statement_multi`.

## Technical Solution
- **Enhanced Parser**: Added `"print"` case to `parse_basic_statement_multi` in `parser_statements.f90`
- **Proper AST Generation**: Print statements now generate proper `print_statement` AST nodes
- **Variable Tracking**: Existing `process_print_statement_node_children` correctly handles variable tracking

## Test Coverage
Added comprehensive test suite `test_print_variable_tracking.f90`:
- ✅ Simple variable in print statement (`print *, arg`)
- ✅ Multiple variables in print statement (`print *, x, y`)  
- ✅ Variables in print expressions (`print *, a + b`)

## Impact
- **Fixed Dead Code Analysis**: Variables used in print statements are now properly detected
- **AST-Based Analysis**: Pure AST-based variable tracking now works without text-based workarounds
- **No Regressions**: All existing tests pass

## Test Results
```fortran
subroutine test_sub(arg)
  integer :: arg
  print *, arg    \! 'arg' now correctly detected as used
end subroutine
```

**Before**: `get_identifiers_in_subtree()` returned `[]`  
**After**: `get_identifiers_in_subtree()` returns `["arg"]` ✅

Fixes #135

🤖 Generated with [Claude Code](https://claude.ai/code)


___

### **PR Type**
Bug fix


___

### **Description**
- Fix print statement variable tracking in dead code analysis

- Add print case to parser for proper AST node generation

- Enable variable detection in print statements and expressions

- Add comprehensive test suite for print variable tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parser"] -- "Add print case" --> B["parse_basic_statement_multi"]
  B -- "Generate proper AST" --> C["print_statement node"]
  C -- "Enable tracking" --> D["get_identifiers_in_subtree"]
  D -- "Find variables" --> E["Dead code analysis"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser_statements.f90</strong><dd><code>Add print statement parsing support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_statements.f90

<ul><li>Add <code>print</code> case to <code>parse_basic_statement_multi</code> function<br> <li> Enable proper AST node generation for print statements<br> <li> Call <code>parse_print_statement</code> for print tokens</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/138/files#diff-3b8f0e50d97c2b33fb2385b4522a393e2a1c62df0c84a838da279f354c66f2df">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_print_variable_tracking.f90</strong><dd><code>Add print variable tracking test suite</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/analysis/test_print_variable_tracking.f90

<ul><li>Add comprehensive test suite for print variable tracking<br> <li> Test simple variable usage in print statements<br> <li> Test multiple variables and expressions in print statements<br> <li> Include helper function to find print nodes in AST</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/138/files#diff-d2875c0c199e2c30b7b42eb6ddebec5a151f0cb6f404329dd8d26ec57c9301be">+225/-0</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

