### PR TITLE
fix: CLI: replace STOP with quiet exit to avoid 'STOP n' messages (fixes #1312)

### DIFF
--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -4,6 +4,7 @@ program fortfront_cli
     use debug_trace, only: trace_init, trace_enter, trace_leave
     use cli_env, only: init_cli_trace
     use cli_io, only: read_all_stdin_or_file
+    use process_exit, only: exit_quiet
     implicit none
     
     character(len=:), allocatable :: input_text, output_text, error_msg
@@ -33,7 +34,7 @@ program fortfront_cli
             allocate(character(len=arg_len) :: arg_str, stat=alloc_stat)
             if (alloc_stat /= 0) then
                 write(error_unit, '(A,I0,A)') 'Memory allocation failed for command argument (stat=', alloc_stat, ')'
-                stop EXIT_FAILURE
+                call exit_quiet(EXIT_FAILURE)
             end if
             call get_command_argument(i, value=arg_str)
 
@@ -47,7 +48,7 @@ program fortfront_cli
                     write(error_unit, '(A,A)') 'Error: Unknown option ', trim(arg_str)
                     write(error_unit, '(A)') ''
                     write(error_unit, '(A)') 'Try ''fortfront --help'' for usage information.'
-                    stop EXIT_FAILURE
+                    call exit_quiet(EXIT_FAILURE)
                 end if
 
                 if (from_file) then
@@ -55,7 +56,7 @@ program fortfront_cli
                     write(error_unit, '(A)') 'fortfront processes one file at a time or reads from stdin.'
                     write(error_unit, '(A)') ''
                     write(error_unit, '(A)') 'Try ''fortfront --help'' for usage information.'
-                    stop EXIT_FAILURE
+                    call exit_quiet(EXIT_FAILURE)
                 end if
 
                 from_file = .true.
@@ -65,7 +66,7 @@ program fortfront_cli
             deallocate(arg_str, stat=alloc_stat)
             if (alloc_stat /= 0) then
                 write(error_unit, '(A,I0,A)') 'Memory deallocation failed for command argument (stat=', alloc_stat, ')'
-                stop EXIT_FAILURE
+                call exit_quiet(EXIT_FAILURE)
             end if
         end do
     end if
@@ -90,7 +91,7 @@ program fortfront_cli
         write(output_unit, '(A)') '    cat input.lf | fortfront  # Transpile from stdin'
         write(output_unit, '(A)') '    echo "x = 5" | fortfront  # Transpile string'
         call trace_leave('cli:main')
-        stop EXIT_SUCCESS
+        call exit_quiet(EXIT_SUCCESS)
     end if
     
     ! Handle version option
@@ -99,7 +100,7 @@ program fortfront_cli
         write(output_unit, '(A)') 'Lazy Fortran to Standard Fortran Transpiler'
         write(output_unit, '(A)') 'https://github.com/lazy-fortran/fortfront'
         call trace_leave('cli:main')
-        stop EXIT_SUCCESS
+        call exit_quiet(EXIT_SUCCESS)
     end if
     
     ! Read input (from file or stdin) using robust chunked reader
@@ -143,7 +144,7 @@ program fortfront_cli
             if (index(error_msg, '[SYNTAX_ERROR]') > 0 .or. &
                 index(error_msg, '[VALIDATION') > 0 .or. &
                 index(error_msg, '[PARSER_') > 0) then
-                stop EXIT_FAILURE
+                call exit_quiet(EXIT_FAILURE)
             end if
             ! Unrecognized input reports are advisory only; continue with success to
             ! match historical CLI behaviour for pipeline fallbacks.
@@ -153,7 +154,7 @@ program fortfront_cli
     ! If no output was generated and no error was reported, treat as failure
     if (.not. allocated(output_text) .or. len(output_text) == 0) then
         write(error_unit, '(A)') 'No output generated'
-        stop EXIT_FAILURE
+        call exit_quiet(EXIT_FAILURE)
     end if
 
     call trace_leave('cli:main')

--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -111,6 +111,10 @@ program fortfront_cli
         call read_all_stdin_or_file(.false., text=input_text, status=io_stat)
     end if
     call trace_leave('cli:read_input')
+    if (io_stat /= 0) then
+        call trace_leave('cli:main')
+        call exit_quiet(EXIT_FAILURE)
+    end if
     block
         character(len=64) :: tmp_msg
         write(tmp_msg, '("CLI: read input done (bytes=",I0,")")') merge(len(input_text), 0, allocated(input_text))

--- a/src/utilities/process_exit.f90
+++ b/src/utilities/process_exit.f90
@@ -1,0 +1,22 @@
+module process_exit
+    use, intrinsic :: iso_c_binding, only: c_int
+    implicit none
+    private
+    public :: exit_quiet
+
+    interface
+        subroutine c_exit(status) bind(C, name="exit")
+            import :: c_int
+            integer(c_int), value :: status
+        end subroutine c_exit
+    end interface
+
+contains
+
+    subroutine exit_quiet(status)
+        integer, intent(in) :: status
+        call c_exit(int(status, kind=c_int))
+    end subroutine exit_quiet
+
+end module process_exit
+

--- a/src/utils/cli_io.f90
+++ b/src/utils/cli_io.f90
@@ -59,14 +59,24 @@ contains
                 read(unit, '(A)', advance='no', iostat=ios, size=sz) buffer
 
                 if (ios == iostat_end) then
-                    if (sz > 0) call append_chunk(buffer(1:sz), text, total_size, capacity)
+                    if (sz > 0) then
+                        call append_chunk(buffer(1:sz), text, total_size, capacity, status)
+                        if (status /= 0) return
+                    end if
                     exit  ! End of file
                 else if (ios == iostat_eor) then
-                    if (sz > 0) call append_chunk(buffer(1:sz), text, total_size, capacity)
-                    call append_newline(text, total_size, capacity)
+                    if (sz > 0) then
+                        call append_chunk(buffer(1:sz), text, total_size, capacity, status)
+                        if (status /= 0) return
+                    end if
+                    call append_newline(text, total_size, capacity, status)
+                    if (status /= 0) return
                     exit  ! End of record
                 else if (ios == 0) then
-                    if (sz > 0) call append_chunk(buffer(1:sz), text, total_size, capacity)
+                    if (sz > 0) then
+                        call append_chunk(buffer(1:sz), text, total_size, capacity, status)
+                        if (status /= 0) return
+                    end if
                 else
                     write(error_unit, '(A,I0,A)') 'Error reading input (iostat=', ios, ')'
                     status = 3
@@ -87,17 +97,19 @@ contains
         call move_alloc(temp_text, text)
     end subroutine read_all_from_unit
 
-    subroutine append_chunk(chunk, text, total_size, capacity)
+    subroutine append_chunk(chunk, text, total_size, capacity, status)
         character(len=*), intent(in) :: chunk
         character(len=:), allocatable, intent(inout) :: text
         integer, intent(inout) :: total_size, capacity
+        integer, intent(inout) :: status
         character(len=:), allocatable :: tmp
         integer :: need
 
         need = total_size + len(chunk)
         if (need > MAX_INPUT_SIZE) then
             write(error_unit, '(A,I0,A)') 'Input exceeds maximum size (', MAX_INPUT_SIZE, ' bytes)'
-            stop 1
+            status = 4
+            return
         end if
         if (need > capacity) then
             do while (capacity < need .and. capacity <= MAX_INPUT_SIZE)
@@ -105,7 +117,8 @@ contains
             end do
             if (capacity < need) then
                 write(error_unit, '(A)') 'Input too large'
-                stop 1
+                status = 4
+                return
             end if
             allocate(character(len=capacity) :: tmp)
             if (total_size > 0) tmp(1:total_size) = text(1:total_size)
@@ -115,15 +128,17 @@ contains
         total_size = total_size + len(chunk)
     end subroutine append_chunk
 
-    subroutine append_newline(text, total_size, capacity)
+    subroutine append_newline(text, total_size, capacity, status)
         character(len=:), allocatable, intent(inout) :: text
         integer, intent(inout) :: total_size, capacity
+        integer, intent(inout) :: status
         character(len=:), allocatable :: tmp
         integer :: need
         need = total_size + 1
         if (need > MAX_INPUT_SIZE) then
             write(error_unit, '(A,I0,A)') 'Input exceeds maximum size (', MAX_INPUT_SIZE, ' bytes)'
-            stop 1
+            status = 4
+            return
         end if
         if (need > capacity) then
             do while (capacity < need .and. capacity <= MAX_INPUT_SIZE)

--- a/src/utils/process_exit.f90
+++ b/src/utils/process_exit.f90
@@ -19,4 +19,3 @@ contains
     end subroutine exit_quiet
 
 end module process_exit
-

--- a/test/system/test_cli_integration.f90
+++ b/test/system/test_cli_integration.f90
@@ -54,6 +54,9 @@ program test_cli_integration
     
     test_count = 0  ! Reset test counter
     
+    ! Test 0: --help prints to stdout, empty stderr, exit 0
+    call test_help_no_stderr()
+
     ! Test 1: Basic CLI I/O works
     call test_basic_io()
     
@@ -797,6 +800,74 @@ contains
             print *, "  Exit code: ", exit_code
         end if
     end subroutine test_empty_input
+
+    subroutine test_help_no_stderr()
+        integer :: run_status, ios
+        character(len=512) :: command
+        character(len=:), allocatable :: executable_path
+        character(len=256) :: line
+        logical :: success
+
+        call test_start("--help returns 0 and empty stderr")
+
+        executable_path = find_fortfront_executable()
+        if (len(executable_path) == 0) then
+            call test_result(.false.)
+            print *, "  ERROR: Could not locate fortfront executable"
+            return
+        end if
+
+        if (is_windows) then
+            command = 'cmd /C ""' // executable_path // '" --help > help_out.txt 2>help_err.txt"'
+        else
+            command = 'bash -lc "' // timeout_wrapper('20') // executable_path // ' --help > help_out.txt 2>help_err.txt"'
+        end if
+        call execute_command_line(command, exitstat=run_status)
+
+        success = (run_status == 0)
+
+        ! Ensure stderr is empty
+        if (success) then
+            open(unit=31, file='help_err.txt', status='old', action='read', iostat=ios)
+            if (ios == 0) then
+                do
+                    read(31, '(A)', iostat=ios) line
+                    if (ios /= 0) exit
+                    if (len_trim(line) > 0) then
+                        success = .false.
+                        exit
+                    end if
+                end do
+                close(31)
+            else
+                success = .false.
+            end if
+        end if
+
+        ! Quick sanity: stdout contains usage header
+        if (success) then
+            open(unit=32, file='help_out.txt', status='old', action='read', iostat=ios)
+            if (ios == 0) then
+                read(32, '(A)', iostat=ios) line
+                if (ios == 0) then
+                    success = (index(line, 'fortfront -') > 0)
+                else
+                    success = .false.
+                end if
+                close(32)
+            else
+                success = .false.
+            end if
+        end if
+
+        call cleanup_file('help_out.txt')
+        call cleanup_file('help_err.txt')
+
+        call test_result(success)
+        if (.not. success) then
+            print *, "  --help did not meet expectations (exit=", run_status, ")"
+        end if
+    end subroutine test_help_no_stderr
     
     subroutine test_start(test_name)
         character(len=*), intent(in) :: test_name


### PR DESCRIPTION
Summary
- Replace Fortran STOP exits in CLI with a quiet C exit binding to avoid stray "STOP n" banners on stdout/stderr.
- Behavior preserved: same exit codes; just no extra STOP lines.

Changes
- Add src/utils/process_exit.f90 providing exit_quiet(status) via bind(C, name="exit").
- Update app/fortfront.f90 to call exit_quiet() instead of stop on success/error paths.
- Add robust stdin/file reader in src/utils/cli_io.f90 and use it in the CLI entry.
- Add system test for CLI behavior: test/system/test_cli_integration.f90 (guarded by RUN_SYSTEM_TESTS=1).

Verification
- Build and run tests:
  make && make test
- Locate built CLI and run --help (no stderr, exit 0):
  exe=$(find build -type f -name fortfront -perm -u+x | head -1)
  "$exe" --help >/tmp/ff_help_out.txt 2>/tmp/ff_help_err.txt; echo $?
  wc -c /tmp/ff_help_err.txt
- Observed locally:
  - Exit code: 0
  - Stderr bytes: 0
  - Stdout starts with:
    fortfront - Lazy Fortran to Standard Fortran Transpiler

Notes
- Keeps CLI output clean for pipelines and tooling that parse stderr.
- Optional follow-up: add a small system test to assert empty stderr for --help.

## Verification (automated)

- make and make test: all tests passed locally.
- RUN_SYSTEM_TESTS=1 fpm test: CLI system tests passed (8/8), including:
  - --help returns 0 and stderr is empty
  - Basic CLI I/O (LF/CRLF/Windows pipe) works
  - Unknown flag and single '-' return non-zero exit
  - 'func' syntax prints program and exits non-zero
  - Empty input produces a valid program

## Additional polish

- Move process_exit module to src/utils/ to align with existing utils layout.
