### PR TITLE
fix: partial fix for print statements missing from output

### DIFF
--- a/src/ast/ast_core.f90
+++ b/src/ast/ast_core.f90
@@ -233,9 +233,8 @@ contains
         node%name = name
         node%uid = generate_uid()
         if (present(body_indices)) then
-            if (size(body_indices) > 0) then
-                node%body_indices = body_indices
-            end if
+            ! Always allocate body_indices to maintain consistency (Issue #600)
+            node%body_indices = body_indices
         end if
         if (present(line)) node%line = line
         if (present(column)) node%column = column

--- a/src/standardizer_declarations.f90
+++ b/src/standardizer_declarations.f90
@@ -99,10 +99,15 @@ contains
         end do
 
         ! Copy remaining statements
-        do i = insert_pos, size(prog%body_indices)
-            new_body_indices(j) = prog%body_indices(i)
-            j = j + 1
-        end do
+        ! Fix for Issue #600: Ensure we preserve existing body when prog%body_indices is not empty
+        if (allocated(prog%body_indices)) then
+            do i = insert_pos, size(prog%body_indices)
+                if (i <= size(prog%body_indices)) then
+                    new_body_indices(j) = prog%body_indices(i)
+                    j = j + 1
+                end if
+            end do
+        end if
 
         ! Update program body
         prog%body_indices = new_body_indices

--- a/test/integration/test_print_fix.f90
+++ b/test/integration/test_print_fix.f90
@@ -1,0 +1,65 @@
+program test_print_fix
+    use iso_fortran_env, only: error_unit
+    implicit none
+    
+    character(len=:), allocatable :: source
+    integer :: output_unit, input_unit
+    character(len=1024) :: line
+    logical :: found_print
+    integer :: io_status, exit_status
+    
+    print *, "Testing Issue #600: Print statements missing from output"
+    
+    ! Create test source file
+    open(newunit=input_unit, file='test_print.f90', status='replace')
+    write(input_unit, '(A)') 'program test'
+    write(input_unit, '(A)') '    print *, "Hello, World!"'
+    write(input_unit, '(A)') 'end program test'
+    close(input_unit)
+    
+    ! Run fortfront on it
+    call execute_command_line('./build/gfortran_*/app/fortfront test_print.f90 > test_print_out.f90 2>&1', exitstat=exit_status)
+    
+    if (exit_status /= 0) then
+        write(error_unit, *) "FAIL: fortfront execution failed with status:", exit_status
+        stop 1
+    end if
+    
+    ! Check output for print statement
+    found_print = .false.
+    open(newunit=output_unit, file='test_print_out.f90', status='old', action='read', iostat=io_status)
+    if (io_status /= 0) then
+        write(error_unit, *) "FAIL: Could not open output file"
+        stop 1
+    end if
+    
+    do
+        read(output_unit, '(A)', iostat=io_status) line
+        if (io_status /= 0) exit
+        
+        if (index(line, 'print') > 0) then
+            found_print = .true.
+            print *, "Found print statement: ", trim(line)
+        end if
+    end do
+    close(output_unit)
+    
+    if (.not. found_print) then
+        write(error_unit, *) "FAIL: Print statement not found in output"
+        write(error_unit, *) "Output file contents:"
+        open(newunit=output_unit, file='test_print_out.f90', status='old')
+        do
+            read(output_unit, '(A)', iostat=io_status) line
+            if (io_status /= 0) exit
+            write(error_unit, '(A)') trim(line)
+        end do
+        close(output_unit)
+        stop 1
+    end if
+    
+    print *, "SUCCESS: Print statement preserved in output"
+    
+    ! Cleanup
+    call execute_command_line('rm -f test_print.f90 test_print_out.f90')
+    
+end program test_print_fix

--- a/test/integration/test_print_parsing.f90
+++ b/test/integration/test_print_parsing.f90
@@ -1,0 +1,62 @@
+program test_print_parsing
+    use iso_fortran_env, only: error_unit
+    use frontend_core
+    use ast_nodes_core
+    use ast_nodes_io
+    implicit none
+    
+    character(len=:), allocatable :: source
+    type(compilation_options_t) :: options
+    character(len=1024) :: error_msg
+    integer :: output_unit, io_status
+    character(len=256) :: line
+    logical :: found_print
+    
+    print *, "Testing print statement parsing"
+    
+    ! Create a temporary source file with print
+    open(newunit=output_unit, file='test_parse.f90', status='replace')
+    write(output_unit, '(A)') 'program test'
+    write(output_unit, '(A)') '    print *, "Hello"'
+    write(output_unit, '(A)') 'end program test'
+    close(output_unit)
+    
+    ! Set up minimal options
+    options%output_file = 'test_parse_out.f90'
+    
+    ! Compile
+    call compile_source('test_parse.f90', options, error_msg)
+    
+    if (len_trim(error_msg) > 0) then
+        print *, "Compilation error:", trim(error_msg)
+        stop 1
+    end if
+    
+    ! Check output
+    found_print = .false.
+    open(newunit=output_unit, file='test_parse_out.f90', status='old', iostat=io_status)
+    if (io_status == 0) then
+        do
+            read(output_unit, '(A)', iostat=io_status) line
+            if (io_status /= 0) exit
+            if (index(line, 'print') > 0) then
+                found_print = .true.
+                print *, "Found:", trim(line)
+            end if
+        end do
+        close(output_unit)
+    end if
+    
+    if (.not. found_print) then
+        print *, "FAIL: No print statement in output"
+        print *, "Output file contents:"
+        call execute_command_line('cat test_parse_out.f90')
+        stop 1
+    end if
+    
+    print *, "SUCCESS: Print statement preserved"
+    
+    ! Cleanup
+    call execute_command_line('rm -f test_parse.f90 test_parse_out.f90')
+    
+end program test_print_parsing


### PR DESCRIPTION
## Summary
- Partial fix for Issue #600 where print statements are completely missing from generated output
- Modified AST node creation to preserve empty body_indices arrays
- Updated standardizer to better handle statement preservation
- Added integration tests demonstrating the issue

## Status
**INCOMPLETE** - Tests still failing. The root cause appears to be in the parsing flow where print statements are not being added to program body indices during initial parsing.

## Problem Analysis
The investigation revealed that:
1. Print statements are correctly tokenized (verified with tokenizer test)
2. The parse_print_statement function exists and should work
3. The issue is that program body_indices remain empty after parsing
4. The program name changes from "test" to "main" suggesting parse_all_statements is being called instead of parse_program_statement

## Test Output
```
program main
    implicit none
end program main
```

Expected:
```
program test
    print *, "Hello, World!"
end program test
```

## Next Steps
- Need to trace through parse_tokens -> parse_program_unit flow
- Determine why body statements aren't being captured
- Fix the parsing to properly populate body_indices

Fixes #600 (partial)

🤖 Generated with [Claude Code](https://claude.ai/code)