### PR TITLE
fix: path_validation: allow '*' and '?' on POSIX; keep invalid on Win (fixes #1314)

### DIFF
--- a/src/utilities/path_validation.f90
+++ b/src/utilities/path_validation.f90
@@ -202,8 +202,10 @@ contains
         logical :: has_invalid
         integer :: i
         character(len=1) :: c
-        
+        logical :: windows_like
+
         has_invalid = .false.
+        windows_like = is_likely_windows_path(path)
         
         do i = 1, len(path)
             c = path(i:i)
@@ -222,7 +224,7 @@ contains
             
             ! Check for dangerous characters that could be used in attacks
             select case (c)
-            case ('|', '&', ';', '`', '$', '(', ')', '{', '}', '[', ']', '*', '?')
+            case ('|', '&', ';', '`', '$', '(', ')', '{', '}', '[', ']')
                 ! These could be used for command injection
                 has_invalid = .true.
                 return
@@ -230,9 +232,44 @@ contains
                 ! These could be used for redirection attacks
                 has_invalid = .true.
                 return
+            case ('*', '?')
+                ! On Windows, these are invalid path characters. On POSIX they are valid
+                ! filename characters; allow them to avoid false positives.
+                if (windows_like) then
+                    has_invalid = .true.
+                    return
+                end if
             end select
         end do
     end function contains_invalid_characters
+
+    ! Heuristic check for Windows-style paths (drive letter, backslashes, UNC)
+    pure logical function is_likely_windows_path(path) result(is_win)
+        character(len=*), intent(in) :: path
+        integer :: n
+        is_win = .false.
+        n = len(path)
+        if (n >= 2) then
+            if (path(1:2) == '\\' .or. path(1:2) == '//') then
+                is_win = .true.
+                return
+            end if
+        end if
+        if (n >= 3) then
+            if (path(2:2) == ':' .and. (path(3:3) == '\\' .or. path(3:3) == '/')) then
+                if ((path(1:1) >= 'A' .and. path(1:1) <= 'Z') .or. &
+                    (path(1:1) >= 'a' .and. path(1:1) <= 'z')) then
+                    is_win = .true.
+                    return
+                end if
+            end if
+        end if
+        ! If the path contains backslashes anywhere, treat it as Windows-like
+        if (index(path, '\\') > 0) then
+            is_win = .true.
+            return
+        end if
+    end function is_likely_windows_path
     
     ! Check for suspicious file extensions
     function has_suspicious_extension(path) result(is_suspicious)

--- a/test/integration/core_features/test_path_validation.f90
+++ b/test/integration/core_features/test_path_validation.f90
@@ -1,0 +1,53 @@
+program test_path_validation
+    use path_validation, only: validate_input_path, path_validation_result_t, &
+        PATH_VALID, PATH_INVALID_CHARACTERS, PATH_INVALID_TRAVERSAL
+    implicit none
+
+    call test_posix_glob_chars_allowed()
+    call test_windows_like_disallows_glob_chars()
+    call test_traversal_rejected()
+    call test_angle_brackets_rejected()
+
+    print *, 'Path validation tests passed'
+
+contains
+
+    subroutine test_posix_glob_chars_allowed()
+        type(path_validation_result_t) :: res
+        res = validate_input_path('data*?.txt')
+        if (res%code /= PATH_VALID) then
+            print *, 'Expected PATH_VALID for POSIX-like filename with * and ?'
+            stop 1
+        end if
+    end subroutine test_posix_glob_chars_allowed
+
+    subroutine test_windows_like_disallows_glob_chars()
+        type(path_validation_result_t) :: res
+        ! Heuristically Windows-like path should reject '?'
+        res = validate_input_path('C:\\temp\\file?.txt')
+        if (res%code /= PATH_INVALID_CHARACTERS) then
+            print *, 'Expected PATH_INVALID_CHARACTERS for Windows-like path with ?'
+            stop 1
+        end if
+    end subroutine test_windows_like_disallows_glob_chars
+
+    subroutine test_traversal_rejected()
+        type(path_validation_result_t) :: res
+        res = validate_input_path('../etc/passwd')
+        if (res%code /= PATH_INVALID_TRAVERSAL) then
+            print *, 'Expected PATH_INVALID_TRAVERSAL for ../ sequence'
+            stop 1
+        end if
+    end subroutine test_traversal_rejected
+
+    subroutine test_angle_brackets_rejected()
+        type(path_validation_result_t) :: res
+        res = validate_input_path('data<.txt')
+        if (res%code /= PATH_INVALID_CHARACTERS) then
+            print *, 'Expected PATH_INVALID_CHARACTERS for angle bracket in filename'
+            stop 1
+        end if
+    end subroutine test_angle_brackets_rejected
+
+end program test_path_validation
+

--- a/test/integration/core_features/test_path_validation.f90
+++ b/test/integration/core_features/test_path_validation.f90
@@ -7,6 +7,8 @@ program test_path_validation
     call test_windows_like_disallows_glob_chars()
     call test_traversal_rejected()
     call test_angle_brackets_rejected()
+    call test_square_brackets_rejected()
+    call test_posix_glob_chars_in_subdir()
 
     print *, 'Path validation tests passed'
 
@@ -48,6 +50,23 @@ contains
             stop 1
         end if
     end subroutine test_angle_brackets_rejected
+    
+    subroutine test_square_brackets_rejected()
+        type(path_validation_result_t) :: res
+        res = validate_input_path('data[1].txt')
+        if (res%code /= PATH_INVALID_CHARACTERS) then
+            print *, 'Expected PATH_INVALID_CHARACTERS for square brackets in filename'
+            stop 1
+        end if
+    end subroutine test_square_brackets_rejected
+
+    subroutine test_posix_glob_chars_in_subdir()
+        type(path_validation_result_t) :: res
+        res = validate_input_path('subdir/data*?.txt')
+        if (res%code /= PATH_VALID) then
+            print *, 'Expected PATH_VALID for POSIX subdir path with * and ?'
+            stop 1
+        end if
+    end subroutine test_posix_glob_chars_in_subdir
 
 end program test_path_validation
-


### PR DESCRIPTION
Summary
- Allow literal '*' and '?' in POSIX-like filenames during input path validation.
- Keep '*' and '?' invalid for Windows-like paths (drive letters, backslashes, UNC).
- Add integration tests: POSIX allowance, Windows-like rejection, traversal, angle and square brackets, and POSIX subdir globs.

Verification
- Commands
  - make test
- Evidence (excerpt)
```
[  0%]       test_path_validation.f90
[ 50%]       test_path_validation.f90  done.
[ 50%]           test_path_validation
[100%]           test_path_validation  done.
Path validation tests passed
```
- Changed files
  - src/utilities/path_validation.f90
  - test/integration/core_features/test_path_validation.f90

Notes
- Security checks remain intact for traversal, control chars, redirection tokens, and bracket characters on all platforms.