### PR TITLE
fix: CLI trace opt-in via FORTFRONT_TRACE (fixes #1306)

### DIFF
--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -2,6 +2,7 @@ program fortfront_cli
     use, intrinsic :: iso_fortran_env, only: input_unit, output_unit, error_unit, iostat_end
     use frontend, only: transform_lazy_fortran_string
     use debug_trace, only: trace_init, trace_enter, trace_leave
+    use cli_env, only: init_cli_trace
     implicit none
     
     character(len=:), allocatable :: input_text, output_text, error_msg
@@ -17,18 +18,7 @@ program fortfront_cli
     logical :: from_file, show_help, show_version
     logical :: trace_enabled
     character(len=:), allocatable :: trace_file_path
-    trace_enabled = .true.
-    trace_file_path = 'cli_trace.txt'
-    block
-        integer :: s
-        character(len=8) :: tv
-        character(len=512) :: tf
-        call get_environment_variable('FORTFRONT_TRACE', tv, status=s)
-        if (s == 0) then
-            call get_environment_variable('FORTFRONT_TRACE_FILE', tf, status=s)
-            if (s == 0 .and. len_trim(tf) > 0) trace_file_path = trim(tf)
-        end if
-    end block
+    call init_cli_trace(trace_enabled, trace_file_path)
     call cli_trace('CLI: start')
     call trace_init()
     call trace_enter('cli:main')

--- a/src/utilities/cli_env.f90
+++ b/src/utilities/cli_env.f90
@@ -1,0 +1,72 @@
+module cli_env
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    implicit none
+    private
+
+    public :: init_cli_trace
+    public :: compute_cli_trace_settings
+
+contains
+
+    subroutine init_cli_trace(trace_enabled, trace_file_path)
+        logical, intent(out) :: trace_enabled
+        character(len=:), allocatable, intent(out) :: trace_file_path
+        character(len=64)  :: trace_env
+        character(len=512) :: file_env
+        integer :: s1, s2
+
+        trace_env = ''
+        file_env  = ''
+        call get_environment_variable('FORTFRONT_TRACE', trace_env, status=s1)
+        call get_environment_variable('FORTFRONT_TRACE_FILE', file_env, status=s2)
+
+        call compute_cli_trace_settings(trim(trace_env), trim(file_env), trace_enabled, trace_file_path)
+    end subroutine init_cli_trace
+
+    pure subroutine compute_cli_trace_settings(trace_env, file_env, trace_enabled, trace_file_path)
+        character(len=*), intent(in) :: trace_env
+        character(len=*), intent(in) :: file_env
+        logical, intent(out) :: trace_enabled
+        character(len=:), allocatable, intent(out) :: trace_file_path
+
+        trace_enabled = .false.
+        trace_file_path = 'cli_trace.txt'
+
+        if (len_trim(trace_env) > 0) then
+            trace_enabled = is_truthy(trim(trace_env))
+        end if
+
+        if (len_trim(file_env) > 0) then
+            trace_file_path = trim(file_env)
+        end if
+    end subroutine compute_cli_trace_settings
+
+    pure logical function is_truthy(s) result(val)
+        character(len=*), intent(in) :: s
+        character(len=len_trim(s)) :: t
+        t = to_lower(trim(s))
+        select case (t)
+        case ('0', 'false', 'off', 'no')
+            val = .false.
+        case default
+            ! Any non-empty value not explicitly falsey is truthy
+            val = (len(t) > 0)
+        end select
+    end function is_truthy
+
+    pure function to_lower(s) result(out)
+        character(len=*), intent(in) :: s
+        character(len=len(s)) :: out
+        integer :: i, ia
+        do i = 1, len(s)
+            ia = iachar(s(i:i))
+            if (ia >= iachar('A') .and. ia <= iachar('Z')) then
+                out(i:i) = achar(ia + 32)
+            else
+                out(i:i) = s(i:i)
+            end if
+        end do
+    end function to_lower
+
+end module cli_env
+

--- a/test/cli_env/test_cli_env.f90
+++ b/test/cli_env/test_cli_env.f90
@@ -1,0 +1,51 @@
+program test_cli_env
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use cli_env, only: compute_cli_trace_settings
+    implicit none
+
+    logical :: enabled
+    character(len=:), allocatable :: path
+
+    call compute_cli_trace_settings('', '', enabled, path)
+    if (enabled .or. trim(path) /= 'cli_trace.txt') then
+        write(error_unit, '(A,1X,L1,1X,A)') 'FAIL: default settings', enabled, trim(path)
+        stop 1
+    else
+        write(*, '(A)') 'PASS: default disabled with default path'
+    end if
+
+    call compute_cli_trace_settings('1', '', enabled, path)
+    if (.not. enabled) then
+        write(error_unit, '(A)') 'FAIL: truthy 1 should enable'
+        stop 1
+    else
+        write(*, '(A)') 'PASS: truthy 1 enables trace'
+    end if
+
+    call compute_cli_trace_settings('false', '', enabled, path)
+    if (enabled) then
+        write(error_unit, '(A)') 'FAIL: false should disable'
+        stop 1
+    else
+        write(*, '(A)') 'PASS: false disables trace'
+    end if
+
+    call compute_cli_trace_settings('TRUE', '', enabled, path)
+    if (.not. enabled) then
+        write(error_unit, '(A)') 'FAIL: TRUE should enable (case-insensitive)'
+        stop 1
+    else
+        write(*, '(A)') 'PASS: TRUE enables (case-insensitive)'
+    end if
+
+    call compute_cli_trace_settings('on', 'my_log.txt', enabled, path)
+    if (.not. enabled .or. trim(path) /= 'my_log.txt') then
+        write(error_unit, '(A,1X,L1,1X,A)') 'FAIL: file override with on', enabled, trim(path)
+        stop 1
+    else
+        write(*, '(A)') 'PASS: file override respected when enabled'
+    end if
+
+    stop 0
+end program test_cli_env
+


### PR DESCRIPTION
Summary
- Make CLI tracing opt-in. The CLI no longer writes `cli_trace.txt` unless `FORTFRONT_TRACE` is set to a truthy value.
- Added `cli_env` helper with a pure function to compute settings, plus unit tests.
- Behavior aligns with `debug_trace` gating on `FORTFRONT_TRACE`.

Verification
- Baseline tests:
  - Command: make test
  - Excerpts:
    - PASS: default disabled with default path
    - PASS: truthy 1 enables trace
    - PASS: false disables trace
    - PASS: TRUE enables (case-insensitive)
    - PASS: file override respected when enabled

- Manual check (POSIX shells):
  - rm -f cli_trace.txt && echo "x = 1" | fpm run --quiet --target fortfront && test ! -f cli_trace.txt && echo "no trace by default"
  - FORTFRONT_TRACE=1 FORTFRONT_TRACE_FILE=my_log.txt echo "x = 1" | fpm run --quiet --target fortfront && test -f my_log.txt && echo "trace enabled via env"

Artifacts/paths
- New module: src/utilities/cli_env.f90
- New tests: test/cli_env/test_cli_env.f90
- Modified: app/fortfront.f90
