### PR TITLE
fix: [test] frontend /comprehensive: xfail tracking (fixes #1137)

### DIFF
--- a/scripts/run_tests_with_xfail.sh
+++ b/scripts/run_tests_with_xfail.sh
@@ -55,14 +55,22 @@ run_with_timeout() {
 
 xfail_file="test/xfail.csv"
 declare -A XFAIL
+declare -A XFAIL_PATTERNS
 if [[ -f "$xfail_file" ]]; then
-  # Format: test_name,issue_url
+  # Format: test_name_or_glob,issue_url
+  # - Exact names must match entries from `fpm test --list`
+  # - Globs supported using shell patterns (*, ?, [..])
   while IFS=, read -r name url; do
     name=$(echo "$name" | sed 's/^ *//;s/ *$//')
     url=$(echo "$url" | sed 's/^ *//;s/ *$//')
     [[ -n "$name" ]] || continue
     [[ "$name" =~ ^# ]] && continue
-    XFAIL["$name"]="$url"
+    if [[ "$name" == *[*?[]* ]]; then
+      # Treat as glob pattern
+      XFAIL_PATTERNS["$name"]="$url"
+    else
+      XFAIL["$name"]="$url"
+    fi
   done < "$xfail_file"
 fi
 
@@ -107,9 +115,23 @@ run_one() {
   local tmp_log
   tmp_log=$(mktemp)
   run_with_timeout "$exe" >"$tmp_log" 2>&1 || code=$?
+  # Determine if this test is expected to fail via exact or pattern match
+  local xfail_url=""
+  if [[ -n "${XFAIL[$t]:-}" ]]; then
+    xfail_url="${XFAIL[$t]}"
+  else
+    # check glob patterns
+    for pat in "${!XFAIL_PATTERNS[@]}"; do
+      if [[ "$t" == $pat ]]; then
+        xfail_url="${XFAIL_PATTERNS[$pat]}"
+        break
+      fi
+    done
+  fi
+
   if [[ $code -eq 0 ]]; then
-    if [[ -n "${XFAIL[$t]:-}" ]]; then
-      echo "[XPASS] $t (was xfail: ${XFAIL[$t]})" | tee -a "$results_dir/summary"
+    if [[ -n "$xfail_url" ]]; then
+      echo "[XPASS] $t (was xfail: $xfail_url)" | tee -a "$results_dir/summary"
       echo "XPASS" >"$results_dir/$t.status"
     else
       echo "[PASS] $t" | tee -a "$results_dir/summary"
@@ -117,9 +139,9 @@ run_one() {
     fi
     rm -f "$tmp_log" 2>/dev/null || true
   elif [[ $code -eq 124 ]]; then
-    if [[ -n "${XFAIL[$t]:-}" ]]; then
+    if [[ -n "$xfail_url" ]]; then
       mv -f "$tmp_log" "logs/${t}.log" 2>/dev/null || true
-      echo "[XFAIL] $t -> timeout after ${TIME_LIMIT}s (${XFAIL[$t]})" | tee -a "$results_dir/summary"
+      echo "[XFAIL] $t -> timeout after ${TIME_LIMIT}s ($xfail_url)" | tee -a "$results_dir/summary"
       echo "XFAIL" >"$results_dir/$t.status"
     else
       mv -f "$tmp_log" "logs/${t}.log" 2>/dev/null || true
@@ -127,9 +149,9 @@ run_one() {
       echo "FAIL" >"$results_dir/$t.status"
     fi
   else
-    if [[ -n "${XFAIL[$t]:-}" ]]; then
+    if [[ -n "$xfail_url" ]]; then
       mv -f "$tmp_log" "logs/${t}.log" 2>/dev/null || true
-      echo "[XFAIL] $t -> exit=$code (${XFAIL[$t]})" | tee -a "$results_dir/summary"
+      echo "[XFAIL] $t -> exit=$code ($xfail_url)" | tee -a "$results_dir/summary"
       echo "XFAIL" >"$results_dir/$t.status"
     else
       mv -f "$tmp_log" "logs/${t}.log" 2>/dev/null || true

--- a/scripts/validate_xfail.sh
+++ b/scripts/validate_xfail.sh
@@ -23,7 +23,7 @@ mapfile -t candidates < <( \
     | awk '{print $1}' \
 )
 
-# Read xfail names (ignore comments/blank lines)
+# Read xfail names (ignore comments/blank lines); support glob patterns (*,?,[...])
 mapfile -t xfails < <(\
   awk -F, 'NF>=1 && $1 !~ /^#/ && $1!="" {gsub(/^ +| +$/, "", $1); print $1}' "$xfail_file"\
 )
@@ -43,18 +43,30 @@ if [[ ${#candidates[@]} -eq 0 ]]; then
   exit 0
 fi
 
-# Compare sets to find dangling xfail entries not present in candidates
-tmpdir=$(mktemp -d)
-trap 'rm -rf "$tmpdir"' EXIT
+# Validate each xfail entry: exact names must exist; globs must match >=1
+stale_list=""
+for name in "${xfails[@]}"; do
+  if [[ "$name" == *[*?[]* ]]; then
+    # glob pattern
+    matched=0
+    for cand in "${candidates[@]}"; do
+      if [[ "$cand" == $name ]]; then matched=1; break; fi
+    done
+    if [[ $matched -eq 0 ]]; then
+      stale_list+="$name\n"
+    fi
+  else
+    # exact
+    found=$(printf '%s\n' "${candidates[@]}" | grep -x -- "$name" || true)
+    if [[ -z "$found" ]]; then
+      stale_list+="$name\n"
+    fi
+  fi
+done
 
-printf '%s\n' "${xfails[@]}" | sort -u >"$tmpdir/xfails.txt"
-printf '%s\n' "${candidates[@]}" | sort -u >"$tmpdir/candidates.txt"
-
-missing=$(comm -23 "$tmpdir/xfails.txt" "$tmpdir/candidates.txt" || true)
-
-if [[ -n "$missing" ]]; then
+if [[ -n "$stale_list" ]]; then
   echo "ERROR: stale entries in test/xfail.csv (no matching tests):" >&2
-  echo "$missing" | sed 's/^/  - /' >&2
+  printf "%b" "$stale_list" | sed 's/^/  - /' >&2
   echo "Please remove or correct these entries to avoid XPASS noise." >&2
   exit 1
 fi

--- a/scripts/xfail_runner.sh
+++ b/scripts/xfail_runner.sh
@@ -11,8 +11,28 @@ xfail_file="$repo_root/test/xfail.csv"
 TIME_LIMIT=${TIME_LIMIT:-120}
 
 issue=""
+# Support both exact names and glob patterns in test/xfail.csv
 if [[ -f "$xfail_file" ]]; then
-  issue=$(awk -F, -v n="$name" 'BEGIN{found=""} $1==n{found=$2} END{print found}' "$xfail_file")
+  # Exact match fast-path
+  issue=$(awk -F, -v n="$name" 'BEGIN{found=""} $1==n{gsub(/\r$/, "", $2); found=$2} END{print found}' "$xfail_file")
+  if [[ -z "$issue" ]]; then
+    # Pattern match: treat entries containing glob metacharacters (*, ?, [) as shell globs
+    while IFS=, read -r pat url; do
+      # Trim spaces
+      pat=$(echo "$pat" | sed 's/^ *//;s/ *$//')
+      url=$(echo "$url" | sed 's/^ *//;s/ *$//')
+      # Skip comments/blank lines
+      [[ -z "$pat" ]] && continue
+      [[ "$pat" =~ ^# ]] && continue
+      # Only consider globs here; exact names already handled above
+      if [[ "$pat" == *[*?[]* ]]; then
+        if [[ "$name" == $pat ]]; then
+          issue="$url"
+          break
+        fi
+      fi
+    done < "$xfail_file"
+  fi
 fi
 
 mkdir -p "$repo_root/logs"

--- a/test/xfail.csv
+++ b/test/xfail.csv
@@ -1,3 +1,5 @@
 # test_name,issue_url
 # Temporary expected failure mappings; replace with real fixes and remove.
-# Keep names exactly as in `fpm test --list`.
+# Names can be either exact test names (as in `fpm test --list`) or
+# shell globs to match multiple tests (e.g., `test_frontend_*`).
+# Format: name_or_glob,https://github.com/<org>/<repo>/issues/<n>


### PR DESCRIPTION
Summary
- Add glob pattern support to `test/xfail.csv` and update xfail-aware runner/validator to handle groups of tests.

Scope
- scripts/run_tests_with_xfail.sh
- scripts/validate_xfail.sh
- test/xfail.csv (comment docs only; no entries added)

Verification
- Baseline tests:
  - Command: `make test`
  - Result: full pass locally (no xfails present).
- Glob support demonstration (non-committed, local):
  - Command:
    - `printf "test_codegen_*,https://github.com/lazy-fortran/fortfront/issues/1137\n" > test/xfail.csv`
    - `TIME_LIMIT=60 TEST_JOBS=1 scripts/run_tests_with_xfail.sh | tee logs/xfail_glob_demo.out`
    - `git checkout -- test/xfail.csv` (restore)
  - Excerpts:
    - XPASS lines observed for matching tests (example):
      - `[XPASS] test_codegen_core_comprehensive (was xfail: https://github.com/lazy-fortran/fortfront/issues/1137)`
      - `[XPASS] test_codegen_comprehensive (was xfail: https://github.com/lazy-fortran/fortfront/issues/1137)`
    - Summary shows zero FAIL; XPASS>0 as expected.

Rationale
- Issue #1137 tracks grouped failing tests. Glob support makes it practical to temporarily xfail coherent groups (e.g., `frontend` comprehensive) without enumerating every test name. Validator enforces that globs match at least one discovered test and that linked issues remain open.

Verification (Update)
- Updated scripts/xfail_runner.sh to honor glob entries in test/xfail.csv so the default Makefile path (fpm --runner) matches validator behavior.
- Local run: make test → full pass (no xfails present).
