### PR TITLE
fix: Make very slow test faster (fixes #1296)

### DIFF
--- a/test/parser/test_expression_iterative.f90
+++ b/test/parser/test_expression_iterative.f90
@@ -304,6 +304,7 @@ contains
         type(compilation_options_t) :: options
         integer :: unit, iostat, i
         integer :: paren_group
+        integer :: chunk_size, remaining
 
         print *, "Testing extreme parentheses nesting (depth =", depth, ')'
         test_extreme_parentheses_depth = .true.
@@ -316,24 +317,34 @@ contains
         write(unit, '(a)') '    real :: value'
         write(unit, '(a)', advance='no') '    value = '
         paren_group = 0
-        do i = 1, depth
-            write(unit, '(a)', advance='no') '('
-            paren_group = paren_group + 1
-            if (mod(paren_group, 64) == 0) then
+        i = 1
+        do while (i <= depth)
+            remaining = depth - i + 1
+            chunk_size = merge(64, remaining, remaining >= 64)
+            if (chunk_size > remaining) chunk_size = remaining
+            write(unit, '(a)', advance='no') repeat('(', chunk_size)
+            paren_group = paren_group + chunk_size
+            if (paren_group >= 64 .and. i + chunk_size <= depth) then
                 write(unit, '(a)') '&'
                 write(unit, '(a)', advance='no') '    & '
                 paren_group = 0
             end if
+            i = i + chunk_size
         end do
         write(unit, '(a)', advance='no') '1.0'
         paren_group = 0
-        do i = 1, depth
+        i = 1
+        do while (i <= depth)
+            remaining = depth - i + 1
+            chunk_size = merge(64, remaining, remaining >= 64)
+            if (chunk_size > remaining) chunk_size = remaining
             if (paren_group == 0 .and. i > 1 .and. i < depth) then
                 write(unit, '(a)') '&'
                 write(unit, '(a)', advance='no') '    & '
             end if
-            write(unit, '(a)', advance='no') ')'
-            paren_group = mod(paren_group + 1, 64)
+            write(unit, '(a)', advance='no') repeat(')', chunk_size)
+            paren_group = mod(paren_group + chunk_size, 64)
+            i = i + chunk_size
         end do
         write(unit, '(a)') ''
         write(unit, '(a)') '    print *, value'


### PR DESCRIPTION
Summary
- Optimize generation of extreme parentheses test to reduce I/O calls.
- Replace 4096 single-character writes with ~64 chunked writes using repeat('(') and repeat(')') respecting continuation lines every 64.
- Keeps depth at 4096; improves performance on slower filesystems/Windows CI without altering coverage.

Changes
- test/parser/test_expression_iterative.f90: rewrite test_extreme_parentheses_depth() file emission in chunks.

Verification
- Commands:
  - make test
  - make test-small-stack TEST_STACK_KB=1024
- Observations:
  - All tests pass locally.
  - Expression Iterative Parsing Tests complete without noticeable delay.
  - Reduced test duration vs. baseline due to fewer write syscalls.
- Artifacts:
  - Generated: test_expression_iterative_extreme.lf, test_expression_iterative_extreme_out.f90

Notes
- No functional changes to parser; test now generates input efficiently while preserving semantics.