### PR TITLE
fix: correct logical operator precedence and .not. implementation

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,6 @@
 # Development Backlog
 
 ## DOING (Current Work)
-- [ ] #493: Operator precedence: Incorrect logical operator precedence and parenthesization (branch: fix-operator-precedence-493)
 
 ## SPRINT BACKLOG (Ordered by Priority)
 
@@ -32,6 +31,10 @@
 - [ ] #487: Array literal: Nested arrays incorrectly typed as 1D instead of 2D (type correctness)
 - [ ] #494: Array parsing: Array slice assignment with stride produces empty program (core functionality)
 - [ ] #496: Loop parsing: Array assignment in do loop generates unparsed comment (parser defect)
+
+### QUALITY IMPROVEMENTS - Testing and Code Robustness
+- [ ] #527: test: add dedicated test for issue #493 logical operator precedence
+- [ ] #528: refactor: improve error handling in parse_unary function
 
 ## PRODUCT BACKLOG
 
@@ -95,6 +98,7 @@
 - [ ] #380: feat: create unified arena API for external tools (fluff, ffc)
 
 ## DONE
+- [x] #493: Operator precedence: Incorrect logical operator precedence and parenthesization (branch: fix-operator-precedence-493)
 - [x] #524: fix: update codegen field names after module split refactoring (compilation blocker)
 - [x] #521: Preserve comments and blank lines (source fidelity - critical for CST)
 - [x] #498: I/O parsing: Write statements not recognized as valid Fortran (core Fortran support)

--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -1,7 +1,7 @@
 # Development Backlog
 
 ## DOING (Current Work)
-- [ ] #493: Operator precedence: Incorrect logical operator precedence and parenthesization (correctness)
+- [ ] #493: Operator precedence: Incorrect logical operator precedence and parenthesization (branch: fix-operator-precedence-493)
 
 ## SPRINT BACKLOG (Ordered by Priority)
 

--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -320,7 +320,10 @@ contains
         character(len=:), allocatable :: left_code, right_code
 
         ! Generate code for operands with parentheses when needed
-        if (node%left_index > 0 .and. node%left_index <= arena%size) then
+        if (node%left_index == 0) then
+            ! Unary operation - no left operand
+            left_code = ""
+        else if (node%left_index > 0 .and. node%left_index <= arena%size) then
             left_code = generate_code_from_arena(arena, node%left_index)
             ! Add parentheses if left operand has lower precedence
             if (needs_parentheses(arena, node%left_index, node%operator, .true.)) then
@@ -341,7 +344,10 @@ contains
         end if
 
         ! Combine with operator - precedence-aware spacing
-        if (trim(node%operator) == ':') then
+        if (node%left_index == 0) then
+            ! Unary operation (no left operand) - for .not., unary +, unary -
+            code = trim(node%operator)//" "//right_code
+        else if (trim(node%operator) == ':') then
             ! Array slicing operator
             if (len(left_code) == 0) then
                 ! Empty lower bound: :upper


### PR DESCRIPTION
## Summary
- Fixed .not. operator implementation to be proper unary operation instead of incorrect binary operation with .false.
- Corrected operator precedence chain so unary operators have higher precedence than exponentiation
- Updated code generation to properly handle unary operations using left_index == 0 marker

## Problem Solved
Fixes issue #493: Logical operators had incorrect precedence causing syntactically invalid generated code.

**Before:**
```fortran
result = (.false. .not. .true.) .and. .false.  ! Invalid syntax
```

**After:**
```fortran  
result = (.not. .true.) .and. .false.  ! Valid syntax with correct precedence
```

## Changes
1. **Parser expressions**: Modified .not. to use left_index=0 instead of creating binary op with .false.
2. **Code generation**: Added handling for unary operations when left_index == 0
3. **Precedence chain**: Fixed parse_factor -> parse_power -> parse_unary -> parse_primary

## Test plan
- [x] Basic logical precedence: `.not. a .and. b` generates `(.not. a) .and. b`
- [x] Complex expressions: `.not. a .and. b .or. .not. c` generates correct precedence
- [x] Unary arithmetic: `-2 ** 2` generates `0 - 2**2` (correct precedence)
- [x] Existing parser tests still pass
- [x] Generated code compiles with standard Fortran compilers

🤖 Generated with [Claude Code](https://claude.ai/code)