### PR TITLE
fix(cli): ensure trailing newline + flush; enable Windows tests (fixes #1267)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,6 +440,19 @@ jobs:
           exit 1
         }
 
+    - name: Run tests (Windows)
+      shell: pwsh
+      env:
+        RUN_SYSTEM_TESTS: '1'
+      run: |
+        Write-Host "🧪 Running full test suite on Windows"
+        # Ensure FPM and MinGW are on PATH for this step
+        $env:PATH = "C:\\tools\\fpm;$env:PATH"
+        gfortran --version
+        fpm --version
+        # Run tests with the same flags used on Linux
+        fpm test --flag "-cpp -fmax-stack-var-size=65536" -j 2
+
     - name: Cleanup build cache and logs (Windows)
       if: always()
       shell: pwsh


### PR DESCRIPTION
Summary
- Ensure CLI writes trailing newline when missing and flushes stdout (already on main).
- Enable Windows CI to actually run the full test suite with RUN_SYSTEM_TESTS=1.

Scope
- app/fortfront.f90, .github/workflows/ci.yml.

Verification
- Local: RUN_SYSTEM_TESTS=1 build/**/test/test_cli_integration passed.
- Windows CI will now execute tests and validate CLI piping behavior.

Rationale
- Windows pipes/redirects can drop buffered output without newline/flush.
- Previous Windows job validated build only; tests were skipped. This aligns CI with Linux.
