### PR TITLE
fix: resolve semantic_context_t vtable interface mismatch blocking CI system

### DIFF
--- a/src/semantic/analyzers/semantic_analyzer.f90
+++ b/src/semantic/analyzers/semantic_analyzer.f90
@@ -37,6 +37,7 @@ module semantic_analyzer
     use constant_transformation, only: fold_constants_in_arena
     use error_handling, only: error_collection_t, create_error_collection, result_t, &
                                create_error_result, ERROR_SEMANTIC
+    use semantic_context_types, only: semantic_context_base_t
     implicit none
     private
 
@@ -46,7 +47,7 @@ module semantic_analyzer
     public :: has_semantic_errors
 
     ! Semantic analysis context
-    type :: semantic_context_t
+    type, extends(semantic_context_base_t) :: semantic_context_t
         type(scope_stack_t) :: scopes  ! Hierarchical scope management
         integer :: next_var_id = 0
         type(substitution_t) :: subst
@@ -69,6 +70,9 @@ module semantic_analyzer
         procedure :: validate_bounds => validate_array_access_bounds
         procedure :: check_conformance => check_array_shape_conformance
         procedure :: has_errors => semantic_context_has_errors
+        ! Implement required abstract procedures from semantic_context_base_t
+        procedure :: get_context_name => semantic_get_context_name
+        procedure :: clone_context => semantic_clone_context
         generic :: assignment(=) => assign
     end type semantic_context_t
 
@@ -79,6 +83,12 @@ contains
         type(semantic_context_t) :: ctx
         type(poly_type_t) :: builtin_scheme
         type(mono_type_t) :: real_to_real, real_type
+        
+        ! Initialize base class components
+        ctx%context_id = 1
+        ctx%context_name = "semantic_context"
+        
+        ! Initialize basic components
         ctx%scopes = create_scope_stack()
         ctx%subst%count = 0
         ctx%param_tracker%count = 0
@@ -996,5 +1006,34 @@ contains
         
         if (ctx%strict_mode .and. ctx%errors%has_errors()) return
     end subroutine check_undefined_variables_internal
+
+    ! Implementation of required abstract procedures from semantic_context_base_t
+    
+    ! Get context name
+    function semantic_get_context_name(this) result(name)
+        class(semantic_context_t), intent(in) :: this
+        character(:), allocatable :: name
+        name = "semantic_context"
+    end function semantic_get_context_name
+    
+    ! Clone context (simplified implementation)  
+    function semantic_clone_context(this) result(cloned)
+        class(semantic_context_t), intent(in) :: this
+        class(semantic_context_base_t), allocatable :: cloned
+        type(semantic_context_t) :: temp_context
+        
+        ! Copy basic components - simplified for compatibility
+        temp_context%context_id = this%context_id
+        temp_context%context_name = this%context_name
+        temp_context%scopes = this%scopes
+        temp_context%next_var_id = this%next_var_id
+        temp_context%subst = this%subst
+        temp_context%param_tracker = this%param_tracker
+        temp_context%temp_tracker = this%temp_tracker
+        temp_context%errors = this%errors
+        temp_context%strict_mode = this%strict_mode
+        
+        allocate(cloned, source=temp_context)
+    end function semantic_clone_context
 
 end module semantic_analyzer

--- a/src/semantic/analyzers/semantic_analyzer.f90
+++ b/src/semantic/analyzers/semantic_analyzer.f90
@@ -56,6 +56,10 @@ module semantic_analyzer
         type(error_collection_t) :: errors  ! Collect semantic errors
         logical :: strict_mode = .false.  ! True for standard Fortran (implicit none), false for lazy Fortran
     contains
+        ! Implement required abstract procedures from semantic_context_base_t FIRST
+        procedure :: get_context_name => semantic_get_context_name
+        procedure :: clone_context => semantic_clone_context
+        ! Other procedures
         procedure :: infer => infer_type
         procedure :: infer_stmt => infer_statement_type
         procedure :: unify => unify_types
@@ -70,9 +74,6 @@ module semantic_analyzer
         procedure :: validate_bounds => validate_array_access_bounds
         procedure :: check_conformance => check_array_shape_conformance
         procedure :: has_errors => semantic_context_has_errors
-        ! Implement required abstract procedures from semantic_context_base_t
-        procedure :: get_context_name => semantic_get_context_name
-        procedure :: clone_context => semantic_clone_context
         generic :: assignment(=) => assign
     end type semantic_context_t
 

--- a/src/semantic/pipeline/semantic_pipeline_integration.f90
+++ b/src/semantic/pipeline/semantic_pipeline_integration.f90
@@ -32,9 +32,8 @@ contains
         ! Run traditional semantic analysis first for compatibility
         call analyze_program(local_context, arena, node_index)
         
-        ! Run pipeline analyzers - type hierarchy fixed but not enabled yet
-        ! Pipeline integration requires additional interface work for production stability
-        ! call pipeline%run_analysis(arena, node_index, local_context)
+        ! Run pipeline analyzers - now enabled with correct vtable interface
+        call pipeline%run_analysis(arena, node_index, local_context)
         
         ! Return context if provided
         if (present(context)) then


### PR DESCRIPTION
## Summary
- Fixed critical vtable interface mismatch in semantic_context_t that was blocking Sprint #4 CI system
- Extended semantic_context_t to properly inherit from semantic_context_base_t 
- Restored pipeline integration functionality that was disabled due to type hierarchy issues

## Test plan
- [x] test_analysis_plugins compiles and executes successfully
- [x] All 5 analysis plugins register without vtable errors
- [x] Pipeline integration runs with correct type interface
- [x] Broader test suite continues to pass without regressions
- [x] CI system unblocked for multisprint development workflow

🤖 Generated with [Claude Code](https://claude.ai/code)