### PR TITLE
fix: BUG: Incomplete function definitions generate invalid Fortran sy (fixes #1049)

### DIFF
--- a/src/utilities/input_validation.f90
+++ b/src/utilities/input_validation.f90
@@ -14,6 +14,7 @@ module input_validation
     public :: validate_basic_syntax
     public :: check_missing_then_statements
     public :: check_incomplete_statements
+    public :: check_incomplete_lazy_function_defs
     public :: check_for_fortran_content
     public :: check_missing_end_constructs
     public :: contains_invalid_patterns
@@ -26,6 +27,7 @@ module input_validation
     private :: is_likely_valid_fortran
     private :: has_any_fortran_patterns
     private :: is_likely_fortran_expression
+    private :: detect_lazy_func_header
 
 contains
 
@@ -75,7 +77,11 @@ contains
         ! Check for incomplete statements first (most critical syntax errors)
         call check_incomplete_statements(tokens, source_lines, error_msg)
         if (error_msg /= "") return
-        
+
+        ! Detect Lazy Fortran-style incomplete function headers using 'func'
+        call check_incomplete_lazy_function_defs(tokens, source_lines, error_msg)
+        if (error_msg /= "") return
+
         ! Look for missing 'then' in if statements (Issue #256 primary test case)
         ! This is more specific than missing end constructs, so check it first
         call check_missing_then_statements(tokens, source_lines, error_msg)
@@ -87,6 +93,72 @@ contains
         if (error_msg /= "") return
         
     end subroutine validate_basic_syntax
+
+    ! Detect "func name(args)" headers without proper Fortran function syntax
+    ! and report a clear, actionable diagnostic instead of emitting invalid code.
+    subroutine check_incomplete_lazy_function_defs(tokens, source_lines, error_msg)
+        type(token_t), intent(in) :: tokens(:)
+        character(len=*), intent(in) :: source_lines(:)
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        integer :: i
+        logical :: found
+
+        error_msg = ""
+        found = .false.
+
+        do i = 1, size(tokens)
+            if (tokens(i)%kind == TK_EOF) exit
+
+            if (detect_lazy_func_header(tokens, i)) then
+                error_msg = format_enhanced_error( &
+     &              "Incomplete function-like definition: 'func' is not valid Fortran", &
+     &              tokens(i)%line, tokens(i)%column, source_lines, &
+     &              "Replace 'func' with 'function' and add 'end function'", &
+     &              "SYNTAX_ERROR")
+                found = .true.
+                exit
+            end if
+        end do
+    end subroutine check_incomplete_lazy_function_defs
+
+    ! Helper: detect pattern "func <identifier>( ... )" at the start of a line
+    logical function detect_lazy_func_header(tokens, pos) result(is_lazy_func)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: pos
+        integer :: j
+        integer :: current_line
+
+        is_lazy_func = .false.
+        if (pos < 1 .or. pos > size(tokens)) return
+
+        ! Token text must literally be "func" and appear at line start
+        if (.not. (tokens(pos)%kind == TK_IDENTIFIER .and. trim(tokens(pos)%text) == "func")) return
+
+        current_line = tokens(pos)%line
+        ! Ensure it's at line start (no tokens before it on the same line)
+        if (pos > 1) then
+            if (tokens(pos-1)%line == current_line) return
+        end if
+
+        ! Next must be identifier then an opening parenthesis on same line
+        j = pos + 1
+        if (j <= size(tokens) .and. tokens(j)%line == current_line .and. &
+     &      tokens(j)%kind == TK_IDENTIFIER) then
+            j = j + 1
+            if (j <= size(tokens) .and. tokens(j)%line == current_line .and. &
+     &          tokens(j)%kind == TK_OPERATOR .and. tokens(j)%text == "(") then
+                ! Look ahead for closing paren on same line (header form)
+                do while (j <= size(tokens) .and. tokens(j)%line == current_line)
+                    if (tokens(j)%kind == TK_OPERATOR .and. tokens(j)%text == ")") then
+                        is_lazy_func = .true.
+                        return
+                    end if
+                    j = j + 1
+                end do
+            end if
+        end if
+    end function detect_lazy_func_header
 
     ! Check for missing 'then' statements (Issue #256 primary test case)
     subroutine check_missing_then_statements(tokens, source_lines, error_msg)

--- a/test/error_reporting/test_issue_1049_incomplete_func.f90
+++ b/test/error_reporting/test_issue_1049_incomplete_func.f90
@@ -1,0 +1,30 @@
+program test_issue_1049_incomplete_func
+    use frontend, only: transform_lazy_fortran_string
+    implicit none
+
+    character(len=:), allocatable :: source, output, error_msg
+    logical :: passed
+
+    print *, '=== Issue #1049: Incomplete func definition ==='
+
+    ! Reproduction: Lazy Fortran-style function header without proper body
+    source = 'func incomplete_function(x: int)' // new_line('a') // &
+             'result = incomplete_function(5)'
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    passed = (index(error_msg, 'Incomplete function-like definition') > 0 .and. &
+              index(error_msg, 'func') > 0 .and. &
+              index(output, 'COMPILATION FAILED') > 0)
+
+    if (passed) then
+        print *, '  PASS: Detected incomplete func definition with clear diagnostic'
+        stop 0
+    else
+        print *, '  FAIL: Did not detect incomplete func definition'
+        print *, '    error_msg = ', trim(error_msg)
+        print *, '    output (first 120 chars) = ', output(1:min(120, len(output)))
+        stop 1
+    end if
+end program test_issue_1049_incomplete_func
+


### PR DESCRIPTION
Summary
- Detects and reports incomplete Lazy Fortran function headers using 'func' with a clear diagnostic, avoiding invalid Fortran output.

Scope
- src/utilities/input_validation.f90
- test/error_reporting/test_issue_1049_incomplete_func.f90

Verification
- Ran `make test` locally; full suite passes including the new test.
- New test asserts error_msg contains a specific diagnostic and output contains 'COMPILATION FAILED'.

Rationale
- Prevents emission of malformed Fortran when users write `func name(...)` without a proper body; provides actionable guidance to use `function` and add `end function`.
