### PR TITLE
fix: Subroutines generate extra unnamed_subroutine() in output (fixes #1260)

### DIFF
--- a/src/frontend_parsing.f90
+++ b/src/frontend_parsing.f90
@@ -339,16 +339,17 @@ contains
                 end if
                 unit_end = i
             end do
-        else if (unit_type == "subroutine" .or. unit_type == "function" .or. unit_type == "program") then
-            ! For subroutines, functions and programs, find the matching "end"
-            nesting_level = 1
+        else if (unit_type == "subroutine" .or. unit_type == "function") then
+            ! For standalone subroutines and functions, find the matching "end"
+            ! Note: We only handle standalone procedures here. 
+            ! Internal procedures are handled by the default logic below
             do i = start_pos + 1, size(tokens)
                 if (tokens(i)%kind == TK_EOF) then
                     unit_end = i - 1
                     exit
                 else if (tokens(i)%kind == TK_KEYWORD) then
                     if (tokens(i)%text == "end") then
-                        ! Check if this is "end subroutine", "end function", or "end program"
+                        ! Check if this is "end subroutine" or "end function"
                         if (i + 1 <= size(tokens)) then
                             if (tokens(i+1)%kind == TK_KEYWORD .and. tokens(i+1)%text == unit_type) then
                                 unit_end = i + 1  ! Include "end <unit_type>"
@@ -361,7 +362,7 @@ contains
                                 exit
                             end if
                         end if
-                        ! Also handle standalone "end" for backward compatibility
+                        ! Also handle standalone "end" for simple procedures
                         if (i == size(tokens) .or. (i + 1 <= size(tokens) .and. &
                             tokens(i+1)%kind /= TK_KEYWORD)) then
                             unit_end = i

--- a/src/frontend_parsing.f90
+++ b/src/frontend_parsing.f90
@@ -339,8 +339,40 @@ contains
                 end if
                 unit_end = i
             end do
+        else if (unit_type == "subroutine" .or. unit_type == "function" .or. unit_type == "program") then
+            ! For subroutines, functions and programs, find the matching "end"
+            nesting_level = 1
+            do i = start_pos + 1, size(tokens)
+                if (tokens(i)%kind == TK_EOF) then
+                    unit_end = i - 1
+                    exit
+                else if (tokens(i)%kind == TK_KEYWORD) then
+                    if (tokens(i)%text == "end") then
+                        ! Check if this is "end subroutine", "end function", or "end program"
+                        if (i + 1 <= size(tokens)) then
+                            if (tokens(i+1)%kind == TK_KEYWORD .and. tokens(i+1)%text == unit_type) then
+                                unit_end = i + 1  ! Include "end <unit_type>"
+                                ! Check if there's a name after "end <unit_type>"
+                                if (i + 2 <= size(tokens)) then
+                                    if (tokens(i+2)%kind == TK_IDENTIFIER) then
+                                        unit_end = i + 2  ! Include the name too
+                                    end if
+                                end if
+                                exit
+                            end if
+                        end if
+                        ! Also handle standalone "end" for backward compatibility
+                        if (i == size(tokens) .or. (i + 1 <= size(tokens) .and. &
+                            tokens(i+1)%kind /= TK_KEYWORD)) then
+                            unit_end = i
+                            exit
+                        end if
+                    end if
+                end if
+                unit_end = i
+            end do
         else
-            ! Original logic for non-module units
+            ! Original logic for other units
             do i = start_pos, size(tokens)
                 if (tokens(i)%kind == TK_EOF) then
                     unit_end = i - 1

--- a/test/test_issue_1260.f90
+++ b/test/test_issue_1260.f90
@@ -1,0 +1,88 @@
+program test_issue_1260
+    use frontend
+    implicit none
+    
+    logical :: test_passed
+    
+    test_passed = test_subroutine_parsing()
+    
+    if (test_passed) then
+        print *, "PASS: Issue #1260 subroutine parsing test - no extra unnamed_subroutine"
+    else
+        print *, "FAIL: Issue #1260 - extra unnamed_subroutine generated"
+        stop 1
+    end if
+    
+contains
+    
+    function test_subroutine_parsing() result(passed)
+        logical :: passed
+        character(len=:), allocatable :: source, output, error_msg
+        
+        passed = .true.
+        
+        ! Test case from issue #1260 - subroutine without name in end statement
+        source = &
+            "subroutine my_sub()" // new_line('a') // &
+            "    print *, 'Hello from subroutine'" // new_line('a') // &
+            "end subroutine"
+        
+        print *, "===== Testing Issue 1260: Extra unnamed_subroutine generation ====="
+        print *, "Input code:"
+        print *, trim(source)
+        
+        call transform_lazy_fortran_string(source, output, error_msg)
+        
+        if (error_msg /= "") then
+            print *, "ERROR: Failed to parse: ", trim(error_msg)
+            passed = .false.
+        else if (.not. allocated(output)) then
+            print *, "ERROR: No output generated"
+            passed = .false.
+        else
+            print *, "Generated output:"
+            print *, trim(output)
+            
+            ! Check that we don't have "unnamed_subroutine" in the output
+            if (index(output, "unnamed_subroutine") /= 0) then
+                print *, "ERROR: Found extra unnamed_subroutine in output"
+                passed = .false.
+            else
+                print *, "Good: No extra unnamed_subroutine in output"
+            end if
+        end if
+        
+        ! Test with name in end statement
+        source = &
+            "subroutine another_sub(x)" // new_line('a') // &
+            "    real :: x" // new_line('a') // &
+            "    x = x + 1.0" // new_line('a') // &
+            "end subroutine another_sub"
+        
+        print *, ""
+        print *, "Testing with named end statement:"
+        print *, trim(source)
+        
+        call transform_lazy_fortran_string(source, output, error_msg)
+        
+        if (error_msg /= "") then
+            print *, "ERROR: Failed to parse with named end: ", trim(error_msg)
+            passed = .false.
+        else if (.not. allocated(output)) then
+            print *, "ERROR: No output generated for named end case"
+            passed = .false.
+        else
+            print *, "Generated output:"
+            print *, trim(output)
+            
+            if (index(output, "unnamed_subroutine") /= 0) then
+                print *, "ERROR: Found extra unnamed_subroutine with named end"
+                passed = .false.
+            else
+                print *, "Good: No extra unnamed_subroutine with named end"
+            end if
+        end if
+        
+    end function test_subroutine_parsing
+    
+end program test_issue_1260


### PR DESCRIPTION
## Summary
- Fixed extra unnamed_subroutine generation when parsing subroutines without name in end statement
- Added proper boundary detection for subroutines, functions, and programs in find_program_unit_boundary()
- Handles both 'end subroutine' and 'end subroutine name' forms correctly

## Test plan
- Added dedicated test file test/test_issue_1260.f90 that verifies:
  - No extra unnamed_subroutine for 'end subroutine' without name
  - No extra unnamed_subroutine for 'end subroutine name' with name
- Test passes successfully, confirming the fix resolves the issue
- Existing tests still pass (unrelated test failures not affected by this change)