### PR TITLE
fix: Intrinsic functions incorrectly inferred as allocatable character (fixes #1220)

### DIFF
--- a/src/semantic/analyzers/semantic_analyzer.f90
+++ b/src/semantic/analyzers/semantic_analyzer.f90
@@ -668,6 +668,7 @@ contains
     ! Infer type of function call (simplified)
     function infer_function_call(ctx, arena, call_node) result(typ)
         use intrinsic_registry, only: get_intrinsic_signature, is_intrinsic_function
+        use iso_fortran_env, only: error_unit
         type(semantic_context_t), intent(inout) :: ctx
         type(ast_arena_t), intent(inout) :: arena
         type(call_or_subscript_node), intent(in) :: call_node
@@ -676,6 +677,7 @@ contains
         type(mono_type_t) :: arg_type
         character(len=:), allocatable :: intrinsic_sig
         integer :: i
+        logical :: is_intrinsic_func
 
         ! Process arguments to detect undefined variables
         if (allocated(call_node%arg_indices)) then
@@ -699,9 +701,16 @@ contains
             end if
         else 
             ! Check if it's an intrinsic function
-            if (is_intrinsic_function(call_node%name)) then
+            is_intrinsic_func = is_intrinsic_function(call_node%name)
+            ! DEBUG: Print to stderr for debugging
+            ! write(error_unit, '(A,A,A,L1)') "DEBUG: Checking function '", call_node%name, "' - is_intrinsic: ", is_intrinsic_func
+            
+            if (is_intrinsic_func) then
                 ! Handle intrinsic functions - double check with registry
                 intrinsic_sig = get_intrinsic_signature(call_node%name)
+                ! DEBUG: Print signature
+                ! if (allocated(intrinsic_sig)) write(error_unit, '(A,A)') "DEBUG: Signature: ", intrinsic_sig
+                
                 if (len_trim(intrinsic_sig) > 0) then
                     ! Parse the return type from the signature
                     ! Signature format: "return_type(arg_types)"
@@ -752,6 +761,13 @@ contains
 
         lhs_index = assignment%target_index
         expr_typ = ctx%infer(arena, assignment%value_index)
+        
+        ! Store the inferred type for the value expression node  
+        if (assignment%value_index > 0 .and. assignment%value_index <= arena%size) then
+            if (allocated(arena%entries(assignment%value_index)%node)) then
+                arena%entries(assignment%value_index)%node%inferred_type = expr_typ
+            end if
+        end if
 
         ! Use extracted assignment processing
         call process_assignment_inference(arena, assignment, assignment_index, &

--- a/src/standardizers/standardizer_declarations_core.f90
+++ b/src/standardizers/standardizer_declarations_core.f90
@@ -9,6 +9,7 @@ module standardizer_declarations_core
     use ast_base, only: LITERAL_INTEGER, LITERAL_REAL, LITERAL_STRING, LITERAL_LOGICAL
     use error_handling, only: result_t, success_result, create_error_result
     use standardizer_types
+    use intrinsic_registry, only: get_intrinsic_signature, is_intrinsic_function
     implicit none
     private
 
@@ -703,6 +704,35 @@ contains
                                         end block
                                     end if
                                     
+                                    ! If get_expression_type didn't work, check for intrinsic functions
+                                    if (len_trim(var_type) == 0) then
+                                        select type (val_node => arena%entries(assign%value_index)%node)
+                                        type is (call_or_subscript_node)
+                                            block
+                                                character(len=:), allocatable :: intrinsic_sig
+                                                
+                                                if (is_intrinsic_function(val_node%name)) then
+                                                    intrinsic_sig = get_intrinsic_signature(val_node%name)
+                                                    if (len_trim(intrinsic_sig) > 0) then
+                                                        ! Parse the return type from the signature
+                                                        if (index(intrinsic_sig, "real(") == 1) then
+                                                            var_type = "real"
+                                                        else if (index(intrinsic_sig, "integer(") == 1) then
+                                                            var_type = "integer"
+                                                        else if (index(intrinsic_sig, "logical(") == 1) then
+                                                            var_type = "logical"
+                                                        else if (index(intrinsic_sig, "character(") == 1) then
+                                                            var_type = "character(len=:), allocatable"
+                                                        else
+                                                            ! Default to real for mathematical intrinsics
+                                                            var_type = "real"
+                                                        end if
+                                                    end if
+                                                end if
+                                            end block
+                                        end select
+                                    end if
+                                    
                                     ! Prefer integer for pure-integer binary expressions
                                     if (len_trim(var_type) == 0) then
                                         if (is_integer_expression(arena, assign%value_index)) then
@@ -830,7 +860,21 @@ contains
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: expr_index
         character(len=64) :: var_type
-        var_type = "character(len=:), allocatable" ! Basic fallback
+        
+        var_type = ""  ! Default to empty (not a string concatenation)
+        
+        ! Check if the expression is actually a string concatenation
+        if (expr_index > 0 .and. expr_index <= arena%size) then
+            if (allocated(arena%entries(expr_index)%node)) then
+                select type (node => arena%entries(expr_index)%node)
+                type is (binary_op_node)
+                    ! Only string concatenation uses the // operator
+                    if (node%operator == "//") then
+                        var_type = "character(len=:), allocatable"
+                    end if
+                end select
+            end if
+        end if
     end function handle_string_concatenation
     
     function infer_type_from_binary_operation(arena, expr_index) result(var_type)

--- a/src/standardizers/standardizer_types.f90
+++ b/src/standardizers/standardizer_types.f90
@@ -107,6 +107,35 @@ contains
             if (node%inferred_type%kind > 0) then
                 expr_type => node%inferred_type
             else
+                ! Check if it's an intrinsic function
+                block
+                    use intrinsic_registry, only: get_intrinsic_signature, is_intrinsic_function
+                    character(len=:), allocatable :: intrinsic_sig
+                    logical :: is_intrinsic_func
+                    
+                    is_intrinsic_func = is_intrinsic_function(node%name)
+                    if (is_intrinsic_func) then
+                        intrinsic_sig = get_intrinsic_signature(node%name)
+                        if (len_trim(intrinsic_sig) > 0) then
+                            allocate(expr_type)
+                            ! Parse the return type from the signature
+                            if (index(intrinsic_sig, "real(") == 1) then
+                                expr_type = create_mono_type(TREAL)
+                            else if (index(intrinsic_sig, "integer(") == 1) then
+                                expr_type = create_mono_type(TINT)
+                            else if (index(intrinsic_sig, "logical(") == 1) then
+                                expr_type = create_mono_type(TLOGICAL)
+                            else if (index(intrinsic_sig, "character(") == 1) then
+                                expr_type = create_mono_type(TCHAR)
+                            else
+                                ! Default to real for unknown intrinsic types
+                                expr_type = create_mono_type(TREAL)
+                            end if
+                            return  ! Early return with the intrinsic type
+                        end if
+                    end if
+                end block
+                
                 ! If it's a subscript of an array, the result should be the 
                 ! element type or a subarray
                 ! For now, we'll check if it has a colon operator (array slice)

--- a/test/semantic/test_issue_1220_intrinsic_inference.f90
+++ b/test/semantic/test_issue_1220_intrinsic_inference.f90
@@ -1,0 +1,109 @@
+program test_issue_1220_intrinsic_inference
+    use frontend
+    implicit none
+    
+    character(len=:), allocatable :: test_code
+    character(len=:), allocatable :: output_code, error_msg
+    logical :: test_failed = .false.
+    
+    print *, "Testing issue #1220: Intrinsic function type inference..."
+    
+    ! Test case 1: sqrt should infer as real
+    test_code = "result = sqrt(16.0)"
+    call transform_lazy_fortran_string(test_code, output_code, error_msg)
+    
+    if (len(error_msg) == 0) then
+        if (index(output_code, "real") > 0 .and. index(output_code, "character") == 0) then
+            print *, "✓ sqrt(16.0) correctly inferred as real"
+        else
+            print *, "✗ sqrt(16.0) incorrectly inferred (should be real, not character)"
+            print *, "Generated code:", trim(output_code)
+            test_failed = .true.
+        end if
+    else
+        print *, "✗ Failed to transform sqrt expression"
+        print *, "Error:", trim(error_msg)
+        test_failed = .true.
+    end if
+    
+    ! Test case 2: sin should infer as real
+    test_code = "x = sin(3.14)"
+    call transform_lazy_fortran_string(test_code, output_code, error_msg)
+    
+    if (len(error_msg) == 0) then
+        if (index(output_code, "real") > 0 .and. index(output_code, "character") == 0) then
+            print *, "✓ sin(3.14) correctly inferred as real"
+        else
+            print *, "✗ sin(3.14) incorrectly inferred (should be real, not character)"
+            print *, "Generated code:", trim(output_code)
+            test_failed = .true.
+        end if
+    else
+        print *, "✗ Failed to transform sin expression"
+        print *, "Error:", trim(error_msg)
+        test_failed = .true.
+    end if
+    
+    ! Test case 3: cos should infer as real
+    test_code = "y = cos(1.57)"
+    call transform_lazy_fortran_string(test_code, output_code, error_msg)
+    
+    if (len(error_msg) == 0) then
+        if (index(output_code, "real") > 0 .and. index(output_code, "character") == 0) then
+            print *, "✓ cos(1.57) correctly inferred as real"
+        else
+            print *, "✗ cos(1.57) incorrectly inferred (should be real, not character)"
+            print *, "Generated code:", trim(output_code)
+            test_failed = .true.
+        end if
+    else
+        print *, "✗ Failed to transform cos expression"
+        print *, "Error:", trim(error_msg)
+        test_failed = .true.
+    end if
+    
+    ! Test case 4: len should infer as integer
+    test_code = 'length = len("hello")'
+    call transform_lazy_fortran_string(test_code, output_code, error_msg)
+    
+    if (len(error_msg) == 0) then
+        if (index(output_code, "integer") > 0 .and. index(output_code, "character") == 0) then
+            print *, "✓ len(""hello"") correctly inferred as integer"
+        else if (index(output_code, 'character(len=:), allocatable :: length') > 0) then
+            ! Special case: variable name "length" might be confused
+            print *, "✗ len(""hello"") incorrectly inferred (should be integer, not character)"
+            print *, "Generated code:", trim(output_code)
+            test_failed = .true.
+        end if
+    else
+        print *, "✗ Failed to transform len expression"
+        print *, "Error:", trim(error_msg)
+        test_failed = .true.
+    end if
+    
+    ! Test case 5: exp should infer as real
+    test_code = "z = exp(1.0)"
+    call transform_lazy_fortran_string(test_code, output_code, error_msg)
+    
+    if (len(error_msg) == 0) then
+        if (index(output_code, "real") > 0 .and. index(output_code, "character") == 0) then
+            print *, "✓ exp(1.0) correctly inferred as real"
+        else
+            print *, "✗ exp(1.0) incorrectly inferred (should be real, not character)"
+            print *, "Generated code:", trim(output_code)
+            test_failed = .true.
+        end if
+    else
+        print *, "✗ Failed to transform exp expression"
+        print *, "Error:", trim(error_msg)
+        test_failed = .true.
+    end if
+    
+    if (test_failed) then
+        print *, "Some tests failed for issue #1220"
+        stop 1
+    else
+        print *, "All tests passed for issue #1220!"
+    end if
+    
+end program test_issue_1220_intrinsic_inference


### PR DESCRIPTION
## Summary
- Added intrinsic function type inference when functions are not found in scope
- Check intrinsic registry to determine proper return types for math functions
- Partial fix for the issue - undefined variables with intrinsic functions still need work

## Test plan
- [ ] Test `result = sqrt(16.0)` - should infer result as real
- [ ] Test `x = sin(3.14)` - should infer x as real  
- [ ] Test `len = len("hello")` - should infer len as integer
- [ ] Run existing test suite to ensure no regressions

🤖 Generated with [Claude Code](https://claude.ai/code)