### PR TITLE
enhancement: mixed constructs - allow implicit module above explicit program (Issue #511)

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,21 +1,20 @@
 # Development Backlog
 
 ## DOING (Current Work)
-- [ ] #511: enhancement: mixed constructs - allow also implicit module above explicit program (PR #514 failing tests - needs AST-level transformation approach)
+- [ ] #497: I/O parsing: Read statements generate 'Unknown node type' error (core Fortran support)
 
 ## CURRENT SPRINT (Ordered by Priority)
 
 ### CRITICAL - System Functionality Blockers
 
 ### HIGH PRIORITY - Core Parser Gaps
-- [ ] #497: I/O parsing: Read statements generate 'Unknown node type' error (core Fortran support)
 - [ ] #498: I/O parsing: Write statements not recognized as valid Fortran (core Fortran support)
 - [ ] #492: Statement parsing: Semicolon-separated statements only process first statement (parser completeness)
 - [ ] #495: Semantic analysis: Undefined variables not detected in expressions (type system gap)
 - [ ] #493: Operator precedence: Incorrect logical operator precedence and parenthesization (correctness)
 
 ### MEDIUM PRIORITY - Enhancements
-- [ ] #511: enhancement: mixed constructs - allow also implicit module above explicit program (related to #489) - PR #514 partial implementation, architectural decision needed
+- [ ] #511: enhancement: mixed constructs - allow also implicit module above explicit program (PR #514 in draft - architectural analysis required per Issue #517)
 
 ### PERFORMANCE CRISIS - Development Velocity
 - [ ] #502: performance: investigate test execution bottlenecks causing 7m20s runtime (BLOCKING development)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,6 +1,7 @@
 # Development Backlog
 
 ## DOING (Current Work)
+- [ ] #511: enhancement: mixed constructs - allow also implicit module above explicit program (PR #514 failing tests - needs AST-level transformation approach)
 
 ## CURRENT SPRINT (Ordered by Priority)
 

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,6 @@
 # Development Backlog
 
 ## DOING (Current Work)
-- [ ] #511: enhancement: mixed constructs - allow also implicit module above explicit program (related to #489)
 
 ## CURRENT SPRINT (Ordered by Priority)
 
@@ -13,6 +12,9 @@
 - [ ] #492: Statement parsing: Semicolon-separated statements only process first statement (parser completeness)
 - [ ] #495: Semantic analysis: Undefined variables not detected in expressions (type system gap)
 - [ ] #493: Operator precedence: Incorrect logical operator precedence and parenthesization (correctness)
+
+### MEDIUM PRIORITY - Enhancements
+- [ ] #511: enhancement: mixed constructs - allow also implicit module above explicit program (related to #489) - PR #514 partial implementation, architectural decision needed
 
 ### PERFORMANCE CRISIS - Development Velocity
 - [ ] #502: performance: investigate test execution bottlenecks causing 7m20s runtime (BLOCKING development)

--- a/app/debug_511.f90
+++ b/app/debug_511.f90
@@ -1,0 +1,26 @@
+program debug_511
+    use frontend
+    implicit none
+    
+    character(len=:), allocatable :: input, output, error_msg
+    
+    input = &
+        "type :: a"//new_line('A')// &
+        "    integer :: t"//new_line('A')// &
+        "end type :: a"//new_line('A')// &
+        ""//new_line('A')// &
+        "program pro"//new_line('A')// &
+        "    type(a) :: testy"//new_line('A')// &
+        "    testy%t = 3"//new_line('A')// &
+        "end program pro"
+    
+    print *, "Input:"
+    print *, input
+    print *, ""
+    
+    call transform_lazy_fortran_string(input, output, error_msg)
+    
+    print *, "Output:"
+    print *, output
+    
+end program debug_511

--- a/app/debug_tokens.f90
+++ b/app/debug_tokens.f90
@@ -1,0 +1,47 @@
+program debug_tokens
+    use frontend
+    use lexer_core, only: token_t, TK_EOF, TK_NEWLINE
+    implicit none
+    
+    character(len=:), allocatable :: input
+    type(token_t), allocatable :: tokens(:)
+    integer :: i
+    
+    input = &
+        "type :: a"//new_line('A')// &
+        "    integer :: t"//new_line('A')// &
+        "end type :: a"//new_line('A')// &
+        ""//new_line('A')// &
+        "program pro"//new_line('A')// &
+        "    type(a) :: testy"//new_line('A')// &
+        "    testy%t = 3"//new_line('A')// &
+        "end program pro"
+    
+    print *, "Input:"
+    print *, input
+    print *, ""
+    
+    ! Use internal lexer interface
+    block
+        use frontend_core, only: lex_source
+        character(len=:), allocatable :: error_msg
+        call lex_source(input, tokens, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "Lexer error:", error_msg
+            stop 1
+        end if
+    end block
+    
+    print *, "Tokens:"
+    do i = 1, size(tokens)
+        if (tokens(i)%kind == TK_EOF) then
+            print '(I3, A)', i, ": [EOF]"
+        else if (tokens(i)%kind == TK_NEWLINE) then
+            print '(I3, A)', i, ": [NEWLINE]"
+        else
+            print '(I3, A, A, A, I0, A, I0)', i, ": '", trim(tokens(i)%text), &
+                "' (line ", tokens(i)%line, ", col ", tokens(i)%column
+        end if
+    end do
+    
+end program debug_tokens

--- a/src/frontend_parsing.f90
+++ b/src/frontend_parsing.f90
@@ -27,149 +27,6 @@ module frontend_parsing
 
 contains
 
-    ! Transform tokens for implicit module wrapping (Issue #511)
-    subroutine transform_for_implicit_module(tokens, transformed_tokens)
-        type(token_t), intent(in) :: tokens(:)
-        type(token_t), allocatable, intent(out) :: transformed_tokens(:)
-        integer :: decl_end, prog_start
-        type(token_t), allocatable :: module_tokens(:)
-        type(token_t), allocatable :: program_tokens(:)
-        integer :: i, idx
-        
-        ! print *, "DEBUG: transform_for_implicit_module called"
-        
-        ! Find the boundary between declarations and program
-        call find_declaration_program_boundary(tokens, decl_end, prog_start)
-        
-        ! print *, "DEBUG: decl_end =", decl_end, "prog_start =", prog_start
-        
-        if (decl_end > 0 .and. prog_start > 0 .and. prog_start <= size(tokens)) then
-            ! print *, "DEBUG: Creating module wrapper"
-            ! Create module wrapping the declarations
-            module_tokens = wrap_declarations_in_module(tokens, 1, decl_end)
-            ! print *, "DEBUG: Module tokens created, size =", size(module_tokens)
-            
-            ! Add use statement to program
-            program_tokens = add_use_statement_to_program(tokens(prog_start:), 1)
-            
-            ! Combine into transformed tokens
-            allocate(transformed_tokens(size(module_tokens) + size(program_tokens) + 2))
-            
-            idx = 1
-            ! Add module tokens
-            do i = 1, size(module_tokens)
-                transformed_tokens(idx) = module_tokens(i)
-                idx = idx + 1
-            end do
-            
-            ! Add separator newline
-            transformed_tokens(idx)%kind = TK_NEWLINE
-            transformed_tokens(idx)%text = ""
-            transformed_tokens(idx)%line = module_tokens(size(module_tokens))%line + 1
-            transformed_tokens(idx)%column = 1
-            idx = idx + 1
-            
-            ! Add program tokens with adjusted line numbers
-            do i = 1, size(program_tokens)
-                transformed_tokens(idx) = program_tokens(i)
-                transformed_tokens(idx)%line = transformed_tokens(idx)%line + &
-                                              module_tokens(size(module_tokens))%line + 1
-                idx = idx + 1
-            end do
-            
-            ! Add final EOF if needed
-            if (transformed_tokens(idx-1)%kind /= TK_EOF) then
-                transformed_tokens(idx)%kind = TK_EOF
-                transformed_tokens(idx)%text = ""
-                transformed_tokens(idx)%line = transformed_tokens(idx-1)%line
-                transformed_tokens(idx)%column = transformed_tokens(idx-1)%column + 1
-            else
-                idx = idx - 1  ! Don't include extra EOF
-            end if
-            
-            ! Resize to actual size
-            if (idx < size(transformed_tokens)) then
-                transformed_tokens = transformed_tokens(1:idx)
-            end if
-        else
-            ! Should not happen, but fallback to original tokens
-            allocate(transformed_tokens(size(tokens)))
-            transformed_tokens = tokens
-        end if
-    end subroutine transform_for_implicit_module
-    
-    ! Parse transformed tokens (simplified version of parse_tokens)
-    subroutine parse_transformed_tokens(tokens, arena, prog_index, error_msg)
-        type(token_t), intent(in) :: tokens(:)
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(out) :: prog_index
-        character(len=*), intent(out) :: error_msg
-        
-        ! Local variables for arena-based parsing
-        integer, allocatable :: body_indices(:)
-        integer :: stmt_index
-        integer :: i, unit_start, unit_end, stmt_count
-        type(token_t), allocatable :: unit_tokens(:)
-        logical :: has_explicit_program_unit
-        
-        error_msg = ""
-        stmt_count = 0
-        allocate (body_indices(0))
-        
-        ! For transformed tokens, we know there's an explicit program
-        has_explicit_program_unit = .true.
-        
-        ! Parse program units, not individual lines
-        i = 1
-        do while (i <= size(tokens))
-            ! Don't exit on first EOF - there might be more content
-            if (i == size(tokens) .and. tokens(i)%kind == TK_EOF) exit
-            
-            ! Skip empty lines (just EOF tokens)
-            if (tokens(i)%kind == TK_EOF .and. i < size(tokens)) then
-                i = i + 1
-                cycle
-            end if
-            
-            ! Find program unit boundary
-            call find_program_unit_boundary(tokens, i, unit_start, unit_end, &
-                                           has_explicit_program_unit)
-            
-            ! Check for valid boundary
-            if (unit_end < unit_start) then
-                ! No valid unit found (e.g., after parsing all content)
-                i = i + 1
-                if (i > size(tokens)) exit
-                cycle
-            end if
-            
-            ! Check if this unit has any meaningful content
-            if (.not. unit_has_meaningful_content(tokens, unit_start, unit_end)) then
-                i = unit_end + 1
-                cycle
-            end if
-            
-            ! Process unit if it has meaningful content
-            if (should_process_unit(tokens, unit_start, unit_end)) then
-                call process_program_unit(tokens, unit_start, unit_end, arena, &
-                                        has_explicit_program_unit, stmt_index)
-                
-                if (stmt_index > 0) then
-                    ! Add to body indices
-                    body_indices = [body_indices, stmt_index]
-                    stmt_count = stmt_count + 1
-                end if
-            end if
-            
-            i = unit_end + 1
-            
-            ! Continue processing remaining tokens
-        end do
-        
-        ! Create final program structure
-        call create_final_program_structure(arena, body_indices, stmt_count, &
-                                          has_explicit_program_unit, prog_index, error_msg)
-    end subroutine parse_transformed_tokens
 
     ! Create a container for multiple top-level program units
     function create_multi_unit_container(arena, unit_indices) result(container_index)
@@ -194,26 +51,11 @@ contains
         integer :: stmt_index
         integer :: i, unit_start, unit_end, stmt_count
         type(token_t), allocatable :: unit_tokens(:)
-        type(token_t), allocatable :: transformed_tokens(:)
         logical :: has_explicit_program_unit
-        logical :: needs_implicit_module
-        integer :: decl_end, prog_start
 
         error_msg = ""
         stmt_count = 0
         allocate (body_indices(0))
-        
-        ! Check for Issue #511 scenario: declarations before explicit program
-        needs_implicit_module = has_declarations_before_program(tokens)
-        
-        if (needs_implicit_module) then
-            ! For now, disable the transformation due to parsing issues
-            ! The detection works but transformation needs refinement
-            ! print *, "DEBUG: Issue #511 scenario detected - transforming tokens"
-            ! call transform_for_implicit_module(tokens, transformed_tokens)
-            ! call parse_transformed_tokens(transformed_tokens, arena, prog_index, error_msg)
-            ! return
-        end if
         
         has_explicit_program_unit = detect_explicit_program_unit(tokens)
 
@@ -829,6 +671,5 @@ contains
 
     include 'frontend_parsing_unit_detection.inc'
     include 'frontend_parsing_boundary_detection.inc'
-    include 'frontend_parsing_implicit_module.inc'
 
 end module frontend_parsing

--- a/src/frontend_parsing_implicit_module.inc
+++ b/src/frontend_parsing_implicit_module.inc
@@ -1,0 +1,282 @@
+    ! Check if there are declarations before an explicit program
+    function has_declarations_before_program(tokens) result(has_decls)
+        type(token_t), intent(in) :: tokens(:)
+        logical :: has_decls
+        integer :: i
+        logical :: found_declarations, found_explicit_program
+        
+        has_decls = .false.
+        found_declarations = .false.
+        found_explicit_program = .false.
+        
+        ! Debug output
+        ! print *, "DEBUG: Checking for declarations before program, total tokens:", size(tokens)
+        
+        ! Scan tokens to find declarations before explicit program
+        do i = 1, size(tokens)
+            if (tokens(i)%kind == TK_KEYWORD) then
+                ! Debug each keyword  
+                ! print *, "DEBUG: Token", i, "keyword:", trim(tokens(i)%text)
+                
+                ! Check for explicit program statement
+                if (tokens(i)%text == "program") then
+                    ! Check that it's not "end program"
+                    if (i == 1) then
+                        found_explicit_program = .true.
+                        ! print *, "DEBUG: Found explicit program at position 1"
+                        exit
+                    else if (i > 1) then
+                        if (tokens(i-1)%kind /= TK_KEYWORD .or. tokens(i-1)%text /= "end") then
+                            found_explicit_program = .true.
+                            ! print *, "DEBUG: Found explicit program at position", i
+                            exit
+                        end if
+                    end if
+                    
+                ! Check for declaration keywords that appear before program
+                else if (.not. found_explicit_program) then
+                    select case (tokens(i)%text)
+                    case ("type", "interface", "integer", "real", "logical", &
+                          "character", "double", "complex")
+                        ! For type, check if it's a type definition (type ::)
+                        if (tokens(i)%text == "type") then
+                            if (i + 1 <= size(tokens)) then
+                                if (tokens(i+1)%kind == TK_OPERATOR .and. &
+                                    tokens(i+1)%text == "::") then
+                                    found_declarations = .true.
+                                else if (i + 2 <= size(tokens) .and. &
+                                         tokens(i+1)%kind == TK_IDENTIFIER .and. &
+                                         tokens(i+2)%kind == TK_OPERATOR .and. &
+                                         tokens(i+2)%text == "::") then
+                                    ! type name :: case
+                                    found_declarations = .true.
+                                end if
+                            end if
+                        else
+                            ! Other declaration keywords
+                            found_declarations = .true.
+                            ! print *, "DEBUG: Found declaration keyword:", trim(tokens(i)%text)
+                        end if
+                    end select
+                end if
+            end if
+        end do
+        
+        ! We have declarations before program if both conditions are met
+        has_decls = found_declarations .and. found_explicit_program
+        ! print *, "DEBUG: has_declarations_before_program result:", has_decls
+        ! print *, "DEBUG: found_declarations:", found_declarations, "found_explicit_program:", found_explicit_program
+    end function has_declarations_before_program
+    
+    ! Find the boundary between declarations and explicit program
+    subroutine find_declaration_program_boundary(tokens, decl_end, prog_start)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(out) :: decl_end, prog_start
+        integer :: i
+        
+        decl_end = 0
+        prog_start = 0
+        
+        ! Find where the explicit program starts
+        do i = 1, size(tokens)
+            if (tokens(i)%kind == TK_KEYWORD .and. tokens(i)%text == "program") then
+                ! Check that it's not "end program"
+                if (i == 1) then
+                    prog_start = i
+                    decl_end = i - 1
+                    exit
+                else if (tokens(i-1)%kind /= TK_KEYWORD .or. tokens(i-1)%text /= "end") then
+                    prog_start = i
+                    ! Find the actual end of declarations (skip whitespace/comments)
+                    decl_end = i - 1
+                    do while (decl_end > 0)
+                        if (tokens(decl_end)%kind /= TK_EOF .and. &
+                            tokens(decl_end)%kind /= TK_NEWLINE .and. &
+                            tokens(decl_end)%kind /= TK_COMMENT) then
+                            exit
+                        end if
+                        decl_end = decl_end - 1
+                    end do
+                    exit
+                end if
+            end if
+        end do
+    end subroutine find_declaration_program_boundary
+    
+    ! Create tokens for implicit module wrapping declarations
+    function wrap_declarations_in_module(tokens, decl_start, decl_end) result(module_tokens)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: decl_start, decl_end
+        type(token_t), allocatable :: module_tokens(:)
+        integer :: i, idx, num_tokens
+        
+        ! print *, "DEBUG: wrap_declarations_in_module: decl_start =", decl_start, "decl_end =", decl_end
+        
+        ! Validate bounds
+        if (decl_start < 1 .or. decl_end > size(tokens) .or. decl_start > decl_end) then
+            ! print *, "ERROR: Invalid bounds in wrap_declarations_in_module"
+            allocate(module_tokens(0))
+            return
+        end if
+        
+        ! Calculate number of tokens needed
+        ! module implicit_module + implicit none + declarations + end module + extra space
+        num_tokens = 10 + (decl_end - decl_start + 1) + 5
+        allocate(module_tokens(num_tokens))
+        
+        idx = 1
+        
+        ! Add "module implicit_module"
+        module_tokens(idx)%kind = TK_KEYWORD
+        module_tokens(idx)%text = "module"
+        module_tokens(idx)%line = 1
+        module_tokens(idx)%column = 1
+        idx = idx + 1
+        
+        module_tokens(idx)%kind = TK_IDENTIFIER
+        module_tokens(idx)%text = "implicit_module"
+        module_tokens(idx)%line = 1
+        module_tokens(idx)%column = 8
+        idx = idx + 1
+        
+        module_tokens(idx)%kind = TK_NEWLINE
+        module_tokens(idx)%text = ""
+        module_tokens(idx)%line = 1
+        module_tokens(idx)%column = 23
+        idx = idx + 1
+        
+        ! Add "implicit none"
+        module_tokens(idx)%kind = TK_KEYWORD
+        module_tokens(idx)%text = "implicit"
+        module_tokens(idx)%line = 2
+        module_tokens(idx)%column = 5
+        idx = idx + 1
+        
+        module_tokens(idx)%kind = TK_KEYWORD
+        module_tokens(idx)%text = "none"
+        module_tokens(idx)%line = 2
+        module_tokens(idx)%column = 14
+        idx = idx + 1
+        
+        module_tokens(idx)%kind = TK_NEWLINE
+        module_tokens(idx)%text = ""
+        module_tokens(idx)%line = 2
+        module_tokens(idx)%column = 18
+        idx = idx + 1
+        
+        ! Copy declaration tokens (preserving original tokens exactly)
+        do i = decl_start, decl_end
+            module_tokens(idx) = tokens(i)
+            ! Adjust line numbers to account for module header
+            module_tokens(idx)%line = module_tokens(idx)%line + 2
+            idx = idx + 1
+        end do
+        
+        ! Add newline if needed
+        if (module_tokens(idx-1)%kind /= TK_NEWLINE) then
+            module_tokens(idx)%kind = TK_NEWLINE
+            module_tokens(idx)%text = ""
+            module_tokens(idx)%line = module_tokens(idx-1)%line
+            module_tokens(idx)%column = module_tokens(idx-1)%column + &
+                                       len(module_tokens(idx-1)%text)
+            idx = idx + 1
+        end if
+        
+        ! Add "end module implicit_module"
+        module_tokens(idx)%kind = TK_KEYWORD
+        module_tokens(idx)%text = "end"
+        module_tokens(idx)%line = module_tokens(idx-1)%line + 1
+        module_tokens(idx)%column = 1
+        idx = idx + 1
+        
+        module_tokens(idx)%kind = TK_KEYWORD
+        module_tokens(idx)%text = "module"
+        module_tokens(idx)%line = module_tokens(idx-1)%line
+        module_tokens(idx)%column = 5
+        idx = idx + 1
+        
+        module_tokens(idx)%kind = TK_IDENTIFIER
+        module_tokens(idx)%text = "implicit_module"
+        module_tokens(idx)%line = module_tokens(idx-1)%line
+        module_tokens(idx)%column = 12
+        
+        ! Resize if we allocated too much
+        if (idx < num_tokens) then
+            module_tokens = module_tokens(1:idx)
+        end if
+    end function wrap_declarations_in_module
+    
+    ! Add use statement to program tokens
+    function add_use_statement_to_program(tokens, prog_start) result(new_tokens)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: prog_start
+        type(token_t), allocatable :: new_tokens(:)
+        integer :: i, idx, prog_name_end
+        integer :: num_new_tokens
+        
+        ! Find end of program statement (program name)
+        prog_name_end = prog_start + 1
+        do while (prog_name_end <= size(tokens))
+            if (tokens(prog_name_end)%kind == TK_NEWLINE .or. &
+                tokens(prog_name_end)%kind == TK_EOF) then
+                exit
+            end if
+            prog_name_end = prog_name_end + 1
+        end do
+        
+        ! Allocate space for new tokens (original + use statement tokens)
+        num_new_tokens = size(tokens) + 4  ! use implicit_module newline
+        allocate(new_tokens(num_new_tokens))
+        
+        idx = 1
+        
+        ! Copy up to end of program statement
+        do i = prog_start, prog_name_end - 1
+            new_tokens(idx) = tokens(i)
+            idx = idx + 1
+        end do
+        
+        ! Add newline after program statement if needed
+        if (tokens(prog_name_end)%kind == TK_NEWLINE) then
+            new_tokens(idx) = tokens(prog_name_end)
+            idx = idx + 1
+        else
+            new_tokens(idx)%kind = TK_NEWLINE
+            new_tokens(idx)%text = ""
+            new_tokens(idx)%line = tokens(prog_name_end-1)%line
+            new_tokens(idx)%column = tokens(prog_name_end-1)%column + &
+                                     len(tokens(prog_name_end-1)%text)
+            idx = idx + 1
+        end if
+        
+        ! Add "use implicit_module"
+        new_tokens(idx)%kind = TK_KEYWORD
+        new_tokens(idx)%text = "use"
+        new_tokens(idx)%line = new_tokens(idx-1)%line + 1
+        new_tokens(idx)%column = 5
+        idx = idx + 1
+        
+        new_tokens(idx)%kind = TK_IDENTIFIER
+        new_tokens(idx)%text = "implicit_module"
+        new_tokens(idx)%line = new_tokens(idx-1)%line
+        new_tokens(idx)%column = 9
+        idx = idx + 1
+        
+        new_tokens(idx)%kind = TK_NEWLINE
+        new_tokens(idx)%text = ""
+        new_tokens(idx)%line = new_tokens(idx-1)%line
+        new_tokens(idx)%column = 24
+        idx = idx + 1
+        
+        ! Copy remaining tokens (skip the newline we already handled)
+        do i = prog_name_end + 1, size(tokens)
+            new_tokens(idx) = tokens(i)
+            new_tokens(idx)%line = new_tokens(idx)%line + 1
+            idx = idx + 1
+        end do
+        
+        ! Resize if needed
+        if (idx - 1 < num_new_tokens) then
+            new_tokens = new_tokens(1:idx-1)
+        end if
+    end function add_use_statement_to_program

--- a/src/frontend_transformation.f90
+++ b/src/frontend_transformation.f90
@@ -18,6 +18,7 @@ module frontend_transformation
     use ast_nodes_core, only: program_node
     use frontend_parsing, only: parse_tokens
     use frontend_core, only: lex_source, emit_fortran
+    use frontend_utilities, only: has_declarations_before_program
 
     implicit none
     private

--- a/src/frontend_utilities.f90
+++ b/src/frontend_utilities.f90
@@ -3,11 +3,12 @@ module frontend_utilities
     ! Contains helper functions and utilities
 
     use path_validation, only: validate_output_path, path_validation_result_t
+    use lexer_core, only: token_t, TK_KEYWORD, TK_OPERATOR, TK_IDENTIFIER
 
     implicit none
     private
 
-    public :: write_output_file, int_to_str
+    public :: write_output_file, int_to_str, has_declarations_before_program
 
 contains
 
@@ -43,5 +44,65 @@ contains
         character(len=20) :: str
         write (str, '(I0)') num
     end function int_to_str
+
+    ! Check if there are declarations before an explicit program (Issue #511)
+    ! This is used by codegen to detect when implicit module wrapping is needed
+    function has_declarations_before_program(tokens) result(has_decls)
+        type(token_t), intent(in) :: tokens(:)
+        logical :: has_decls
+        integer :: i
+        logical :: found_declarations, found_explicit_program
+        
+        has_decls = .false.
+        found_declarations = .false.
+        found_explicit_program = .false.
+        
+        ! Scan tokens to find declarations before explicit program
+        do i = 1, size(tokens)
+            if (tokens(i)%kind == TK_KEYWORD) then
+                ! Check for explicit program statement
+                if (tokens(i)%text == "program") then
+                    ! Check that it's not "end program"
+                    if (i == 1) then
+                        found_explicit_program = .true.
+                        exit
+                    else if (i > 1) then
+                        if (tokens(i-1)%kind /= TK_KEYWORD .or. tokens(i-1)%text /= "end") then
+                            found_explicit_program = .true.
+                            exit
+                        end if
+                    end if
+                    
+                ! Check for declaration keywords that appear before program
+                else if (.not. found_explicit_program) then
+                    select case (tokens(i)%text)
+                    case ("type", "interface", "integer", "real", "logical", &
+                          "character", "double", "complex")
+                        ! For type, check if it's a type definition (type ::)
+                        if (tokens(i)%text == "type") then
+                            if (i + 1 <= size(tokens)) then
+                                if (tokens(i+1)%kind == TK_OPERATOR .and. &
+                                    tokens(i+1)%text == "::") then
+                                    found_declarations = .true.
+                                else if (i + 2 <= size(tokens) .and. &
+                                         tokens(i+1)%kind == TK_IDENTIFIER .and. &
+                                         tokens(i+2)%kind == TK_OPERATOR .and. &
+                                         tokens(i+2)%text == "::") then
+                                    ! type name :: case
+                                    found_declarations = .true.
+                                end if
+                            end if
+                        else
+                            ! Other declaration keywords
+                            found_declarations = .true.
+                        end if
+                    end select
+                end if
+            end if
+        end do
+        
+        ! We have declarations before program if both conditions are met
+        has_decls = found_declarations .and. found_explicit_program
+    end function has_declarations_before_program
 
 end module frontend_utilities

--- a/test/codegen/test_issue_511_implicit_module_before_program.f90
+++ b/test/codegen/test_issue_511_implicit_module_before_program.f90
@@ -1,0 +1,253 @@
+! Test for Issue #511 - Allow implicit module above explicit program
+! The derived type before the explicit program should be wrapped in a module
+! and automatically imported into the program
+
+program test_issue_511_implicit_module_before_program
+    use frontend
+    implicit none
+
+    character(len=:), allocatable :: input, expected, actual, error_msg
+
+    ! Test 1: Single type declaration before explicit program
+    call run_test("Single type declaration before explicit program")
+    
+    input = &
+        "type :: a"//new_line('A')// &
+        "    integer :: t"//new_line('A')// &
+        "end type :: a"//new_line('A')// &
+        ""//new_line('A')// &
+        "program pro"//new_line('A')// &
+        "    type(a) :: testy"//new_line('A')// &
+        "    testy%t = 3"//new_line('A')// &
+        "end program pro"
+    
+    expected = &
+        "module implicit_module"//new_line('A')// &
+        "    implicit none"//new_line('A')// &
+        ""//new_line('A')// &
+        "    type :: a"//new_line('A')// &
+        "        integer :: t"//new_line('A')// &
+        "    end type a"//new_line('A')// &
+        "end module implicit_module"//new_line('A')// &
+        ""//new_line('A')// &
+        "program pro"//new_line('A')// &
+        "    use implicit_module, only: a"//new_line('A')// &
+        "    implicit none"//new_line('A')// &
+        ""//new_line('A')// &
+        "    type(a) :: testy"//new_line('A')// &
+        ""//new_line('A')// &
+        "    testy%t = 3"//new_line('A')// &
+        "end program pro"
+    
+    call compile_and_check(input, expected)
+
+    ! Test 2: Multiple type declarations before explicit program
+    call run_test("Multiple types before explicit program")
+    
+    input = &
+        "type :: point"//new_line('A')// &
+        "    real :: x, y"//new_line('A')// &
+        "end type point"//new_line('A')// &
+        ""//new_line('A')// &
+        "type :: circle"//new_line('A')// &
+        "    type(point) :: center"//new_line('A')// &
+        "    real :: radius"//new_line('A')// &
+        "end type circle"//new_line('A')// &
+        ""//new_line('A')// &
+        "program test_geom"//new_line('A')// &
+        "    type(circle) :: c"//new_line('A')// &
+        "    c%radius = 5.0"//new_line('A')// &
+        "    c%center%x = 0.0"//new_line('A')// &
+        "    c%center%y = 0.0"//new_line('A')// &
+        "end program test_geom"
+    
+    expected = &
+        "module implicit_module"//new_line('A')// &
+        "    implicit none"//new_line('A')// &
+        ""//new_line('A')// &
+        "    type :: point"//new_line('A')// &
+        "        real :: x, y"//new_line('A')// &
+        "    end type point"//new_line('A')// &
+        ""//new_line('A')// &
+        "    type :: circle"//new_line('A')// &
+        "        type(point) :: center"//new_line('A')// &
+        "        real :: radius"//new_line('A')// &
+        "    end type circle"//new_line('A')// &
+        "end module implicit_module"//new_line('A')// &
+        ""//new_line('A')// &
+        "program test_geom"//new_line('A')// &
+        "    use implicit_module, only: point, circle"//new_line('A')// &
+        "    implicit none"//new_line('A')// &
+        ""//new_line('A')// &
+        "    type(circle) :: c"//new_line('A')// &
+        ""//new_line('A')// &
+        "    c%radius = 5.0"//new_line('A')// &
+        "    c%center%x = 0.0"//new_line('A')// &
+        "    c%center%y = 0.0"//new_line('A')// &
+        "end program test_geom"
+
+    call compile_and_check(input, expected)
+
+    ! Test 3: Interface block before explicit program
+    call run_test("Interface block before explicit program")
+    
+    input = &
+        "interface"//new_line('A')// &
+        "    function add_int(a, b) result(c)"//new_line('A')// &
+        "        integer, intent(in) :: a, b"//new_line('A')// &
+        "        integer :: c"//new_line('A')// &
+        "    end function add_int"//new_line('A')// &
+        "end interface"//new_line('A')// &
+        ""//new_line('A')// &
+        "program test_interface"//new_line('A')// &
+        "    integer :: result"//new_line('A')// &
+        "    result = add_int(2, 3)"//new_line('A')// &
+        "end program test_interface"
+    
+    expected = &
+        "module implicit_module"//new_line('A')// &
+        "    implicit none"//new_line('A')// &
+        ""//new_line('A')// &
+        "    interface"//new_line('A')// &
+        "        function add_int(a, b) result(c)"//new_line('A')// &
+        "            integer, intent(in) :: a, b"//new_line('A')// &
+        "            integer :: c"//new_line('A')// &
+        "        end function add_int"//new_line('A')// &
+        "    end interface"//new_line('A')// &
+        "end module implicit_module"//new_line('A')// &
+        ""//new_line('A')// &
+        "program test_interface"//new_line('A')// &
+        "    use implicit_module"//new_line('A')// &
+        "    implicit none"//new_line('A')// &
+        ""//new_line('A')// &
+        "    integer :: result"//new_line('A')// &
+        ""//new_line('A')// &
+        "    result = add_int(2, 3)"//new_line('A')// &
+        "end program test_interface"
+
+    call compile_and_check(input, expected)
+
+    ! Test 4: Mixed declarations before explicit program
+    call run_test("Mixed declarations before explicit program")
+    
+    input = &
+        "integer, parameter :: MAX_SIZE = 100"//new_line('A')// &
+        ""//new_line('A')// &
+        "type :: config"//new_line('A')// &
+        "    integer :: size"//new_line('A')// &
+        "    logical :: enabled"//new_line('A')// &
+        "end type config"//new_line('A')// &
+        ""//new_line('A')// &
+        "program test_config"//new_line('A')// &
+        "    type(config) :: cfg"//new_line('A')// &
+        "    cfg%size = MAX_SIZE"//new_line('A')// &
+        "    cfg%enabled = .true."//new_line('A')// &
+        "end program test_config"
+    
+    expected = &
+        "module implicit_module"//new_line('A')// &
+        "    implicit none"//new_line('A')// &
+        ""//new_line('A')// &
+        "    integer, parameter :: MAX_SIZE = 100"//new_line('A')// &
+        ""//new_line('A')// &
+        "    type :: config"//new_line('A')// &
+        "        integer :: size"//new_line('A')// &
+        "        logical :: enabled"//new_line('A')// &
+        "    end type config"//new_line('A')// &
+        "end module implicit_module"//new_line('A')// &
+        ""//new_line('A')// &
+        "program test_config"//new_line('A')// &
+        "    use implicit_module, only: MAX_SIZE, config"//new_line('A')// &
+        "    implicit none"//new_line('A')// &
+        ""//new_line('A')// &
+        "    type(config) :: cfg"//new_line('A')// &
+        ""//new_line('A')// &
+        "    cfg%size = MAX_SIZE"//new_line('A')// &
+        "    cfg%enabled = .true."//new_line('A')// &
+        "end program test_config"
+
+    call compile_and_check(input, expected)
+
+    ! Test 5: No declarations before explicit program (should not create module)
+    call run_test("No declarations before explicit program")
+    
+    input = &
+        "program simple"//new_line('A')// &
+        "    integer :: i"//new_line('A')// &
+        "    i = 42"//new_line('A')// &
+        "end program simple"
+    
+    expected = &
+        "program simple"//new_line('A')// &
+        "    implicit none"//new_line('A')// &
+        ""//new_line('A')// &
+        "    integer :: i"//new_line('A')// &
+        ""//new_line('A')// &
+        "    i = 42"//new_line('A')// &
+        "end program simple"
+
+    call compile_and_check(input, expected)
+
+contains
+
+    subroutine compile_and_check(input, expected)
+        character(len=*), intent(in) :: input, expected
+        character(len=:), allocatable :: actual_output
+        character(len=:), allocatable :: error_msg_local
+        
+        ! Transform the source
+        call transform_lazy_fortran_string(input, actual_output, error_msg_local)
+        
+        if (len_trim(error_msg_local) > 0) then
+            print *, "Compilation failed: "//trim(error_msg_local)
+            stop 1
+        end if
+        
+        ! Check output
+        if (trim(actual_output) /= trim(expected)) then
+            print *, "Expected:"
+            call print_with_line_numbers(expected)
+            print *, ""
+            print *, "Actual:"
+            call print_with_line_numbers(actual_output)
+            stop 1
+        else
+            print *, "  PASS"
+        end if
+    end subroutine compile_and_check
+    
+    subroutine run_test(test_name)
+        character(len=*), intent(in) :: test_name
+        print *, ""
+        print *, "Test: ", trim(test_name)
+    end subroutine run_test
+    
+    subroutine print_with_line_numbers(code)
+        character(len=*), intent(in) :: code
+        integer :: i, line_num, start_pos
+        character(len=:), allocatable :: line
+        
+        line_num = 1
+        start_pos = 1
+        
+        do i = 1, len(code)
+            if (code(i:i) == new_line('a')) then
+                if (i >= start_pos) then
+                    line = code(start_pos:i-1)
+                    write(*, '(I3,A,A)') line_num, ': ', line
+                else
+                    write(*, '(I3,A)') line_num, ': '
+                end if
+                line_num = line_num + 1
+                start_pos = i + 1
+            end if
+        end do
+        
+        ! Print last line if file doesn't end with newline
+        if (start_pos <= len(code)) then
+            line = code(start_pos:len(code))
+            write(*, '(I3,A,A)') line_num, ': ', line
+        end if
+    end subroutine print_with_line_numbers
+
+end program test_issue_511_implicit_module_before_program


### PR DESCRIPTION
## Summary
Partial implementation of Issue #511 - allowing implicit module declarations above explicit program blocks.

## Current Status
- ✅ Detection logic implemented and working
- ✅ Comprehensive test cases added
- 🚧 Token transformation approach attempted but proved complex
- ❌ Tests currently failing - need AST-level transformation

## Technical Details
The detection correctly identifies when declarations appear before an explicit `program` statement. However, the token-level transformation disrupts the parser's program unit detection logic.

## Next Steps
Need to implement AST-level transformation in the code generation phase instead of token transformation. The approach would be:
1. Parse normally (creating separate units)
2. Detect the pattern in codegen
3. Wrap declarations in implicit module during code generation
4. Inject use statements into the program

## Related
- Builds on #488/#489 mixed constructs foundation
- Inverse scenario of #488 (implicit module before explicit program vs implicit main after module)

## Test Coverage
Comprehensive tests added covering:
- Single type declaration before program
- Multiple type declarations  
- Interface blocks
- Mixed declarations (parameters and types)
- Edge case: no declarations (should not transform)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>