### PR TITLE
fix: Array indexing syntax completely ignored in parsing (fixes #1110)

### DIFF
--- a/src/parser/parser_expressions.f90
+++ b/src/parser/parser_expressions.f90
@@ -713,7 +713,7 @@ contains
     ! POSTFIX OPERATIONS SECTION
     !=================================================================================
 
-    ! Parse array indexing or function call postfix operator (())
+    ! Parse array indexing or function call postfix operator using parentheses: (...)
     function parse_array_indexing_postfix(parser, arena, base_expr) result(expr_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
@@ -794,6 +794,85 @@ contains
             end if
         end block
     end function parse_array_indexing_postfix
+    
+    ! Parse array indexing postfix operator using square brackets: [...]
+    function parse_square_indexing_postfix(parser, arena, base_expr) result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: base_expr
+        integer :: expr_index
+        
+        block
+            integer, allocatable :: arg_indices(:)
+            type(token_t) :: bracket, op_token
+            integer :: arg_count
+            character(len=:), allocatable :: name_for_call
+            
+            arg_count = 0
+            expr_index = base_expr
+            
+            ! Consume opening bracket
+            bracket = parser%consume()
+            
+            ! Parse indices (use same range parser as for parentheses)
+            op_token = parser%peek()
+            if (op_token%kind /= TK_OPERATOR .or. op_token%text /= "]") then
+                block
+                    integer :: arg_index
+                    arg_index = parse_range(parser, arena)
+                    if (arg_index > 0) then
+                        arg_count = 1
+                        allocate (arg_indices(1))
+                        arg_indices(1) = arg_index
+                        
+                        do
+                            op_token = parser%peek()
+                            if (op_token%kind /= TK_OPERATOR .or. &
+                                op_token%text /= ",") exit
+                            
+                            ! Consume comma
+                            op_token = parser%consume()
+                            
+                            ! Parse next index
+                            arg_index = parse_range(parser, arena)
+                            if (arg_index > 0) then
+                                arg_indices = [arg_indices, arg_index]
+                                arg_count = arg_count + 1
+                            else
+                                exit
+                            end if
+                        end do
+                    end if
+                end block
+            end if
+            
+            ! Consume closing bracket if present
+            op_token = parser%peek()
+            if (op_token%kind == TK_OPERATOR .and. op_token%text == "]") then
+                bracket = parser%consume()
+            end if
+            
+            ! Create call_or_subscript node with slice detection (same as parentheses)
+            if (allocated(arg_indices)) then
+                select type (node => arena%entries(expr_index)%node)
+                type is (component_access_node)
+                    name_for_call = node%component_name
+                type is (identifier_node)
+                    name_for_call = node%name
+                class default
+                    if (allocated(arg_indices)) deallocate(arg_indices)
+                    return
+                end select
+                
+                if (allocated(name_for_call)) then
+                    expr_index = &
+                        push_call_or_subscript_with_slice_detection(arena, &
+                        name_for_call, arg_indices, &
+                        bracket%line, bracket%column)
+                end if
+            end if
+        end block
+    end function parse_square_indexing_postfix
      
     ! Parse postfix operators on an expression
     function parse_postfix_ops(parser, arena, base_expr) result(expr_index)
@@ -818,6 +897,8 @@ contains
                 if (expr_index <= 0) exit
             else if (op_token%kind == TK_OPERATOR .and. op_token%text == "(") then
                 expr_index = parse_array_indexing_postfix(parser, arena, expr_index)
+            else if (op_token%kind == TK_OPERATOR .and. op_token%text == "[") then
+                expr_index = parse_square_indexing_postfix(parser, arena, expr_index)
             else
                 exit
             end if

--- a/test/codegen/test_array_indexing_brackets.f90
+++ b/test/codegen/test_array_indexing_brackets.f90
@@ -1,0 +1,73 @@
+program test_array_indexing_brackets
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+    logical :: ok
+
+    print *, "=== Array indexing with square brackets maps to parentheses ==="
+
+    call test_simple_index()
+    call test_multi_index()
+
+contains
+
+    subroutine test_simple_index()
+        print *, "Testing y[1] -> y(1)..."
+        source = "program t" // new_line('a') // &
+                 "  implicit none" // new_line('a') // &
+                 "  integer :: x" // new_line('a') // &
+                 "  x = y[1]" // new_line('a') // &
+                 "end program t"
+
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, "  ERROR:", trim(error_msg)
+                stop 1
+            end if
+        end if
+
+        ok = index(output, "x = y(1)") > 0
+        if (ok) then
+            print *, "  PASS"
+        else
+            print *, "  FAIL: output=", trim(output)
+            stop 1
+        end if
+    end subroutine test_simple_index
+
+    subroutine test_multi_index()
+        print *, "Testing a[i, j+1] -> a(i, j+1)..."
+        source = "program t" // new_line('a') // &
+                 "  implicit none" // new_line('a') // &
+                 "  integer :: i, j" // new_line('a') // &
+                 "  i = 1" // new_line('a') // &
+                 "  j = 2" // new_line('a') // &
+                 "  i = a[i, j+1]" // new_line('a') // &
+                 "end program t"
+
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, "  ERROR:", trim(error_msg)
+                stop 1
+            end if
+        end if
+
+        ok = index(output, "i = a(i, j+1)") > 0 .or. &
+             index(output, "i = a(i,j+1)") > 0 .or. &
+             index(output, "i = a(i, j + 1)") > 0
+        if (ok) then
+            print *, "  PASS"
+        else
+            print *, "  FAIL: output=", trim(output)
+            stop 1
+        end if
+    end subroutine test_multi_index
+
+end program test_array_indexing_brackets


### PR DESCRIPTION
Summary
- Add parser support for square-bracket array indexing `[]` and tests.

Scope
- Update `src/parser/parser_expressions.f90` to parse `[...]` as subscripts.
- Add `test/codegen/test_array_indexing_brackets.f90` verifying `y[1] -> y(1)`.

Verification
- Ran `make test` locally (xfail runner); full pass.
- Static lib build test passes; no CI-impacting changes.

Rationale
- Fixes #1110: previously `x = y[1]` lost indexing; now preserved as `x = y(1)`.
