### PR TITLE
fix: Parser: '! Unparsed' and wrong indent in do loop body for arrays (fixes #1271)

### DIFF
--- a/src/parser/parser_do_constructs.f90
+++ b/src/parser/parser_do_constructs.f90
@@ -94,31 +94,69 @@ contains
             end select
         else if (first_token%kind == TK_IDENTIFIER) then
             block
-                type(token_t) :: id_token, op_token
+                integer :: eq_pos, pos, lhs_size, rhs_size
+                integer :: paren_depth, bracket_depth
                 integer :: target_index, value_index
+                type(token_t), allocatable, target :: lhs_tokens(:)
+                type(token_t), allocatable, target :: rhs_tokens(:)
+                type(parser_state_t) :: lhs_parser
 
-                id_token = parser%consume()
-                op_token = parser%peek()
-
-                if (op_token%kind == TK_OPERATOR .and. op_token%text == "=") then
-                    op_token = parser%consume()  ! consume '='
-                    target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column, parent_index)
-                    ! Get remaining tokens for expression parsing
-                    block
-                        type(token_t), allocatable, target :: expr_tokens(:)
-                        integer :: remaining_count
-                        remaining_count = size(tokens) - parser%current_token + 1
-                        if (remaining_count > 0) then
-                            allocate (expr_tokens(remaining_count))
-                            expr_tokens = tokens(parser%current_token:)
-                            value_index = parse_expression(expr_tokens, arena)
-                            if (value_index > 0) then
-                                stmt_index = push_assignment(arena, target_index, value_index, &
-                                                             id_token%line, id_token%column, &
-                                                             parent_index)
+                eq_pos = 0
+                paren_depth = 0
+                bracket_depth = 0
+                do pos = 2, size(tokens)
+                    select case (tokens(pos)%kind)
+                    case (TK_OPERATOR)
+                        select case (tokens(pos)%text)
+                        case ("(")
+                            paren_depth = paren_depth + 1
+                        case (")")
+                            if (paren_depth > 0) paren_depth = paren_depth - 1
+                        case ("[")
+                            bracket_depth = bracket_depth + 1
+                        case ("]")
+                            if (bracket_depth > 0) bracket_depth = bracket_depth - 1
+                        case ("=")
+                            if (paren_depth == 0 .and. bracket_depth == 0) then
+                                eq_pos = pos
+                                exit
                             end if
-                        end if
-                    end block
+                        end select
+                    case (TK_NEWLINE, TK_EOF)
+                        exit
+                    end select
+                end do
+
+                if (eq_pos > 0) then
+                    lhs_size = eq_pos - 1
+                    rhs_size = size(tokens) - eq_pos
+                    target_index = 0
+                    value_index = 0
+
+                    if (lhs_size > 0) then
+                        allocate (lhs_tokens(lhs_size + 1))
+                        lhs_tokens(1:lhs_size) = tokens(1:eq_pos - 1)
+                        lhs_tokens(lhs_size + 1)%kind = TK_EOF
+                        lhs_tokens(lhs_size + 1)%text = ""
+                        lhs_tokens(lhs_size + 1)%line = tokens(eq_pos)%line
+                        lhs_tokens(lhs_size + 1)%column = tokens(eq_pos)%column
+                        lhs_parser = create_parser_state(lhs_tokens)
+                        target_index = parse_range(lhs_parser, arena)
+                        deallocate (lhs_tokens)
+                    end if
+
+                    if (rhs_size > 0) then
+                        allocate (rhs_tokens(rhs_size))
+                        rhs_tokens = tokens(eq_pos + 1:)
+                        value_index = parse_expression(rhs_tokens, arena)
+                        deallocate (rhs_tokens)
+                    end if
+
+                    if (target_index > 0 .and. value_index > 0) then
+                        stmt_index = push_assignment(arena, target_index, value_index, &
+                                                     first_token%line, first_token%column, &
+                                                     parent_index)
+                    end if
                 end if
             end block
         end if

--- a/test/parser/test_do_loop_array_assignment.f90
+++ b/test/parser/test_do_loop_array_assignment.f90
@@ -1,0 +1,68 @@
+program test_do_loop_array_assignment
+    ! Regression test for Issue #1271: ensure do loop bodies handle array element assignments
+    use frontend, only: compile_source, compilation_options_t
+    use iso_fortran_env, only: error_unit
+    implicit none
+
+    character(len=:), allocatable :: input_path, output_path
+    character(len=256) :: error_msg, line
+    type(compilation_options_t) :: options
+    integer :: unit, iostat
+    logical :: found_assignment, found_unparsed
+
+    print *, "=== Testing array element assignments in do loop bodies (Issue #1271) ==="
+
+    input_path = 'test_do_array_assignment_input.f90'
+    output_path = 'test_do_array_assignment_output.f90'
+
+    open(newunit=unit, file=input_path, status='replace', action='write', iostat=iostat)
+    if (iostat /= 0) then
+        write(error_unit, '(a)') 'ERROR: cannot create input file'
+        stop 1
+    end if
+    write(unit, '(a)') 'program array_update'
+    write(unit, '(a)') '  implicit none'
+    write(unit, '(a)') '  integer :: i'
+    write(unit, '(a)') '  integer :: arr(5)'
+    write(unit, '(a)') '  arr = [1, 2, 3, 4, 5]'
+    write(unit, '(a)') '  do i = 1, 5'
+    write(unit, '(a)') '    arr(i) = arr(i) + 1'
+    write(unit, '(a)') '  end do'
+    write(unit, '(a)') 'end program array_update'
+    close(unit)
+
+    options%output_file = output_path
+    call compile_source(input_path, options, error_msg)
+    if (len_trim(error_msg) > 0) then
+        write(error_unit, '(a)') 'ERROR: '//trim(error_msg)
+        stop 1
+    end if
+
+    open(newunit=unit, file=output_path, status='old', action='read', iostat=iostat)
+    if (iostat /= 0) then
+        write(error_unit, '(a)') 'ERROR: cannot open output file'
+        stop 1
+    end if
+
+    found_assignment = .false.
+    found_unparsed = .false.
+    do
+        read(unit, '(a)', iostat=iostat) line
+        if (iostat /= 0) exit
+        if (index(line, '! Unparsed') > 0) found_unparsed = .true.
+        if (index(adjustl(line), 'arr(i) = arr(i) + 1') > 0) found_assignment = .true.
+    end do
+    close(unit)
+
+    if (found_unparsed) then
+        write(error_unit, '(a)') 'ERROR: unexpected ! Unparsed placeholder emitted'
+        stop 1
+    end if
+    if (.not. found_assignment) then
+        write(error_unit, '(a)') 'ERROR: array assignment missing from output'
+        stop 1
+    end if
+
+    print *, 'PASS: parser keeps array element assignments intact inside do loops'
+    stop 0
+end program test_do_loop_array_assignment


### PR DESCRIPTION
## Summary
- parse do loop body assignments with LHS designators such as array elements by slicing tokens up to '=' and feeding them through the expression parser
- reuse the same path for simple identifiers while keeping placeholder emission only for true unknown statements
- add a regression test that exercises arr(i) = arr(i) + 1 inside a do loop and checks that no '! Unparsed' placeholder appears

## Verification
- make test
- build/gfortran_E6CCE6E96CE5456C/app/fortfront < /tmp/test_do_array_assign.lf
