### PR TITLE
fix: Array assignment generates incomplete invalid code (fixes #869)

### DIFF
--- a/src/parser/parser_basic_statement_module.f90
+++ b/src/parser/parser_basic_statement_module.f90
@@ -54,8 +54,8 @@ contains
                     call analyze_declaration_structure(parser, has_initializer, has_comma)
                     
                     
-                    if (has_initializer .and. .not. has_comma) then
-                        ! Single variable with initializer - use parse_declaration
+                    if (.not. has_comma) then
+                        ! Single-variable declaration (with or without initializer)
                         allocate (stmt_indices(1))
                         stmt_indices(1) = parse_declaration(parser, arena)
                         return
@@ -119,13 +119,89 @@ contains
             block
                 type(token_t) :: id_token, op_token
                 integer :: target_index, value_index
+                integer :: pos, left_end, paren_depth
+                logical :: has_complex_lhs
 
                 id_token = parser%consume()
                 op_token = parser%peek()
 
-                if (op_token%kind == TK_OPERATOR .and. op_token%text == "=") then
+                has_complex_lhs = .false.
+                if (op_token%kind == TK_OPERATOR .and. op_token%text == "(") then
+                    ! LHS is a subscript/call expression like arr(5) = ...
+                    has_complex_lhs = .true.
+                end if
+
+                if (has_complex_lhs) then
+                    ! Find '=' matching at top-level (outside parentheses)
+                    paren_depth = 0
+                    left_end = parser%current_token - 1
+                    do pos = parser%current_token, size(parser%tokens)
+                        if (parser%tokens(pos)%kind == TK_EOF) exit
+                        select case (trim(parser%tokens(pos)%text))
+                        case ("(")
+                            paren_depth = paren_depth + 1
+                        case (")")
+                            if (paren_depth > 0) paren_depth = paren_depth - 1
+                        case ("=")
+                            if (paren_depth == 0) then
+                                left_end = pos - 1
+                                exit
+                            end if
+                        end select
+                        left_end = pos
+                    end do
+
+                    if (left_end >= parser%current_token - 1) then
+                        block
+                            type(token_t), allocatable :: lhs_tokens(:)
+                            integer :: lhs_len
+                            ! Construct LHS token stream: id_token + tokens up to left_end
+                            lhs_len = 1 + max(0, left_end - (parser%current_token) + 1) + 1  ! +EOF
+                            allocate(lhs_tokens(lhs_len))
+                            lhs_tokens(1) = id_token
+                            if (lhs_len >= 2) then
+                                if (left_end >= parser%current_token) then
+                                    lhs_tokens(2:1 + (left_end - parser%current_token + 1)) = &
+                                        parser%tokens(parser%current_token:left_end)
+                                end if
+                            end if
+                            ! EOF sentinel
+                            lhs_tokens(lhs_len)%kind = TK_EOF
+                            lhs_tokens(lhs_len)%text = ""
+                            lhs_tokens(lhs_len)%line = id_token%line
+                            lhs_tokens(lhs_len)%column = id_token%column
+
+                            target_index = parse_expression(lhs_tokens, arena)
+                        end block
+
+                        ! Advance main parser to '=' and consume it
+                        parser%current_token = left_end + 1
+                        op_token = parser%peek()
+                        if (op_token%kind == TK_OPERATOR .and. op_token%text == "=") then
+                            op_token = parser%consume()
+                        end if
+
+                        ! Parse RHS from remaining tokens on this line
+                        block
+                            type(token_t), allocatable :: rhs_tokens(:)
+                            integer :: remaining_count
+                            remaining_count = size(tokens) - parser%current_token + 1
+                            if (remaining_count > 0) then
+                                allocate (rhs_tokens(remaining_count))
+                                rhs_tokens = tokens(parser%current_token:)
+                                value_index = parse_expression(rhs_tokens, arena)
+                                if (value_index > 0 .and. target_index > 0) then
+                                    stmt_index = push_assignment(arena, target_index, value_index, &
+                                                                 id_token%line, id_token%column, &
+                                                                 parent_index)
+                                end if
+                            end if
+                        end block
+                    end if
+                else if (op_token%kind == TK_OPERATOR .and. op_token%text == "=") then
+                    ! Simple identifier assignment: x = expr
                     op_token = parser%consume()  ! consume '='
-    target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column, parent_index)
+                    target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column, parent_index)
                     ! Get remaining tokens for expression parsing
                     block
                         type(token_t), allocatable :: expr_tokens(:)
@@ -135,10 +211,10 @@ contains
                             allocate (expr_tokens(remaining_count))
                             expr_tokens = tokens(parser%current_token:)
                             value_index = parse_expression(expr_tokens, arena)
-                            if (value_index > 0) then
-                        stmt_index = push_assignment(arena, target_index, value_index, &
-                                                         id_token%line, id_token%column, &
-                                                         parent_index)
+                            if (value_index > 0 .and. target_index > 0) then
+                                stmt_index = push_assignment(arena, target_index, value_index, &
+                                                             id_token%line, id_token%column, &
+                                                             parent_index)
                             end if
                         end if
                     end block

--- a/src/parser/parser_declarations.f90
+++ b/src/parser/parser_declarations.f90
@@ -283,8 +283,21 @@ contains
 
         block
             character(len=:), allocatable :: var_name
+            integer, allocatable :: local_dimension_indices(:)
+            logical :: has_local_dimensions
             var_name = token%text
-            
+            has_local_dimensions = .false.
+
+            ! Per-variable dimensions: e.g., "integer :: arr(10)"
+            if (.not. parser%is_at_end()) then
+                token = parser%peek()
+                if (token%text == "(") then
+                    token = parser%consume()  ! consume '('
+                    call parse_array_dimensions(parser, arena, local_dimension_indices)
+                    has_local_dimensions = .true.
+                end if
+            end if
+
             ! Check for initialization
             if (.not. parser%is_at_end()) then
                 token = parser%peek()
@@ -304,6 +317,17 @@ contains
                     type_spec%type_name, &
                     var_name, &
                     dimension_indices=attr_info%global_dimension_indices, &
+                    initializer_index=initializer_index, &
+                    is_allocatable=attr_info%is_allocatable, &
+                    is_pointer=attr_info%is_pointer, &
+                    is_parameter=attr_info%is_parameter &
+                )
+            else if (has_local_dimensions) then
+                decl_index = push_declaration( &
+                    arena, &
+                    type_spec%type_name, &
+                    var_name, &
+                    dimension_indices=local_dimension_indices, &
                     initializer_index=initializer_index, &
                     is_allocatable=attr_info%is_allocatable, &
                     is_pointer=attr_info%is_pointer, &

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -433,22 +433,81 @@ contains
         if (is_multi_assignment) then
             call parse_multi_variable_assignment(parser, arena, stmt_index)
         else
-            ! Original single assignment logic
+            ! Single assignment (identifier or complex LHS like arr(5))
             id_token = parser%consume()
             op_token = parser%peek()
 
-            if (op_token%kind == TK_OPERATOR .and. op_token%text == "=") then
-                op_token = parser%consume()
+            if (op_token%kind == TK_OPERATOR .and. (op_token%text == "=" .or. op_token%text == "(")) then
+                if (op_token%text == "=") then
+                    ! Simple identifier assignment: x = expr
+                    op_token = parser%consume()
+                    target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column)
+                    value_index = parse_range(parser, arena)
+                    if (value_index > 0) then
+                        stmt_index = push_assignment(arena, target_index, value_index, &
+                                                   id_token%line, id_token%column)
+                    end if
+                else if (op_token%text == "(") then
+                    ! Complex LHS: parse expression up to '=' (handles subscripts/slices)
+                    block
+                        integer :: start_pos, pos, paren_depth, left_end
+                        type(token_t), allocatable :: lhs_tokens(:)
+                        type(parser_state_t) :: lhs_parser
+                        integer :: lhs_len
 
-                ! Create target identifier
-                target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column)
+                        start_pos = parser%current_token - 1  ! include id_token already consumed
+                        paren_depth = 0
+                        left_end = start_pos
+                        do pos = parser%current_token, size(parser%tokens)
+                            if (parser%tokens(pos)%kind == TK_EOF) exit
+                            select case (parser%tokens(pos)%text)
+                            case ("(")
+                                paren_depth = paren_depth + 1
+                            case (")")
+                                if (paren_depth > 0) paren_depth = paren_depth - 1
+                            case ("=")
+                                if (paren_depth == 0) then
+                                    left_end = pos - 1
+                                    exit
+                                end if
+                            end select
+                            left_end = pos
+                        end do
 
-                ! Parse value expression
-                value_index = parse_range(parser, arena)
-                
-                if (value_index > 0) then
-                    stmt_index = push_assignment(arena, target_index, value_index, &
-                                               id_token%line, id_token%column)
+                        ! Construct LHS token array: id_token + following tokens up to left_end
+                        lhs_len = (left_end - start_pos + 1) + 1  ! plus EOF
+                        allocate(lhs_tokens(lhs_len))
+                        lhs_tokens(1) = id_token
+                        if (left_end >= parser%current_token) then
+                            lhs_tokens(2:1 + (left_end - parser%current_token + 1)) = &
+                                parser%tokens(parser%current_token:left_end)
+                        end if
+                        lhs_tokens(lhs_len)%kind = TK_EOF
+                        lhs_tokens(lhs_len)%text = ""
+                        lhs_tokens(lhs_len)%line = id_token%line
+                        lhs_tokens(lhs_len)%column = id_token%column
+
+                        lhs_parser = create_parser_state(lhs_tokens)
+                        target_index = parse_range(lhs_parser, arena)
+                    end block
+
+                    ! Advance original parser to '=' and consume it
+                    do while (.not. parser%is_at_end())
+                        op_token = parser%peek()
+                        if (op_token%kind == TK_OPERATOR .and. op_token%text == "=") then
+                            op_token = parser%consume()
+                            exit
+                        else
+                            op_token = parser%consume()
+                        end if
+                    end do
+
+                    ! Parse RHS on original parser
+                    value_index = parse_range(parser, arena)
+                    if (value_index > 0 .and. target_index > 0) then
+                        stmt_index = push_assignment(arena, target_index, value_index, &
+                                                   id_token%line, id_token%column)
+                    end if
                 end if
             end if
         end if

--- a/test/codegen/test_array_assignment_basic.f90
+++ b/test/codegen/test_array_assignment_basic.f90
@@ -1,0 +1,33 @@
+program test_array_assignment_basic
+    ! Regression for issue #869: array assignment should be preserved in codegen
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+
+    source = "program demo" // new_line('a') // &
+             "  implicit none" // new_line('a') // &
+             "  integer :: arr(10)" // new_line('a') // &
+             "  arr(5) = 100" // new_line('a') // &
+             "end program demo"
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) then
+            print *, 'ERROR: ', trim(error_msg)
+            stop 1
+        end if
+    end if
+
+    if (index(output, 'arr(5) = 100') > 0 .or. index(output, 'arr(5)=100') > 0) then
+        print *, 'PASS: array assignment preserved'
+    else
+        print *, 'FAIL: array assignment missing in output'
+        print *, 'Output:'
+        print *, trim(output)
+        stop 1
+    end if
+end program test_array_assignment_basic


### PR DESCRIPTION
Summary
- Fix parsing for array-element assignments and per-variable dimensions.
- Add regression test ensuring `arr(5) = 100` is preserved.

Scope
- Parser: `parser_execution_statements.f90`, `parser_basic_statement_module.f90`, `parser_declarations.f90`.
- Tests: `test/codegen/test_array_assignment_basic.f90`.

Verification
- Commands:
  - make clean && make test TEST_TIMEOUT=120s
- Key outputs:
  - PASS test_array_assignment_basic
  - Overall tests pass locally (see CI for full logs).

Rationale
- Resolves #869 by ensuring the LHS of assignments can be complex (e.g., `arr(5)`), and per-variable array dimensions in declarations are preserved in the AST and codegen.
