### PR TITLE
fix: resolve segmentation fault in do loop parsing (#682)

### DIFF
--- a/src/parser/parser_control_flow.f90
+++ b/src/parser/parser_control_flow.f90
@@ -346,10 +346,13 @@ contains
 
                 ! Move to next statement
                 ! If we stopped at a semicolon, skip over it
-                if (stmt_end + 1 <= size(parser%tokens) .and. &
-                    parser%tokens(stmt_end + 1)%kind == TK_OPERATOR .and. &
-                    parser%tokens(stmt_end + 1)%text == ";") then
-                    parser%current_token = stmt_end + 2
+                if (stmt_end + 1 <= size(parser%tokens)) then
+                    if (parser%tokens(stmt_end + 1)%kind == TK_OPERATOR .and. &
+                        parser%tokens(stmt_end + 1)%text == ";") then
+                        parser%current_token = stmt_end + 2
+                    else
+                        parser%current_token = stmt_end + 1
+                    end if
                 else
                     parser%current_token = stmt_end + 1
                 end if
@@ -579,10 +582,13 @@ contains
 
                 ! Move to next statement
                 ! If we stopped at a semicolon, skip over it
-                if (stmt_end + 1 <= size(parser%tokens) .and. &
-                    parser%tokens(stmt_end + 1)%kind == TK_OPERATOR .and. &
-                    parser%tokens(stmt_end + 1)%text == ";") then
-                    parser%current_token = stmt_end + 2
+                if (stmt_end + 1 <= size(parser%tokens)) then
+                    if (parser%tokens(stmt_end + 1)%kind == TK_OPERATOR .and. &
+                        parser%tokens(stmt_end + 1)%text == ";") then
+                        parser%current_token = stmt_end + 2
+                    else
+                        parser%current_token = stmt_end + 1
+                    end if
                 else
                     parser%current_token = stmt_end + 1
                 end if

--- a/src/semantic/constant_folding.f90
+++ b/src/semantic/constant_folding.f90
@@ -19,7 +19,7 @@ contains
         end do
     end subroutine fold_constants_in_arena
     
-    subroutine fold_node_constants(arena, node_index)
+    recursive subroutine fold_node_constants(arena, node_index)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in) :: node_index
         


### PR DESCRIPTION
## Summary
- Fixed critical segmentation fault in do loop parsing that was causing system crashes
- Resolved array bounds access violations in parser_control_flow.f90
- Added missing recursive attribute to constant folding function

## Changes Made

### parser_control_flow.f90
- Added proper bounds checking before accessing `parser%tokens` array elements
- Nested conditional checks to prevent Fortran's eager evaluation from causing out-of-bounds access
- Fixed lines 582-588 and similar patterns that were accessing `stmt_end+1` without proper guards

### constant_folding.f90
- Added `recursive` attribute to `fold_node_constants` subroutine
- This function needs recursion as it calls itself during binary operation folding

## Test Results
- `test_do_loop_issue_637` now passes without segmentation fault
- Successfully parses simple do loops like `do i = 1, 10`
- Successfully parses do loops with expressions like `do i = n-5, n+5`
- All do loop related tests now pass

## Issue Resolution
Fixes #682 - CRITICAL SYSTEM FAILURE: Do loop parsing causes segfaults

The root cause was improper bounds checking when accessing the tokens array after parsing range expressions in do loops. Fortran evaluates all conditions in an `.and.` statement even if the first is false, which was causing array access violations.

🤖 Generated with [Claude Code](https://claude.ai/code)