### PR TITLE
Partial fix for Issue #176: Variable initialization preservation

### DIFF
--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,64 @@
+# Known Issues
+
+## Issue #176: Variable Initialization Values Removed During Formatting
+
+**Status:** Partially Fixed / Known Limitation
+
+**Description:** 
+Variable initialization values are removed when processing Fortran code that contains both variable declarations with initializers and executable statements.
+
+**Example:**
+```fortran
+! Input
+program test
+    implicit none
+    integer :: x = 42
+    real :: y = 3.14
+    print *, x, y
+end program test
+
+! Output (incorrect)
+program test
+    implicit none
+    integer :: x
+    real(8) :: y
+    
+    print *, x, y
+end program test
+```
+
+**Technical Details:**
+The issue occurs during the standardization phase when the AST is processed. The standardizer correctly preserves the structure but the initializer indices are not properly maintained through the transformation pipeline when executable statements are present.
+
+**Attempted Fixes:**
+1. Modified `can_group_declarations` to prevent grouping of declarations with initializers
+2. Updated `ast_factory` to properly check for non-zero initializer indices
+3. Added fallback checks in code generation
+
+**Workaround:**
+For now, avoid using inline initialization in programs with executable statements. Instead, initialize variables separately:
+
+```fortran
+program test
+    implicit none
+    integer :: x
+    real :: y
+    
+    x = 42
+    y = 3.14
+    print *, x, y
+end program test
+```
+
+**Impact:**
+This issue affects program semantics as initialized values are lost, potentially leading to undefined behavior if the variables are used before being assigned.
+
+## Issue #177: Line Continuation Removal
+
+**Status:** Architectural Limitation
+
+**Description:**
+Line continuations (`&`) are removed during parsing as the lexer handles them transparently. This is by design but means the original formatting with line continuations cannot be preserved.
+
+**Workaround:**
+The formatter will reformat long lines according to its own rules rather than preserving original line breaks.

--- a/src/ast/ast_factory.f90
+++ b/src/ast/ast_factory.f90
@@ -238,7 +238,7 @@ contains
             decl%has_kind = .false.
         end if
 
-        if (present(initializer_index)) then
+        if (present(initializer_index) .and. initializer_index > 0) then
             decl%initializer_index = initializer_index
             decl%has_initializer = .true.
         else
@@ -331,7 +331,7 @@ contains
             decl%has_kind = .false.
         end if
 
-        if (present(initializer_index)) then
+        if (present(initializer_index) .and. initializer_index > 0) then
             decl%initializer_index = initializer_index
             decl%has_initializer = .true.
         else

--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -1868,6 +1868,12 @@ contains
         type(declaration_node), intent(in) :: node1, node2
         logical :: can_group
 
+        ! Don't group declarations that have initializers
+        if (node1%has_initializer .or. node2%has_initializer) then
+            can_group = .false.
+            return
+        end if
+
         can_group = trim(node1%type_name) == trim(node2%type_name) .and. &
                     node1%kind_value == node2%kind_value .and. &
                     node1%has_kind .eqv. node2%has_kind .and. &
@@ -1957,6 +1963,15 @@ contains
                 if (allocated(arena%entries(body_indices(i))%node)) then
                     select type (node => arena%entries(body_indices(i))%node)
                     type is (declaration_node)
+                        ! Check if this declaration has initializer
+                        if (node%has_initializer .or. node%initializer_index > 0) then
+                            ! Don't group declarations with initializers, generate individually
+                            stmt_code = generate_code_from_arena(arena, body_indices(i))
+                            code = code//indent//stmt_code//new_line('a')
+                            i = i + 1
+                            cycle
+                        end if
+                        
                         ! Start of declaration group
                         group_type = node%type_name
                         group_kind = node%kind_value
@@ -2432,6 +2447,12 @@ contains
         integer :: param_idx1, param_idx2
         character(len=:), allocatable :: intent1, intent2
         logical :: optional1, optional2
+        
+        ! Don't group declarations that have initializers
+        if (node1%has_initializer .or. node2%has_initializer) then
+            can_group = .false.
+            return
+        end if
         
         ! First check basic grouping criteria
         can_group = can_group_declarations(node1, node2)


### PR DESCRIPTION
## Summary

This PR provides a partial fix for Issue #176 where variable initialization values were being removed during code transformation. While the core issue in the standardizer remains, this PR improves the handling and documents the limitation.

## Changes Made

1. **ast_factory.f90**: Fixed `push_declaration` to only set `has_initializer` flag when `initializer_index > 0`
2. **codegen_core.f90**: 
   - Modified `can_group_declarations` to prevent grouping declarations with initializers
   - Added fallback check for `initializer_index` in grouped body generation
3. **KNOWN_ISSUES.md**: Documented the remaining limitation and provided workarounds

## Current Status

- ✅ Initializations are preserved when there are no executable statements
- ✅ Proper handling of the `has_initializer` flag
- ❌ Initializations still lost when program contains executable statements (documented limitation)

## Test Results

The issue persists for the full test case but the partial fixes prevent incorrect grouping of initialized declarations and improve the overall robustness of the code.

## Related Issues

- Partially addresses #176
- Related to #175 (function result clauses)
- Related to #182 (function parameter handling)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>