### PR TITLE
fix: resolve write statement recognition in input validation layer

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,14 +1,13 @@
 # Development Backlog
 
 ## DOING (Current Work)
-- [ ] #497: I/O parsing: Read statements generate 'Unknown node type' error (core Fortran support)
+- [ ] #498: I/O parsing: Write statements not recognized as valid Fortran (core Fortran support)
 
 ## CURRENT SPRINT (Ordered by Priority)
 
 ### CRITICAL - System Functionality Blockers
 
 ### HIGH PRIORITY - Core Parser Gaps
-- [ ] #498: I/O parsing: Write statements not recognized as valid Fortran (core Fortran support)
 - [ ] #492: Statement parsing: Semicolon-separated statements only process first statement (parser completeness)
 - [ ] #495: Semantic analysis: Undefined variables not detected in expressions (type system gap)
 - [ ] #493: Operator precedence: Incorrect logical operator precedence and parenthesization (correctness)
@@ -99,6 +98,7 @@
 - [ ] #380: feat: create unified arena API for external tools (fluff, ffc)
 
 ## DONE (Sprint Completed)
+- [x] #497: I/O parsing: Read statements generate 'Unknown node type' error (core Fortran support)
 - [x] #508: Comment line in module causes main program to be discarded (CRITICAL - parser core functionality)
 - [x] #509: subroutine and end subroutine, function and end function should be indented the same (code generation formatting)
 - [x] #488: Mixed constructs: Implicit main statements ignored when module present (CRITICAL - core lazy-fortran use case)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -3,7 +3,7 @@
 ## DOING (Current Work)
 - [ ] #498: I/O parsing: Write statements not recognized as valid Fortran (core Fortran support)
 
-## CURRENT SPRINT (Ordered by Priority)
+## SPRINT BACKLOG (Ordered by Priority)
 
 ### CRITICAL - System Functionality Blockers
 
@@ -36,7 +36,7 @@
 - [ ] #494: Array parsing: Array slice assignment with stride produces empty program (core functionality)
 - [ ] #496: Loop parsing: Array assignment in do loop generates unparsed comment (parser defect)
 
-## TODO (Lower Priority - Post Sprint)
+## PRODUCT BACKLOG
 
 ### CST/AST Converter Enhancements (ENHANCEMENT)
 - [ ] #483: feat: enable enhanced AST nodes with CST references
@@ -97,7 +97,7 @@
 - [ ] #381: doc: create comprehensive arena architecture documentation
 - [ ] #380: feat: create unified arena API for external tools (fluff, ffc)
 
-## DONE (Sprint Completed)
+## DONE 
 - [x] #497: I/O parsing: Read statements generate 'Unknown node type' error (core Fortran support)
 - [x] #508: Comment line in module causes main program to be discarded (CRITICAL - parser core functionality)
 - [x] #509: subroutine and end subroutine, function and end function should be indented the same (code generation formatting)

--- a/src/input_validation.f90
+++ b/src/input_validation.f90
@@ -244,7 +244,8 @@ contains
                     tokens(i)%text == "character" .or. tokens(i)%text == "logical" .or. &
                     tokens(i)%text == "implicit" .or. tokens(i)%text == "none" .or. &
                     tokens(i)%text == "end" .or. tokens(i)%text == "if" .or. &
-                    tokens(i)%text == "do" .or. tokens(i)%text == "print") then
+                    tokens(i)%text == "do" .or. tokens(i)%text == "print" .or. &
+                    tokens(i)%text == "read" .or. tokens(i)%text == "write") then
                     has_fortran_keywords = .true.
                 end if
             end if

--- a/test/codegen/test_issue_498_write_statements.f90
+++ b/test/codegen/test_issue_498_write_statements.f90
@@ -1,0 +1,167 @@
+program test_issue_498_write_statements
+    ! Test case for Issue #498: Write statements not recognized as valid Fortran
+    ! Tests specifically the input validation layer that was causing UNRECOGNIZED_INPUT
+    use lexer_core
+    use input_validation, only: validate_basic_syntax
+    use frontend, only: transform_lazy_fortran_string
+    implicit none
+
+    call test_write_statement_validation()
+    call test_write_with_string_literal()
+    call test_write_with_variables()
+    call test_write_with_format()
+    call test_write_integration()
+
+contains
+
+    subroutine test_write_statement_validation()
+        character(len=:), allocatable :: source, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(tokenize_result_t) :: lex_result
+
+        print *, "Test: write statement input validation"
+
+        ! Test the exact case from Issue #498
+        source = "write(*,*) 'Hello'"
+        
+        ! Tokenize
+        lex_result = tokenize_safe(source)
+        if (lex_result%result%is_failure()) then
+            print *, "FAIL: Tokenization failed: ", trim(lex_result%result%error_message)
+            stop 1
+        end if
+        tokens = lex_result%tokens
+
+        ! Validate - this should NOT generate UNRECOGNIZED_INPUT error
+        call validate_basic_syntax(source, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Input validation failed: ", error_msg
+            stop 1
+        end if
+
+        print *, "PASS: write statement input validation"
+    end subroutine test_write_statement_validation
+
+    subroutine test_write_with_string_literal()
+        character(len=:), allocatable :: source, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(tokenize_result_t) :: lex_result
+
+        print *, "Test: write with string literal validation"
+
+        source = "write(*,*) 'Hello World'"
+        
+        ! Tokenize
+        lex_result = tokenize_safe(source)
+        if (lex_result%result%is_failure()) then
+            print *, "FAIL: Tokenization failed: ", trim(lex_result%result%error_message)
+            stop 1
+        end if
+        tokens = lex_result%tokens
+
+        ! Validate
+        call validate_basic_syntax(source, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Input validation failed: ", error_msg
+            stop 1
+        end if
+
+        print *, "PASS: write with string literal validation"
+    end subroutine test_write_with_string_literal
+
+    subroutine test_write_with_variables()
+        character(len=:), allocatable :: source, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(tokenize_result_t) :: lex_result
+
+        print *, "Test: write with variables validation"
+
+        source = "write(*,*) x, y, z"
+        
+        ! Tokenize
+        lex_result = tokenize_safe(source)
+        if (lex_result%result%is_failure()) then
+            print *, "FAIL: Tokenization failed: ", trim(lex_result%result%error_message)
+            stop 1
+        end if
+        tokens = lex_result%tokens
+
+        ! Validate
+        call validate_basic_syntax(source, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Input validation failed: ", error_msg
+            stop 1
+        end if
+
+        print *, "PASS: write with variables validation"
+    end subroutine test_write_with_variables
+
+    subroutine test_write_with_format()
+        character(len=:), allocatable :: source, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(tokenize_result_t) :: lex_result
+
+        print *, "Test: write with format validation"
+
+        source = "write(*, '(A)') 'formatted'"
+        
+        ! Tokenize
+        lex_result = tokenize_safe(source)
+        if (lex_result%result%is_failure()) then
+            print *, "FAIL: Tokenization failed: ", trim(lex_result%result%error_message)
+            stop 1
+        end if
+        tokens = lex_result%tokens
+
+        ! Validate
+        call validate_basic_syntax(source, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Input validation failed: ", error_msg
+            stop 1
+        end if
+
+        print *, "PASS: write with format validation"
+    end subroutine test_write_with_format
+
+    subroutine test_write_integration()
+        character(len=:), allocatable :: source, generated, error_msg
+
+        print *, "Test: write statement full integration"
+
+        ! Test the exact failure case from Issue #498 through full pipeline
+        source = "write(*,*) 'Hello'"
+        
+        ! Transform through full frontend (same as CLI)
+        call transform_lazy_fortran_string(source, generated, error_msg)
+        
+        ! Check compilation succeeded
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: Compilation failed: ", trim(error_msg)
+            stop 1
+        end if
+
+        ! Check proper program structure generated
+        if (index(generated, "program main") == 0) then
+            print *, "FAIL: No program structure generated"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        ! Check write statement preserved
+        if (index(generated, "write") == 0) then
+            print *, "FAIL: Write statement not preserved"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        ! Check string literal preserved
+        if (index(generated, "Hello") == 0) then
+            print *, "FAIL: String literal not preserved"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        print *, "PASS: write statement full integration"
+    end subroutine test_write_integration
+
+end program test_issue_498_write_statements


### PR DESCRIPTION
## Summary

Fixes Issue #498: Write statements not recognized as valid Fortran (core Fortran support)

- Add 'write' and 'read' keywords to Fortran keyword recognition list in input_validation module
- Resolves UNRECOGNIZED_INPUT error when using write statements via CLI  
- Issue was in input validation layer, not parser (which already supported write statements)
- Add comprehensive tests for Issue #498 covering all write statement patterns

## Technical Details

The issue occurred because the `check_for_fortran_content` function in `input_validation.f90` was missing `"write"` and `"read"` from its list of recognized Fortran keywords. While the parser and dispatcher correctly handled write statements, the input validation layer would reject them as unrecognized input before they reached the parser.

## Testing

- All existing I/O parsing tests continue to pass
- New comprehensive test suite for Issue #498 validates:
  - Basic write statement validation 
  - Write statements with string literals
  - Write statements with variables
  - Write statements with format specifiers
  - Full integration through CLI pipeline
- Input validation module tests pass
- No regressions in existing functionality

## Test Plan

- [x] Write statement parsing works correctly
- [x] Read statement parsing continues to work
- [x] Both statements generate proper Fortran code
- [x] Input validation accepts I/O statements
- [x] Full CLI integration functional
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)