### PR TITLE
fix: cli_io: infinite loop when input exceeds MAX_INPUT_SIZE (fixes #1320)

### DIFF
--- a/src/utils/cli_io.f90
+++ b/src/utils/cli_io.f90
@@ -112,7 +112,7 @@ contains
             return
         end if
         if (need > capacity) then
-            do while (capacity < need .and. capacity <= MAX_INPUT_SIZE)
+            do while (capacity < need .and. capacity < MAX_INPUT_SIZE)
                 capacity = min(capacity * 2, MAX_INPUT_SIZE)
             end do
             if (capacity < need) then
@@ -141,9 +141,14 @@ contains
             return
         end if
         if (need > capacity) then
-            do while (capacity < need .and. capacity <= MAX_INPUT_SIZE)
+            do while (capacity < need .and. capacity < MAX_INPUT_SIZE)
                 capacity = min(capacity * 2, MAX_INPUT_SIZE)
             end do
+            if (capacity < need) then
+                write(error_unit, '(A)') 'Input too large'
+                status = 4
+                return
+            end if
             allocate(character(len=capacity) :: tmp)
             if (total_size > 0) tmp(1:total_size) = text(1:total_size)
             call move_alloc(tmp, text)

--- a/test/utils/test_cli_io_large_input.f90
+++ b/test/utils/test_cli_io_large_input.f90
@@ -1,0 +1,36 @@
+program test_cli_io_large_input
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use cli_io, only: read_all_stdin_or_file
+    implicit none
+
+    character(len=:), allocatable :: text
+    integer :: status
+    character(len=*), parameter :: fname = 'tmp_large_input.txt'
+    integer :: u, i
+    character(len=10240) :: line
+
+    line = repeat('a', len(line))
+
+    open(newunit=u, file=fname, status='replace', action='write')
+    do i = 1, 1024
+        write(u, '(A)') line
+    end do
+    close(u)
+
+    call read_all_stdin_or_file(.true., fname, text, status)
+
+    if (status == 4) then
+        print *, 'PASS: Large input correctly reported as too large'
+    else
+        print *, 'FAIL: Expected status=4 for too large input, got', status
+        if (allocated(text)) then
+            print *, 'INFO: Partial text length =', len(text)
+        end if
+        stop 1
+    end if
+
+    ! Cleanup
+    open(newunit=u, file=fname, status='old', action='read')
+    close(u, status='delete')
+end program test_cli_io_large_input
+


### PR DESCRIPTION
Summary
- Fixes a potential infinite loop in cli_io when reading input larger than MAX_INPUT_SIZE (10 MiB).
- Applies the corrected growth condition to both append_chunk and append_newline and retains the post-loop guard.

Verification
- Baseline:
  - make test
  - All tests pass.
- Regression test:
  - New test: test/utils/test_cli_io_large_input.f90
  - Writes a ~10 MiB+ file and verifies read_all_stdin_or_file returns status=4.

Commands
- make test

Expected output excerpt
- ...
  PASS: Large input correctly reported as too large
  ...

Artifacts
- src/utils/cli_io.f90
- test/utils/test_cli_io_large_input.f90

Notes
- No changes to public APIs; behavior for valid inputs unchanged.
