### PR TITLE
fix: document how to run CLI system tests (fixes #1318)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,19 @@ rm -f t.lf my_log.txt
 # Build and run tests
 make test
 ```
+
+### Running CLI System Tests
+- The CLI integration tests invoke external tools and are disabled by default.
+- Enable them with environment variable `RUN_SYSTEM_TESTS=1`.
+
+- POSIX shells:
+  - `RUN_SYSTEM_TESTS=1 make test`
+  - or `RUN_SYSTEM_TESTS=1 fpm test`
+
+- Windows (PowerShell):
+  - `$env:RUN_SYSTEM_TESTS=1; fpm test`
+
+- Notes:
+  - These tests build the `fortfront` CLI and exercise stdin/pipe behavior.
+  - Timeouts are applied in the test harness to keep runs bounded.
+  - Regular `make test` (without the env var) runs the fast unit/integration suite only.


### PR DESCRIPTION
Summary\n- Add "Running CLI System Tests" section to README.md.\n- Explain RUN_SYSTEM_TESTS=1 gate and provide POSIX/Windows examples.\n\nVerification\n- Baseline tests pass:\n  - Command: make test\n  - Output: All fortfront API integration tests passed!\n- System tests toggle is documented and discoverable:\n  - Command: rg -n RUN_SYSTEM_TESTS test/system/test_cli_integration.f90\n  - Excerpt: "Enable explicitly with: RUN_SYSTEM_TESTS=1 fpm test"\n- Example invocation (POSIX):\n  - RUN_SYSTEM_TESTS=1 fpm test\n- Example invocation (Windows PowerShell):\n  - :RUN_SYSTEM_TESTS=1; fpm test\n\nNo behavior changes to code; docs only.\n