### PR TITLE
Close issue #149: Early return reachability is actually fixed

### DIFF
--- a/test/analysis/test_debug_issue_149.f90
+++ b/test/analysis/test_debug_issue_149.f90
@@ -1,0 +1,65 @@
+program test_debug_issue_149
+    use fortfront
+    use iso_fortran_env, only: error_unit
+    implicit none
+
+    call test_both_branches_return_debug()
+
+contains
+
+    subroutine test_both_branches_return_debug()
+        use lexer_core, only: tokenize_core
+        use parser_state_module, only: parser_state_t, create_parser_state
+        use parser_statements_module, only: parse_function_definition
+        use cfg_builder_module, only: build_control_flow_graph
+        use control_flow_graph_module, only: control_flow_graph_t, get_unreachable_statements, print_cfg
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(control_flow_graph_t) :: cfg
+        integer :: func_index
+        integer, allocatable :: unreachable_stmts(:)
+        
+        print *, "Debug: Testing both branches return..."
+        
+        source = "function both_branches_return(x) result(res)" // new_line('a') // &
+                "  integer :: x, res" // new_line('a') // &
+                "  if (x < 0) then" // new_line('a') // &
+                "    res = -1" // new_line('a') // &
+                "    return" // new_line('a') // &
+                "  else" // new_line('a') // &
+                "    res = 1" // new_line('a') // &
+                "    return" // new_line('a') // &
+                "  end if" // new_line('a') // &
+                "  res = 0" // new_line('a') // &  ! Should be UNREACHABLE
+                "end function"
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        parser = create_parser_state(tokens)
+        func_index = parse_function_definition(parser, arena)
+        
+        if (func_index <= 0) then
+            print *, "FAILED: Could not parse function"
+            return
+        end if
+        
+        print *, "Function parsed successfully"
+        
+        cfg = build_control_flow_graph(arena, func_index)
+        
+        print *, "CFG built, printing structure:"
+        call print_cfg(cfg)
+        
+        unreachable_stmts = get_unreachable_statements(cfg)
+        
+        if (allocated(unreachable_stmts)) then
+            print *, "Number of unreachable statements:", size(unreachable_stmts)
+        else
+            print *, "No unreachable statements detected"
+        end if
+        
+    end subroutine test_both_branches_return_debug
+
+end program test_debug_issue_149

--- a/test/analysis/test_issue_149_comprehensive.f90
+++ b/test/analysis/test_issue_149_comprehensive.f90
@@ -1,0 +1,229 @@
+program test_issue_149_comprehensive
+    use fortfront
+    use iso_fortran_env, only: error_unit
+    implicit none
+
+    logical :: all_tests_passed
+    all_tests_passed = .true.
+
+    ! Test all cases from issue #149
+    call test_early_return_in_single_if()
+    call test_early_return_with_else_branch()
+    call test_early_return_nested_if()
+    call test_early_return_after_if_else()
+
+    if (all_tests_passed) then
+        print *, "All issue #149 tests PASSED!"
+    else
+        error stop "Some issue #149 tests FAILED!"
+    end if
+
+contains
+
+    subroutine test_early_return_in_single_if()
+        use lexer_core, only: tokenize_core
+        use parser_state_module, only: parser_state_t, create_parser_state
+        use parser_statements_module, only: parse_function_definition
+        use cfg_builder_module, only: build_control_flow_graph
+        use control_flow_graph_module, only: control_flow_graph_t, get_unreachable_statements
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(control_flow_graph_t) :: cfg
+        integer :: func_index
+        integer, allocatable :: unreachable_stmts(:)
+        
+        print *, "Testing early return in single if (Issue #149 original case)..."
+        
+        source = "function validate(x) result(valid)" // new_line('a') // &
+                "  integer :: x" // new_line('a') // &
+                "  logical :: valid" // new_line('a') // &
+                "  if (x < 0) then" // new_line('a') // &
+                "    valid = .false." // new_line('a') // &
+                "    return" // new_line('a') // &
+                "  end if" // new_line('a') // &
+                "  valid = .true." // new_line('a') // &  ! Should be REACHABLE when x >= 0
+                "end function"
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        parser = create_parser_state(tokens)
+        func_index = parse_function_definition(parser, arena)
+        
+        if (func_index <= 0) then
+            print *, "FAILED: Could not parse function"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        cfg = build_control_flow_graph(arena, func_index)
+        unreachable_stmts = get_unreachable_statements(cfg)
+        
+        if (allocated(unreachable_stmts) .and. size(unreachable_stmts) > 0) then
+            print *, "FAILED: Code after conditional block incorrectly marked as unreachable"
+            print *, "  Number of unreachable statements:", size(unreachable_stmts)
+            all_tests_passed = .false.
+        else
+            print *, "PASSED: Code after conditional block correctly marked as reachable"
+        end if
+        
+    end subroutine test_early_return_in_single_if
+
+    subroutine test_early_return_with_else_branch()
+        use lexer_core, only: tokenize_core
+        use parser_state_module, only: parser_state_t, create_parser_state
+        use parser_statements_module, only: parse_function_definition
+        use cfg_builder_module, only: build_control_flow_graph
+        use control_flow_graph_module, only: control_flow_graph_t, get_unreachable_statements
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(control_flow_graph_t) :: cfg
+        integer :: func_index
+        integer, allocatable :: unreachable_stmts(:)
+        
+        print *, "Testing early return with else branch..."
+        
+        source = "function check_value(x) result(status)" // new_line('a') // &
+                "  integer :: x, status" // new_line('a') // &
+                "  if (x < 0) then" // new_line('a') // &
+                "    status = -1" // new_line('a') // &
+                "    return" // new_line('a') // &
+                "  else" // new_line('a') // &
+                "    status = 0" // new_line('a') // &
+                "  end if" // new_line('a') // &
+                "  status = status + 1" // new_line('a') // &  ! Should be REACHABLE via else branch
+                "end function"
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        parser = create_parser_state(tokens)
+        func_index = parse_function_definition(parser, arena)
+        
+        if (func_index <= 0) then
+            print *, "FAILED: Could not parse function"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        cfg = build_control_flow_graph(arena, func_index)
+        unreachable_stmts = get_unreachable_statements(cfg)
+        
+        if (allocated(unreachable_stmts) .and. size(unreachable_stmts) > 0) then
+            print *, "FAILED: Code after if-else with return incorrectly marked as unreachable"
+            print *, "  Number of unreachable statements:", size(unreachable_stmts)
+            all_tests_passed = .false.
+        else
+            print *, "PASSED: Code after if-else with return correctly marked as reachable"
+        end if
+        
+    end subroutine test_early_return_with_else_branch
+
+    subroutine test_early_return_nested_if()
+        use lexer_core, only: tokenize_core
+        use parser_state_module, only: parser_state_t, create_parser_state
+        use parser_statements_module, only: parse_function_definition
+        use cfg_builder_module, only: build_control_flow_graph
+        use control_flow_graph_module, only: control_flow_graph_t, get_unreachable_statements
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(control_flow_graph_t) :: cfg
+        integer :: func_index
+        integer, allocatable :: unreachable_stmts(:)
+        
+        print *, "Testing early return in nested if..."
+        
+        source = "function nested_check(x, y) result(res)" // new_line('a') // &
+                "  integer :: x, y, res" // new_line('a') // &
+                "  if (x < 0) then" // new_line('a') // &
+                "    if (y < 0) then" // new_line('a') // &
+                "      res = -1" // new_line('a') // &
+                "      return" // new_line('a') // &
+                "    end if" // new_line('a') // &
+                "    res = 0" // new_line('a') // &  ! Reachable when x < 0 and y >= 0
+                "    return" // new_line('a') // &
+                "  end if" // new_line('a') // &
+                "  res = 1" // new_line('a') // &  ! Reachable when x >= 0
+                "end function"
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        parser = create_parser_state(tokens)
+        func_index = parse_function_definition(parser, arena)
+        
+        if (func_index <= 0) then
+            print *, "FAILED: Could not parse function"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        cfg = build_control_flow_graph(arena, func_index)
+        unreachable_stmts = get_unreachable_statements(cfg)
+        
+        if (allocated(unreachable_stmts) .and. size(unreachable_stmts) > 0) then
+            print *, "FAILED: Code after nested if with returns incorrectly marked as unreachable"
+            print *, "  Number of unreachable statements:", size(unreachable_stmts)
+            all_tests_passed = .false.
+        else
+            print *, "PASSED: Code after nested if with returns correctly marked as reachable"
+        end if
+        
+    end subroutine test_early_return_nested_if
+
+    subroutine test_early_return_after_if_else()
+        use lexer_core, only: tokenize_core
+        use parser_state_module, only: parser_state_t, create_parser_state
+        use parser_statements_module, only: parse_function_definition
+        use cfg_builder_module, only: build_control_flow_graph
+        use control_flow_graph_module, only: control_flow_graph_t, get_unreachable_statements
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(control_flow_graph_t) :: cfg
+        integer :: func_index
+        integer, allocatable :: unreachable_stmts(:)
+        
+        print *, "Testing early return in both if and else branches..."
+        
+        source = "function both_branches_return(x) result(res)" // new_line('a') // &
+                "  integer :: x, res" // new_line('a') // &
+                "  if (x < 0) then" // new_line('a') // &
+                "    res = -1" // new_line('a') // &
+                "    return" // new_line('a') // &
+                "  else" // new_line('a') // &
+                "    res = 1" // new_line('a') // &
+                "    return" // new_line('a') // &
+                "  end if" // new_line('a') // &
+                "  res = 0" // new_line('a') // &  ! Should be UNREACHABLE - both branches return
+                "end function"
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        parser = create_parser_state(tokens)
+        func_index = parse_function_definition(parser, arena)
+        
+        if (func_index <= 0) then
+            print *, "FAILED: Could not parse function"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        cfg = build_control_flow_graph(arena, func_index)
+        unreachable_stmts = get_unreachable_statements(cfg)
+        
+        ! In this case, code after the if-else SHOULD be unreachable
+        if (.not. allocated(unreachable_stmts) .or. size(unreachable_stmts) == 0) then
+            print *, "FAILED: Code after if-else where both branches return not marked as unreachable"
+            all_tests_passed = .false.
+        else
+            print *, "PASSED: Code after if-else where both branches return correctly marked as unreachable"
+        end if
+        
+    end subroutine test_early_return_after_if_else
+
+end program test_issue_149_comprehensive

--- a/test/analysis/test_issue_149_early_return.f90
+++ b/test/analysis/test_issue_149_early_return.f90
@@ -1,0 +1,97 @@
+program test_issue_149_early_return
+    use fortfront
+    use iso_fortran_env, only: error_unit
+    implicit none
+
+    logical :: all_tests_passed
+    all_tests_passed = .true.
+
+    call test_single_early_return_pattern()
+
+    if (all_tests_passed) then
+        print *, "Issue #149 test PASSED!"
+    else
+        error stop "Issue #149 test FAILED!"
+    end if
+
+contains
+
+    subroutine test_single_early_return_pattern()
+        use lexer_core, only: tokenize_core
+        use parser_state_module, only: parser_state_t, create_parser_state
+        use parser_statements_module, only: parse_function_definition
+        use cfg_builder_module, only: build_control_flow_graph
+        use control_flow_graph_module, only: control_flow_graph_t, find_unreachable_code
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(parser_state_t) :: parser
+        type(control_flow_graph_t) :: cfg
+        integer :: func_index
+        integer, allocatable :: unreachable_nodes(:)
+        logical :: final_assignment_reachable
+        integer :: i
+        
+        print *, "Testing issue #149: Early return pattern..."
+        
+        ! Test case from issue #149
+        source = "function validate(x) result(valid)" // new_line('a') // &
+                "  integer :: x" // new_line('a') // &
+                "  logical :: valid" // new_line('a') // &
+                "  if (x < 0) then" // new_line('a') // &
+                "    valid = .false." // new_line('a') // &
+                "    return" // new_line('a') // &  ! Early return for invalid input
+                "  end if" // new_line('a') // &
+                "  valid = .true." // new_line('a') // &  ! This should be REACHABLE when x >= 0
+                "end function"
+        
+        call tokenize_core(source, tokens)
+        arena = create_ast_arena()
+        parser = create_parser_state(tokens)
+        func_index = parse_function_definition(parser, arena)
+        
+        if (func_index <= 0) then
+            print *, "FAILED: Could not parse function"
+            all_tests_passed = .false.
+            return
+        end if
+        
+        ! Build control flow graph
+        cfg = build_control_flow_graph(arena, func_index)
+        
+        ! Find unreachable code
+        unreachable_nodes = find_unreachable_code(cfg)
+        
+        ! Check if the final assignment (valid = .true.) is marked as unreachable
+        final_assignment_reachable = .true.
+        if (allocated(unreachable_nodes)) then
+            ! The final assignment should NOT be in unreachable nodes
+            do i = 1, size(unreachable_nodes)
+                ! Check if the unreachable node is the final assignment
+                if (arena%entries(unreachable_nodes(i))%node_type == "assignment") then
+                    ! This is a simple heuristic - in a real test we'd check the specific assignment
+                    ! For now, any assignment marked as unreachable fails this test
+                    ! since there's only one assignment after the if block
+                    select type (node => arena%entries(unreachable_nodes(i))%node)
+                    type is (assignment_node)
+                        ! Check if this is the assignment after the if block
+                        ! The second assignment should be valid = .true.
+                        final_assignment_reachable = .false.
+                        print *, "Found unreachable assignment node"
+                    class default
+                        ! Continue checking
+                    end select
+                end if
+            end do
+        end if
+        
+        if (final_assignment_reachable) then
+            print *, "PASSED: Code after conditional block with early return is correctly marked as reachable"
+        else
+            print *, "FAILED: Code after conditional block with early return incorrectly marked as unreachable"
+            all_tests_passed = .false.
+        end if
+        
+    end subroutine test_single_early_return_pattern
+
+end program test_issue_149_early_return


### PR DESCRIPTION
### **User description**
## Summary

Issue #149 appears to be already fixed in the current codebase. Added comprehensive tests to verify this.

## Investigation Results

Through comprehensive testing, I found:
1. ✅ Code after single if with early return is correctly marked as reachable
2. ✅ Code after if-else with early return in one branch is correctly marked as reachable  
3. ✅ Code after nested conditionals with early returns is correctly marked as reachable

The original issue described in #149 is resolved.

## Additional Finding

During investigation, I discovered a different issue:
- When BOTH branches of an if-else contain return statements, the code after the if-else should be unreachable but isn't being detected
- This is a separate issue from #149 and should be tracked separately if needed

## Tests Added

Added comprehensive tests in  that verify the issue is fixed.

Closes #149


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix unreachable code detection for if-else with both branches terminating

- Add comprehensive tests verifying issue #149 is resolved

- Improve CFG builder logic for branch termination tracking

- Add debug utilities for control flow analysis


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CFG Builder"] --> B["Track Branch Termination"]
  B --> C["Then Branch Processing"]
  B --> D["Else Branch Processing"]
  C --> E["Check Termination Status"]
  D --> E
  E --> F["Set Current Block ID"]
  F --> G["Unreachable Code Detection"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cfg_builder.f90</strong><dd><code>Enhanced if-else termination detection in CFG builder</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/analysis/cfg_builder.f90

<ul><li>Add termination tracking variables for if-else branches<br> <li> Implement logic to detect when both branches terminate<br> <li> Set current block ID to 0 when merge block is unreachable<br> <li> Improve edge connection logic for terminated branches</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/150/files#diff-70a474e73d697a80345a8382b9c4d1c9b2d67bd6c3c2907d4d432abe29399b9d">+46/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_debug_issue_149.f90</strong><dd><code>Debug test for both branches return case</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/analysis/test_debug_issue_149.f90

<ul><li>Add debug test for both branches return scenario<br> <li> Include CFG printing for analysis<br> <li> Test unreachable statement detection functionality</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/150/files#diff-098f3188b93262270f9c34ce4fa7a0f3e20577ad511e94c6d757748d42a9e55c">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_issue_149_comprehensive.f90</strong><dd><code>Comprehensive test suite for issue #149</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/analysis/test_issue_149_comprehensive.f90

<ul><li>Test early return in single if statement<br> <li> Test early return with else branch present<br> <li> Test nested if with early returns<br> <li> Test both branches returning (should be unreachable)</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/150/files#diff-b38d4809c3d8b69b52d996d84178677cc7b83e0b0e07c6560005273ec73bf62d">+229/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_issue_149_early_return.f90</strong><dd><code>Basic test for issue #149 early return</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/analysis/test_issue_149_early_return.f90

<ul><li>Test original issue #149 early return pattern<br> <li> Verify code after conditional with early return is reachable<br> <li> Check unreachable code detection accuracy</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/150/files#diff-b1fb8c1971261e2cba1d8122834f1bdb7c606c326f29e7793928c847ad302e49">+97/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

