### PR TITLE
ci: fix coverage checks on push events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,7 +212,7 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             name: 'coverage/project',
-            head_sha: context.payload.pull_request.head.sha,
+            head_sha: context.sha,
             status: 'completed',
             conclusion: projectPassed ? 'success' : 'failure',
             output: {
@@ -229,7 +229,7 @@ jobs:
             owner: context.repo.owner,
             repo: context.repo.repo,
             name: 'coverage/patch',
-            head_sha: context.payload.pull_request.head.sha,
+            head_sha: context.sha,
             status: 'completed',
             conclusion: patchPassed ? 'success' : 'failure',
             output: {


### PR DESCRIPTION
Summary
- Fix failing main CI by using `context.sha` for coverage check creation on push events.

Scope
- Update `.github/workflows/ci.yml` only; no code or tests changed.

Verification
- Local tests pass via `make test` (all green).
- CI failure reproduced in logs: run 17394548735, job `test-linux`, step "Create coverage checks" fails due to `context.payload.pull_request` being undefined on push.
- This PR triggers PR CI; the push failure path is adjusted and should pass on main after merge.

Rationale
- On push events there is no `pull_request` payload; using `context.sha` is required for the Checks API. This resolves intermittent red on main where tests and coverage succeed but check creation fails.
