### PR TITLE
fix: CRITICAL CLI BUG: Debug output contamination breaks pipelin

### DIFF
--- a/src/frontend_transformation.f90
+++ b/src/frontend_transformation.f90
@@ -5,6 +5,7 @@ module frontend_transformation
     use lexer_core, only: token_t, tokenize_core, TK_EOF, TK_KEYWORD, &
                            TK_COMMENT, TK_NEWLINE, TK_OPERATOR, TK_IDENTIFIER, &
                            TK_NUMBER, TK_STRING, TK_UNKNOWN
+    use iso_fortran_env, only: error_unit
     use compiler_arena, only: compiler_arena_t, create_compiler_arena, destroy_compiler_arena
     use semantic_analyzer, only: semantic_context_t, create_semantic_context, &
                                    analyze_program, has_semantic_errors
@@ -235,8 +236,8 @@ contains
             ! Try to continue parsing with partial results if we have a valid program
             if (prog_index > 0 .and. prog_index <= compiler_arena%ast%size) then
                 ! We have a partial parse - continue with what we have
-                ! Log the parsing warning but don't fail completely
-                write(*, '(A,A)') "Warning: Parsing issues detected but continuing: ", error_msg
+                ! Log the parsing warning to stderr but don't fail completely
+                write(error_unit, '(A,A)') "Warning: Parsing issues detected but continuing: ", error_msg
                 error_msg = ""  ! Clear error to continue processing
             else
                 call handle_parsing_error(compiler_arena, prog_index, error_msg, output)

--- a/test/system/test_cli_integration.f90
+++ b/test/system/test_cli_integration.f90
@@ -265,6 +265,7 @@ contains
         character(len=512) :: command
         character(len=:), allocatable :: executable_path
         logical :: success, err_empty
+        integer(kind=8) :: err_size
 
         call test_start("No stdout contamination")
 
@@ -280,14 +281,14 @@ contains
 
         success = (run_status == 0)
         
-        ! Check stdout does not start with warnings/debug
+        ! Check stdout contains no warnings/debug prefixes on first line
         if (success) then
             open(newunit=unit_out, file='test_out_clean.txt', status='old', action='read', iostat=exit_code)
             if (exit_code == 0) then
                 read(unit_out, '(A)', end=10, iostat=exit_code) output_line
 10              close(unit_out)
                 if (exit_code == 0) then
-                    if (index(output_line, 'Warning:') == 1 .or. index(output_line, 'DEBUG:') == 1) then
+                    if (index(output_line, 'Warning:') > 0 .or. index(output_line, 'DEBUG:') > 0) then
                         success = .false.
                     end if
                 end if
@@ -296,13 +297,11 @@ contains
             end if
         end if
 
-        ! Check stderr is empty
+        ! Check stderr is empty using file size
         if (success) then
-            open(newunit=unit_err, file='test_err_clean.txt', status='old', action='read', iostat=stat)
+            inquire(file='test_err_clean.txt', size=err_size, iostat=stat)
             if (stat == 0) then
-                read(unit_err, '(A)', end=20, iostat=stat) output_line
-20              close(unit_err)
-                err_empty = (stat /= 0)  ! reading failed or hit EOF immediately
+                err_empty = (err_size == 0)
             else
                 err_empty = .true.
             end if

--- a/test/system/test_cli_integration.f90
+++ b/test/system/test_cli_integration.f90
@@ -42,6 +42,9 @@ program test_cli_integration
 
     ! Test 3: Empty input handling
     call test_empty_input()
+
+    ! Test 4: No stdout contamination (warnings go to stderr)
+    call test_no_stdout_contamination()
     
     print *, ""
     print *, "=== Test Summary ==="
@@ -255,6 +258,65 @@ contains
             print *, "  Exit code: ", run_status
         end if
     end subroutine test_invalid_flag_exit_code
+    
+    subroutine test_no_stdout_contamination()
+        integer :: exit_code, run_status, unit_err, unit_out, stat
+        character(len=1000) :: output_line
+        character(len=512) :: command
+        character(len=:), allocatable :: executable_path
+        logical :: success, err_empty
+
+        call test_start("No stdout contamination")
+
+        executable_path = find_fortfront_executable()
+        if (len(executable_path) == 0) then
+            call test_result(.false.)
+            print *, "  ERROR: Could not locate fortfront executable"
+            return
+        end if
+
+        command = 'echo "x = 5" | ' // executable_path // ' > test_out_clean.txt 2>test_err_clean.txt'
+        call execute_command_line(command, exitstat=run_status)
+
+        success = (run_status == 0)
+        
+        ! Check stdout does not start with warnings/debug
+        if (success) then
+            open(newunit=unit_out, file='test_out_clean.txt', status='old', action='read', iostat=exit_code)
+            if (exit_code == 0) then
+                read(unit_out, '(A)', end=10, iostat=exit_code) output_line
+10              close(unit_out)
+                if (exit_code == 0) then
+                    if (index(output_line, 'Warning:') == 1 .or. index(output_line, 'DEBUG:') == 1) then
+                        success = .false.
+                    end if
+                end if
+            else
+                success = .false.
+            end if
+        end if
+
+        ! Check stderr is empty
+        if (success) then
+            open(newunit=unit_err, file='test_err_clean.txt', status='old', action='read', iostat=stat)
+            if (stat == 0) then
+                read(unit_err, '(A)', end=20, iostat=stat) output_line
+20              close(unit_err)
+                err_empty = (stat /= 0)  ! reading failed or hit EOF immediately
+            else
+                err_empty = .true.
+            end if
+            success = success .and. err_empty
+        end if
+
+        call execute_command_line('rm -f test_out_clean.txt test_err_clean.txt', exitstat=exit_code)
+
+        call test_result(success)
+        if (.not. success) then
+            print *, "  Stdout contamination detected or stderr not empty"
+            print *, "  Exit code: ", run_status
+        end if
+    end subroutine test_no_stdout_contamination
     
     subroutine test_empty_input()
         integer :: exit_code


### PR DESCRIPTION
This fixes #805 by routing parser continuation warnings to stderr instead of stdout, keeping generated Fortran on stdout for clean piping. Baseline tests pass locally.\n\nRepro (before): echo 'x = 5' | fortfront -> debug/warning lines on stdout.\nAfter: stdout contains only Fortran; warnings go to stderr.