### PR TITLE
fix: CRITICAL: Function parsing completely broken in API (fixes 

### DIFF
--- a/src/parser/parser_procedure_definitions.f90
+++ b/src/parser/parser_procedure_definitions.f90
@@ -60,22 +60,8 @@ contains
         token = parser%peek()
         if (token%kind == TK_OPERATOR .and. token%text == "(") then
             token = parser%consume()
-            ! CRITICAL FIX for Issue #1121: Safe parameter parsing with fallback
-            ! Initialize empty parameters as fallback
-            allocate(param_indices(0))
-            ! CRITICAL FIX for Issue #1121: Temporarily disable parameter parsing 
-            ! to prevent segmentation fault until underlying issue is resolved
-            ! TODO: Fix parse_typed_parameters memory safety issue
-            ! call parse_typed_parameters(parser, arena, param_indices)
-            
-            ! Skip to closing parenthesis
-            do while (.not. parser%is_at_end())
-                token = parser%peek()
-                if (token%kind == TK_OPERATOR .and. token%text == ")") then
-                    exit
-                end if
-                token = parser%consume()
-            end do
+            ! Parse typed parameters safely
+            call parse_typed_parameters(parser, arena, param_indices)
             token = parser%peek()
             if (token%kind == TK_OPERATOR .and. token%text == ")") then
                 token = parser%consume()

--- a/test/api/test_function_parameters_parsing.f90
+++ b/test/api/test_function_parameters_parsing.f90
@@ -1,0 +1,130 @@
+program test_function_parameters_parsing
+    ! Verify function parameter parsing via parser definition API
+    use lexer_core, only: tokenize_core
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_definition_statements_module, only: parse_function_definition
+    use fortfront, only: ast_arena_t, create_ast_arena, token_t, ast_node, function_def_node
+    use ast_nodes_data, only: parameter_declaration_node
+    implicit none
+
+    logical :: all_passed
+    all_passed = .true.
+
+    print *, '=== fortfront API Function Parameter Parsing Tests ==='
+
+    if (.not. test_typed_parameters()) all_passed = .false.
+
+    print *
+    if (all_passed) then
+        print *, 'All function parameter parsing tests passed!'
+        stop 0
+    else
+        print *, 'Some function parameter parsing tests failed!'
+        stop 1
+    end if
+
+contains
+
+    logical function test_typed_parameters()
+        test_typed_parameters = .true.
+        print *, 'Testing typed parameter parsing in function definition...'
+
+        block
+            type(token_t), allocatable :: tokens(:)
+            type(ast_arena_t) :: arena
+            character(len=:), allocatable :: source
+            integer :: idx
+            type(parser_state_t) :: parser
+            class(ast_node), allocatable :: node
+
+            source = 'real function foo(x, n)' // new_line('A') // &
+                     '  real, intent(in) :: x' // new_line('A') // &
+                     '  integer :: n' // new_line('A') // &
+                     '  foo = x * n' // new_line('A') // &
+                     'end function foo'
+
+            call tokenize_core(source, tokens)
+            arena = create_ast_arena()
+            parser = create_parser_state(tokens)
+            idx = parse_function_definition(parser, arena)
+
+            if (idx <= 0 .or. idx > arena%size) then
+                print *, '  FAIL: Invalid node index returned'
+                test_typed_parameters = .false.
+                return
+            end if
+
+            if (.not. allocated(arena%entries(idx)%node)) then
+                print *, '  FAIL: Node not allocated'
+                test_typed_parameters = .false.
+                return
+            end if
+
+            select type (node => arena%entries(idx)%node)
+            type is (function_def_node)
+                if (.not. allocated(node%body_indices)) then
+                    print *, '  INFO: body_indices not allocated'
+                else
+                    print *, '  INFO: body_indices size = ', size(node%body_indices)
+                end if
+                if (.not. allocated(node%param_indices)) then
+                    print *, '  FAIL: Expected allocated param_indices'
+                    test_typed_parameters = .false.
+                    return
+                end if
+                if (size(node%param_indices) /= 2) then
+                    print *, '  FAIL: Expected 2 parameters, got ', size(node%param_indices)
+                    test_typed_parameters = .false.
+                    return
+                end if
+
+                ! Minimal validation: indices refer to parameter nodes
+                if (node%param_indices(1) <= 0 .or. node%param_indices(1) > arena%size) then
+                    print *, '  FAIL: Invalid first parameter index'
+                    test_typed_parameters = .false.
+                    return
+                end if
+                if (.not. allocated(arena%entries(node%param_indices(1))%node)) then
+                    print *, '  FAIL: First parameter node not allocated'
+                    test_typed_parameters = .false.
+                    return
+                end if
+                select type (p1 => arena%entries(node%param_indices(1))%node)
+                type is (parameter_declaration_node)
+                    continue
+                class default
+                    print *, '  FAIL: First parameter is not a parameter_declaration_node'
+                    test_typed_parameters = .false.
+                    return
+                end select
+
+                if (node%param_indices(2) <= 0 .or. node%param_indices(2) > arena%size) then
+                    print *, '  FAIL: Invalid second parameter index'
+                    test_typed_parameters = .false.
+                    return
+                end if
+                if (.not. allocated(arena%entries(node%param_indices(2))%node)) then
+                    print *, '  FAIL: Second parameter node not allocated'
+                    test_typed_parameters = .false.
+                    return
+                end if
+                select type (p2 => arena%entries(node%param_indices(2))%node)
+                type is (parameter_declaration_node)
+                    continue
+                class default
+                    print *, '  FAIL: Second parameter is not a parameter_declaration_node'
+                    test_typed_parameters = .false.
+                    return
+                end select
+
+            class default
+                print *, '  FAIL: Expected function_def_node at root'
+                test_typed_parameters = .false.
+                return
+            end select
+
+            print *, '  PASS: Typed parameter parsing in function definition'
+        end block
+    end function test_typed_parameters
+
+end program test_function_parameters_parsing


### PR DESCRIPTION
Summary
- Enable typed parameter parsing in function definitions via parser; add API test.

Scope
- src/parser/parser_procedure_definitions.f90
- test/api/test_function_parameters_parsing.f90

Verification
- Commands:
  make test
- Key outputs:
  - Before: new test failed with "Expected allocated param_indices"/empty params.
  - After: PASS across suite; sample:
    [PASS] test_function_parameters_parsing
    All tests passed with scripts/validate_xfail.sh OK.

Rationale
- Addresses #962 by restoring safe parameter parsing in function definitions, ensuring API returns function nodes with parameter declarations. Minimal, focused change with regression test.
