### PR TITLE
fix:  (fixes #1106)

### DIFF
--- a/fpm.toml
+++ b/fpm.toml
@@ -9,12 +9,17 @@ stdlib = "*"
 json-fortran = { git = "https://github.com/jacobwilliams/json-fortran.git", tag = "8.3.0" }
 
 [build]
-auto-executables = true
+# Lock executables to explicit list to prevent accidental test binaries in app/
+auto-executables = false
 auto-tests = true
 auto-examples = true
+
+[[executable]]
+name = "fortfront"
+source-dir = "app"
+main = "fortfront.f90"
 
 [fortran]
 implicit-external = false
 implicit-typing = false
 source-form = "free"
-


### PR DESCRIPTION
Summary
- Prevent accidental test executables from being picked up by fpm, ensuring default `fpm run` executes only the CLI.

Scope
- Update `fpm.toml` to disable auto-executables and declare the `fortfront` binary explicitly.

Verification
- Ran `make test` (fpm tests) locally: all tests passed within 120s.
- With only `app/fortfront.f90` present, behavior remains unchanged; this change hardens config against future accidental files in `app/`.

Rationale
- Addresses issue #1106 by eliminating the root cause (auto-discovery of extra executables). Keeps CLI output clean without requiring users to pass `--target`.
