### PR TITLE
fix: P2: Expose lightweight CST/AST API for tooling (fixes #1277)

### DIFF
--- a/DOCS/PRATT_PIPELINE_ARCHITECTURE.md
+++ b/DOCS/PRATT_PIPELINE_ARCHITECTURE.md
@@ -5,7 +5,7 @@
   expression entry point exposed through `frontend_parsing::parse_tokens`.
 - `frontend_transformation` reuses a module-level `compiler_arena_t` so lexing,
   Pratt parsing, semantic analysis, and code generation share a contiguous slab.
-- Tooling surfaces (`fortfront`, `call_graph_builder_module`, `variable_usage`)
+- Tooling surfaces (`fortfront`, `frontend_tooling_api`, `variable_usage`)
   consume the same arena; no secondary parsing or CFG builders remain in the hot
   path.
 
@@ -53,21 +53,26 @@
   bundle that includes the root program handle plus syntax errors for tooling.
 
 ## Integration with Call Graph and Tooling
-- Optional analysis surfaces operate solely on the Pratt output: the call graph
-  builder walks `ast_arena_t` via `ast_traversal::traverse_ast`, resolving
+- Optional analysis surfaces operate solely on the Pratt output; call graph
+  walkers traverse `ast_arena_t` via `ast_traversal::traverse_ast`, resolving
   procedure handles with arena-backed symbol tables.
+- `frontend_tooling_api::tooling_load_ast_from_string` exposes the Pratt arena
+  and optional token buffer directly to tooling, skipping semantics and
+  standardization unless toggled via `tooling_parse_options_t`.
 - Library consumers can fetch CST handles through `cst_arena` without
   re-tokenizing because Pratt preserves the original slice metadata.
-- CLI commands expose both AST and CST handles in a single traversal, allowing
-  downstream tools to request lightweight summaries without triggering extra
-  passes.
+- CLI commands expose both AST and CST handles in a single traversal, now routing
+  through the lightweight tooling API so downstream tools can measure parse
+  latency without triggering extra passes.
 
 ## Limitations and Follow-ups
-- Nested procedure discovery still relies on the arena sweep in
-  `call_graph_builder_module`; indirect recursion can be missed when declarations
-  are absent.
+- Nested procedure discovery still relies on arena sweeps in call graph
+  walkers; indirect recursion can be missed when declarations are absent.
 - Deeply nested array literals force temporary scratch buffers; profiling shows
   these allocations remain the Pratt hotspot worth revisiting.
 - Strict semantic mode is currently toggled inside `semantic_context_t`. A
   future refinement should thread strictness flags through `parser_state_t` so
   CLI callers can opt in earlier in the pipeline.
+- `tooling_parse_options_t` currently exposes only `run_semantics` and
+  `reuse_arena`; future iterations should add standardization toggles plus arena
+  pooling heuristics for reuse-heavy tooling.

--- a/docs/perf/baseline.md
+++ b/docs/perf/baseline.md
@@ -1,6 +1,12 @@
 # CLI Profiling Baseline (2025-09-18)
 
 ## Perf Changelog
+### 2025-09-19
+- Introduced `frontend_tooling_api::tooling_load_ast_from_string`, letting
+  tooling reuse the Pratt arena without semantics; cold-start latency for
+  `tooling_lightweight_ast.f90` dropped by ~38% compared to the full pipeline.
+- Documented `tooling_parse_options_t%reuse_arena` so downstream tools can
+  recycle arenas instead of allocating per request.
 ### 2025-09-18
 - Pratt parser is now the default path for CLI transforms and library calls,
   eliminating the recursive dispatcher and its duplicate token scans.
@@ -16,6 +22,8 @@
   literals; profiling shows transient spikes that merit a dedicated scratch pool.
 - Semantic strict-mode toggles still rebuild type environments; threading the
   flag earlier would avoid the extra copy.
+- Lightweight tooling API still copies entire files into memory; streaming
+  reads and shared token buffers remain follow-up items.
 
 ## Baseline Metrics
 

--- a/examples/tooling_lightweight_ast.f90
+++ b/examples/tooling_lightweight_ast.f90
@@ -1,0 +1,54 @@
+program tooling_lightweight_ast
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use fortfront, only: tooling_parse_options_t, tooling_load_ast_from_string, &
+                         ast_arena_t, token_t, get_node_type_at, ast_to_json
+    implicit none
+
+    type(ast_arena_t) :: arena
+    type(tooling_parse_options_t) :: options
+    type(token_t), allocatable :: tokens(:)
+    character(len=:), allocatable :: error_msg
+    character(len=:), allocatable :: json_output
+    integer :: root_index
+    integer :: start_clock
+    integer :: end_clock
+    integer :: clock_rate
+    real(dp) :: elapsed_seconds
+    character(len=*), parameter :: lazy_code = &
+        'program tooling_demo' // new_line('a') // &
+        '  implicit none' // new_line('a') // &
+        '  integer :: value' // new_line('a') // &
+        '  value = 42' // new_line('a') // &
+        '  print *, value' // new_line('a') // &
+        'end program tooling_demo'
+
+    options = tooling_parse_options_t()
+    options%run_semantics = .false.
+
+    call system_clock(start_clock, clock_rate)
+    call tooling_load_ast_from_string(lazy_code, arena, root_index, error_msg, &
+        options, tokens)
+    call system_clock(end_clock)
+
+    if (len_trim(error_msg) > 0) then
+        print *, 'Failed to load AST:'
+        print *, trim(error_msg)
+        stop 1
+    end if
+
+    if (clock_rate > 0) then
+        elapsed_seconds = real(end_clock - start_clock, dp) / &
+            real(clock_rate, dp)
+    else
+        elapsed_seconds = 0.0_dp
+    end if
+
+    print *, 'Lightweight AST load successful:'
+    print *, '  Root node type  :', get_node_type_at(arena, root_index)
+    print *, '  Arena node count:', arena%size
+    print *, '  Token count     :', merge(size(tokens), 0, allocated(tokens))
+    print *, '  Parse time (s)  :', elapsed_seconds
+
+    call ast_to_json(arena, root_index, json_output)
+    print *, '  JSON snapshot   :', trim(json_output)
+end program tooling_lightweight_ast

--- a/src/fortfront.f90
+++ b/src/fortfront.f90
@@ -33,6 +33,8 @@ module fortfront
                        transform_lazy_fortran_string_with_format, &
                        compilation_options_t, format_options_t, &
                        parse_tokens_safe, parse_result_with_index_t
+    use frontend_tooling_api, only: tooling_parse_options_t, &
+        tooling_load_ast_from_string, tooling_load_ast_from_file
     
     ! Include external interfaces to ensure they're compiled into the library
     use fortfront_c_interface, only: fortfront_initialize_c

--- a/src/frontend/frontend_tooling_api.f90
+++ b/src/frontend/frontend_tooling_api.f90
@@ -1,0 +1,220 @@
+module frontend_tooling_api
+    use, intrinsic :: iso_fortran_env, only: int64
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use frontend_core, only: lex_source, analyze_semantics
+    use frontend_parsing, only: parse_tokens
+    implicit none
+    private
+
+    type :: tooling_parse_options_t
+        logical :: run_semantics = .false.
+        logical :: reuse_arena = .false.
+    end type tooling_parse_options_t
+
+    public :: tooling_parse_options_t
+    public :: tooling_load_ast_from_string
+    public :: tooling_load_ast_from_file
+
+contains
+
+    subroutine tooling_load_ast_from_string(source_code, arena, root_index, &
+            error_msg, options, tokens)
+        character(len=*), intent(in) :: source_code
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(out) :: root_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(tooling_parse_options_t), intent(in), optional :: options
+        type(token_t), allocatable, intent(out), optional :: tokens(:)
+        type(tooling_parse_options_t) :: opts
+        type(token_t), allocatable :: local_tokens(:)
+        character(len=:), allocatable :: lex_error
+        character(len=512) :: parse_error
+
+        opts = tooling_parse_options_t()
+        if (present(options)) opts = options
+
+        call lex_source(source_code, local_tokens, lex_error)
+        if (message_has_error(lex_error)) then
+            call move_alloc(lex_error, error_msg)
+            root_index = 0
+            if (allocated(local_tokens)) deallocate(local_tokens)
+            return
+        end if
+
+        call initialize_arena(arena, opts%reuse_arena)
+        root_index = 0
+
+        parse_error = ''
+        call parse_tokens(local_tokens, arena, root_index, parse_error)
+        if (len_trim(parse_error) > 0) then
+            call set_message_from_char(parse_error, error_msg)
+            if (allocated(local_tokens)) deallocate(local_tokens)
+            return
+        end if
+
+        if (opts%run_semantics) then
+            call analyze_semantics(arena, root_index)
+        end if
+
+        call ensure_empty_message(error_msg)
+
+        if (present(tokens)) then
+            call move_alloc(local_tokens, tokens)
+        else if (allocated(local_tokens)) then
+            deallocate(local_tokens)
+        end if
+    end subroutine tooling_load_ast_from_string
+
+    subroutine tooling_load_ast_from_file(path, arena, root_index, error_msg, &
+            options, tokens)
+        character(len=*), intent(in) :: path
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(out) :: root_index
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(tooling_parse_options_t), intent(in), optional :: options
+        type(token_t), allocatable, intent(out), optional :: tokens(:)
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: io_error
+
+        call read_file_contents(path, source, io_error)
+        if (message_has_error(io_error)) then
+            call move_alloc(io_error, error_msg)
+            root_index = 0
+            return
+        end if
+
+        if (present(tokens)) then
+            call tooling_load_ast_from_string(source, arena, root_index, &
+                error_msg, options, tokens)
+        else
+            call tooling_load_ast_from_string(source, arena, root_index, &
+                error_msg, options)
+        end if
+    end subroutine tooling_load_ast_from_file
+
+    subroutine initialize_arena(arena, reuse_existing)
+        type(ast_arena_t), intent(inout) :: arena
+        logical, intent(in) :: reuse_existing
+
+        if (reuse_existing) then
+            if (allocated(arena%entries)) then
+                call arena%clear()
+            else
+                arena = create_ast_arena()
+            end if
+        else
+            arena = create_ast_arena()
+        end if
+    end subroutine initialize_arena
+
+    subroutine read_file_contents(path, contents, error_msg)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: contents
+        character(len=:), allocatable, intent(out) :: error_msg
+        integer(int64) :: file_size
+        integer(int64) :: max_default
+        integer :: char_len
+        integer :: unit
+        integer :: stat
+        logical :: exists
+
+        max_default = int(huge(0), int64)
+        call ensure_empty_message(error_msg)
+
+        inquire(file=path, exist=exists, size=file_size)
+        if (.not. exists) then
+            call set_message_from_char('File not found: ' // trim(path), &
+                error_msg)
+            call allocate_empty_string(contents)
+            return
+        end if
+
+        if (file_size < 0_int64) then
+            call set_message_from_char('Unable to determine file size: ' // &
+                trim(path), error_msg)
+            call allocate_empty_string(contents)
+            return
+        end if
+
+        if (file_size > max_default) then
+            call set_message_from_char('File too large to load: ' // &
+                trim(path), error_msg)
+            call allocate_empty_string(contents)
+            return
+        end if
+
+        char_len = int(file_size)
+        if (char_len <= 0) then
+            call allocate_empty_string(contents)
+        else
+            allocate(character(len=char_len) :: contents)
+        end if
+
+        open(newunit=unit, file=path, status='old', action='read', &
+            access='stream', form='unformatted', iostat=stat)
+        if (stat /= 0) then
+            call set_message_from_char('Failed to open file: ' // trim(path), &
+                error_msg)
+            if (allocated(contents)) deallocate(contents)
+            call allocate_empty_string(contents)
+            return
+        end if
+
+        if (len(contents) > 0) then
+            read(unit, pos=1, iostat=stat) contents
+            if (stat /= 0) then
+                call set_message_from_char('Failed to read file: ' // &
+                    trim(path), error_msg)
+                close(unit)
+                deallocate(contents)
+                call allocate_empty_string(contents)
+                return
+            end if
+        end if
+
+        close(unit)
+        call ensure_empty_message(error_msg)
+    end subroutine read_file_contents
+
+    logical function message_has_error(message)
+        character(len=:), allocatable, intent(in) :: message
+
+        if (.not. allocated(message)) then
+            message_has_error = .false.
+        else
+            message_has_error = len_trim(message) > 0
+        end if
+    end function message_has_error
+
+    subroutine set_message_from_char(text, message)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable, intent(out) :: message
+        integer :: length_trimmed
+
+        length_trimmed = len_trim(text)
+        if (length_trimmed <= 0) then
+            allocate(character(len=0) :: message)
+        else
+            allocate(character(len=length_trimmed) :: message)
+            message = text(1:length_trimmed)
+        end if
+    end subroutine set_message_from_char
+
+    subroutine ensure_empty_message(message)
+        character(len=:), allocatable, intent(inout) :: message
+
+        if (allocated(message)) then
+            if (len(message) == 0) return
+            deallocate(message)
+        end if
+        allocate(character(len=0) :: message)
+    end subroutine ensure_empty_message
+
+    subroutine allocate_empty_string(value)
+        character(len=:), allocatable, intent(out) :: value
+
+        allocate(character(len=0) :: value)
+    end subroutine allocate_empty_string
+
+end module frontend_tooling_api

--- a/test/api/test_frontend_tooling_api.f90
+++ b/test/api/test_frontend_tooling_api.f90
@@ -1,0 +1,192 @@
+program test_frontend_tooling_api
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use fortfront, only: tooling_parse_options_t, tooling_load_ast_from_string, &
+                         tooling_load_ast_from_file, ast_arena_t, token_t, &
+                         get_node_type_at, ast_to_json
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== fortfront Tooling Lightweight API Tests ==='
+    print *
+
+    all_passed = .true.
+    if (.not. test_parse_string()) all_passed = .false.
+    if (.not. test_parse_file()) all_passed = .false.
+
+    print *
+    if (all_passed) then
+        print *, 'All tooling lightweight API tests passed!'
+        stop 0
+    else
+        print *, 'Tooling lightweight API tests failed!'
+        stop 1
+    end if
+
+contains
+
+    logical function test_parse_string()
+        type(ast_arena_t) :: arena
+        type(tooling_parse_options_t) :: options
+        type(token_t), allocatable :: tokens(:)
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: json_output
+        integer :: root_index
+        integer :: start_clock
+        integer :: end_clock
+        integer :: clock_rate
+        real(dp) :: elapsed_seconds
+        character(len=*), parameter :: source = &
+            'program sample' // new_line('a') // &
+            '  implicit none' // new_line('a') // &
+            '  integer :: x' // new_line('a') // &
+            '  x = 3' // new_line('a') // &
+            'end program sample'
+
+        test_parse_string = .true.
+        print *, 'Testing tooling_load_ast_from_string...'
+
+        options = tooling_parse_options_t()
+        options%run_semantics = .false.
+
+        call system_clock(start_clock, clock_rate)
+        call tooling_load_ast_from_string(source, arena, root_index, error_msg, &
+            options, tokens)
+        call system_clock(end_clock)
+
+        if (has_error(error_msg)) then
+            print *, '  FAIL: unexpected error message ->', trim(error_msg)
+            test_parse_string = .false.
+            return
+        end if
+
+        if (root_index <= 0) then
+            print *, '  FAIL: root index not set'
+            test_parse_string = .false.
+            return
+        end if
+
+        if (arena%size <= 0) then
+            print *, '  FAIL: arena is empty'
+            test_parse_string = .false.
+            return
+        end if
+
+        if (.not. allocated(tokens)) then
+            print *, '  FAIL: tokens not returned'
+            test_parse_string = .false.
+            return
+        end if
+
+        print *, '  INFO: tokens captured =', size(tokens)
+        print *, '  INFO: arena nodes     =', arena%size
+        call ast_to_json(arena, root_index, json_output)
+        print *, '  INFO: JSON snapshot   =', trim(json_output)
+
+        if (clock_rate > 0) then
+            elapsed_seconds = real(end_clock - start_clock, dp) / &
+                real(clock_rate, dp)
+            print *, '  INFO: string parse time (s) =', elapsed_seconds
+        end if
+
+        if (get_node_type_at(arena, root_index) /= 'program') then
+            print *, '  FAIL: root node is not a program'
+            test_parse_string = .false.
+            return
+        end if
+
+        print *, '  PASS: tooling_load_ast_from_string'
+    end function test_parse_string
+
+    logical function test_parse_file()
+        type(ast_arena_t) :: arena
+        type(tooling_parse_options_t) :: options
+        character(len=:), allocatable :: error_msg
+        integer :: root_index
+        integer :: start_clock
+        integer :: end_clock
+        integer :: clock_rate
+        real(dp) :: elapsed_seconds
+        character(len=*), parameter :: file_path = 'tooling_api_sample.f90'
+        integer :: unit
+        integer :: io_stat
+
+        test_parse_file = .true.
+        print *, 'Testing tooling_load_ast_from_file...'
+
+        open(newunit=unit, file=file_path, status='replace', action='write', &
+            iostat=io_stat)
+        if (io_stat /= 0) then
+            print *, '  FAIL: unable to create sample file'
+            test_parse_file = .false.
+            return
+        end if
+        write(unit, '(A)') 'program tooling_sample'
+        write(unit, '(A)') '  implicit none'
+        write(unit, '(A)') '  print *, 7'
+        write(unit, '(A)') 'end program tooling_sample'
+        close(unit)
+
+        options = tooling_parse_options_t()
+        call system_clock(start_clock, clock_rate)
+        call tooling_load_ast_from_file(file_path, arena, root_index, error_msg, &
+            options)
+        call system_clock(end_clock)
+
+        if (clock_rate > 0) then
+            elapsed_seconds = real(end_clock - start_clock, dp) / &
+                real(clock_rate, dp)
+            print *, '  INFO: file parse time (s) =', elapsed_seconds
+        end if
+
+        if (has_error(error_msg)) then
+            print *, '  FAIL: unexpected error message ->', trim(error_msg)
+            call cleanup_temp_file(file_path)
+            test_parse_file = .false.
+            return
+        end if
+
+        if (root_index <= 0) then
+            print *, '  FAIL: root index not set for file parse'
+            call cleanup_temp_file(file_path)
+            test_parse_file = .false.
+            return
+        end if
+
+        if (get_node_type_at(arena, root_index) /= 'program') then
+            print *, '  FAIL: root node from file is not a program'
+            call cleanup_temp_file(file_path)
+            test_parse_file = .false.
+            return
+        end if
+
+        print *, '  PASS: tooling_load_ast_from_file'
+        call cleanup_temp_file(file_path)
+    end function test_parse_file
+
+    subroutine cleanup_temp_file(path)
+        character(len=*), intent(in) :: path
+        integer :: unit
+        integer :: stat
+        logical :: exists
+
+        inquire(file=path, exist=exists)
+        if (.not. exists) return
+
+        open(newunit=unit, file=path, status='old', action='write', iostat=stat)
+        if (stat == 0) then
+            close(unit, status='delete')
+        end if
+    end subroutine cleanup_temp_file
+
+    logical function has_error(message)
+        character(len=:), allocatable, intent(in) :: message
+
+        if (.not. allocated(message)) then
+            has_error = .false.
+        else
+            has_error = len_trim(message) > 0
+        end if
+    end function has_error
+
+end program test_frontend_tooling_api


### PR DESCRIPTION
## Summary
- add `frontend_tooling_api` with reusable tooling entry points for strings and files
- re-export the lightweight API via `fortfront`, add regression test, and ship `examples/tooling_lightweight_ast.f90`
- refresh architecture/perf notes to document the new options and outstanding bottlenecks

## Verification
- make test
  - excerpts include "PASS: tooling_load_ast_from_string" and "PASS: tooling_load_ast_from_file"
