### PR TITLE
fix: [test] standard /roundtrip: xfail tracking (fixes #1138)

### DIFF
--- a/test/xfail.csv
+++ b/test/xfail.csv
@@ -45,8 +45,6 @@ test_issue_312_character_type_handling,https://github.com/krystophny/fortfront/i
 test_frontend_codegen_comprehensive,https://github.com/krystophny/fortfront/issues/1137
 test_all_github_issues_fixed,https://github.com/krystophny/fortfront/issues/1137
 test_external_tool_integration,https://github.com/krystophny/fortfront/issues/1137
-# Group: standard/roundtrip (1138)
-test_standard_fortran_roundtrip,https://github.com/krystophny/fortfront/issues/1138
 # Group: module/comment (1139)
 test_issue_508_module_comment_main,https://github.com/krystophny/fortfront/issues/1139
 # Group: disable/type/std (1140)


### PR DESCRIPTION
Summary
- Remove stale xfail entry for test_standard_fortran_roundtrip.

Scope
- Update test/xfail.csv only; no code behavior changes.

Verification
- Ran `make test` locally (120s cap): full pass with no XPASS/XFAIL lines.
- Baseline passed before change; passes after change (logs above in CI).

Rationale
- Issue #1138 tracks a now-obsolete xfail; cleaning it reduces XPASS noise and keeps the xfail map accurate.
