### PR TITLE
Fix broken fortrun link in README (issue #233)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ end program main
 
 ### Integration with fortrun
 
-fortfront is designed to work seamlessly with [fortrun](../fortrun):
+fortfront is designed to work seamlessly with [fortrun](https://github.com/lazy-fortran/fortrun):
 
 ```bash
 # fortrun automatically uses fortfront for .lf files

--- a/test/integration/test_readme_links.f90
+++ b/test/integration/test_readme_links.f90
@@ -1,0 +1,61 @@
+program test_readme_links
+    implicit none
+    logical :: test_passed
+    
+    ! Test that README contains correct fortrun link
+    call test_fortrun_link(test_passed)
+    
+    if (test_passed) then
+        print *, "PASS: README fortrun link test"
+    else
+        print *, "FAIL: README fortrun link test"
+        stop 1
+    end if
+contains
+
+subroutine test_fortrun_link(test_passed)
+    implicit none
+    logical, intent(out) :: test_passed
+    character(len=:), allocatable :: readme_content
+    character(len=*), parameter :: expected_link = &
+        "https://github.com/lazy-fortran/fortrun"
+    character(len=*), parameter :: wrong_link = "../fortrun"
+    
+    ! Read README file content
+    call read_readme_file(readme_content)
+    
+    ! Test that correct link is present and wrong link is absent
+    test_passed = index(readme_content, expected_link) > 0 .and. &
+                  index(readme_content, wrong_link) == 0
+end subroutine test_fortrun_link
+
+subroutine read_readme_file(content)
+    implicit none
+    character(len=:), allocatable, intent(out) :: content
+    integer :: unit, ios
+    character(len=1000) :: line
+    character(len=:), allocatable :: temp_content
+    
+    ! Open README.md file
+    open(newunit=unit, file="README.md", status="old", &
+         action="read", iostat=ios)
+    
+    if (ios /= 0) then
+        print *, "Error: Cannot open README.md"
+        stop 1
+    end if
+    
+    ! Read file line by line
+    temp_content = ""
+    do
+        read(unit, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        temp_content = temp_content // trim(line) // new_line('A')
+    end do
+    
+    close(unit)
+    
+    ! Return the content
+    content = temp_content
+end subroutine read_readme_file
+end program test_readme_links


### PR DESCRIPTION
## Summary
- Fixed broken relative link `../fortrun` in README.md 
- Replaced with correct GitHub URL: `https://github.com/lazy-fortran/fortrun`
- Added comprehensive test to validate README links and prevent regression

## TDD Implementation
- **RED**: Created test that validates README contains correct fortrun link
- **GREEN**: Fixed the broken link to make test pass
- **REFACTOR**: Cleaned up test code for maintainability

## Test Coverage
- New test `test_readme_links.f90` validates:
  - Correct GitHub URL is present in README
  - Old relative path is completely removed
  - File reading and link validation logic

## Files Changed
- `README.md`: Single line fix - relative path to absolute GitHub URL
- `test/integration/test_readme_links.f90`: New test ensuring link correctness

## Test plan
- [x] All existing tests continue to pass
- [x] New README link test passes
- [x] Manual verification: link resolves to correct repository
- [x] No regression in other documentation
- [x] Clean commit with only relevant changes

🤖 Generated with [Claude Code](https://claude.ai/code)