### PR TITLE
fix: update BACKLOG.md to reflect Issue #407 re-opened status

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -26,6 +26,7 @@
 - [ ] #397: CST: Implement CST to AST converter with bidirectional linking
 
 ### Code Quality and Refactoring (ENHANCEMENT)
+- [ ] #407: Refactor: Extract multi-variable declaration handling from parse_declaration (Re-opened after regression fixes needed)
 - [ ] #406: Refactor: Extract variable parsing and initialization logic from parse_declaration
 - [ ] #364: refactor: break down parse_declaration function (519 lines -> <100 lines)
 - [ ] #365: refactor: break down large functions >200 lines (9 functions)
@@ -41,4 +42,4 @@
 - [ ] #361: Create GCC Bug 114612 test suite and permanent regression prevention
 
 ## DONE (Completed)
-- [x] #407: Error Handling: Migrate lexer to unified result_t error handling
+- [x] #427: Error Handling: Migrate lexer to unified result_t error handling


### PR DESCRIPTION
Minor correction to BACKLOG.md after discovering that Issue #407 needed to be re-opened due to regressions in PR #429.

## Changes
- Move Issue #407 from DONE section to Code Quality section with note about re-opening
- Correct DONE entry to reference Issue #427 (actual completed lexer migration work)

## Context
Issue #407 was re-opened after PR #429 was closed due to critical regressions:
- 47+ test failures on Windows
- Multiple segmentation faults on Linux  
- Type specifier preservation broken
- Memory safety violations in assignment operators

This ensures BACKLOG.md accurately reflects current status for batch work mode.