### PR TITLE
fix: replace STOP statements with proper exit() calls - Issue #806

### DIFF
--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -10,6 +10,8 @@ program fortfront_cli
     integer :: num_args, arg_len, i
     integer, parameter :: MAX_INPUT_SIZE = 10485760  ! 10MB safety limit
     integer, parameter :: INITIAL_CAPACITY = 8192
+    integer, parameter :: EXIT_SUCCESS = 0
+    integer, parameter :: EXIT_FAILURE = 1
     logical :: from_file, show_help, show_version
     
     ! Process command line arguments
@@ -53,7 +55,7 @@ program fortfront_cli
         write(output_unit, '(A)') '    fortfront input.lf        # Transpile file'
         write(output_unit, '(A)') '    cat input.lf | fortfront  # Transpile from stdin'
         write(output_unit, '(A)') '    echo "x = 5" | fortfront  # Transpile string'
-        stop 0
+        call exit(EXIT_SUCCESS)
     end if
     
     ! Handle version option
@@ -61,7 +63,7 @@ program fortfront_cli
         write(output_unit, '(A)') 'fortfront 0.1.0'
         write(output_unit, '(A)') 'Lazy Fortran to Standard Fortran Transpiler'
         write(output_unit, '(A)') 'https://github.com/krystophny/fortfront'
-        stop 0
+        call exit(EXIT_SUCCESS)
     end if
     
     ! Read input (from file or stdin)
@@ -75,7 +77,7 @@ program fortfront_cli
              iostat=io_stat)
         if (io_stat /= 0) then
             write(error_unit, '(A,A)') 'Cannot open file: ', filename
-            stop 1
+            call exit(EXIT_FAILURE)
         end if
         
         do
@@ -84,7 +86,7 @@ program fortfront_cli
             if (io_stat > 0) then
                 write(error_unit, '(A,A)') 'Error reading file: ', filename
                 close(file_unit)
-                stop 1
+                call exit(EXIT_FAILURE)
             end if
             
             call append_line_to_input(buffer, input_text, total_size, capacity)
@@ -97,7 +99,7 @@ program fortfront_cli
             if (io_stat == iostat_end) exit
             if (io_stat > 0) then
                 write(error_unit, '(A)') 'Error reading input'
-                stop 1
+                call exit(EXIT_FAILURE)
             end if
             
             call append_line_to_input(buffer, input_text, total_size, capacity)
@@ -119,7 +121,7 @@ program fortfront_cli
     ! Handle errors
     if (error_msg /= "" .and. index(error_msg, "Cannot open") > 0) then
         write(error_unit, '(A)') trim(error_msg)
-        stop 1
+        call exit(EXIT_FAILURE)
     else if (error_msg /= "") then
         write(error_unit, '(A)') trim(error_msg)
     end if
@@ -129,7 +131,7 @@ program fortfront_cli
         write(output_unit, '(A)', advance='no') output_text
     else
         write(error_unit, '(A)') 'No output generated'
-        stop 1
+        call exit(EXIT_FAILURE)
     end if
 
 contains
@@ -147,7 +149,7 @@ contains
         if (total_size + line_len + 1 > MAX_INPUT_SIZE) then
             write(error_unit, '(A,I0,A)') 'Input exceeds maximum size (', &
                 MAX_INPUT_SIZE, ' bytes)'
-            stop 1
+            call exit(EXIT_FAILURE)
         end if
         
         ! Grow buffer if needed
@@ -160,7 +162,7 @@ contains
             if (capacity > MAX_INPUT_SIZE) then
                 write(error_unit, '(A,I0,A)') 'Input exceeds maximum size (', &
                     MAX_INPUT_SIZE, ' bytes)'
-                stop 1
+                call exit(EXIT_FAILURE)
             end if
             
             allocate(character(len=capacity) :: temp_text)


### PR DESCRIPTION
## Summary
- Replace all STOP 0/1 statements in CLI application with proper `call exit()` using EXIT_SUCCESS/EXIT_FAILURE constants
- Eliminate unprofessional STOP statement output visible to users
- Maintain identical error handling behavior with clean CLI standards compliance

## Technical Changes
- **Root Cause**: STOP statements were printing to stdout/stderr, violating CLI standards
- **Solution**: Use `iso_fortran_env` `call exit()` with proper integer constants
- **Scope**: Only CLI application (`app/fortfront.f90`) - test files unchanged
- **Compatibility**: GCC 15.2.1 compatible implementation using standard intrinsics

## Test Evidence
### Before Fix:
```bash
./fortfront --version
# Output: fortfront 0.1.0 ... STOP 0

./fortfront nonexistent.lf  
# Output: Cannot open file: nonexistent.lf
#         STOP 1
```

### After Fix:
```bash  
./fortfront --version && echo "Exit code: $?"
# Output: fortfront 0.1.0
#         Lazy Fortran to Standard Fortran Transpiler
#         https://github.com/krystophny/fortfront
#         Exit code: 0

./fortfront nonexistent.lf; echo "Exit code: $?"
# Output: Cannot open file: nonexistent.lf
#         Exit code: 1
```

## Verification Checklist
- [x] --version: Clean output, exit code 0 (no STOP 0)
- [x] --help: Clean output, exit code 0 (no STOP 0)
- [x] File errors: Clean error message, exit code 1 (no STOP 1)
- [x] Build system: CMAKE compilation successful
- [x] CI tests: Full test suite passes
- [x] Professional CLI: No visible STOP statements in any case

## Professional CLI Standards Achieved
- ✅ Clean termination without internal Fortran messages
- ✅ Proper UNIX exit codes (0=success, 1=failure)  
- ✅ Professional user experience for scripting/automation
- ✅ Maintains all existing functionality and error handling

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>