### PR TITLE
fix: Multi-line input parsing drops subsequent lines silently (fixes #1111)

### DIFF
--- a/src/semantic/analyzers/semantic_assignment_inference.f90
+++ b/src/semantic/analyzers/semantic_assignment_inference.f90
@@ -9,7 +9,7 @@ module semantic_assignment_inference
     use semantic_validation_utils, only: update_identifier_type_in_arena
     use error_handling, only: result_t, create_error_result, ERROR_SEMANTIC
     use scope_manager, only: scope_stack_t
-    use semantic_function_analysis, only: infer_type_from_usage_context
+    ! No direct dependency on function analysis here
     use error_handling, only: error_collection_t
     implicit none
     private
@@ -30,7 +30,8 @@ contains
         type(error_collection_t), intent(inout) :: errors
         logical, intent(in) :: strict_mode
         integer, intent(inout) :: next_var_id
-        type(poly_type_t), allocatable :: scheme, existing_scheme
+        type(poly_type_t) :: scheme
+        type(poly_type_t), allocatable :: existing_scheme
         type(result_t) :: error_result
 
         if (lhs_index > 0 .and. lhs_index <= arena%size) then
@@ -67,7 +68,6 @@ contains
                     call update_identifier_type_in_arena(arena, lhs_node%name, expr_typ)
                     
                     ! Generalize the expression type and define/update in scope
-                    allocate(scheme)
                     scheme = create_poly_type(forall_vars=[type_var_t::], mono=expr_typ)
                     call scopes%define(lhs_node%name, scheme)
                 end select

--- a/src/semantic/analyzers/semantic_assignment_inference.f90
+++ b/src/semantic/analyzers/semantic_assignment_inference.f90
@@ -53,8 +53,8 @@ contains
                             )
                             call errors%add_result(error_result)
                         else
-                            ! Lazy Fortran mode: auto-declare with inferred type
-                            expr_typ = infer_type_from_usage_context(lhs_node%name, next_var_id)
+                            ! Lazy Fortran mode: auto-declare using the expression's inferred type
+                            ! Keep expr_typ as computed from the RHS to drive accurate typing
                         end if
                     end if
                     

--- a/src/standardizers/standardizer_allocatable.f90
+++ b/src/standardizers/standardizer_allocatable.f90
@@ -551,17 +551,21 @@ contains
                             ! Check if this declaration needs to be marked
                             do j = 1, var_count
                                 if (trim(stmt%var_name) == trim(string_vars_needing_allocatable(j))) then
-                                    if (stmt%inferred_type%kind > 0) then
-                                        stmt%inferred_type%alloc_info%needs_allocatable_string = .true.
-                                        ! Clear type_name so codegen uses inferred_type
-                                        stmt%type_name = ""
-                                    else
-                                        ! Create an inferred_type for the declaration
-                                        stmt%inferred_type%kind = TCHAR
-                                        stmt%inferred_type%size = 0  ! Unknown size for allocatable
-                                        stmt%inferred_type%alloc_info%needs_allocatable_string = .true.
-                                        ! Clear type_name so codegen uses inferred_type
-                                        stmt%type_name = ""
+                                    ! Guard: only mark character declarations as allocatable strings.
+                                    ! Avoid changing non-character types (e.g., integer/real) into character.
+                                    if (trim(stmt%type_name) == 'character' .or. stmt%inferred_type%kind == TCHAR) then
+                                        if (stmt%inferred_type%kind > 0) then
+                                            stmt%inferred_type%alloc_info%needs_allocatable_string = .true.
+                                            ! Clear type_name so codegen uses inferred_type
+                                            stmt%type_name = ""
+                                        else
+                                            ! Create an inferred_type for the declaration
+                                            stmt%inferred_type%kind = TCHAR
+                                            stmt%inferred_type%size = 0  ! Unknown size for allocatable
+                                            stmt%inferred_type%alloc_info%needs_allocatable_string = .true.
+                                            ! Clear type_name so codegen uses inferred_type
+                                            stmt%type_name = ""
+                                        end if
                                     end if
                                     exit
                                 end if

--- a/test/frontend/test_string_transformation.f90
+++ b/test/frontend/test_string_transformation.f90
@@ -21,6 +21,9 @@ program test_string_transformation
     
     ! Test 4: Multiple statements
     call test_multiple_statements()
+
+    ! Test 4b: Multi-line string concatenation
+    call test_multi_line_string_concat()
     
     ! Test 5: Syntax error handling
     call test_syntax_error()
@@ -30,6 +33,9 @@ program test_string_transformation
     
     ! Test 7: Complex expression
     call test_complex_expression()
+
+    ! Test 8: Non-character declarations unaffected by string logic
+    call test_non_character_declaration_safety()
     
     print *, ""
     print *, "=== Test Summary ==="
@@ -131,6 +137,55 @@ contains
             print *, "  Error: ", trim(error_msg)
         end if
     end subroutine test_multiple_statements
+
+    subroutine test_multi_line_string_concat()
+        character(len=:), allocatable :: input, output, error_msg
+        logical :: success
+        
+        call test_start("Multi-line string concatenation")
+        
+        input = "s = 'a' // 'b'" // new_line('A') // &
+                "t = s // 'c'" // new_line('A') // &
+                "print *, t"
+        
+        call transform_lazy_fortran_string(input, output, error_msg)
+        
+        ! Expect no errors and both assignments preserved in output
+        success = (len_trim(error_msg) == 0) .and. &
+                  (index(output, "s = 'a' // 'b'") > 0) .and. &
+                  (index(output, "t = s // 'c'") > 0)
+        
+        call test_result(success)
+        if (.not. success) then
+            print *, "  Error: ", trim(error_msg)
+            print *, "  Output: ", trim(output)
+        end if
+    end subroutine test_multi_line_string_concat
+
+    subroutine test_non_character_declaration_safety()
+        character(len=:), allocatable :: input, output, error_msg
+        logical :: success
+        
+        call test_start("Non-character declaration safety")
+        
+        input = "integer :: n" // new_line('A') // &
+                "n = 5" // new_line('A') // &
+                "s = 'x'" // new_line('A') // &
+                "s = s // 'y'" // new_line('A') // &
+                "print *, n, s"
+        
+        call transform_lazy_fortran_string(input, output, error_msg)
+        
+        ! Ensure integer declaration remains and character handling applies only to strings
+        success = (len_trim(error_msg) == 0) .and. &
+                  (index(output, "integer :: n") > 0)
+        
+        call test_result(success)
+        if (.not. success) then
+            print *, "  Error: ", trim(error_msg)
+            print *, "  Output: ", trim(output)
+        end if
+    end subroutine test_non_character_declaration_safety
     
     subroutine test_syntax_error()
         character(len=:), allocatable :: output, error_msg


### PR DESCRIPTION
Summary
- Fix multi-line input handling by ensuring undefined vars adopt RHS-inferred types and by not converting non-character declarations into character allocatables.

Scope
- src/semantic/analyzers/semantic_assignment_inference.f90
- src/standardizers/standardizer_allocatable.f90

Verification
- Ran `make test` locally; all non-xfail tests pass. Previously failing `test_string_transformation` and `test_ast_semantic_introspection` now pass.

Rationale
- Undefined variable typing must follow the assigned expression, not name heuristics. Also, allocatable string marking should only apply to character declarations to prevent incorrect types in multi-statement inputs.
