### PR TITLE
fix: [test] where /forall: xfail tracking (fixes #1134)

### DIFF
--- a/src/codegen/codegen_control_flow.f90
+++ b/src/codegen/codegen_control_flow.f90
@@ -246,7 +246,8 @@ contains
         type(where_node), intent(in) :: node
         integer, intent(in) :: node_index
         character(len=:), allocatable :: code
-        character(len=:), allocatable :: mask_code
+        character(len=:), allocatable :: mask_code, body_code
+        integer :: i
 
         ! Generate mask expression
         if (node%mask_expr_index > 0) then
@@ -255,10 +256,38 @@ contains
             mask_code = ".true."
         end if
 
-        ! Generate where construct with body
-        code = "where (" // mask_code // ")" // new_line('A') // &
-               "    ! where body statements" // new_line('A') // &
-               "end where"
+        ! WHERE header
+        code = "where (" // mask_code // ")"
+
+        ! WHERE body
+        if (allocated(node%where_body_indices)) then
+            body_code = generate_grouped_body_internal(arena, node%where_body_indices, 1)
+            if (len(body_code) > 0) then
+                code = code // new_line('A') // body_code
+            end if
+        end if
+
+        ! ELSEWHERE clauses (including final ELSEWHERE without mask)
+        if (allocated(node%elsewhere_clauses)) then
+            do i = 1, size(node%elsewhere_clauses)
+                if (node%elsewhere_clauses(i)%mask_index > 0) then
+                    mask_code = generate_code_from_arena(arena, node%elsewhere_clauses(i)%mask_index)
+                    code = code // new_line('A') // "elsewhere (" // mask_code // ")"
+                else
+                    code = code // new_line('A') // "elsewhere"
+                end if
+
+                if (allocated(node%elsewhere_clauses(i)%body_indices)) then
+                    body_code = generate_grouped_body_internal(arena, node%elsewhere_clauses(i)%body_indices, 1)
+                    if (len(body_code) > 0) then
+                        code = code // new_line('A') // body_code
+                    end if
+                end if
+            end do
+        end if
+
+        ! END WHERE
+        code = code // new_line('A') // "end where"
     end function generate_code_where
 
     ! Generate code for forall constructs
@@ -267,11 +296,50 @@ contains
         type(forall_node), intent(in) :: node
         integer, intent(in) :: node_index
         character(len=:), allocatable :: code
+        character(len=:), allocatable :: header, part
+        character(len=:), allocatable :: body_code
+        integer :: i
 
-        ! Generate forall construct with basic triplet
-        code = "forall (i = 1:n)" // new_line('A') // &
-               "    ! forall body statements" // new_line('A') // &
-               "end forall"
+        header = "forall ("
+        if (node%num_indices > 0 .and. allocated(node%index_names) .and. &
+            allocated(node%lower_bound_indices) .and. allocated(node%upper_bound_indices) .and. &
+            allocated(node%stride_indices)) then
+            do i = 1, node%num_indices
+                if (i > 1) header = header // ", "
+
+                part = ""
+                part = trim(node%index_names(i)) // " = "
+
+                if (node%lower_bound_indices(i) > 0) then
+                    part = part // generate_code_from_arena(arena, node%lower_bound_indices(i))
+                end if
+                part = part // ":"
+                if (node%upper_bound_indices(i) > 0) then
+                    part = part // generate_code_from_arena(arena, node%upper_bound_indices(i))
+                end if
+                if (node%stride_indices(i) > 0) then
+                    part = part // ":" // generate_code_from_arena(arena, node%stride_indices(i))
+                end if
+
+                header = header // part
+            end do
+        end if
+
+        if (node%has_mask .and. node%mask_expr_index > 0) then
+            header = header // ", " // generate_code_from_arena(arena, node%mask_expr_index)
+        end if
+        header = header // ")"
+
+        code = header
+
+        if (allocated(node%body_indices)) then
+            body_code = generate_grouped_body_internal(arena, node%body_indices, 1)
+            if (len(body_code) > 0) then
+                code = code // new_line('A') // body_code
+            end if
+        end if
+
+        code = code // new_line('A') // "end forall"
     end function generate_code_forall
 
     ! Generate code for associate constructs

--- a/test/codegen/test_where_forall_codegen.f90
+++ b/test/codegen/test_where_forall_codegen.f90
@@ -74,6 +74,22 @@ contains
             print *, '  FAIL: Missing END WHERE'
             test_where_codegen = .false.
         end if
+
+        ! Stronger content checks (mask and assignments)
+        if (index(code, 'a > 0') == 0) then
+            print *, '  FAIL: WHERE mask not found'
+            test_where_codegen = .false.
+        end if
+
+        if (index(code, 'a = a + 1') == 0) then
+            print *, '  FAIL: THEN-body assignment missing'
+            test_where_codegen = .false.
+        end if
+
+        if (index(code, 'a = 0') == 0) then
+            print *, '  FAIL: ELSEWHERE-body assignment missing'
+            test_where_codegen = .false.
+        end if
     end function test_where_codegen
 
     logical function test_forall_codegen()
@@ -114,6 +130,17 @@ contains
 
         if (index(code, 'end forall') == 0) then
             print *, '  FAIL: Missing END FORALL'
+            test_forall_codegen = .false.
+        end if
+
+        ! Stronger content checks (triplet and body)
+        if (index(code, 'i = 1:n') == 0) then
+            print *, '  FAIL: FORALL triplet not found'
+            test_forall_codegen = .false.
+        end if
+
+        if (index(code, 'i = 1') == 0) then
+            print *, '  FAIL: FORALL body assignment missing'
             test_forall_codegen = .false.
         end if
     end function test_forall_codegen

--- a/test/codegen/test_where_forall_codegen.f90
+++ b/test/codegen/test_where_forall_codegen.f90
@@ -1,0 +1,121 @@
+program test_where_forall_codegen
+    use frontend_core, only: emit_fortran
+    use ast_core, only: ast_arena_t, create_ast_arena, LITERAL_INTEGER
+    use ast_factory, only: push_program, push_identifier, push_literal, push_binary_op, &
+                           push_assignment
+    use ast_factory, only: push_where_construct_with_elsewhere, push_forall
+    implicit none
+
+    logical :: all_passed
+    all_passed = .true.
+
+    if (.not. test_where_codegen()) all_passed = .false.
+    if (.not. test_forall_codegen()) all_passed = .false.
+
+    if (all_passed) then
+        print *, 'All WHERE/FORALL codegen tests passed!'
+    else
+        print *, 'Some WHERE/FORALL codegen tests failed!'
+    end if
+
+contains
+
+    logical function test_where_codegen()
+        type(ast_arena_t) :: arena
+        integer :: mask_idx, a_id, zero_id, one_id
+        integer :: rhs_add_idx, assign_then_idx, assign_else_idx
+        integer :: where_idx, prog_idx
+        character(len=:), allocatable :: code
+
+        test_where_codegen = .true.
+        print *, 'Testing WHERE construct code generation...'
+
+        arena = create_ast_arena()
+
+        ! Build mask: a > 0
+        a_id    = push_identifier(arena, 'a')
+        zero_id = push_literal(arena, '0', LITERAL_INTEGER)
+        mask_idx = push_binary_op(arena, a_id, zero_id, '>')
+
+        ! THEN body: a = a + 1
+        one_id = push_literal(arena, '1', LITERAL_INTEGER)
+        rhs_add_idx = push_binary_op(arena, a_id, one_id, '+')
+        assign_then_idx = push_assignment(arena, a_id, rhs_add_idx)
+
+        ! ELSEWHERE body: a = 0
+        assign_else_idx = push_assignment(arena, a_id, zero_id)
+
+        ! WHERE with ELSEWHERE
+        where_idx = push_where_construct_with_elsewhere(arena, mask_idx, &
+                        where_body_indices=[assign_then_idx], &
+                        elsewhere_body_indices=[assign_else_idx])
+
+        prog_idx = push_program(arena, 'main', [where_idx])
+
+        call emit_fortran(arena, prog_idx, code)
+
+        if (.not. allocated(code)) then
+            print *, '  FAIL: No code generated for WHERE'
+            test_where_codegen = .false.
+            return
+        end if
+
+        if (index(code, 'where (') == 0) then
+            print *, '  FAIL: Missing WHERE header'
+            test_where_codegen = .false.
+        end if
+
+        if (index(code, 'elsewhere') == 0) then
+            print *, '  FAIL: Missing ELSEWHERE clause'
+            test_where_codegen = .false.
+        end if
+
+        if (index(code, 'end where') == 0) then
+            print *, '  FAIL: Missing END WHERE'
+            test_where_codegen = .false.
+        end if
+    end function test_where_codegen
+
+    logical function test_forall_codegen()
+        type(ast_arena_t) :: arena
+        integer :: i_id, n_id, one_id
+        integer :: assign_idx, forall_idx, prog_idx
+        character(len=:), allocatable :: code
+
+        test_forall_codegen = .true.
+        print *, 'Testing FORALL construct code generation...'
+
+        arena = create_ast_arena()
+
+        ! Triplet: i = 1:n (no stride)
+        i_id   = push_identifier(arena, 'i')
+        one_id = push_literal(arena, '1', LITERAL_INTEGER)
+        n_id   = push_identifier(arena, 'n')
+
+        ! Body: i = 1 (arbitrary simple assignment for codegen presence)
+        assign_idx = push_assignment(arena, i_id, one_id)
+
+        forall_idx = push_forall(arena, 'i', one_id, n_id, 0, 0, [assign_idx])
+
+        prog_idx = push_program(arena, 'main', [forall_idx])
+
+        call emit_fortran(arena, prog_idx, code)
+
+        if (.not. allocated(code)) then
+            print *, '  FAIL: No code generated for FORALL'
+            test_forall_codegen = .false.
+            return
+        end if
+
+        if (index(code, 'forall (') == 0) then
+            print *, '  FAIL: Missing FORALL header'
+            test_forall_codegen = .false.
+        end if
+
+        if (index(code, 'end forall') == 0) then
+            print *, '  FAIL: Missing END FORALL'
+            test_forall_codegen = .false.
+        end if
+    end function test_forall_codegen
+
+end program test_where_forall_codegen

--- a/test/xfail.csv
+++ b/test/xfail.csv
@@ -35,7 +35,6 @@ test_dependency_validation,https://github.com/krystophny/fortfront/issues/1133
 test_comprehensive_validation_coverage,https://github.com/krystophny/fortfront/issues/1133
 # Group: where/forall (1134)
 test_where_forall_ast,https://github.com/krystophny/fortfront/issues/1134
-test_where_forall_codegen,https://github.com/krystophny/fortfront/issues/1134
 # Group: char/types (1135)
 test_issue_180_character_arrays,https://github.com/krystophny/fortfront/issues/1135
 test_issue_187_char_arrays,https://github.com/krystophny/fortfront/issues/1135


### PR DESCRIPTION
Summary
- Implement real code generation for WHERE and FORALL constructs and enable passing tests.

Scope
- Update: src/codegen/codegen_control_flow.f90
- Update: test/xfail.csv (remove passing xfail)
- Add: test/codegen/test_where_forall_codegen.f90

Verification
- Ran `make test` locally with 120s timeout; full suite passed.
- New test `test_where_forall_codegen` passes and xfail removed to avoid XPASS.

Rationale
- Addresses open tracking issue for WHERE/FORALL (codegen was stubbed). This brings constructs in line with other control-flow generators and removes a known xfail.
