### PR TITLE
fix: P1: Optimize HM inference allocations and identifier handling (fixes #1276)

### DIFF
--- a/src/common/identifier_table.f90
+++ b/src/common/identifier_table.f90
@@ -1,0 +1,249 @@
+module identifier_table
+    use iso_fortran_env, only: int32, int64
+    implicit none
+    private
+
+    integer, parameter, public :: identifier_id_kind = int32
+
+    type :: identifier_entry_t
+        character(len=:), allocatable :: value
+        integer(int32) :: hash = 0_int32
+        integer(int32) :: next = 0_int32
+    end type identifier_entry_t
+
+    type, public :: identifier_table_t
+        type(identifier_entry_t), allocatable :: entries(:)
+        integer(int32), allocatable :: buckets(:)
+        integer(int32) :: count = 0_int32
+        integer(int32) :: entry_capacity = 0_int32
+        integer(int32) :: bucket_count = 0_int32
+    end type identifier_table_t
+
+    public :: identifier_table_init, identifier_table_reset
+    public :: identifier_table_intern, identifier_table_find
+    public :: identifier_table_get
+
+contains
+
+    subroutine identifier_table_init(table, initial_bucket_count)
+        type(identifier_table_t), intent(inout) :: table
+        integer, intent(in), optional :: initial_bucket_count
+        integer :: bucket_count
+
+        table%count = 0_int32
+        table%entry_capacity = 0_int32
+        table%bucket_count = 0_int32
+        if (allocated(table%entries)) deallocate(table%entries)
+        if (allocated(table%buckets)) deallocate(table%buckets)
+
+        if (present(initial_bucket_count)) then
+            bucket_count = max(16, initial_bucket_count)
+        else
+            bucket_count = 64
+        end if
+        call rebuild_buckets(table, bucket_count)
+    end subroutine identifier_table_init
+
+    subroutine identifier_table_reset(table)
+        type(identifier_table_t), intent(inout) :: table
+
+        table%count = 0_int32
+        if (allocated(table%buckets)) then
+            table%buckets = 0_int32
+        end if
+    end subroutine identifier_table_reset
+
+    function identifier_table_intern(table, raw_value) result(id)
+        type(identifier_table_t), intent(inout) :: table
+        character(len=*), intent(in) :: raw_value
+        integer(int32) :: id
+        character(len=:), allocatable :: key
+        integer(int32) :: hash
+
+        key = trim(raw_value)
+        if (.not. allocated(table%buckets)) then
+            call identifier_table_init(table)
+        end if
+
+        hash = compute_hash(key)
+        id = lookup_entry(table, key, hash)
+        if (id > 0_int32) return
+
+        call ensure_entry_capacity(table, table%count + 1_int32)
+        call ensure_bucket_capacity(table, table%count + 1_int32)
+
+        table%count = table%count + 1_int32
+        if (allocated(table%entries(table%count)%value)) then
+            deallocate(table%entries(table%count)%value)
+        end if
+        allocate(character(len=len(key)) :: table%entries(table%count)%value)
+        table%entries(table%count)%value = key
+        table%entries(table%count)%hash = hash
+        table%entries(table%count)%next = 0_int32
+
+        call insert_into_buckets(table, table%count)
+        id = table%count
+    end function identifier_table_intern
+
+    function identifier_table_find(table, raw_value) result(id)
+        type(identifier_table_t), intent(in) :: table
+        character(len=*), intent(in) :: raw_value
+        integer(int32) :: id
+        character(len=:), allocatable :: key
+        integer(int32) :: hash
+
+        if (.not. allocated(table%buckets)) then
+            id = 0_int32
+            return
+        end if
+
+        if (table%count <= 0_int32) then
+            id = 0_int32
+            return
+        end if
+
+        key = trim(raw_value)
+        hash = compute_hash(key)
+        id = lookup_entry(table, key, hash)
+    end function identifier_table_find
+
+    function identifier_table_get(table, id) result(value)
+        type(identifier_table_t), intent(in) :: table
+        integer(int32), intent(in) :: id
+        character(len=:), allocatable :: value
+
+        if (id <= 0_int32 .or. id > table%count) then
+            allocate(character(len=0) :: value)
+            value = ''
+            return
+        end if
+
+        value = table%entries(id)%value
+    end function identifier_table_get
+
+    pure function compute_hash(key) result(hash)
+        character(len=*), intent(in) :: key
+        integer(int32) :: hash
+        integer(int64) :: acc
+        integer :: i, length
+
+        acc = 1469598103934665603_int64
+        length = len_trim(key)
+        do i = 1, length
+            acc = ieor(acc, int(iachar(key(i:i)), int64))
+            acc = acc * 1099511628211_int64
+        end do
+        hash = int(iand(acc, int(z'7fffffff', int64)), int32)
+        if (hash == 0_int32) hash = 1_int32
+    end function compute_hash
+
+    subroutine ensure_entry_capacity(table, required)
+        type(identifier_table_t), intent(inout) :: table
+        integer(int32), intent(in) :: required
+        type(identifier_entry_t), allocatable :: new_entries(:)
+        integer :: new_capacity
+
+        if (required <= table%entry_capacity) return
+
+        if (table%entry_capacity <= 0_int32) then
+            new_capacity = 32
+        else
+            new_capacity = table%entry_capacity
+        end if
+
+        do while (required > new_capacity)
+            new_capacity = new_capacity * 2
+        end do
+
+        allocate(new_entries(new_capacity))
+        if (table%entry_capacity > 0_int32 .and. table%count > 0_int32) then
+            new_entries(1:table%count) = table%entries(1:table%count)
+        end if
+        call move_alloc(new_entries, table%entries)
+        table%entry_capacity = new_capacity
+    end subroutine ensure_entry_capacity
+
+    subroutine ensure_bucket_capacity(table, required_count)
+        type(identifier_table_t), intent(inout) :: table
+        integer(int32), intent(in) :: required_count
+        integer :: desired
+
+        desired = table%bucket_count
+        if (desired <= 0) desired = 64
+
+        do while (required_count > desired * 3 / 4)
+            desired = desired * 2
+        end do
+
+        if (desired /= table%bucket_count) then
+            call rebuild_buckets(table, desired)
+        end if
+    end subroutine ensure_bucket_capacity
+
+    subroutine rebuild_buckets(table, new_bucket_count)
+        type(identifier_table_t), intent(inout) :: table
+        integer, intent(in) :: new_bucket_count
+        integer(int32) :: i
+
+        if (allocated(table%buckets)) deallocate(table%buckets)
+        allocate(table%buckets(new_bucket_count))
+        table%buckets = 0_int32
+        table%bucket_count = new_bucket_count
+
+        if (table%count <= 0_int32) return
+
+        do i = table%count, 1, -1
+            call insert_into_buckets(table, i)
+        end do
+    end subroutine rebuild_buckets
+
+    subroutine insert_into_buckets(table, entry_id)
+        type(identifier_table_t), intent(inout) :: table
+        integer(int32), intent(in) :: entry_id
+        integer :: bucket
+
+        bucket = bucket_index(table%entries(entry_id)%hash, table%bucket_count)
+        table%entries(entry_id)%next = table%buckets(bucket)
+        table%buckets(bucket) = entry_id
+    end subroutine insert_into_buckets
+
+    integer function bucket_index(hash, bucket_count) result(index)
+        integer(int32), intent(in) :: hash
+        integer, intent(in) :: bucket_count
+        integer(int64) :: mod_value
+
+        if (bucket_count <= 0) then
+            index = 1
+            return
+        end if
+
+        mod_value = modulo(int(hash, int64), int(bucket_count, int64))
+        index = int(mod_value, kind(index)) + 1
+    end function bucket_index
+
+    function lookup_entry(table, key, hash) result(id)
+        type(identifier_table_t), intent(in) :: table
+        character(len=*), intent(in) :: key
+        integer(int32), intent(in) :: hash
+        integer(int32) :: id
+        integer :: bucket
+        integer(int32) :: current
+
+        id = 0_int32
+        if (table%bucket_count <= 0_int32) return
+
+        bucket = bucket_index(hash, table%bucket_count)
+        current = table%buckets(bucket)
+
+        do while (current > 0_int32)
+            if (table%entries(current)%hash == hash) then
+                if (table%entries(current)%value == key) then
+                    id = current
+                    return
+                end if
+            end if
+            current = table%entries(current)%next
+        end do
+    end function lookup_entry
+
+end module identifier_table

--- a/src/semantic/scope_manager.f90
+++ b/src/semantic/scope_manager.f90
@@ -2,7 +2,10 @@ module scope_manager
     ! Hierarchical scope management for semantic analysis
     use iso_fortran_env, only: error_unit
     use type_system_unified
-    use error_handling, only: result_t, create_error_result, success_result, ERROR_MEMORY
+    use identifier_table, only: identifier_table_t, identifier_table_init, &
+        identifier_table_intern, identifier_table_find, identifier_id_kind
+    use error_handling, only: result_t, create_error_result, &
+        success_result, ERROR_MEMORY
     implicit none
     private
 
@@ -23,6 +26,7 @@ module scope_manager
         integer :: scope_type = SCOPE_GLOBAL
         character(len=:), allocatable :: name  ! e.g., module name, function name
         type(type_env_t) :: env
+        type(identifier_table_t), pointer :: identifiers => null()
         ! No parent pointer - stack handles hierarchy
     contains
         procedure :: lookup => scope_lookup
@@ -38,6 +42,7 @@ module scope_manager
         type(scope_t), allocatable :: scopes(:)  ! Stack of scopes (contiguous memory)
         integer :: depth = 0                     ! Current depth (top of stack)
         integer :: capacity = 0                  ! Array capacity
+        type(identifier_table_t), pointer :: identifier_storage => null()
         ! No current/global pointers - use array indices
     contains
         procedure :: push => stack_push_scope
@@ -60,10 +65,11 @@ module scope_manager
 contains
 
     ! Create a new scope (no parent pointer - stack handles hierarchy)
-    subroutine create_scope(scope, scope_type, name)
+    subroutine create_scope(scope, scope_type, name, identifiers)
         type(scope_t), intent(out) :: scope
         integer, intent(in) :: scope_type
         character(len=*), intent(in), optional :: name
+        type(identifier_table_t), target, intent(inout), optional :: identifiers
 
         scope%scope_type = scope_type
 
@@ -73,17 +79,26 @@ contains
             scope%name = ""
         end if
 
+        if (present(identifiers)) then
+            scope%identifiers => identifiers
+            scope%env%identifiers => identifiers
+        else
+            nullify(scope%identifiers)
+            nullify(scope%env%identifiers)
+        end if
+
         ! Initialize empty environment (allocate on heap to avoid large stack usage)
         scope%env%count = 0
         scope%env%capacity = 64
-        if (allocated(scope%env%names)) deallocate(scope%env%names)
+        if (allocated(scope%env%name_ids)) deallocate(scope%env%name_ids)
         if (allocated(scope%env%schemes)) deallocate(scope%env%schemes)
-        allocate(scope%env%names(scope%env%capacity))
+        allocate(scope%env%name_ids(scope%env%capacity))
         allocate(scope%env%schemes(scope%env%capacity))
 
     end subroutine create_scope
 
-    ! Create a new scope stack with global scope (intent(out) to avoid large return copies)
+    ! Create a new scope stack with global scope
+    ! Intent(out) avoids large return copies
     subroutine create_scope_stack(stack)
         type(scope_stack_t), intent(out) :: stack
 
@@ -91,7 +106,12 @@ contains
         stack%capacity = 10
         allocate (stack%scopes(stack%capacity))
         stack%depth = 1
-        call create_scope(stack%scopes(1), SCOPE_GLOBAL, "global")
+        if (.not. associated(stack%identifier_storage)) then
+            allocate(stack%identifier_storage)
+        end if
+        call identifier_table_init(stack%identifier_storage)
+        call create_scope(stack%scopes(1), SCOPE_GLOBAL, "global", &
+            stack%identifier_storage)
 
     end subroutine create_scope_stack
 
@@ -108,6 +128,10 @@ contains
             return
         end if
 
+        if (.not. associated(this%identifiers)) then
+            return
+        end if
+
         ! Fixed arrays are always allocated, check count instead
         if (this%env%count == 0) then
             return
@@ -116,8 +140,13 @@ contains
         ! Direct implementation to avoid type-bound procedure issues
         block
             integer :: j
+            integer(identifier_id_kind) :: name_id
+
+            name_id = identifier_table_find(this%identifiers, name)
+            if (name_id <= 0) return
+
             do j = 1, this%env%count
-                if (this%env%names(j) == name) then
+                if (this%env%name_ids(j) == name_id) then
                     ! Allocate and use assignment operator for deep copy
                     allocate (scheme)
                     scheme = this%env%schemes(j)
@@ -133,17 +162,26 @@ contains
         class(scope_t), intent(inout) :: this
         character(len=*), intent(in) :: name
         type(poly_type_t), intent(in) :: scheme
+        integer(identifier_id_kind) :: name_id
+        integer :: j
+
+        if (.not. associated(this%identifiers)) then
+            write(error_unit, '(A)') &
+                'ERROR [scope_manager]: scope missing identifier table; skipping define'
+            return
+        end if
 
         ! Robust define with local allocation guards
-        if (.not. allocated(this%env%names) .or. .not. allocated(this%env%schemes)) then
+        if (.not. allocated(this%env%name_ids) .or. &
+                .not. allocated(this%env%schemes)) then
             if (this%env%capacity <= 0) this%env%capacity = 64
-            allocate(this%env%names(this%env%capacity))
+            allocate(this%env%name_ids(this%env%capacity))
             allocate(this%env%schemes(this%env%capacity))
             this%env%count = 0
-        else if (size(this%env%names) == 0 .or. size(this%env%schemes) == 0) then
+        else if (size(this%env%name_ids) == 0 .or. size(this%env%schemes) == 0) then
             if (this%env%capacity <= 0) this%env%capacity = 64
-            deallocate(this%env%names, this%env%schemes)
-            allocate(this%env%names(this%env%capacity))
+            deallocate(this%env%name_ids, this%env%schemes)
+            allocate(this%env%name_ids(this%env%capacity))
             allocate(this%env%schemes(this%env%capacity))
             this%env%count = 0
         end if
@@ -151,35 +189,34 @@ contains
         if (this%env%count >= this%env%capacity) then
             block
                 integer :: new_capacity, j
-                character(len=128), allocatable :: new_names(:)
+                integer(identifier_id_kind), allocatable :: new_ids(:)
                 type(poly_type_t), allocatable :: new_schemes(:)
                 new_capacity = max(64, this%env%capacity*2)
-                allocate(new_names(new_capacity))
+                allocate(new_ids(new_capacity))
                 allocate(new_schemes(new_capacity))
                 if (this%env%count > 0) then
                     do j = 1, this%env%count
-                        new_names(j) = this%env%names(j)
+                        new_ids(j) = this%env%name_ids(j)
                         new_schemes(j) = this%env%schemes(j)
                     end do
                 end if
-                call move_alloc(new_names, this%env%names)
+                call move_alloc(new_ids, this%env%name_ids)
                 call move_alloc(new_schemes, this%env%schemes)
                 this%env%capacity = new_capacity
             end block
         end if
 
-        block
-            integer :: j
-            do j = 1, this%env%count
-                if (this%env%names(j) == name) then
-                    this%env%schemes(j) = scheme
-                    return
-                end if
-            end do
-        end block
+        name_id = identifier_table_intern(this%identifiers, name)
+
+        do j = 1, this%env%count
+            if (this%env%name_ids(j) == name_id) then
+                this%env%schemes(j) = scheme
+                return
+            end if
+        end do
 
         this%env%count = this%env%count + 1
-        this%env%names(this%env%count) = name
+        this%env%name_ids(this%env%count) = name_id
         this%env%schemes(this%env%count) = scheme
 
     end subroutine scope_define
@@ -207,9 +244,17 @@ contains
                         if (allocated(this%scopes(i)%name)) then
                             temp_scopes(i)%name = this%scopes(i)%name
                         end if
-                        ! Deep copy env via assignment (allocates and copies used elements)
+                        ! Deep copy env via assignment (allocates and copies entries)
                         temp_scopes(i)%env = this%scopes(i)%env
-                        call temp_scopes(i)%env%ensure_capacity(max(64, temp_scopes(i)%env%count))
+                        call temp_scopes(i)%env%ensure_capacity(max(64, &
+                            temp_scopes(i)%env%count))
+                        if (associated(this%scopes(i)%identifiers)) then
+                            temp_scopes(i)%identifiers => this%identifier_storage
+                            temp_scopes(i)%env%identifiers => this%identifier_storage
+                        else
+                            nullify(temp_scopes(i)%identifiers)
+                            nullify(temp_scopes(i)%env%identifiers)
+                        end if
                     end do
                 end block
             end if
@@ -225,9 +270,12 @@ contains
         if (allocated(new_scope%name)) then
             this%scopes(this%depth)%name = new_scope%name
         end if
+        this%scopes(this%depth)%identifiers => this%identifier_storage
         ! Deep copy env via assignment (allocates and copies used elements)
         this%scopes(this%depth)%env = new_scope%env
-        call this%scopes(this%depth)%env%ensure_capacity(max(64, this%scopes(this%depth)%env%count))
+        this%scopes(this%depth)%env%identifiers => this%identifier_storage
+        call this%scopes(this%depth)%env%ensure_capacity(max(64, &
+            this%scopes(this%depth)%env%count))
 
     end subroutine stack_push_scope
 
@@ -238,7 +286,8 @@ contains
         if (this%depth > 1) then
             this%depth = this%depth - 1
         else
-            write(error_unit, '(A)') "ERROR [scope_manager]: Cannot pop global scope - ignoring pop request"
+            write(error_unit, '(A)') &
+                'ERROR [scope_manager]: Cannot pop global scope - ignoring pop request'
             ! Don't modify depth - keep the global scope intact
         end if
 
@@ -272,11 +321,13 @@ contains
 
         if (this%depth > 0) then
             ! Ensure environment arrays exist for current scope
-            call this%scopes(this%depth)%env%ensure_capacity(max(64, this%scopes(this%depth)%env%count+1))
+            call this%scopes(this%depth)%env%ensure_capacity(max(64, &
+                this%scopes(this%depth)%env%count+1))
             ! Use direct scope_define to avoid type-bound procedure issues with arrays
             call scope_define(this%scopes(this%depth), name, scheme)
         else
-            write(error_unit, '(A)') "ERROR [scope_manager]: No current scope for define operation - ignoring definition"
+            write(error_unit, '(A)') &
+                'ERROR [scope_manager]: No current scope for define; ignoring'
             ! Don't perform the definition if there's no current scope
         end if
 
@@ -288,7 +339,7 @@ contains
         character(len=*), intent(in) :: module_name
         type(scope_t) :: new_scope
 
-        call create_scope(new_scope, SCOPE_MODULE, module_name)
+        call create_scope(new_scope, SCOPE_MODULE, module_name, this%identifier_storage)
         call this%push(new_scope)
 
     end subroutine stack_enter_module
@@ -299,7 +350,8 @@ contains
         character(len=*), intent(in) :: function_name
         type(scope_t) :: new_scope
 
-        call create_scope(new_scope, SCOPE_FUNCTION, function_name)
+        call create_scope(new_scope, SCOPE_FUNCTION, function_name, &
+            this%identifier_storage)
         call this%push(new_scope)
 
     end subroutine stack_enter_function
@@ -310,7 +362,8 @@ contains
         character(len=*), intent(in) :: subroutine_name
         type(scope_t) :: new_scope
 
-        call create_scope(new_scope, SCOPE_SUBROUTINE, subroutine_name)
+        call create_scope(new_scope, SCOPE_SUBROUTINE, subroutine_name, &
+            this%identifier_storage)
         call this%push(new_scope)
 
     end subroutine stack_enter_subroutine
@@ -320,7 +373,7 @@ contains
         class(scope_stack_t), intent(inout) :: this
         type(scope_t) :: new_scope
 
-        call create_scope(new_scope, SCOPE_BLOCK, "")
+        call create_scope(new_scope, SCOPE_BLOCK, "", this%identifier_storage)
         call this%push(new_scope)
 
     end subroutine stack_enter_block
@@ -332,9 +385,10 @@ contains
         type(scope_t) :: new_scope
 
         if (present(interface_name)) then
-            call create_scope(new_scope, SCOPE_INTERFACE, interface_name)
+            call create_scope(new_scope, SCOPE_INTERFACE, interface_name, &
+                this%identifier_storage)
         else
-            call create_scope(new_scope, SCOPE_INTERFACE, "")
+            call create_scope(new_scope, SCOPE_INTERFACE, "", this%identifier_storage)
         end if
         call this%push(new_scope)
 
@@ -371,6 +425,13 @@ contains
             copy%name = this%name
         end if
         copy%env = this%env  ! Uses type_env_t assignment (deep copy)
+        if (associated(this%identifiers)) then
+            copy%identifiers => this%identifiers
+            copy%env%identifiers => this%identifiers
+        else
+            nullify(copy%identifiers)
+            nullify(copy%env%identifiers)
+        end if
     end function scope_deep_copy
 
     ! Assignment operator for scope_t (deep copy)
@@ -383,6 +444,13 @@ contains
             lhs%name = rhs%name
         end if
         lhs%env = rhs%env  ! Uses type_env_t assignment (deep copy)
+        if (associated(rhs%identifiers)) then
+            lhs%identifiers => rhs%identifiers
+            lhs%env%identifiers => rhs%identifiers
+        else
+            nullify(lhs%identifiers)
+            nullify(lhs%env%identifiers)
+        end if
     end subroutine scope_assign
 
     ! Deep copy a scope stack
@@ -393,11 +461,29 @@ contains
 
         copy%depth = this%depth
         copy%capacity = this%capacity
+        if (associated(this%identifier_storage)) then
+            if (.not. associated(copy%identifier_storage)) then
+                allocate(copy%identifier_storage)
+            end if
+            copy%identifier_storage = this%identifier_storage
+        else
+            if (associated(copy%identifier_storage)) then
+                deallocate(copy%identifier_storage)
+            end if
+            nullify(copy%identifier_storage)
+        end if
 
         if (allocated(this%scopes)) then
             allocate (copy%scopes(size(this%scopes)))
             do i = 1, size(this%scopes)
                 copy%scopes(i) = this%scopes(i)  ! Uses scope_t assignment (deep copy)
+                if (associated(copy%identifier_storage)) then
+                    copy%scopes(i)%identifiers => copy%identifier_storage
+                    copy%scopes(i)%env%identifiers => copy%identifier_storage
+                else
+                    nullify(copy%scopes(i)%identifiers)
+                    nullify(copy%scopes(i)%env%identifiers)
+                end if
             end do
         end if
     end function scope_stack_deep_copy
@@ -410,11 +496,29 @@ contains
 
         lhs%depth = rhs%depth
         lhs%capacity = rhs%capacity
+        if (associated(rhs%identifier_storage)) then
+            if (.not. associated(lhs%identifier_storage)) then
+                allocate(lhs%identifier_storage)
+            end if
+            lhs%identifier_storage = rhs%identifier_storage
+        else
+            if (associated(lhs%identifier_storage)) then
+                deallocate(lhs%identifier_storage)
+            end if
+            nullify(lhs%identifier_storage)
+        end if
 
         if (allocated(rhs%scopes)) then
             allocate (lhs%scopes(size(rhs%scopes)))
             do i = 1, size(rhs%scopes)
                 lhs%scopes(i) = rhs%scopes(i)  ! Uses scope_t assignment (deep copy)
+                if (associated(lhs%identifier_storage)) then
+                    lhs%scopes(i)%identifiers => lhs%identifier_storage
+                    lhs%scopes(i)%env%identifiers => lhs%identifier_storage
+                else
+                    nullify(lhs%scopes(i)%identifiers)
+                    nullify(lhs%scopes(i)%env%identifiers)
+                end if
             end do
         end if
     end subroutine scope_stack_assign

--- a/src/semantic/semantic_query_api.f90
+++ b/src/semantic/semantic_query_api.f90
@@ -9,6 +9,7 @@ module semantic_query_api
                              SCOPE_INTERFACE
     use type_system_unified, only: mono_type_t, poly_type_t, type_var_t, &
                                    TVAR, TINT, TREAL, TCHAR, TLOGICAL, TFUN, TARRAY
+    use identifier_table, only: identifier_table_get
     use fortfront_types, only: symbol_info_t, symbol_reference_t
     use ast_core
     use ast_nodes_core, only: identifier_node
@@ -480,7 +481,10 @@ contains
         allocate(symbols(count))
         
         do i = 1, count
-            symbols(i)%name = this%context%scopes%scopes(target_depth)%env%names(i)
+            symbols(i)%name = identifier_table_get(
+                this%context%scopes%identifier_storage,
+                this%context%scopes%scopes(target_depth)%env%name_ids(i)
+            )
             symbols(i)%type_info = this%context%instantiate( &
                 this%context%scopes%scopes(target_depth)%env%schemes(i))
             symbols(i)%is_parameter = .false.
@@ -592,7 +596,10 @@ contains
         allocate(symbols(count))
         
         do i = 1, count
-            symbols(i)%name = context%scopes%scopes(target_depth)%env%names(i)
+            symbols(i)%name = identifier_table_get(
+                context%scopes%identifier_storage,
+                context%scopes%scopes(target_depth)%env%name_ids(i)
+            )
             symbols(i)%type_info = context%instantiate( &
                 context%scopes%scopes(target_depth)%env%schemes(i))
             symbols(i)%is_parameter = .false.

--- a/src/semantic/types/type_system_unified.f90
+++ b/src/semantic/types/type_system_unified.f90
@@ -4,7 +4,10 @@ module type_system_unified
     
     use iso_fortran_env, only: error_unit
     use type_system_arena
-    use error_handling, only: result_t, create_error_result, success_result, ERROR_MEMORY
+    use error_handling, only: result_t, create_error_result, &
+        success_result, ERROR_MEMORY
+    use identifier_table, only: identifier_table_t, identifier_id_kind, &
+        identifier_table_intern, identifier_table_find
     implicit none
     private
 
@@ -89,7 +92,6 @@ module type_system_unified
     integer, parameter :: MAX_SUBST_SIZE = 512
     ! Increase environment capacity to better handle larger inputs (Issue #1046)
     integer, parameter :: MAX_ENV_SIZE = 4096
-    integer, parameter :: MAX_NAME_LEN = 128
     
     type :: substitution_t
         integer :: count = 0
@@ -107,8 +109,9 @@ module type_system_unified
     type :: type_env_t
         integer :: count = 0
         integer :: capacity = 0
-        character(len=MAX_NAME_LEN), allocatable :: names(:)
+        integer(identifier_id_kind), allocatable :: name_ids(:)
         type(poly_type_t), allocatable :: schemes(:)
+        type(identifier_table_t), pointer :: identifiers => null()
         logical :: capacity_exceeded_reported = .false.
         logical :: is_fixed = .false.
     contains
@@ -356,21 +359,27 @@ contains
         lhs%is_fixed = rhs%is_fixed
         if (lhs%capacity <= 0) then
             ! Try to infer capacity from source arrays if available
-            if (allocated(rhs%names)) lhs%capacity = size(rhs%names)
+            if (allocated(rhs%name_ids)) lhs%capacity = size(rhs%name_ids)
             if (lhs%capacity <= 0) lhs%capacity = lhs%count
         end if
         if (lhs%capacity < lhs%count) lhs%capacity = lhs%count
-        if (allocated(lhs%names)) deallocate(lhs%names)
+        if (allocated(lhs%name_ids)) deallocate(lhs%name_ids)
         if (allocated(lhs%schemes)) deallocate(lhs%schemes)
         if (lhs%capacity > 0) then
-            allocate(lhs%names(lhs%capacity))
+            allocate(lhs%name_ids(lhs%capacity))
             allocate(lhs%schemes(lhs%capacity))
         end if
-        
+
+        if (associated(rhs%identifiers)) then
+            lhs%identifiers => rhs%identifiers
+        else
+            nullify(lhs%identifiers)
+        end if
+
         ! Copy only used elements
         if (rhs%count > 0) then
             do i = 1, rhs%count
-                lhs%names(i) = rhs%names(i)
+                lhs%name_ids(i) = rhs%name_ids(i)
                 lhs%schemes(i) = rhs%schemes(i)
             end do
         end if
@@ -581,20 +590,27 @@ contains
         class(type_env_t), intent(inout) :: this
         character(len=*), intent(in) :: name
         type(poly_type_t), intent(in) :: scheme
+        integer(identifier_id_kind) :: name_id
+
+        if (.not. associated(this%identifiers)) then
+            write(error_unit, '(A)') &
+                'ERROR: type_env_t missing identifier table; skipping insert'
+            return
+        end if
 
         ! Initialize capacity lazily. If user set capacity manually use it.
-        if (.not. allocated(this%names) .or. .not. allocated(this%schemes)) then
+        if (.not. allocated(this%name_ids) .or. .not. allocated(this%schemes)) then
             if (this%capacity > 0) then
                 this%is_fixed = .true.
             else
                 this%capacity = 64
                 this%is_fixed = .false.
             end if
-            allocate(this%names(this%capacity))
+            allocate(this%name_ids(this%capacity))
             allocate(this%schemes(this%capacity))
         else
             ! Handle pathological zero-sized allocations defensively
-            if (size(this%names) == 0 .or. size(this%schemes) == 0) then
+            if (size(this%name_ids) == 0 .or. size(this%schemes) == 0) then
                 if (this%capacity <= 0) this%capacity = 64
                 call type_env_ensure_capacity(this, max(1, this%count + 1))
             end if
@@ -604,8 +620,10 @@ contains
         if (this%count >= this%capacity) then
             if (this%is_fixed) then
                 if (.not. this%capacity_exceeded_reported) then
-                    write(error_unit, *) "ERROR: Type environment capacity exceeded (", this%capacity, ")"
-                    write(error_unit, *) "Consider increasing MAX_ENV_SIZE parameter"
+                    write(error_unit, *) &
+                        'ERROR: Type environment capacity exceeded (', &
+                        this%capacity, ')'
+                    write(error_unit, *) 'Consider increasing MAX_ENV_SIZE parameter'
                     this%capacity_exceeded_reported = .true.
                 end if
                 return
@@ -614,19 +632,25 @@ contains
                 call type_env_ensure_capacity(this, this%count + 1)
             end if
         end if
-        
+
         ! Add binding
-        this%count = this%count + 1
-        
-        ! Check name length and handle appropriately
-        if (len(name) > MAX_NAME_LEN) then
-            write(error_unit, *) "ERROR: Name too long (", len(name), " > ", MAX_NAME_LEN, ")"
-            ! Truncate name and continue rather than stopping
-            this%names(this%count) = name(1:MAX_NAME_LEN)
-        else
-            this%names(this%count) = name
+        name_id = identifier_table_intern(this%identifiers, name)
+
+        ! Replace existing entry if name already present
+        if (this%count > 0) then
+            block
+                integer :: idx
+                do idx = 1, this%count
+                    if (this%name_ids(idx) == name_id) then
+                        this%schemes(idx) = scheme
+                        return
+                    end if
+                end do
+            end block
         end if
-        
+
+        this%count = this%count + 1
+        this%name_ids(this%count) = name_id
         this%schemes(this%count) = scheme
     end subroutine type_env_extend
     
@@ -634,24 +658,24 @@ contains
         class(type_env_t), intent(inout) :: this
         integer, intent(in) :: required
         ! Ensure arrays exist; if not fixed, grow to meet required
-        if (.not. allocated(this%names) .or. .not. allocated(this%schemes)) then
+        if (.not. allocated(this%name_ids) .or. .not. allocated(this%schemes)) then
             if (this%capacity <= 0) then
                 this%capacity = max(64, required)
                 this%is_fixed = .false.
             end if
-            allocate(this%names(this%capacity))
+            allocate(this%name_ids(this%capacity))
             allocate(this%schemes(this%capacity))
-        else if (size(this%names) == 0 .or. size(this%schemes) == 0) then
+        else if (size(this%name_ids) == 0 .or. size(this%schemes) == 0) then
             ! Repair zero-sized arrays
             if (this%capacity <= 0) this%capacity = max(64, required)
             block
                 integer :: new_capacity
-                character(len=MAX_NAME_LEN), allocatable :: new_names(:)
+                integer(identifier_id_kind), allocatable :: new_ids(:)
                 type(poly_type_t), allocatable :: new_schemes(:)
                 new_capacity = max(this%capacity, required)
-                allocate(new_names(new_capacity))
+                allocate(new_ids(new_capacity))
                 allocate(new_schemes(new_capacity))
-                call move_alloc(new_names, this%names)
+                call move_alloc(new_ids, this%name_ids)
                 call move_alloc(new_schemes, this%schemes)
                 this%capacity = new_capacity
             end block
@@ -659,18 +683,18 @@ contains
             ! Grow dynamically
             block
                 integer :: new_capacity, i
-                character(len=MAX_NAME_LEN), allocatable :: new_names(:)
+                integer(identifier_id_kind), allocatable :: new_ids(:)
                 type(poly_type_t), allocatable :: new_schemes(:)
                 new_capacity = max(this%capacity*2, required)
-                allocate(new_names(new_capacity))
+                allocate(new_ids(new_capacity))
                 allocate(new_schemes(new_capacity))
                 if (this%count > 0) then
                     do i = 1, this%count
-                        new_names(i) = this%names(i)
+                        new_ids(i) = this%name_ids(i)
                         new_schemes(i) = this%schemes(i)
                     end do
                 end if
-                call move_alloc(new_names, this%names)
+                call move_alloc(new_ids, this%name_ids)
                 call move_alloc(new_schemes, this%schemes)
                 this%capacity = new_capacity
             end block

--- a/test/semantic/test_gcc_15_2_1_compatibility.f90
+++ b/test/semantic/test_gcc_15_2_1_compatibility.f90
@@ -4,6 +4,7 @@ program test_gcc_15_2_1_compatibility
     ! instead of allocatable components that cause crashes
     
     use type_system_unified
+    use identifier_table, only: identifier_table_t, identifier_table_init
     use iso_fortran_env, only: int64
     implicit none
     
@@ -81,6 +82,7 @@ contains
     
     subroutine test_type_env_basic()
         type(type_env_t) :: env1, env2
+        type(identifier_table_t), target :: table
         type(poly_type_t) :: scheme
         type(mono_type_t) :: mono
         
@@ -89,7 +91,10 @@ contains
         ! Create a simple type scheme
         mono = create_mono_type(TINT)
         scheme = create_poly_type([type_var_t::], mono)
-        
+
+        call identifier_table_init(table)
+        env1%identifiers => table
+
         ! Add to environment
         call env1%extend("x", scheme)
         call env1%extend("y", scheme)
@@ -180,6 +185,7 @@ contains
     
     subroutine test_large_type_env()
         type(type_env_t) :: env
+        type(identifier_table_t), target :: table
         type(poly_type_t) :: scheme
         type(mono_type_t) :: mono
         integer :: i
@@ -189,7 +195,10 @@ contains
         
         mono = create_mono_type(TINT)
         scheme = create_poly_type([type_var_t::], mono)
-        
+
+        call identifier_table_init(table)
+        env%identifiers => table
+
         ! Add many environment entries
         do i = 1, 100
             write(var_name, '("var", I0)') i

--- a/test/semantic/test_issue_354_crash.f90
+++ b/test/semantic/test_issue_354_crash.f90
@@ -4,6 +4,7 @@ program test_issue_354_crash
     ! and tests assignment operations that crash with the bug
     
     use type_system_unified
+    use identifier_table, only: identifier_table_t, identifier_table_init
     implicit none
     
     print *, "=== Testing Issue #354: GCC 15.2.1 Allocatable Crash ==="
@@ -44,6 +45,7 @@ contains
     subroutine test_uninitialized_type_env()
         type(type_env_t) :: envs(5)  ! Array of uninitialized environments
         type(type_env_t) :: source_env
+        type(identifier_table_t), target :: table
         type(poly_type_t) :: scheme
         type(mono_type_t) :: mono
         integer :: i
@@ -53,6 +55,9 @@ contains
         ! Create valid environment
         mono = create_mono_type(TREAL)
         scheme = create_poly_type([type_var_t::], mono)
+        call identifier_table_init(table)
+        source_env%identifiers => table
+
         call source_env%extend("x", scheme)
         
         ! This would crash with undefined allocatable components

--- a/test/semantic/test_scope_manager_basic.f90
+++ b/test/semantic/test_scope_manager_basic.f90
@@ -1,6 +1,7 @@
 program test_scope_manager_basic
     use scope_manager
     use type_system_unified
+    use identifier_table, only: identifier_table_get
     use iso_fortran_env, only: error_unit
     implicit none
 
@@ -14,6 +15,7 @@ program test_scope_manager_basic
     call test_scope_creation()
     call test_scope_stack_creation()
     call test_scope_lookup_empty()
+    call test_identifier_interning_reuse()
 
     write (*, '(A,I0,A,I0,A)') "Passed ", pass_count, " out of ", test_count, " tests."
     if (pass_count /= test_count) then
@@ -81,5 +83,63 @@ contains
             write (*, '(A)') "FAIL: Empty scope lookup should return unallocated"
         end if
     end subroutine test_scope_lookup_empty
+
+    subroutine test_identifier_interning_reuse()
+        type(scope_stack_t) :: stack
+        type(mono_type_t) :: mono
+        type(poly_type_t) :: scheme
+        integer :: initial_count
+        integer :: foo_id_first, foo_id_second
+        character(len=:), allocatable :: interned_name
+
+        test_count = test_count + 1
+
+        write (*, '(A)') 'Testing identifier interning reuse...'
+        call create_scope_stack(stack)
+
+        mono = create_mono_type(TINT)
+        scheme = create_poly_type([type_var_t::], mono)
+
+        associate(env => stack%scopes(stack%depth)%env)
+        initial_count = env%count
+        call stack%define('foo', scheme)
+        if (env%count /= initial_count + 1) then
+            write (*, '(A)') 'FAIL: First definition did not increment count'
+            return
+        end if
+
+        foo_id_first = env%name_ids(1)
+        interned_name = identifier_table_get(stack%identifier_storage, foo_id_first)
+        if (interned_name /= 'foo') then
+            write (*, '(A)') 'FAIL: Interned name mismatch for first definition'
+            return
+        end if
+
+        call stack%define('foo', scheme)
+        foo_id_second = env%name_ids(1)
+        if (env%count /= initial_count + 1) then
+            write (*, '(A)') 'FAIL: Duplicate definition created extra entry'
+            return
+        end if
+        if (foo_id_second /= foo_id_first) then
+            write (*, '(A)') 'FAIL: Duplicate definition produced new identifier id'
+            return
+        end if
+
+        call stack%define('bar', scheme)
+        if (env%count /= initial_count + 2) then
+            write (*, '(A)') 'FAIL: Second unique definition did not increment count'
+            return
+        end if
+        if (env%name_ids(2) == foo_id_first) then
+            write (*, '(A)') 'FAIL: Distinct identifiers share the same intern id'
+            return
+        end if
+
+        end associate
+
+        pass_count = pass_count + 1
+        write (*, '(A)') 'PASS: Identifier interning reuse'
+    end subroutine test_identifier_interning_reuse
 
 end program test_scope_manager_basic

--- a/test/semantic/test_type_env_capacity_guard.f90
+++ b/test/semantic/test_type_env_capacity_guard.f90
@@ -1,32 +1,42 @@
 program test_type_env_capacity_guard
     use type_system_unified, only: type_env_t, mono_type_t, poly_type_t, &
         type_var_t, create_mono_type, create_poly_type, TINT
+    use identifier_table, only: identifier_table_t, identifier_table_init
     implicit none
 
     type(type_env_t) :: env
     type(mono_type_t) :: m
     type(poly_type_t) :: p
     type(type_var_t), allocatable :: forall_vars(:)
-    integer :: i
+    type(identifier_table_t), target :: table
 
     ! Set a very small capacity to trigger guard logic quickly
     env%capacity = 2
+    env%is_fixed = .true.
+    call identifier_table_init(table)
+    env%identifiers => table
 
     ! Create a simple type scheme to insert
     m = create_mono_type(TINT)
     allocate(forall_vars(0))
     p = create_poly_type(forall_vars, m)
 
-    do i = 1, 10
-        call env%extend('x', p)
-    end do
+    call env%extend('x1', p)
+    call env%extend('x2', p)
+    call env%extend('x3', p)
 
-    ! Expect the count to be capped at capacity (no overflow)
     if (env%count /= env%capacity) then
-        print *, 'FAIL: env%count=', env%count, ' capacity=', env%capacity
+        print *, 'FAIL: guard did not enforce fixed capacity'
+        print *, 'count=', env%count, 'capacity=', env%capacity
         stop 1
-    else
-        print *, 'PASS: type_env capacity guard works (count=', env%count, ')'
     end if
+
+    call env%extend('x2', p)
+    if (env%count /= env%capacity) then
+        print *, 'FAIL: duplicate definition altered count'
+        stop 1
+    end if
+
+    print *, 'PASS: type_env capacity guard respected fixed capacity'
 
 end program test_type_env_capacity_guard


### PR DESCRIPTION
## Summary
- add a shared identifier interning table used by scope and type environments to cut redundant string storage
- rewrite scope stack and type environment operations to work with identifier ids and preserve the shared intern table across copies
- extend semantic tests to cover identifier reuse, fixed-capacity guards, and env setup edge cases

## Verification
- `make test`
  - `PASS: Identifier interning reuse`
  - `PASS: type_env capacity guard respected fixed capacity`
  - `All fortfront API transform tests passed`
