### PR TITLE
test(runner): enforce 300s per-test timeout to prevent hangs

### DIFF
--- a/scripts/xfail_runner.sh
+++ b/scripts/xfail_runner.sh
@@ -5,15 +5,31 @@ exe="$1"
 name=$(basename "$exe")
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
 xfail_file="$repo_root/test/xfail.csv"
+
+# Per-repo policy: enforce a strict 300s cap for all test runs
+# Allow override via TIME_LIMIT env var for local experimentation
+TIME_LIMIT=${TIME_LIMIT:-300}
+
 issue=""
 if [[ -f "$xfail_file" ]]; then
   issue=$(awk -F, -v n="$name" 'BEGIN{found=""} $1==n{found=$2} END{print found}' "$xfail_file")
 fi
 
 mkdir -p "$repo_root/logs"
-"$exe" > "$repo_root/logs/${name}.log" 2>&1 || code=$? || code=0
+
+# Run the test with a timeout; capture exit code robustly
+code=0
+if command -v timeout >/dev/null 2>&1; then
+  # Send SIGTERM at TIME_LIMIT, escalate to SIGKILL after 5s, preserve exit code
+  timeout --preserve-status -k 5s "${TIME_LIMIT}s" "$exe" \
+    > "$repo_root/logs/${name}.log" 2>&1 || code=$? || code=0
+else
+  # Fallback: no timeout available; still run and capture code
+  "$exe" > "$repo_root/logs/${name}.log" 2>&1 || code=$? || code=0
+fi
 code=${code:-0}
 
+# Interpret results, including timeout exit (124)
 if [[ $code -eq 0 ]]; then
   if [[ -n "$issue" ]]; then
     echo "[XPASS] $name (was xfail: $issue)"
@@ -21,6 +37,15 @@ if [[ $code -eq 0 ]]; then
     echo "[PASS] $name"
   fi
   exit 0
+elif [[ $code -eq 124 ]]; then
+  # Timeout
+  if [[ -n "$issue" ]]; then
+    echo "[XFAIL] $name -> timeout after ${TIME_LIMIT}s ($issue)"
+    exit 0
+  else
+    echo "[FAIL] $name -> timeout after ${TIME_LIMIT}s (see logs/${name}.log)"
+    exit 1
+  fi
 else
   if [[ -n "$issue" ]]; then
     echo "[XFAIL] $name -> exit=$code ($issue)"
@@ -30,4 +55,3 @@ else
     exit 1
   fi
 fi
-

--- a/scripts/xfail_runner.sh
+++ b/scripts/xfail_runner.sh
@@ -20,8 +20,9 @@ mkdir -p "$repo_root/logs"
 # Run the test with a timeout; capture exit code robustly
 code=0
 if command -v timeout >/dev/null 2>&1; then
-  # Send SIGTERM at TIME_LIMIT, escalate to SIGKILL after 5s, preserve exit code
-  timeout --preserve-status -k 5s "${TIME_LIMIT}s" "$exe" \
+  # Send SIGTERM at TIME_LIMIT, escalate to SIGKILL after 5s.
+  # Do not preserve child status so timeout returns 124 on timeout consistently.
+  timeout -k 5s "${TIME_LIMIT}s" "$exe" \
     > "$repo_root/logs/${name}.log" 2>&1 || code=$? || code=0
 else
   # Fallback: no timeout available; still run and capture code


### PR DESCRIPTION
This PR enforces a strict 300s timeout per test in scripts/xfail_runner.sh using `timeout -k 5s`.\n\nWhy\n- Prevent indefinite hangs and align with repo testing policy (strict 300s cap).\n\nWhat\n- Add TIME_LIMIT env override (default 300).\n- Treat timeout (exit 124) as FAIL unless listed in xfail.csv (then XFAIL).\n- Log remains in logs/<test>.log.\n\nEvidence (local)\n- Baseline: `timeout 300s make -s test` completed; the suite ran successfully, with one failure earlier now fixed in branch (test_implicit_none_dedup).\n- After change: `timeout 300s make -s test` completed; per-test cap enforced; no hangs observed.\n- Manual simulation: validated PASS (exit 0), FAIL (exit 2), and TIMEOUT (exit 124) cases with temporary scripts.\n\nHow to use\n- Adjust per-test cap: `TIME_LIMIT=120 make test`.\n\nScope\n- Only scripts/xfail_runner.sh changed. No binaries/artifacts committed.