### PR TITLE
fix: log ignore + cleanup (fixes #1100)

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -4,18 +4,16 @@ set -euo pipefail
 # Prevent committing log/output files accidentally
 blocked_patterns=("*.log" "*.err" "*.out" "logs/*")
 
-# Collect staged files
-staged=$(git diff --cached --name-only)
-
+# Collect staged files (NUL-delimited to handle spaces/newlines safely)
 block=false
-for f in $staged; do
+while IFS= read -r -d '' f; do
   for pat in "${blocked_patterns[@]}"; do
     if [[ $f == $pat ]]; then
       echo "Pre-commit: refusing to commit '$f' (matches $pat)" >&2
       block=true
     fi
   done
-done
+done < <(git diff --cached --name-only -z)
 
 if $block; then
   echo "Remove these files from the commit or update .gitignore." >&2
@@ -23,4 +21,3 @@ if $block; then
 fi
 
 exit 0
-

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prevent committing log/output files accidentally
+blocked_patterns=("*.log" "*.err" "*.out" "logs/*")
+
+# Collect staged files
+staged=$(git diff --cached --name-only)
+
+block=false
+for f in $staged; do
+  for pat in "${blocked_patterns[@]}"; do
+    if [[ $f == $pat ]]; then
+      echo "Pre-commit: refusing to commit '$f' (matches $pat)" >&2
+      block=true
+    fi
+  done
+done
+
+if $block; then
+  echo "Remove these files from the commit or update .gitignore." >&2
+  exit 1
+fi
+
+exit 0
+

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,9 @@ test_old_api.o
 *.a
 *.so
 
-# Log files
+# Log files and outputs
 *.log
+*.err
+*.out
+logs/
 examples/external_tool_example

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test coverage clean clean-coverage clean-test-artifacts help install libfortfront.a example
+.PHONY: all build test coverage clean clean-coverage clean-test-artifacts clean-logs help install libfortfront.a example setup-githooks
 
 # Default target
 all: build
@@ -157,3 +157,9 @@ help:
 	@echo "  make clean-coverage - Clean coverage files only"
 	@echo "  make clean-test-artifacts - Clean test temporary files only"
 	@echo "  make help     - Show this help message"
+	@echo "  make setup-githooks - Configure repo to use .githooks/"
+
+# Configure git to use the repo's githooks directory
+setup-githooks:
+	@git config core.hooksPath .githooks
+	@echo "Configured git core.hooksPath to .githooks"

--- a/Makefile
+++ b/Makefile
@@ -68,6 +68,7 @@ install: libfortfront.a
 # Run tests
 test:
 	# Ensure a clean workspace before running tests and remove artifacts after
+	$(MAKE) -s clean-logs
 	$(MAKE) -s clean-test-artifacts
 	fpm test --runner "scripts/xfail_runner.sh"
 	$(MAKE) -s clean-test-artifacts
@@ -111,6 +112,7 @@ clean: clean-test-artifacts
 	fpm clean --all
 	rm -f libfortfront.a
 	rm -rf fortfront_modules/
+	$(MAKE) -s clean-logs
 
 # Clean coverage files only
 clean-coverage:
@@ -133,6 +135,13 @@ clean-test-artifacts:
 		test_simple_plugin_registry test_standalone_events test_output \
 		debug_error_test debug_*_test 2>/dev/null || true
 	@echo "Test artifacts cleaned"
+
+# Clean logs to prevent accumulation
+clean-logs:
+	@echo "Cleaning old log files..."
+	rm -f *.log *.err *.out 2>/dev/null || true
+	find logs -type f -name '*.log' -delete 2>/dev/null || true
+	@echo "Logs cleaned"
 
 # Help target
 help:

--- a/scripts/xfail_runner.sh
+++ b/scripts/xfail_runner.sh
@@ -17,6 +17,14 @@ fi
 
 mkdir -p "$repo_root/logs"
 
+# Prune old logs to prevent repository bloat (infra hygiene)
+# - Remove logs older than LOG_RETENTION_DAYS (default: 7)
+# - Keep directory tidy but non-destructive for recent runs
+LOG_RETENTION_DAYS=${LOG_RETENTION_DAYS:-7}
+if [ -d "$repo_root/logs" ]; then
+  find "$repo_root/logs" -type f -name '*.log' -mtime +"$LOG_RETENTION_DAYS" -delete 2>/dev/null || true
+fi
+
 # Internal helper: run a command with a timeout even if GNU timeout is absent.
 # Behavior:
 # - Returns 124 on timeout, mirroring GNU timeout.


### PR DESCRIPTION
- Add *.err, *.out and logs/ to .gitignore\n- Prune old logs in test runner (LOG_RETENTION_DAYS, default 7)\n- Add clean-logs target; invoked by make test/clean\n- Add repo pre-commit hook to block log files from commits\n\nTests: baseline 'make test' passes locally (120s timeout).