### PR TITLE
fix: [test] Other failing tests: xfail tracking (fixes #1141)

### DIFF
--- a/scripts/validate_xfail.sh
+++ b/scripts/validate_xfail.sh
@@ -24,8 +24,12 @@ mapfile -t candidates < <( \
 )
 
 # Read xfail names (ignore comments/blank lines)
-mapfile -t xfails < <(awk -F, 'NF>=1 && $1 !~ /^#/ && $1!="" {print $1}' "$xfail_file")
-mapfile -t issue_urls < <(awk -F, 'NF>=2 && $1 !~ /^#/ && $1!="" {gsub(/\r$/, "", $2); print $2}' "$xfail_file")
+mapfile -t xfails < <(\
+  awk -F, 'NF>=1 && $1 !~ /^#/ && $1!="" {gsub(/^ +| +$/, "", $1); print $1}' "$xfail_file"\
+)
+mapfile -t issue_urls < <(\
+  awk -F, 'NF>=2 && $1 !~ /^#/ && $1!="" {gsub(/\r$/, "", $2); gsub(/^ +| +$/, "", $2); print $2}' "$xfail_file"\
+)
 
 # If there are no xfails, nothing to validate
 if [[ ${#xfails[@]} -eq 0 ]]; then
@@ -57,23 +61,41 @@ fi
 
 # Validate that referenced issues are open (best-effort; skip non-GitHub URLs)
 closed_list=""
-for url in "${issue_urls[@]:-}"; do
-  [[ -z "$url" ]] && continue
-  if [[ "$url" =~ ^https://github.com/([^/]+)/([^/]+)/issues/([0-9]+)$ ]]; then
-    owner_repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
-    num="${BASH_REMATCH[3]}"
-    state=$(gh issue view "$num" --repo "$owner_repo" --json state --jq .state 2>/dev/null || echo unknown)
-    if [[ "$state" != "OPEN" ]]; then
-      closed_list+="${url} (state: ${state})\n"
+skipped_list=""
+if command -v gh >/dev/null 2>&1; then
+  for url in "${issue_urls[@]:-}"; do
+    [[ -z "$url" ]] && continue
+    if [[ "$url" =~ ^https://github.com/([^/]+)/([^/]+)/issues/([0-9]+)$ ]]; then
+      owner_repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+      num="${BASH_REMATCH[3]}"
+      # If the query fails (e.g., no network/unauthenticated), treat as skipped not an error
+      state=$(gh issue view "$num" --repo "$owner_repo" --json state --jq .state 2>/dev/null || echo __UNKNOWN__)
+      if [[ "$state" == "OPEN" ]]; then
+        :
+      elif [[ "$state" == "__UNKNOWN__" ]]; then
+        skipped_list+="${url} (state query failed)\n"
+      else
+        closed_list+="${url} (state: ${state})\n"
+      fi
     fi
+  done
+else
+  # gh not available; skip issue-state validation to avoid CI flakiness
+  if [[ ${#issue_urls[@]} -gt 0 ]]; then
+    skipped_list+="gh CLI not found; skipped validation for ${#issue_urls[@]} URLs\n"
   fi
-done
+fi
 
 if [[ -n "$closed_list" ]]; then
   echo "ERROR: xfail entries point to closed/non-open issues:" >&2
   printf "%b" "$closed_list" | sed 's/^/  - /' >&2
   echo "Please remove these xfail rows now that tests should pass." >&2
   exit 1
+fi
+
+if [[ -n "$skipped_list" ]]; then
+  echo "WARN: skipped issue-state validation for some xfail URLs:" >&2
+  printf "%b" "$skipped_list" | sed 's/^/  - /' >&2
 fi
 
 exit 0

--- a/scripts/validate_xfail.sh
+++ b/scripts/validate_xfail.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Validate that every entry in test/xfail.csv corresponds to an actual
-# test executable known to fpm (via `fpm test --list`).
+# Validate xfail mappings:
+# - Each test name exists in `fpm test --list` output.
+# - Each mapped GitHub issue URL refers to an OPEN issue.
 
 repo_root=$(cd "$(dirname "$0")/.." && pwd)
 xfail_file="$repo_root/test/xfail.csv"
@@ -24,6 +25,7 @@ mapfile -t candidates < <( \
 
 # Read xfail names (ignore comments/blank lines)
 mapfile -t xfails < <(awk -F, 'NF>=1 && $1 !~ /^#/ && $1!="" {print $1}' "$xfail_file")
+mapfile -t issue_urls < <(awk -F, 'NF>=2 && $1 !~ /^#/ && $1!="" {gsub(/\r$/, "", $2); print $2}' "$xfail_file")
 
 # If there are no xfails, nothing to validate
 if [[ ${#xfails[@]} -eq 0 ]]; then
@@ -50,6 +52,27 @@ if [[ -n "$missing" ]]; then
   echo "ERROR: stale entries in test/xfail.csv (no matching tests):" >&2
   echo "$missing" | sed 's/^/  - /' >&2
   echo "Please remove or correct these entries to avoid XPASS noise." >&2
+  exit 1
+fi
+
+# Validate that referenced issues are open (best-effort; skip non-GitHub URLs)
+closed_list=""
+for url in "${issue_urls[@]:-}"; do
+  [[ -z "$url" ]] && continue
+  if [[ "$url" =~ ^https://github.com/([^/]+)/([^/]+)/issues/([0-9]+)$ ]]; then
+    owner_repo="${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+    num="${BASH_REMATCH[3]}"
+    state=$(gh issue view "$num" --repo "$owner_repo" --json state --jq .state 2>/dev/null || echo unknown)
+    if [[ "$state" != "OPEN" ]]; then
+      closed_list+="${url} (state: ${state})\n"
+    fi
+  fi
+done
+
+if [[ -n "$closed_list" ]]; then
+  echo "ERROR: xfail entries point to closed/non-open issues:" >&2
+  printf "%b" "$closed_list" | sed 's/^/  - /' >&2
+  echo "Please remove these xfail rows now that tests should pass." >&2
   exit 1
 fi
 

--- a/test/xfail.csv
+++ b/test/xfail.csv
@@ -1,5 +1,3 @@
 # test_name,issue_url
 # Temporary expected failure mappings; replace with real fixes and remove.
-# Added for CI stability per issue #1136
-# NOTE: Keep names exactly as in `fpm test --list`.
-test_ast_traversal_simple,https://github.com/lazy-fortran/fortfront/issues/1136
+# Keep names exactly as in `fpm test --list`.


### PR DESCRIPTION
Summary
- Remove stale xfail entry for a now-passing test and ensure xfail entries point to open issues only.

Scope
- scripts/validate_xfail.sh: add check for closed/non-open issue URLs.
- test/xfail.csv: remove stale mapping (issue already closed; test now passes).

Verification
- Baseline: `make test` passed locally before changes.
- After change: `make test` passes with no XPASS; tail excerpt shows `test_ast_traversal_simple` now `[PASS]` and no xfail validation warnings.
  Commands:
    - `make test` (timeout 120s)
  Key outputs:
    - `[PASS] test_ast_traversal_simple`
    - No `[XPASS]` entries; `scripts/validate_xfail.sh` reports no errors.

Rationale
- Keeps xfail.csv accurate and prevents drift by failing CI when entries reference closed issues.
