### PR TITLE
fix: Build cache bloat cleanup (fixes #1114)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,13 @@ jobs:
         echo "🛡️ Running fraud prevention validation"
         ./scripts/ci_fraud_prevention.sh
 
+    - name: Cleanup build cache and logs
+      if: always()
+      run: |
+        echo "Pruning old fpm build cache directories and logs"
+        make prune-build-cache PRUNE_KEEP=2 || true
+        bash scripts/prune_logs.sh || true
+
     - name: Generate coverage data (optimized)
       if: false  # coverage disabled
       run: |
@@ -430,6 +437,26 @@ jobs:
           Write-Host "❌ FRAUD RECOVERY FAILURE: All Windows build attempts failed"
           Write-Host "This indicates genuine systematic Windows CI issues"
           exit 1
+        }
+
+    - name: Cleanup build cache and logs (Windows)
+      if: always()
+      shell: pwsh
+      run: |
+        Write-Host "Pruning old build cache directories (keeping 2 newest)"
+        if (Test-Path build) {
+          Get-ChildItem build -Directory -ErrorAction SilentlyContinue |
+            Where-Object { $_.Name -like 'gfortran_*' } |
+            Sort-Object LastWriteTime -Descending |
+            Select-Object -Skip 2 |
+            ForEach-Object { Remove-Item $_.FullName -Recurse -Force -ErrorAction SilentlyContinue }
+        }
+        Write-Host "Deleting stale logs older than 7 days"
+        $logDir = Join-Path (Get-Location) 'logs'
+        if (Test-Path $logDir) {
+          Get-ChildItem $logDir -Recurse -Include *.log -ErrorAction SilentlyContinue |
+            Where-Object { $_.LastWriteTime -lt (Get-Date).AddDays(-7) } |
+            ForEach-Object { Remove-Item $_.FullName -Force -ErrorAction SilentlyContinue }
         }
 
   # macOS CI temporarily disabled due to runner issues

--- a/scripts/prune_logs.sh
+++ b/scripts/prune_logs.sh
@@ -18,15 +18,19 @@ fi
 # Delete logs older than RETAIN_DAYS
 find "$log_dir" -type f -name "*.log" -mtime +"$RETAIN_DAYS" -print -delete 2>/dev/null || true
 
-# Keep only the newest KEEP_COUNT logs (by mtime)
-count=$(find "$log_dir" -type f -name "*.log" | wc -l | awk "{print $1}")
+# Keep only the newest KEEP_COUNT logs (by mtime), robust to spaces in names
+count=$(find "$log_dir" -type f -name "*.log" -print0 | tr -cd '\0' | wc -c)
 if [ "$count" -gt "$KEEP_COUNT" ]; then
-  # List all logs sorted by mtime newest first, skip first KEEP_COUNT, delete the rest
-  find "$log_dir" -type f -name "*.log" -printf "%T@ %p\n" | sort -nr | awk -v k="$KEEP_COUNT" "NR>k{print $2}" | xargs -r rm -f
+  # Build null-delimited list with timestamps, sort desc by mtime, drop first KEEP_COUNT,
+  # strip timestamps, and delete the remainder.
+  find "$log_dir" -type f -name "*.log" -printf '%T@ %p\0' \
+    | sort -z -nr \
+    | awk -v RS='\0' -v ORS='\0' -v k="$KEEP_COUNT" 'NR>k{print}' \
+    | cut -z -d' ' -f2- \
+    | xargs -0 -r rm -f --
 fi
 
 # Also clean stray top-level logs to avoid accumulation
 find "$repo_root" -maxdepth 1 -type f \(
   -name "*.log" -o -name "*.err" -o -name "*.out"
 \) -mtime +"$RETAIN_DAYS" -print -delete 2>/dev/null || true
-

--- a/scripts/prune_logs.sh
+++ b/scripts/prune_logs.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Prune log files in logs/ to control disk usage.
+# Policy:
+# - Delete logs older than RETAIN_DAYS (default: 7 days)
+# - Keep at most KEEP_COUNT newest logs overall (default: 50)
+#
+repo_root="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+log_dir="$repo_root/logs"
+RETAIN_DAYS="${RETAIN_DAYS:-7}"
+KEEP_COUNT="${KEEP_COUNT:-50}"
+
+if [ ! -d "$log_dir" ]; then
+  exit 0
+fi
+
+# Delete logs older than RETAIN_DAYS
+find "$log_dir" -type f -name "*.log" -mtime +"$RETAIN_DAYS" -print -delete 2>/dev/null || true
+
+# Keep only the newest KEEP_COUNT logs (by mtime)
+count=$(find "$log_dir" -type f -name "*.log" | wc -l | awk "{print $1}")
+if [ "$count" -gt "$KEEP_COUNT" ]; then
+  # List all logs sorted by mtime newest first, skip first KEEP_COUNT, delete the rest
+  find "$log_dir" -type f -name "*.log" -printf "%T@ %p\n" | sort -nr | awk -v k="$KEEP_COUNT" "NR>k{print $2}" | xargs -r rm -f
+fi
+
+# Also clean stray top-level logs to avoid accumulation
+find "$repo_root" -maxdepth 1 -type f \(
+  -name "*.log" -o -name "*.err" -o -name "*.out"
+\) -mtime +"$RETAIN_DAYS" -print -delete 2>/dev/null || true
+


### PR DESCRIPTION
Summary
- Add CI steps to prune old build caches and logs. Introduce `scripts/prune_logs.sh` for log rotation.

Scope
- .github/workflows/ci.yml
- scripts/prune_logs.sh

Verification
- Local test suite passes (`make test`, 120s timeout). CI unaffected functionally; only post-steps added. New script is no-op if `logs/` absent.

Rationale
- Address disk bloat noted in issue #1114 by pruning `build/gfortran_*` to newest 2 and deleting stale logs (older than 7 days, keep newest 50).
