### PR TITLE
fix: [test] allocatable /arrays: xfail tracking (fixes #1128)

### DIFF
--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -89,6 +89,10 @@ contains
             code = generate_code_comment(node)
         type is (blank_line_node)
             code = generate_code_blank_line(node)
+        type is (allocate_statement_node)
+            code = generate_code_allocate_statement(arena, node, node_index)
+        type is (deallocate_statement_node)
+            code = generate_code_deallocate_statement(arena, node, node_index)
             
         ! Control flow nodes
         type is (if_node)

--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -24,6 +24,8 @@ module codegen_statements
     public :: generate_code_implicit_statement
     public :: generate_code_comment
     public :: generate_code_blank_line
+    public :: generate_code_allocate_statement
+    public :: generate_code_deallocate_statement
 
 contains
     ! Generate code for assignment statements
@@ -343,5 +345,92 @@ contains
     end function generate_code_blank_line
 
     ! generate_code_from_arena is provided as an interface at the module level
+
+    ! Generate code for allocate statements
+    function generate_code_allocate_statement(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(allocate_statement_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+        character(len=:), allocatable :: args, var_code, shape_code
+        integer :: i, j
+
+        args = ""
+
+        if (allocated(node%var_indices)) then
+            do i = 1, size(node%var_indices)
+                if (i > 1) args = args // ", "
+                if (node%var_indices(i) > 0 .and. node%var_indices(i) <= arena%size) then
+                    var_code = generate_code_from_arena(arena, node%var_indices(i))
+                else
+                    var_code = ""
+                end if
+                if (i == 1) then
+                    ! Attach shape to the first variable if present
+                    if (allocated(node%shape_indices)) then
+                        if (size(node%shape_indices) > 0) then
+                            shape_code = ""
+                            do j = 1, size(node%shape_indices)
+                                if (j > 1) shape_code = shape_code // ", "
+                                if (node%shape_indices(j) > 0 .and. node%shape_indices(j) <= arena%size) then
+                                    shape_code = shape_code // generate_code_from_arena(arena, node%shape_indices(j))
+                                end if
+                            end do
+                            if (len(shape_code) > 0) then
+                                var_code = var_code // "(" // shape_code // ")"
+                            end if
+                        end if
+                    end if
+                end if
+                args = args // var_code
+            end do
+        end if
+
+        ! Optional keyword arguments
+        if (node%stat_var_index > 0 .and. node%stat_var_index <= arena%size) then
+            args = args // ", stat=" // generate_code_from_arena(arena, node%stat_var_index)
+        end if
+        if (node%errmsg_var_index > 0 .and. node%errmsg_var_index <= arena%size) then
+            args = args // ", errmsg=" // generate_code_from_arena(arena, node%errmsg_var_index)
+        end if
+        if (node%source_expr_index > 0 .and. node%source_expr_index <= arena%size) then
+            args = args // ", source=" // generate_code_from_arena(arena, node%source_expr_index)
+        end if
+        if (node%mold_expr_index > 0 .and. node%mold_expr_index <= arena%size) then
+            args = args // ", mold=" // generate_code_from_arena(arena, node%mold_expr_index)
+        end if
+
+        code = "allocate(" // args // ")"
+    end function generate_code_allocate_statement
+
+    ! Generate code for deallocate statements
+    function generate_code_deallocate_statement(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(deallocate_statement_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+        character(len=:), allocatable :: args
+        integer :: i
+
+        args = ""
+
+        if (allocated(node%var_indices)) then
+            do i = 1, size(node%var_indices)
+                if (i > 1) args = args // ", "
+                if (node%var_indices(i) > 0 .and. node%var_indices(i) <= arena%size) then
+                    args = args // generate_code_from_arena(arena, node%var_indices(i))
+                end if
+            end do
+        end if
+
+        if (node%stat_var_index > 0 .and. node%stat_var_index <= arena%size) then
+            args = args // ", stat=" // generate_code_from_arena(arena, node%stat_var_index)
+        end if
+        if (node%errmsg_var_index > 0 .and. node%errmsg_var_index <= arena%size) then
+            args = args // ", errmsg=" // generate_code_from_arena(arena, node%errmsg_var_index)
+        end if
+
+        code = "deallocate(" // args // ")"
+    end function generate_code_deallocate_statement
 
 end module codegen_statements

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -437,7 +437,8 @@ contains
               'implicit', 'none', 'parameter', 'dimension', 'allocatable', &
               'intent', 'in', 'out', 'inout', 'use', 'module', 'contains', &
               'public', 'private', 'type', 'class', 'extends', 'abstract', &
-              'procedure', 'interface', 'generic', 'operator', 'assignment', 'print', 'read', 'write', 'call')
+              'procedure', 'interface', 'generic', 'operator', 'assignment', 'print', 'read', 'write', 'call', &
+              'allocate', 'deallocate')
             keyword = .true.
         case default
             keyword = .false.

--- a/src/standardizers/standardizer_types.f90
+++ b/src/standardizers/standardizer_types.f90
@@ -453,7 +453,9 @@ contains
                                             if (step_val == INVALID_INTEGER) then
                                                 sz = calculate_loop_size(arena, node%element_indices(3), node%element_indices(4), 0)
                                             else
-                                                sz = calculate_loop_size(arena, node%element_indices(3), node%element_indices(4), node%element_indices(5))
+                                                sz = calculate_loop_size(arena, node%element_indices(3), &
+                                                                         node%element_indices(4), &
+                                                                         node%element_indices(5))
                                             end if
                                             if (sz > 0) then
                                                 write(var_type, '(a,a,i0,a)') trim(elem_type_str), ", dimension(", sz, ")"

--- a/test/codegen/test_basic_allocate_codegen.f90
+++ b/test/codegen/test_basic_allocate_codegen.f90
@@ -11,20 +11,21 @@ program test_basic_allocate_codegen
         'integer, parameter :: n = 100' // new_line('a') // &
         'integer, dimension(n) :: arr'   // new_line('a') // &
         'integer, allocatable :: dyn_arr(:)' // new_line('a') // &
-        'allocate(dyn_arr(n))' // new_line('a')
+        'allocate(dyn_arr(n))' // new_line('a') // &
+        'deallocate(dyn_arr)'
 
     call transform_lazy_fortran_string(source, output, error_msg)
 
-    ok = index(output, 'allocate(dyn_arr(n))') > 0
+    ok = index(output, 'allocate(dyn_arr(n))') > 0 .and. &
+         index(output, 'deallocate(dyn_arr)') > 0
 
     if (.not. ok) then
-        print *, 'FAIL: allocate statement not preserved in output'
+        print *, 'FAIL: allocate/deallocate statement(s) not preserved in output'
         print *, 'Output:'
         print *, trim(output)
         stop 1
     end if
 
-    print *, 'PASS: allocate statement preserved'
+    print *, 'PASS: allocate/deallocate statements preserved'
     stop 0
 end program test_basic_allocate_codegen
-

--- a/test/codegen/test_basic_allocate_codegen.f90
+++ b/test/codegen/test_basic_allocate_codegen.f90
@@ -1,0 +1,30 @@
+program test_basic_allocate_codegen
+    use frontend, only: transform_lazy_fortran_string
+    implicit none
+
+    character(len=:), allocatable :: source, output, error_msg
+    logical :: ok
+
+    print *, '=== Codegen: allocate/deallocate preservation ==='
+
+    source = '' // &
+        'integer, parameter :: n = 100' // new_line('a') // &
+        'integer, dimension(n) :: arr'   // new_line('a') // &
+        'integer, allocatable :: dyn_arr(:)' // new_line('a') // &
+        'allocate(dyn_arr(n))' // new_line('a')
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    ok = index(output, 'allocate(dyn_arr(n))') > 0
+
+    if (.not. ok) then
+        print *, 'FAIL: allocate statement not preserved in output'
+        print *, 'Output:'
+        print *, trim(output)
+        stop 1
+    end if
+
+    print *, 'PASS: allocate statement preserved'
+    stop 0
+end program test_basic_allocate_codegen
+

--- a/test/lexer/test_frontend_lexer_keywords.f90
+++ b/test/lexer/test_frontend_lexer_keywords.f90
@@ -11,6 +11,7 @@ program test_lexer_keywords
     if (.not. test_control_keywords()) all_passed = .false.
     if (.not. test_type_keywords()) all_passed = .false.
     if (.not. test_io_keywords()) all_passed = .false.
+    if (.not. test_memory_keywords()) all_passed = .false.
     if (.not. test_case_insensitive()) all_passed = .false.
 
     ! Report results
@@ -142,6 +143,34 @@ contains
 
         print '(a)', "PASS: I/O keyword tokenization"
     end function test_io_keywords
+
+    logical function test_memory_keywords()
+        type(token_t), allocatable :: tokens(:)
+        character(len=10), dimension(2) :: mem_keywords = [ &
+            "allocate  ", "deallocate" &
+        ]
+        integer :: i
+
+        test_memory_keywords = .true.
+        print '(a)', "Testing memory keyword tokenization..."
+
+        do i = 1, size(mem_keywords)
+            call tokenize_core(trim(mem_keywords(i)), tokens)
+            if (tokens(1)%kind /= TK_KEYWORD) then
+                print '(a,a)', "FAIL: Expected KEYWORD token for: ", trim(mem_keywords(i))
+                test_memory_keywords = .false.
+                return
+            end if
+
+            if (tokens(1)%text /= trim(mem_keywords(i))) then
+                print '(a,a)', "FAIL: Wrong text for keyword: ", trim(mem_keywords(i))
+                test_memory_keywords = .false.
+                return
+            end if
+        end do
+
+        print '(a)', "PASS: Memory keyword tokenization"
+    end function test_memory_keywords
 
     logical function test_case_insensitive()
         type(token_t), allocatable :: tokens(:)


### PR DESCRIPTION
Summary
- Add allocate/deallocate code generation and lex them as keywords to preserve allocation statements.

Scope
- src/lexer/lexer_scanners.f90
- src/codegen/codegen_core.f90
- src/codegen/codegen_statements.f90
- test/codegen/test_basic_allocate_codegen.f90
- test/lexer/test_frontend_lexer_keywords.f90

Verification
- Ran: make test (120s timeout)
- Key excerpt (new/updated tests):
  PASS: test_basic_allocate_codegen
  - Asserts both `allocate(dyn_arr(n))` and `deallocate(dyn_arr)` are preserved in output.
  PASS: test_frontend_lexer_keywords
  - Asserts `allocate` and `deallocate` tokenize as `TK_KEYWORD`.
- Manual CLI check:
  echo "allocate(dyn_arr(n))" | build/.../app/fortfront
  Output now includes program scaffolding (no errors) and preserves allocate when in context.

Rationale
- Lexer did not classify "allocate/deallocate" as keywords, so parser dropped the statements.
- Codegen lacked handlers for allocate/deallocate nodes. Implementing both restores expected behavior for allocatable arrays.
