### PR TITLE
fix: CRITICAL CLI DEFECT: Error exit codes return 0 instead of non-zero (fixes #837)

### DIFF
--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -35,7 +35,7 @@ program fortfront_cli
             write(error_unit, '(A,A)') 'Error: Unknown option ', trim(arg_str)
             write(error_unit, '(A)') ''
             write(error_unit, '(A)') 'Try ''fortfront --help'' for usage information.'
-            call exit(EXIT_FAILURE)
+            error stop EXIT_FAILURE
         else
             ! Treat as filename
             from_file = .true.
@@ -48,7 +48,7 @@ program fortfront_cli
             write(error_unit, '(A)') 'fortfront processes one file at a time or reads from stdin.'
             write(error_unit, '(A)') ''
             write(error_unit, '(A)') 'Try ''fortfront --help'' for usage information.'
-            call exit(EXIT_FAILURE)
+            error stop EXIT_FAILURE
         end if
     end if
     
@@ -70,7 +70,7 @@ program fortfront_cli
         write(output_unit, '(A)') '    fortfront input.lf        # Transpile file'
         write(output_unit, '(A)') '    cat input.lf | fortfront  # Transpile from stdin'
         write(output_unit, '(A)') '    echo "x = 5" | fortfront  # Transpile string'
-        call exit(EXIT_SUCCESS)
+        stop EXIT_SUCCESS
     end if
     
     ! Handle version option
@@ -78,7 +78,7 @@ program fortfront_cli
         write(output_unit, '(A)') 'fortfront 0.1.0'
         write(output_unit, '(A)') 'Lazy Fortran to Standard Fortran Transpiler'
         write(output_unit, '(A)') 'https://github.com/krystophny/fortfront'
-        call exit(EXIT_SUCCESS)
+        stop EXIT_SUCCESS
     end if
     
     ! Read input (from file or stdin)
@@ -92,7 +92,7 @@ program fortfront_cli
              iostat=io_stat)
         if (io_stat /= 0) then
             write(error_unit, '(A,A)') 'Cannot open file: ', filename
-            call exit(EXIT_FAILURE)
+            error stop EXIT_FAILURE
         end if
         
         do
@@ -101,7 +101,7 @@ program fortfront_cli
             if (io_stat > 0) then
                 write(error_unit, '(A,A)') 'Error reading file: ', filename
                 close(file_unit)
-                call exit(EXIT_FAILURE)
+                error stop EXIT_FAILURE
             end if
             
             call append_line_to_input(buffer, input_text, total_size, capacity)
@@ -114,7 +114,7 @@ program fortfront_cli
             if (io_stat == iostat_end) exit
             if (io_stat > 0) then
                 write(error_unit, '(A)') 'Error reading input'
-                call exit(EXIT_FAILURE)
+                error stop EXIT_FAILURE
             end if
             
             call append_line_to_input(buffer, input_text, total_size, capacity)
@@ -136,7 +136,7 @@ program fortfront_cli
     ! Handle errors
     if (error_msg /= "" .and. index(error_msg, "Cannot open") > 0) then
         write(error_unit, '(A)') trim(error_msg)
-        call exit(EXIT_FAILURE)
+        error stop EXIT_FAILURE
     else if (error_msg /= "") then
         write(error_unit, '(A)') trim(error_msg)
     end if
@@ -146,7 +146,7 @@ program fortfront_cli
         write(output_unit, '(A)', advance='no') output_text
     else
         write(error_unit, '(A)') 'No output generated'
-        call exit(EXIT_FAILURE)
+        error stop EXIT_FAILURE
     end if
 
 contains
@@ -164,7 +164,7 @@ contains
         if (total_size + line_len + 1 > MAX_INPUT_SIZE) then
             write(error_unit, '(A,I0,A)') 'Input exceeds maximum size (', &
                 MAX_INPUT_SIZE, ' bytes)'
-            call exit(EXIT_FAILURE)
+            error stop EXIT_FAILURE
         end if
         
         ! Grow buffer if needed
@@ -177,7 +177,7 @@ contains
             if (capacity > MAX_INPUT_SIZE) then
                 write(error_unit, '(A,I0,A)') 'Input exceeds maximum size (', &
                     MAX_INPUT_SIZE, ' bytes)'
-                call exit(EXIT_FAILURE)
+                error stop EXIT_FAILURE
             end if
             
             allocate(character(len=capacity) :: temp_text)

--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -133,12 +133,10 @@ program fortfront_cli
     ! Transform lazy fortran to standard fortran
     call transform_lazy_fortran_string(input_text, output_text, error_msg)
     
-    ! Handle errors
-    if (error_msg /= "" .and. index(error_msg, "Cannot open") > 0) then
+    ! Handle errors: any error message implies non-zero exit
+    if (error_msg /= "") then
         write(error_unit, '(A)') trim(error_msg)
         error stop EXIT_FAILURE
-    else if (error_msg /= "") then
-        write(error_unit, '(A)') trim(error_msg)
     end if
     
     ! Write output to stdout

--- a/test/system/test_cli_integration.f90
+++ b/test/system/test_cli_integration.f90
@@ -214,7 +214,7 @@ contains
         ! Clean up test files
         call execute_command_line('rm -f test_output2.txt test_error2.txt', exitstat=exit_code)
         
-        ! Should still exit successfully but output should contain error markers
+        ! Invalid source input should not crash; current design returns 0
         success = (exit_code == 0)
         
         call test_result(success)

--- a/test/system/test_cli_integration.f90
+++ b/test/system/test_cli_integration.f90
@@ -191,7 +191,7 @@ contains
     end subroutine test_basic_io
     
     subroutine test_error_handling()
-        integer :: exit_code
+        integer :: exit_code, run_status
         character(len=512) :: command
         character(len=:), allocatable :: executable_path
         logical :: success
@@ -209,30 +209,39 @@ contains
         ! Run with invalid input
         command = 'echo "invalid fortran code @#$%" | ' // executable_path // ' > ' // &
                   'test_output2.txt 2>test_error2.txt'
-        call execute_command_line(command, exitstat=exit_code)
+        call execute_command_line(command, exitstat=run_status)
         
         ! Clean up test files
         call execute_command_line('rm -f test_output2.txt test_error2.txt', exitstat=exit_code)
         
         ! Invalid source input should not crash; current design returns 0
-        success = (exit_code == 0)
+        success = (run_status == 0)
         
         call test_result(success)
         if (.not. success) then
             print *, "  Error handling failed"
-            print *, "  Exit code: ", exit_code
+            print *, "  Exit code: ", run_status
         end if
     end subroutine test_error_handling
 
     subroutine test_invalid_flag_exit_code()
         integer :: exit_code, run_status
         character(len=512) :: command
+        character(len=:), allocatable :: executable_path
         logical :: success
 
         call test_start("Unknown flag returns non-zero exit")
 
-        ! Use fpm run to ensure the current build is used
-        command = 'fpm run -- --nonexistent-flag > test_output_flag.txt 2>test_error_flag.txt'
+        ! Find the fortfront executable
+        executable_path = find_fortfront_executable()
+        if (len(executable_path) == 0) then
+            call test_result(.false.)
+            print *, "  ERROR: Could not locate fortfront executable"
+            return
+        end if
+
+        ! Run with an unknown flag; expect non-zero exit
+        command = executable_path // ' --nonexistent-flag > test_output_flag.txt 2>test_error_flag.txt'
         call execute_command_line(command, exitstat=run_status)
 
         ! Clean up test files

--- a/test/system/test_cli_integration.f90
+++ b/test/system/test_cli_integration.f90
@@ -36,7 +36,10 @@ program test_cli_integration
     
     ! Test 2: Error handling works
     call test_error_handling()
-    
+
+    ! Test 2b: Unknown flag returns non-zero exit code
+    call test_invalid_flag_exit_code()
+
     ! Test 3: Empty input handling
     call test_empty_input()
     
@@ -140,7 +143,7 @@ contains
     
     
     subroutine test_basic_io()
-        integer :: exit_code
+        integer :: exit_code, run_status
         character(len=1000) :: output_line
         character(len=512) :: command
         character(len=:), allocatable :: executable_path
@@ -159,9 +162,9 @@ contains
         ! Run: echo "print *, 'test'" | fortfront
         command = 'echo "print *, ''test''" | ' // executable_path // ' > ' // &
                   'test_output.txt 2>test_error.txt'
-        call execute_command_line(command, exitstat=exit_code)
+        call execute_command_line(command, exitstat=run_status)
         
-        success = (exit_code == 0)
+        success = (run_status == 0)
         
         if (success) then
             ! Check if output contains expected Fortran code
@@ -183,7 +186,7 @@ contains
         if (.not. success) then
             print *, "  Failed to run basic CLI command"
             print *, "  Executable path: ", executable_path
-            print *, "  Exit code: ", exit_code
+            print *, "  Exit code: ", run_status
         end if
     end subroutine test_basic_io
     
@@ -220,6 +223,29 @@ contains
             print *, "  Exit code: ", exit_code
         end if
     end subroutine test_error_handling
+
+    subroutine test_invalid_flag_exit_code()
+        integer :: exit_code, run_status
+        character(len=512) :: command
+        logical :: success
+
+        call test_start("Unknown flag returns non-zero exit")
+
+        ! Use fpm run to ensure the current build is used
+        command = 'fpm run -- --nonexistent-flag > test_output_flag.txt 2>test_error_flag.txt'
+        call execute_command_line(command, exitstat=run_status)
+
+        ! Clean up test files
+        call execute_command_line('rm -f test_output_flag.txt test_error_flag.txt', exitstat=exit_code)
+
+        success = (run_status /= 0)
+
+        call test_result(success)
+        if (.not. success) then
+            print *, "  Expected non-zero exit for unknown flag"
+            print *, "  Exit code: ", run_status
+        end if
+    end subroutine test_invalid_flag_exit_code
     
     subroutine test_empty_input()
         integer :: exit_code


### PR DESCRIPTION
Fixes CLI to return non-zero on errors (invalid flags).

- Change: use STOP codes and ensure unknown flag path exits with non-zero.
- Tests: add explicit unknown-flag exit test; keep invalid-input test behavior.
- Evidence: `fortfront --nonexistent-flag` now exits 1.