### PR TITLE
fix: respect strict mode for undefined variable detection in Lazy Fortran

Critical regression fix that restores Lazy Fortran functionality by properly handling undefined variables based on compilation mode.

**Problem**: Semantic analyzer was reporting undefined variables as errors in BOTH Lazy Fortran and Standard Fortran modes, breaking the core Lazy Fortran feature of automatic variable declaration.

**Solution**: 
- Check  before reporting undefined variable errors
- In Standard Fortran mode (): Report undefined variables as errors (existing behavior) 
- In Lazy Fortran mode (): Auto-declare undefined variables by adding them to scope
- Apply the fix to both  and  functions

**Testing**: 
- Verified mode detection works correctly (Lazy Fortran → strict_mode = false)
- Confirmed undefined variables are no longer reported as errors in Lazy Fortran mode
- Standard Fortran behavior remains unchanged

Fixes #530 - Semantic analysis regression causing 30+ test failures

### DIFF
--- a/src/semantic/semantic_analyzer.f90
+++ b/src/semantic/semantic_analyzer.f90
@@ -444,21 +444,32 @@ contains
             ! Found in environment - instantiate the type scheme
             typ = ctx%instantiate(scheme)
         else
-            ! Not found - undefined variable error (Issue #495)
-            ! Report undefined variable error in BOTH modes
-            ! The difference is that lazy Fortran continues analysis, strict mode may stop
-            error_result = create_error_result( &
-                "Undefined variable '" // ident%name // "'", &
-                ERROR_SEMANTIC, &
-                component="semantic_analyzer", &
-                context="infer_identifier", &
-                suggestion="Declare the variable before using it" &
-            )
-            call ctx%errors%add_result(error_result)
-            
-            ! Always create fresh type variable for continued analysis (both modes)
-            ! This enables type inference and allows analysis to continue
-            typ = create_mono_type(TVAR, var=ctx%fresh_type_var())
+            ! Not found - behavior depends on mode
+            if (ctx%strict_mode) then
+                ! Standard Fortran mode: undefined variable is an error
+                error_result = create_error_result( &
+                    "Undefined variable '" // ident%name // "'", &
+                    ERROR_SEMANTIC, &
+                    component="semantic_analyzer", &
+                    context="infer_identifier", &
+                    suggestion="Declare the variable before using it" &
+                )
+                call ctx%errors%add_result(error_result)
+                
+                ! Create fresh type variable for continued analysis
+                typ = create_mono_type(TVAR, var=ctx%fresh_type_var())
+            else
+                ! Lazy Fortran mode: auto-declare undefined variables
+                ! Create a fresh type variable and add to scope for future use
+                typ = create_mono_type(TVAR, var=ctx%fresh_type_var())
+                
+                ! Create polymorphic type scheme (no generalization needed for simple variables)
+                block
+                    type(poly_type_t) :: new_scheme
+                    new_scheme = create_poly_type(forall_vars=[type_var_t::], mono=typ)
+                    call ctx%scopes%define(ident%name, new_scheme)
+                end block
+            end if
         end if
     end function infer_identifier
 
@@ -578,18 +589,20 @@ contains
                         existing_typ = ctx%instantiate(existing_scheme)
                         call ctx%unify(existing_typ, expr_typ)
                     else
-                        ! Assignment to undefined variable - Issue #495
-                        ! Report undefined variable error
-                        error_result = create_error_result( &
-                            "Undefined variable '" // lhs_node%name // "' in assignment", &
-                            ERROR_SEMANTIC, &
-                            component="semantic_analyzer", &
-                            context="infer_assignment", &
-                            suggestion="Declare the variable before assigning to it" &
-                        )
-                        call ctx%errors%add_result(error_result)
+                        ! Assignment to undefined variable - behavior depends on mode
+                        if (ctx%strict_mode) then
+                            ! Standard Fortran mode: undefined variable is an error
+                            error_result = create_error_result( &
+                                "Undefined variable '" // lhs_node%name // "' in assignment", &
+                                ERROR_SEMANTIC, &
+                                component="semantic_analyzer", &
+                                context="infer_assignment", &
+                                suggestion="Declare the variable before assigning to it" &
+                            )
+                            call ctx%errors%add_result(error_result)
+                        end if
                         
-                        ! Continue analysis with inferred type for recovery
+                        ! Continue analysis with inferred type (both modes)
                         expr_typ = ctx%apply_subst_to_type(expr_typ)
                     end if
                     


### PR DESCRIPTION
## Summary
- Fix semantic analysis regression that broke Lazy Fortran undefined variable handling
- Restore proper mode-dependent behavior in semantic analyzer
- Ensure Standard Fortran mode continues to report undefined variables as errors

## Root Cause  
The semantic analyzer was ignoring the `strict_mode` flag and always reporting undefined variables as errors, regardless of compilation mode. This broke Lazy Fortran's core feature of automatic variable inference and declaration.

## Changes
1. **infer_identifier function**: Check `ctx%strict_mode` before reporting undefined variable errors
2. **infer_assignment function**: Check `ctx%strict_mode` before reporting assignment to undefined variable errors  
3. **Lazy Fortran mode**: Auto-declare undefined variables by creating type schemes and adding them to scope
4. **Standard Fortran mode**: Continue existing behavior of reporting undefined variables as errors

## Testing
- Verified mode detection works correctly for both Lazy and Standard Fortran
- Confirmed undefined variable handling respects compilation mode
- Manual testing shows Lazy Fortran code compiles without semantic errors

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>