### PR TITLE
fix: Single-line if statements without 'then' keyword not supported (fixes #1259)

### DIFF
--- a/src/utilities/input_validation.f90
+++ b/src/utilities/input_validation.f90
@@ -207,26 +207,53 @@ contains
                     if (.not. found_then) then
                         ! Check if this looks like a complete if condition without 'then'
                         block
-                            logical :: has_condition_tokens
-                            integer :: k
+                            logical :: has_condition_tokens, has_statement_after_condition
+                            integer :: k, paren_count
                             
                             has_condition_tokens = .false.
+                            has_statement_after_condition = .false.
+                            paren_count = 0
                             
                             ! Look for condition tokens after 'if' on the same line
                             do k = i + 1, size(tokens)
                                 if (tokens(k)%kind == TK_EOF) exit
                                 if (tokens(k)%line > current_line) exit
                                 
-                                ! Found condition tokens (identifier, operator, number)
-                                if (tokens(k)%kind == TK_IDENTIFIER .or. &
-                                    tokens(k)%kind == TK_OPERATOR .or. &
-                                    tokens(k)%kind == TK_NUMBER) then
+                                ! Track parentheses to find end of condition
+                                if (tokens(k)%kind == TK_OPERATOR) then
+                                    if (tokens(k)%text == "(") then
+                                        paren_count = paren_count + 1
+                                        has_condition_tokens = .true.
+                                    else if (tokens(k)%text == ")") then
+                                        paren_count = paren_count - 1
+                                        ! Check if we've closed all parens and what comes after
+                                        if (paren_count == 0 .and. k < size(tokens)) then
+                                            ! Check the token after closing paren
+                                            if (k + 1 <= size(tokens) .and. tokens(k + 1)%line == current_line) then
+                                                ! Check if it's a valid statement keyword for single-line if
+                                                if (tokens(k + 1)%kind == TK_KEYWORD) then
+                                                    select case (tokens(k + 1)%text)
+                                                    case ("print", "write", "read", "call", "stop", &
+                                                          "cycle", "exit", "return", "go", "error", "goto")
+                                                        has_statement_after_condition = .true.
+                                                    end select
+                                                else if (tokens(k + 1)%kind == TK_IDENTIFIER) then
+                                                    ! Could be an assignment or call statement
+                                                    has_statement_after_condition = .true.
+                                                end if
+                                            end if
+                                        end if
+                                    else
+                                        has_condition_tokens = .true.
+                                    end if
+                                else if (tokens(k)%kind == TK_IDENTIFIER .or. &
+                                         tokens(k)%kind == TK_NUMBER) then
                                     has_condition_tokens = .true.
                                 end if
                             end do
                             
-                            ! If we have condition tokens but no 'then', this is an error
-                            if (has_condition_tokens) then
+                            ! If we have condition tokens but no 'then', check if it's a valid single-line if
+                            if (has_condition_tokens .and. .not. has_statement_after_condition) then
                                 error_msg = format_enhanced_error("Missing 'then' after 'if' condition", &
                                                                 tokens(if_pos)%line, tokens(if_pos)%column, &
                                                                 source_lines, &

--- a/test/parser/test_single_line_if.f90
+++ b/test/parser/test_single_line_if.f90
@@ -1,0 +1,25 @@
+! Test for Issue #1259: Single-line if statements without 'then' keyword
+! This test ensures that single-line if statements are accepted by the parser
+program test_single_line_if
+    implicit none
+    
+    ! These single-line if statements should compile without errors
+    print *, "Testing single-line if statements (Issue #1259)"
+    
+    block
+        integer :: x
+        x = 10
+        
+        ! Single-line if with print statement
+        if (x > 5) print *, "x is greater than 5"
+        
+        ! Single-line if with assignment
+        if (x > 0) x = x + 1
+        
+        ! Single-line if with stop
+        if (x < 0) stop 1
+    end block
+    
+    print *, "PASS: Single-line if statements work"
+    
+end program test_single_line_if


### PR DESCRIPTION
## Summary
- Fixed input validation to allow single-line if statements without the 'then' keyword
- Single-line if statements are valid Fortran syntax and should be accepted

## Changes
- Modified `src/utilities/input_validation.f90` to recognize valid single-line if statements
- Added logic to check for valid statements (print, write, call, assignments) after if conditions
- Added test case demonstrating single-line if usage

## Verification
Tested with the example from issue #1259:
```bash
echo "if (x > 5) print *, 'Greater than 5'" | ./build/gfortran_*/app/fortfront
```

Now produces valid output instead of a syntax error. The parser already supported this syntax, but the input validation was rejecting it before parsing.

Fixes #1259