### PR TITLE
fix: codegen: mixed declaration loses non-parameter locals in procedures (fixes #1304)

### DIFF
--- a/src/codegen/codegen_utilities.f90
+++ b/src/codegen/codegen_utilities.f90
@@ -452,6 +452,41 @@ contains
                                     end do
                                     
                                     code = code // new_line('A')
+
+                                    ! Also emit a declaration for non-parameter variables (locals)
+                                    block
+                                        character(len=:), allocatable :: nonparam_list
+                                        logical :: have_nonparam
+                                        character(len=:), allocatable :: local_type
+                                        logical :: local_append_kind
+
+                                        nonparam_list = ""
+                                        have_nonparam = .false.
+                                        do j = 1, size(node%var_names)
+                                            if (.not. is_param(j)) then
+                                                if (have_nonparam) then
+                                                    nonparam_list = nonparam_list // ", " // trim(node%var_names(j))
+                                                else
+                                                    nonparam_list = trim(node%var_names(j))
+                                                end if
+                                                have_nonparam = .true.
+                                            end if
+                                        end do
+
+                                        if (have_nonparam) then
+                                            local_type = trim(node%type_name)
+                                            local_append_kind = node%has_kind
+                                            if (local_type == 'real' .and. .not. local_append_kind) then
+                                                local_type = 'real(8)'
+                                            end if
+                                            code = code // indent_str // local_type
+                                            if (local_append_kind) then
+                                                code = code // "(" // trim(adjustl(int_to_string(node%kind_value))) // ")"
+                                            end if
+                                            ! Intentionally do NOT add intent/optional for non-parameters
+                                            code = code // " :: " // nonparam_list // new_line('A')
+                                        end if
+                                    end block
                                 end if
                                 
                                 deallocate(is_param)

--- a/test/test_module_contains_functions.f90
+++ b/test/test_module_contains_functions.f90
@@ -6,15 +6,15 @@ program test_module_contains_functions
     use lexer_core, only: token_t
     use ast_arena_modern, only: ast_arena_t, create_ast_arena
     implicit none
-    
+
     call test_module_with_function()
     call test_module_with_subroutine()
     call test_module_with_multiple_procedures()
     print *, ""
     print *, "All module contains tests completed."
-    
+
 contains
-    
+
     subroutine test_module_with_function()
         character(:), allocatable :: input_code
         character(:), allocatable :: output_code
@@ -22,7 +22,7 @@ contains
         type(token_t), allocatable :: tokens(:)
         type(ast_arena_t) :: arena
         integer :: prog_index
-        
+
         ! Test module with function
         input_code = "module test_mod" // new_line('A') // &
                      "contains" // new_line('A') // &
@@ -31,50 +31,50 @@ contains
                      "c = a + b" // new_line('A') // &
                      "end function add" // new_line('A') // &
                      "end module test_mod"
-        
+
         print *, ""
         print *, "Test: Module with function"
         print *, "Input:"
         print *, trim(input_code)
-        
+
         ! Parse the code
         arena = create_ast_arena()
         call lex_source(input_code, tokens, error_msg)
-        
+
         if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
             print *, "Lexing error: ", trim(error_msg)
             error stop 1
         end if
-        
+
         call parse_tokens(tokens, arena, prog_index, error_msg)
-        
+
         if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
             print *, "Parsing error: ", error_msg
             error stop 1
         end if
-        
+
         ! Generate code
         call emit_fortran(arena, prog_index, output_code)
-        
+
         print *, "Output:"
         print *, trim(output_code)
-        
+
         ! Check that the contains section and function are preserved
         if (index(output_code, 'contains') == 0) then
             print *, "FAIL: 'contains' keyword missing from output"
             error stop 1
         end if
-        
+
         if (index(output_code, 'function add') == 0) then
             print *, "FAIL: 'function add' missing from output"
             error stop 1
         end if
-        
+
         if (.not. contains_without_spaces(output_code, 'c=a+b')) then
             print *, "FAIL: Function body 'c = a + b' missing from output"
             error stop 1
         end if
-        
+
         ! Ensure mixed declaration is split: parameters vs local
         if (.not. contains_without_spaces(output_code, 'integer::a,b')) then
             print *, "FAIL: Parameter declaration 'integer :: a, b' missing or not grouped"
@@ -84,10 +84,10 @@ contains
             print *, "FAIL: Local variable 'c' missing from separate declaration"
             error stop 1
         end if
-        
+
         print *, "[PASS] Module with function"
     end subroutine test_module_with_function
-    
+
     subroutine test_module_with_subroutine()
         character(:), allocatable :: input_code
         character(:), allocatable :: output_code
@@ -95,7 +95,7 @@ contains
         type(token_t), allocatable :: tokens(:)
         type(ast_arena_t) :: arena
         integer :: prog_index
-        
+
         ! Test module with subroutine
         input_code = "module math_mod" // new_line('A') // &
                      "contains" // new_line('A') // &
@@ -106,45 +106,45 @@ contains
                      "y = temp" // new_line('A') // &
                      "end subroutine swap" // new_line('A') // &
                      "end module math_mod"
-        
+
         print *, ""
         print *, "Test: Module with subroutine"
         print *, "Input:"
         print *, trim(input_code)
-        
+
         ! Parse the code
         arena = create_ast_arena()
         call lex_source(input_code, tokens, error_msg)
-        
+
         if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
             print *, "Lexing error: ", trim(error_msg)
             error stop 1
         end if
-        
+
         call parse_tokens(tokens, arena, prog_index, error_msg)
-        
+
         if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
             print *, "Parsing error: ", error_msg
             error stop 1
         end if
-        
+
         ! Generate code
         call emit_fortran(arena, prog_index, output_code)
-        
+
         print *, "Output:"
         print *, trim(output_code)
-        
+
         ! Check that the contains section and subroutine are preserved
         if (index(output_code, 'contains') == 0) then
             print *, "FAIL: 'contains' keyword missing from output"
             error stop 1
         end if
-        
+
         if (index(output_code, 'subroutine swap') == 0) then
             print *, "FAIL: 'subroutine swap' missing from output"
             error stop 1
         end if
-        
+
         if (.not. contains_without_spaces(output_code, 'temp=x')) then
             print *, "FAIL: Subroutine body missing from output"
             error stop 1
@@ -155,10 +155,10 @@ contains
             print *, "FAIL: Local variable 'temp' missing from output declaration"
             error stop 1
         end if
-        
+
         print *, "[PASS] Module with subroutine"
     end subroutine test_module_with_subroutine
-    
+
     subroutine test_module_with_multiple_procedures()
         character(:), allocatable :: input_code
         character(:), allocatable :: output_code
@@ -166,7 +166,7 @@ contains
         type(token_t), allocatable :: tokens(:)
         type(ast_arena_t) :: arena
         integer :: prog_index
-        
+
         ! Test module with multiple procedures
         input_code = "module utils_mod" // new_line('A') // &
                      "contains" // new_line('A') // &
@@ -179,52 +179,52 @@ contains
                      "print *, val" // new_line('A') // &
                      "end subroutine print_value" // new_line('A') // &
                      "end module utils_mod"
-        
+
         print *, ""
         print *, "Test: Module with multiple procedures"
-        
+
         ! Parse the code
         arena = create_ast_arena()
         call lex_source(input_code, tokens, error_msg)
-        
+
         if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
             print *, "Lexing error: ", trim(error_msg)
             error stop 1
         end if
-        
+
         call parse_tokens(tokens, arena, prog_index, error_msg)
-        
+
         if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
             print *, "Parsing error: ", error_msg
             error stop 1
         end if
-        
+
         ! Generate code
         call emit_fortran(arena, prog_index, output_code)
-        
+
         print *, "Output:"
         print *, trim(output_code)
-        
+
         ! Check that both procedures are preserved
         if (index(output_code, 'function square') == 0) then
             print *, "FAIL: 'function square' missing from output"
             error stop 1
         end if
-        
+
         ! Check for function body - allow either with or without spaces around *
         if (.not. contains_without_spaces(output_code, 'res=x*x')) then
             print *, "FAIL: Function body missing from output"
             error stop 1
         end if
-        
+
         if (index(output_code, 'subroutine print_value') == 0) then
             print *, "FAIL: 'subroutine print_value' missing from output"
             error stop 1
         end if
-        
+
         print *, "[PASS] Module with multiple procedures"
     end subroutine test_module_with_multiple_procedures
-    
+
     logical function contains_without_spaces(text, pattern)
         character(len=*), intent(in) :: text
         character(len=*), intent(in) :: pattern

--- a/test/test_module_contains_functions.f90
+++ b/test/test_module_contains_functions.f90
@@ -75,6 +75,16 @@ contains
             error stop 1
         end if
         
+        ! Ensure mixed declaration is split: parameters vs local
+        if (.not. contains_without_spaces(output_code, 'integer::a,b')) then
+            print *, "FAIL: Parameter declaration 'integer :: a, b' missing or not grouped"
+            error stop 1
+        end if
+        if (.not. contains_without_spaces(output_code, 'integer::c')) then
+            print *, "FAIL: Local variable 'c' missing from separate declaration"
+            error stop 1
+        end if
+        
         print *, "[PASS] Module with function"
     end subroutine test_module_with_function
     

--- a/test/test_module_contains_functions.f90
+++ b/test/test_module_contains_functions.f90
@@ -139,6 +139,12 @@ contains
             print *, "FAIL: Subroutine body missing from output"
             error stop 1
         end if
+
+        ! Ensure local variable from mixed declaration is preserved
+        if (index(output_code, 'real(8) :: temp') == 0) then
+            print *, "FAIL: Local variable 'temp' missing from output declaration"
+            error stop 1
+        end if
         
         print *, "[PASS] Module with subroutine"
     end subroutine test_module_with_subroutine


### PR DESCRIPTION
Summary
- Fix codegen loss of non-parameter locals when a mixed multi-variable declaration includes both dummy arguments and local variables.
- Now emits both a parameter declaration and a separate local declaration.

Verification
- Baseline tests:
  - Run: `make test`
  - Expect all tests to pass.
- Focused reproduction:
  - Input:
    ```fortran
    module m
    contains
      subroutine swap(x, y)
        real :: x, y, temp
        temp = x; x = y; y = temp
      end subroutine swap
    end module m
    ```
  - Transform via API or CLI; in output, verify both lines exist:
    - `real(8) :: x, y`
    - `real(8) :: temp`
- Added assertion:
  - Test: `test/test_module_contains_functions.f90`
  - Checks that `real(8) :: temp` is present in the generated subroutine.

Notes
- Implementation adjusts `generate_grouped_body_with_params` to also emit a local-only declaration for non-parameter names when a multi-declaration mixes params and locals. Intent/optional attributes are not applied to locals.


---

Reviewer verification

- Ran: `make test` on Linux; all tests passed.
- Focus: Verified mixed declaration splitting:
  - Function case: output contains `integer :: a, b` and `integer :: c`.
  - Subroutine case: output contains `real(8) :: x, y` and `real(8) :: temp`.
- Added test strengthening function case (`test/test_module_contains_functions.f90`).

