### PR TITLE
fix: implement proper CLI argument handling for fortfront executable (fixes #779)

### DIFF
--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -4,42 +4,156 @@ program fortfront_cli
     implicit none
     
     character(len=:), allocatable :: input_text, output_text, error_msg
-    character(len=:), allocatable :: temp_text
+    character(len=:), allocatable :: temp_text, arg_str, filename
     character(len=4096) :: buffer
-    integer :: io_stat, total_size, capacity, line_len
+    integer :: io_stat, total_size, capacity, line_len, file_unit
+    integer :: num_args, arg_len, i
     integer, parameter :: MAX_INPUT_SIZE = 10485760  ! 10MB safety limit
     integer, parameter :: INITIAL_CAPACITY = 8192
+    logical :: from_file, show_help, show_version
     
-    ! Secure line-by-line reading with O(N) memory allocation
+    ! Process command line arguments
+    num_args = command_argument_count()
+    show_help = .false.
+    show_version = .false.
+    from_file = .false.
+    
+    ! Handle command line arguments
+    if (num_args > 0) then
+        call get_command_argument(1, length=arg_len)
+        allocate(character(len=arg_len) :: arg_str)
+        call get_command_argument(1, value=arg_str)
+        
+        if (arg_str == "--help" .or. arg_str == "-h") then
+            show_help = .true.
+        else if (arg_str == "--version" .or. arg_str == "-v") then
+            show_version = .true.
+        else
+            ! Treat as filename
+            from_file = .true.
+            filename = arg_str
+        end if
+    end if
+    
+    ! Handle help option
+    if (show_help) then
+        write(output_unit, '(A)') 'fortfront - Lazy Fortran to Standard Fortran Transpiler'
+        write(output_unit, '(A)') ''
+        write(output_unit, '(A)') 'USAGE:'
+        write(output_unit, '(A)') '    fortfront [OPTIONS] [FILE]'
+        write(output_unit, '(A)') ''
+        write(output_unit, '(A)') 'ARGUMENTS:'
+        write(output_unit, '(A)') '    FILE    Input file (reads from stdin if not specified)'
+        write(output_unit, '(A)') ''
+        write(output_unit, '(A)') 'OPTIONS:'
+        write(output_unit, '(A)') '    -h, --help     Show this help message'
+        write(output_unit, '(A)') '    -v, --version  Show version information'
+        write(output_unit, '(A)') ''
+        write(output_unit, '(A)') 'EXAMPLES:'
+        write(output_unit, '(A)') '    fortfront input.lf        # Transpile file'
+        write(output_unit, '(A)') '    cat input.lf | fortfront  # Transpile from stdin'
+        write(output_unit, '(A)') '    echo "x = 5" | fortfront  # Transpile string'
+        stop 0
+    end if
+    
+    ! Handle version option
+    if (show_version) then
+        write(output_unit, '(A)') 'fortfront 0.1.0'
+        write(output_unit, '(A)') 'Lazy Fortran to Standard Fortran Transpiler'
+        write(output_unit, '(A)') 'https://github.com/krystophny/fortfront'
+        stop 0
+    end if
+    
+    ! Read input (from file or stdin)
     capacity = INITIAL_CAPACITY
     allocate(character(len=capacity) :: input_text)
     total_size = 0
     
-    do
-        ! Read line by line for proper redirection and pipe support
-        read(input_unit, '(A)', iostat=io_stat) buffer
-        
-        ! Handle end conditions
-        if (io_stat == iostat_end) exit
-        if (io_stat > 0) then
-            write(error_unit, '(A)') 'Error reading input'
+    if (from_file) then
+        ! Read from file
+        open(newunit=file_unit, file=filename, status='old', action='read', &
+             iostat=io_stat)
+        if (io_stat /= 0) then
+            write(error_unit, '(A,A)') 'Cannot open file: ', filename
             stop 1
         end if
         
-        ! Get actual line length (trimmed content)
+        do
+            read(file_unit, '(A)', iostat=io_stat) buffer
+            if (io_stat == iostat_end) exit
+            if (io_stat > 0) then
+                write(error_unit, '(A,A)') 'Error reading file: ', filename
+                close(file_unit)
+                stop 1
+            end if
+            
+            call append_line_to_input(buffer, input_text, total_size, capacity)
+        end do
+        close(file_unit)
+    else
+        ! Read from stdin (original behavior preserved)
+        do
+            read(input_unit, '(A)', iostat=io_stat) buffer
+            if (io_stat == iostat_end) exit
+            if (io_stat > 0) then
+                write(error_unit, '(A)') 'Error reading input'
+                stop 1
+            end if
+            
+            call append_line_to_input(buffer, input_text, total_size, capacity)
+        end do
+    end if
+    
+    ! Trim to actual size to save memory
+    if (total_size == 0) then
+        allocate(character(len=0) :: temp_text)
+    else
+        allocate(character(len=total_size) :: temp_text)
+        temp_text = input_text(1:total_size)
+    end if
+    call move_alloc(temp_text, input_text)
+    
+    ! Transform lazy fortran to standard fortran
+    call transform_lazy_fortran_string(input_text, output_text, error_msg)
+    
+    ! Handle errors
+    if (error_msg /= "" .and. index(error_msg, "Cannot open") > 0) then
+        write(error_unit, '(A)') trim(error_msg)
+        stop 1
+    else if (error_msg /= "") then
+        write(error_unit, '(A)') trim(error_msg)
+    end if
+    
+    ! Write output to stdout
+    if (allocated(output_text) .and. len(output_text) > 0) then
+        write(output_unit, '(A)', advance='no') output_text
+    else
+        write(error_unit, '(A)') 'No output generated'
+        stop 1
+    end if
+
+contains
+
+    subroutine append_line_to_input(buffer, input_text, total_size, capacity)
+        character(len=*), intent(in) :: buffer
+        character(len=:), allocatable, intent(inout) :: input_text
+        integer, intent(inout) :: total_size, capacity
+        character(len=:), allocatable :: temp_text
+        integer :: line_len
+        
         line_len = len_trim(buffer)
         
-        ! Security check: prevent memory exhaustion attacks  
-        ! Account for content + newline + potential growth
+        ! Security check: prevent memory exhaustion attacks
         if (total_size + line_len + 1 > MAX_INPUT_SIZE) then
             write(error_unit, '(A,I0,A)') 'Input exceeds maximum size (', &
                 MAX_INPUT_SIZE, ' bytes)'
             stop 1
         end if
         
-        ! Grow buffer if needed (double when full)
+        ! Grow buffer if needed
         if (total_size + line_len + 1 > capacity) then
-            do while (capacity < total_size + line_len + 1 .and. capacity <= MAX_INPUT_SIZE)
+            do while (capacity < total_size + line_len + 1 .and. &
+                     capacity <= MAX_INPUT_SIZE)
                 capacity = min(capacity * 2, MAX_INPUT_SIZE)
             end do
             
@@ -49,7 +163,6 @@ program fortfront_cli
                 stop 1
             end if
             
-            ! Reallocate with larger capacity
             allocate(character(len=capacity) :: temp_text)
             if (total_size > 0) then
                 temp_text(1:total_size) = input_text(1:total_size)
@@ -66,40 +179,6 @@ program fortfront_cli
         ! Always add newline to preserve source structure
         input_text(total_size+1:total_size+1) = new_line('A')
         total_size = total_size + 1
-    end do
-    
-    ! Trim to actual size to save memory
-    if (total_size == 0) then
-        allocate(character(len=0) :: temp_text)
-    else
-        allocate(character(len=total_size) :: temp_text)
-        temp_text = input_text(1:total_size)
-    end if
-    call move_alloc(temp_text, input_text)
-    
-    ! Handle empty input gracefully - no special error messages needed
-    ! Empty input is valid and should generate minimal program
-    
-    ! Transform lazy fortran to standard fortran
-    call transform_lazy_fortran_string(input_text, output_text, error_msg)
-    
-    ! For syntax/parsing errors, the error information is included in output_text
-    ! Only stop with error code for system-level failures
-    if (error_msg /= "" .and. index(error_msg, "Cannot open") > 0) then
-        ! System-level error (file I/O, etc.) - report to stderr and exit with error
-        write(error_unit, '(A)') trim(error_msg)
-        stop 1
-    else if (error_msg /= "") then
-        ! Syntax/parsing error - report to stderr but continue with output
-        write(error_unit, '(A)') trim(error_msg)
-    end if
-    
-    ! Write output to stdout
-    if (allocated(output_text) .and. len(output_text) > 0) then
-        write(output_unit, '(A)', advance='no') output_text
-    else
-        write(error_unit, '(A)') 'No output generated'
-        stop 1
-    end if
+    end subroutine append_line_to_input
     
 end program fortfront_cli


### PR DESCRIPTION
## Summary
- Add command-line argument parsing with get_command_argument  
- Implement --version/-v flag showing version, description and URL
- Implement --help/-h flag with usage information and examples
- Preserve original stdin processing functionality when no args
- Add file input support when filename provided as argument
- Refactor input processing into reusable append_line_to_input subroutine

## Technical Verification Evidence
- FMP Build Status: SUCCESS - compiled without errors
- Test Results: ALL LEGACY TESTS PASSING - verified no regressions 
- CLI Behavior Verified:
  * `fortfront --version` outputs proper version information
  * `fortfront --help` shows usage and examples
  * `echo "x=5" | fortfront` preserves original stdin functionality
  * `fortfront file.lf` handles file input correctly
  * Invalid options treated as filenames with appropriate error handling

## Root Cause Analysis
Previously `fortfront --version` output debug test program instead of version info because:
- No command-line argument processing implemented
- All input treated as stdin Lazy Fortran code to transpile
- CLI flags processed as source code input

## Test plan
- [x] Verify --version outputs proper version information
- [x] Verify --help shows comprehensive usage guide  
- [x] Verify stdin processing unchanged (backward compatibility)
- [x] Verify file input functionality works correctly
- [x] Verify error handling for invalid files
- [x] Run full test suite to ensure no regressions
- [x] Verify build system compatibility (FMP working)

Fixes #779

🤖 Generated with [Claude Code](https://claude.ai/code)