### PR TITLE
fix: Phase 3: Frontend umbrella decision (fixes #1292)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -55,6 +55,16 @@ Removed to avoid confusion and build fragmentation. Use FPM/Make.
 3. **Semantic** - Type checking 
 4. **Codegen** - Emits standard Fortran
 
+## Public API
+
+- `frontend` module is the stable public entry point. It re-exports a focused
+  set of routines for lexing, parsing, semantic analysis, transformation, and
+  code generation.
+- Internal modules should depend on narrow modules directly (e.g.,
+  `frontend_parsing`, `frontend_core`, `frontend_transformation`) rather than
+  importing `frontend`.
+- Tests and external consumers may `use frontend` to validate public behavior.
+
 ## Integration
 
 ### With fortrun

--- a/docs/README.md
+++ b/docs/README.md
@@ -65,6 +65,11 @@ Removed to avoid confusion and build fragmentation. Use FPM/Make.
   importing `frontend`.
 - Tests and external consumers may `use frontend` to validate public behavior.
 
+Note on test-only helpers
+- Some debug/test-oriented helpers are currently re-exported to support the
+  internal test suite. These are not part of the stable API surface and may
+  change or be removed between releases without deprecation.
+
 ## Integration
 
 ### With fortrun

--- a/src/frontend.f90
+++ b/src/frontend.f90
@@ -1,8 +1,22 @@
 module frontend
     ! fortfront - Core analysis frontend
     ! Simple, clean interface: Lexer → Parser → Semantic → Standard Fortran codegen
-    ! This module provides backward compatibility by re-exporting functionality
-    ! from the refactored modular structure
+    !
+    ! Decision: keep `frontend` as the stable public entry point
+    ! -------------------------------------------------------------------------
+    ! This module intentionally remains as a thin umbrella that re-exports the
+    ! documented public API from the refactored modules. It exists to provide a
+    ! single import for downstream users and the CLI.
+    !
+    ! Scope policy
+    ! - Only re-export explicitly documented entry points (lexer/parsing,
+    !   semantics, transformation, and codegen helpers).
+    ! - Internal implementation must not depend on `frontend`; internal code
+    !   should import narrow modules directly (e.g., `frontend_parsing`,
+    !   `frontend_core`, `frontend_transformation`).
+    ! - Tests may import `frontend` to validate public behavior.
+    !
+    ! This comment documents the umbrella decision per Phase 3.
 
     ! Re-export core functionality
     use frontend_core, only: lex_source, analyze_semantics, emit_fortran, &

--- a/src/frontend.f90
+++ b/src/frontend.f90
@@ -22,10 +22,12 @@ module frontend
     use frontend_core, only: lex_source, analyze_semantics, emit_fortran, &
                             compile_source, compilation_options_t, &
                             lex_file
-    use frontend_parsing, only: parse_tokens, parse_tokens_safe, parse_result_with_index_t, &
+    use frontend_parsing, only: parse_tokens, parse_tokens_safe, &
+                               parse_result_with_index_t, &
                                find_program_unit_boundary, &
-                               is_function_start, is_end_function, parse_program_unit, &
-                               is_do_loop_start, is_do_while_start, is_select_case_start, &
+                               is_function_start, is_end_function, &
+                               parse_program_unit, is_do_loop_start, &
+                               is_do_while_start, is_select_case_start, &
                                is_end_do, is_end_select, is_if_then_start, is_end_if
     use frontend_transformation, only: transform_lazy_fortran_string, &
                                      transform_lazy_fortran_string_with_format, &

--- a/src/frontend.f90
+++ b/src/frontend.f90
@@ -1,8 +1,8 @@
 module frontend
     ! fortfront - Core analysis frontend
-    ! Simple, clean interface: Lexer → Parser → Semantic → Standard Fortran codegen
+    ! Simple, clean interface: Lexer -> Parser -> Semantic -> Standard Fortran codegen
     !
-    ! Decision: keep `frontend` as the stable public entry point
+    ! Decision: keep frontend as the stable public entry point
     ! -------------------------------------------------------------------------
     ! This module intentionally remains as a thin umbrella that re-exports the
     ! documented public API from the refactored modules. It exists to provide a


### PR DESCRIPTION
Summary
- Documented the decision to keep `frontend` as the stable public entry point.
- Clarified scope policy: only re-export documented APIs; internal code must import narrow modules directly.
- Updated docs to state the public API stance and guidance for internal modules and tests.
- Clarified that debug/test helpers re-exported via `frontend` are not part of the stable API.

Changes
- src/frontend.f90: Added explicit decision banner and scope policy comments; aligned comment style; added stability note for test-only helpers.
- docs/README.md: Added Public API section describing `frontend` module usage; noted instability of test-only helpers.

Verification
- Baseline tests:
  - Command: `make test`
  - Result: Full suite passes locally (rerun after doc/comment tweaks also passes).
- No stray internal imports against policy:
  - Command: `rg -n "^\s*use\s+frontend\b" src`
  - Output:
    src/fortfront.f90:30:    use frontend, only: lex_source, parse_tokens, analyze_semantics, &
    src/interfaces/fortfront_external_interface.f90:5:    use frontend, only: transform_lazy_fortran_string, compilation_options_t, &
    src/interfaces/fortfront_c_interface.f90:6:    use frontend, only: transform_lazy_fortran_string, compilation_options_t, &
  - Interpretation: Only CLI and external interfaces import `frontend`; internal implementation uses narrow modules.

Notes
- This implements the "Keep" path per Phase 3: the module remains a thin re-export with a clearly documented contract.
- Follow-up improvements can further trim exports if desired, but current scope aligns with the acceptance criteria.


Reviewer verification (Codex CLI)
- Ran: make test → all tests pass locally
- Checked imports: only CLI and external interfaces use frontend; internal modules use narrow deps
- No functional changes; comments/docs adhere to style (88 cols, use, only)
