### PR TITLE
fix: resolve segmentation fault in scope_manager create_scope_stack

### DIFF
--- a/src/semantic/scope_manager.f90
+++ b/src/semantic/scope_manager.f90
@@ -84,12 +84,27 @@ contains
     ! Create a new scope stack with global scope
     function create_scope_stack() result(stack)
         type(scope_stack_t) :: stack
+        integer :: i, j
 
         ! Initialize capacity and create global scope
         stack%capacity = 10
         allocate (stack%scopes(stack%capacity))
+        
+        ! CRITICAL FIX: Initialize allocated scopes to prevent segfault
+        ! Only initialize structure-level components, not massive fixed arrays
+        ! The type_env_t fixed arrays have default initializers that should work
+        do i = 1, stack%capacity
+            stack%scopes(i)%scope_type = SCOPE_GLOBAL
+            stack%scopes(i)%name = ""
+            ! env components should use default initializers (count=0, capacity=MAX_ENV_SIZE)
+            ! Fixed arrays (names, schemes) don't need explicit initialization for unused elements
+        end do
+        
         stack%depth = 1
-        stack%scopes(1) = create_scope(SCOPE_GLOBAL, "global")
+        ! Initialize first scope directly without assignment to avoid massive copy
+        stack%scopes(1)%scope_type = SCOPE_GLOBAL
+        stack%scopes(1)%name = "global"
+        ! env is already initialized by type defaults
 
     end function create_scope_stack
 


### PR DESCRIPTION
## Summary
- Fixes critical segmentation fault in build D2DB1B1DCEEACEFA when processing basic input 'x = 5\ny = x + 3'
- Root cause: Memory corruption during scope stack initialization due to massive type_env_t copying
- Solution: Direct scope initialization without assignment-based copying of large fixed arrays

## Technical Details
**Problem Analysis:**
- GDB backtrace showed segfault in `__scope_manager_MOD_create_scope_stack`
- Issue occurred during malloc call when copying scope with large type_env_t (10,240 poly_type_t elements)
- Assignment `stack%scopes(1) = create_scope(SCOPE_GLOBAL, "global")` triggered massive memory copy

**Root Cause:**
- `type_env_t` contains fixed arrays: `schemes(MAX_ENV_SIZE)` where `MAX_ENV_SIZE = 10240`
- Each `poly_type_t` has complex structure with pointers and handles
- Assignment operator triggered deep copy of entire 10,240-element array
- Memory allocation failure during this massive copy operation

**Solution:**
- Replaced assignment with direct field initialization
- Eliminated problematic scope assignment that caused large memory operations
- Maintained all scope functionality while avoiding memory corruption

## Test Evidence
**Before Fix:**
```bash
echo 'x = 5\ny = x + 3' | ./build/gfortran_D2DB1B1DCEEACEFA/app/fortfront
# Result: Segmentation fault (core dumped)
```

**After Fix:**
```bash
echo 'x = 5\ny = x + 3' | ./build/gfortran_D2DB1B1DCEEACEFA/app/fortfront
# Result: 
program main
    implicit none
    integer :: x
    integer :: y
    x = 5
    y = x + 3
end program main
```

**Local Test Validation:**
- ✅ Segfault-specific test: `fpm test test_undefined_var_segfault` - ALL PASS
- ✅ Semantic system test: `fmp test test_semantic_simple` - ALL PASS 
- ✅ Build system: Clean compilation successful
- ✅ Both file and stdin input modes working correctly

## Files Modified
- `/home/ert/code/fortfront/src/semantic/scope_manager.f90` - Fixed create_scope_stack initialization

Fixes #1057

🤖 Generated with [Claude Code](https://claude.ai/code)