### PR TITLE
fix: CRITICAL: Stray file sample_fluff_tool.f90 causes compilation er (fixes #864)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ all: build
 
 # Build the project
 build:
+	# Ensure stray root artifacts (e.g., *.f90 from samples/tests) don't pollute builds
+	$(MAKE) -s clean-test-artifacts
 	fpm build --flag "-cpp -fmax-stack-var-size=65536"
 
 # Create libfortfront.a in project root for external linking


### PR DESCRIPTION
### **User description**
Problem: stray root Fortran file (sample_fluff_tool.f90) can be picked up by non-fpm builds and cause module resolution errors.\n\nSolution: ensure 'make build' cleans root-level artifacts (including *.f90) before invoking fpm, preventing accidental compilation of sample/test files by external build tooling.\n\nEvidence: baseline before/after 'make build' succeeds; fpm tests run with expected XFAILs and no new failures. See logs in last_test_after_change.log.\n\nScope: focused Makefile change only; no unrelated code modifications.


___

### **PR Type**
Bug fix


___

### **Description**
- Clean stray root artifacts before build to prevent compilation errors

- Add `clean-test-artifacts` target call in build process

- Fix module resolution issues caused by sample files


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Process"] --> B["Clean Test Artifacts"]
  B --> C["FMP Build"]
  C --> D["Successful Compilation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Add artifact cleanup to build target</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Add <code>clean-test-artifacts</code> call before <code>fpm build</code><br> <li> Include explanatory comment about preventing artifact pollution</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1143/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

