### PR TITLE
fix: If-then-else control flow generates incomplete code (fixes #1112)

### DIFF
--- a/src/parser/parser_if_constructs.f90
+++ b/src/parser/parser_if_constructs.f90
@@ -429,11 +429,30 @@ contains
 
                 ! Find end of current statement (same line or semicolon boundary)
                 do j = stmt_start, size(parser%tokens)
+                    ! Treat control-flow keywords as hard boundaries within a line
+                    if (parser%tokens(j)%kind == TK_KEYWORD) then
+                        select case (parser%tokens(j)%text)
+                        case ("else", "elseif", "else if")
+                            stmt_end = j - 1
+                            exit
+                        case ("endif", "end if")
+                            stmt_end = j - 1
+                            exit
+                        case ("end")
+                            if (j + 1 <= size(parser%tokens)) then
+                                if (parser%tokens(j+1)%kind == TK_KEYWORD .and. &
+                                    parser%tokens(j+1)%text == "if") then
+                                    stmt_end = j - 1
+                                    exit
+                                end if
+                            end if
+                        end select
+                    end if
                     if (parser%tokens(j)%kind == TK_EOF) then
                         stmt_end = j
                         exit
                     end if
-   if (j > stmt_start .and. parser%tokens(j)%line > parser%tokens(stmt_start)%line) then
+                    if (j > stmt_start .and. parser%tokens(j)%line > parser%tokens(stmt_start)%line) then
                         stmt_end = j - 1
                         exit
                     end if

--- a/test/frontend/test_issue_1112_if_else_single_line.f90
+++ b/test/frontend/test_issue_1112_if_else_single_line.f90
@@ -1,0 +1,39 @@
+program test_issue_1112_if_else_single_line
+    use frontend, only: transform_lazy_fortran_string
+    implicit none
+
+    integer :: test_count, pass_count
+    logical :: ok
+
+    test_count = 1
+    pass_count = 0
+
+    call run_test(ok)
+    if (ok) pass_count = pass_count + 1
+
+    if (pass_count == test_count) then
+        stop 0
+    else
+        stop 1
+    end if
+
+contains
+
+    subroutine run_test(success)
+        logical, intent(out) :: success
+        character(len=:), allocatable :: input, output, error_msg
+
+        input = "if x > 0 then print('positive') else print('non-positive')"
+
+        call transform_lazy_fortran_string(input, output, error_msg)
+
+        success = (len_trim(error_msg) == 0) .and. &
+                  (index(output, "if (x > 0) then") > 0) .and. &
+                  (index(output, "else") > 0) .and. &
+                  (index(output, "print *, 'positive'") > 0) .and. &
+                  (index(output, "print *, 'non-positive'") > 0) .and. &
+                  (index(output, "end if") > 0)
+    end subroutine run_test
+
+end program test_issue_1112_if_else_single_line
+


### PR DESCRIPTION
Summary
- Fix parsing of single-line if-then-else so the else branch is preserved.

Scope
- Parsing only: adjust statement boundary detection in `src/parser/parser_if_constructs.f90`.
- Add focused test: `test/frontend/test_issue_1112_if_else_single_line.f90`.

Verification
- Ran `make test` locally (120s timeout): full pass including new test.
- Manual check: `echo "if x > 0 then print('positive') else print('non-positive')" | fpm run --target fortfront` now includes the else branch.

Rationale
- Addresses issue #1112 where single-line if-then-else lost the else block due to EOL-boundary logic. Now stops before 'else/elseif/endif' keywords on the same line, allowing proper parsing of subsequent branches.
