### PR TITLE
fix: Unparsed if statement within loop (fixes #1324)

### DIFF
--- a/src/frontend_parsing.f90
+++ b/src/frontend_parsing.f90
@@ -11,6 +11,7 @@ module frontend_parsing
     use ast_factory, only: push_program
     use iso_fortran_env, only: error_unit
     use frontend_utilities, only: int_to_str
+    use parser_do_constructs_module, only: ensure_if_do_registration
     use mixed_construct_detector, only: detect_mixed_constructs, mixed_construct_result_t
     use error_handling, only: result_t
 
@@ -83,6 +84,8 @@ contains
 
         error_msg = ""
         prog_index = 0
+
+        call ensure_if_do_registration()
 
         call get_environment_variable('FORTFRONT_DEBUG_DUMP_AST', debug_flag, status=debug_status)
         debug_units = (debug_status == 0 .and. len_trim(debug_flag) > 0)

--- a/src/parser/ensure_if_do_registration_bridge.f90
+++ b/src/parser/ensure_if_do_registration_bridge.f90
@@ -1,0 +1,7 @@
+subroutine ensure_if_do_registration_bridge()
+    use parser_do_constructs_module, only: ensure_if_do_registration
+    implicit none
+
+    call ensure_if_do_registration()
+
+end subroutine ensure_if_do_registration_bridge

--- a/src/parser/parser_do_constructs.f90
+++ b/src/parser/parser_do_constructs.f90
@@ -18,12 +18,114 @@ module parser_do_constructs_module
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_loops, only: do_loop_node
     use ast_factory, only: push_do_loop, push_do_while, push_identifier, push_literal, push_assignment
+    use parser_if_constructs_module, only: parse_if, register_parse_do_loop
     implicit none
     private
+
+    logical, save :: if_hooks_initialized = .false.
 
     public :: parse_do_loop, parse_do_while, parse_do_while_from_do
 
 contains
+
+    subroutine initialize_if_hooks()
+        if (.not. if_hooks_initialized) then
+            call register_parse_do_loop(parse_do_loop)
+            if_hooks_initialized = .true.
+        end if
+    end subroutine initialize_if_hooks
+
+    logical function has_then_before_newline(tokens, start_pos)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_pos
+        integer :: idx
+
+        has_then_before_newline = .false.
+        do idx = start_pos + 1, size(tokens)
+            select case (tokens(idx)%kind)
+            case (TK_KEYWORD)
+                if (tokens(idx)%text == "then") then
+                    has_then_before_newline = .true.
+                    return
+                else if (tokens(idx)%text == "endif" .or. tokens(idx)%text == "end") then
+                    return
+                end if
+            case (TK_NEWLINE, TK_EOF)
+                return
+            end select
+        end do
+    end function has_then_before_newline
+
+    logical function is_else_if_context(tokens, pos)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: pos
+        integer :: idx
+
+        is_else_if_context = .false.
+        idx = pos - 1
+        do while (idx >= 1)
+            select case (tokens(idx)%kind)
+            case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
+                idx = idx - 1
+                cycle
+            case (TK_KEYWORD)
+                if (tokens(idx)%text == "else") then
+                    is_else_if_context = .true.
+                end if
+                return
+            case default
+                return
+            end select
+        end do
+    end function is_else_if_context
+
+    integer function find_matching_end_if(tokens, start_pos)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_pos
+        integer :: depth, idx
+
+        find_matching_end_if = -1
+        if (.not. has_then_before_newline(tokens, start_pos)) return
+
+        depth = 1
+        idx = start_pos + 1
+        do while (idx <= size(tokens))
+            select case (tokens(idx)%kind)
+            case (TK_KEYWORD)
+                select case (tokens(idx)%text)
+                case ("if")
+                    if (.not. is_else_if_context(tokens, idx)) then
+                        if (has_then_before_newline(tokens, idx)) depth = depth + 1
+                    end if
+                case ("endif")
+                    depth = depth - 1
+                    if (depth == 0) then
+                        find_matching_end_if = idx
+                        return
+                    end if
+                case ("end")
+                    if (idx + 1 <= size(tokens)) then
+                        if (tokens(idx + 1)%kind == TK_KEYWORD) then
+                            if (tokens(idx + 1)%text == "if") then
+                                depth = depth - 1
+                                if (depth == 0) then
+                                    find_matching_end_if = idx + 1
+                                    return
+                                end if
+                            end if
+                        end if
+                    end if
+                case ("elseif")
+                    cycle
+                case ("else")
+                    cycle
+                end select
+            case (TK_EOF)
+                exit
+            end select
+            idx = idx + 1
+        end do
+    end function find_matching_end_if
 
     ! Local implementation to avoid circular dependency
     function parse_basic_stmt_local(tokens, arena, parent_index) result(stmt_indices)
@@ -34,6 +136,8 @@ contains
         type(parser_state_t) :: parser
         type(token_t) :: first_token
         integer :: stmt_index
+
+        if (.not. if_hooks_initialized) call initialize_if_hooks()
 
         parser = create_parser_state(tokens)
         first_token = parser%peek()
@@ -74,6 +178,8 @@ contains
         ! Handle different statement types (excluding control flow to avoid circular deps)
         if (first_token%kind == TK_KEYWORD) then
             select case (first_token%text)
+            case ("if")
+                stmt_index = parse_if(parser, arena, parent_index)
             case ("print")
                 stmt_index = parse_print_statement(parser, arena)
             case ("write")
@@ -396,24 +502,40 @@ contains
 
                 stmt_end = stmt_start
 
-                ! Find end of current statement (same line or semicolon boundary)
-                do j = stmt_start, size(parser%tokens)
-                    if (parser%tokens(j)%kind == TK_EOF) then
-                        stmt_end = j
-                        exit
+                block
+                    integer :: block_end
+                    logical :: handled_block
+
+                    handled_block = .false.
+                    if (parser%tokens(stmt_start)%kind == TK_KEYWORD) then
+                        if (parser%tokens(stmt_start)%text == "if") then
+                            block_end = find_matching_end_if(parser%tokens, stmt_start)
+                            if (block_end > stmt_start) then
+                                stmt_end = block_end
+                                handled_block = .true.
+                            end if
+                        end if
                     end if
-   if (j > stmt_start .and. parser%tokens(j)%line > parser%tokens(stmt_start)%line) then
-                        stmt_end = j - 1
-                        exit
+
+                    if (.not. handled_block) then
+                        do j = stmt_start, size(parser%tokens)
+                            if (parser%tokens(j)%kind == TK_EOF) then
+                                stmt_end = j
+                                exit
+                            end if
+                            if (j > stmt_start .and. parser%tokens(j)%line > parser%tokens(stmt_start)%line) then
+                                stmt_end = j - 1
+                                exit
+                            end if
+                            if (j > stmt_start .and. parser%tokens(j)%kind == TK_OPERATOR .and. &
+                                parser%tokens(j)%text == ";") then
+                                stmt_end = j - 1
+                                exit
+                            end if
+                            stmt_end = j
+                        end do
                     end if
-                    ! Check for semicolon as statement separator
-                    if (j > stmt_start .and. parser%tokens(j)%kind == TK_OPERATOR .and. &
-                        parser%tokens(j)%text == ";") then
-                        stmt_end = j - 1
-                        exit
-                    end if
-                    stmt_end = j
-                end do
+                end block
 
                 ! Extract statement tokens
                 if (stmt_end >= stmt_start) then

--- a/src/parser/parser_do_constructs.f90
+++ b/src/parser/parser_do_constructs.f90
@@ -25,6 +25,7 @@ module parser_do_constructs_module
     logical, save :: if_hooks_initialized = .false.
 
     public :: parse_do_loop, parse_do_while, parse_do_while_from_do
+    public :: ensure_if_do_registration
 
 contains
 
@@ -34,6 +35,10 @@ contains
             if_hooks_initialized = .true.
         end if
     end subroutine initialize_if_hooks
+
+    subroutine ensure_if_do_registration()
+        call initialize_if_hooks()
+    end subroutine ensure_if_do_registration
 
     logical function has_then_before_newline(tokens, start_pos)
         type(token_t), intent(in) :: tokens(:)
@@ -356,6 +361,8 @@ contains
         integer :: start_index, end_index, step_index
         integer :: line, column
 
+        call initialize_if_hooks()
+
         step_index = 0  ! Initialize to 0 (no step)
         loop_index = 0  ! Initialize to 0 (failure) in case of early return
 
@@ -630,6 +637,8 @@ contains
         type(token_t) :: do_token
         integer :: line, column
 
+        call initialize_if_hooks()
+
         ! Consume 'do'
         do_token = parser%consume()
         line = do_token%line
@@ -648,6 +657,8 @@ contains
         type(token_t) :: while_token, lparen_token, rparen_token
         integer :: condition_index
         integer, allocatable :: body_indices(:)
+
+        call initialize_if_hooks()
 
         ! Consume 'while'
         while_token = parser%consume()

--- a/src/parser/parser_if_constructs.f90
+++ b/src/parser/parser_if_constructs.f90
@@ -13,7 +13,6 @@ module parser_if_constructs_module
                                                 parse_return_statement, parse_stop_statement, &
                                                 parse_goto_statement, parse_error_stop_statement
     use parser_call_module, only: parse_call_statement
-    use parser_do_constructs_module, only: parse_do_loop
     use parser_declarations, only: parse_declaration, parse_multi_declaration
     use parser_utils, only: analyze_declaration_structure
     use ast_arena_modern, only: ast_arena_t
@@ -23,8 +22,25 @@ module parser_if_constructs_module
     private
 
     public :: parse_if, parse_if_condition, parse_if_body, parse_elseif_block
+    public :: register_parse_do_loop
+
+    abstract interface
+        function parse_do_loop_interface(parser, arena) result(loop_index)
+            import :: parser_state_t, ast_arena_t
+            type(parser_state_t), intent(inout) :: parser
+            type(ast_arena_t), intent(inout) :: arena
+            integer :: loop_index
+        end function parse_do_loop_interface
+    end interface
+
+    procedure(parse_do_loop_interface), pointer :: parse_do_loop_proc => null()
 
 contains
+
+    subroutine register_parse_do_loop(proc)
+        procedure(parse_do_loop_interface) :: proc
+        parse_do_loop_proc => proc
+    end subroutine register_parse_do_loop
 
     ! Local implementation to avoid circular dependency
     function parse_basic_stmt_local(tokens, arena, parent_index) result(stmt_indices)
@@ -99,8 +115,12 @@ contains
                 ! Handle nested if statements
                 stmt_index = parse_if(parser, arena, parent_index)
             case ("do")
-                ! Handle nested do loops
-                stmt_index = parse_do_loop(parser, arena)
+                ! Handle nested do loops when registration provided
+                if (associated(parse_do_loop_proc)) then
+                    stmt_index = parse_do_loop_proc(parser, arena)
+                else
+                    stmt_index = 0
+                end if
             case default
                 ! Unknown or control flow keyword - create placeholder
                 stmt_index = 0

--- a/src/parser/parser_if_constructs.f90
+++ b/src/parser/parser_if_constructs.f90
@@ -35,7 +35,18 @@ module parser_if_constructs_module
 
     procedure(parse_do_loop_interface), pointer :: parse_do_loop_proc => null()
 
+    interface
+        subroutine ensure_if_do_registration_bridge()
+        end subroutine ensure_if_do_registration_bridge
+    end interface
+
 contains
+
+    subroutine ensure_do_parser_ready()
+        if (.not. associated(parse_do_loop_proc)) then
+            call ensure_if_do_registration_bridge()
+        end if
+    end subroutine ensure_do_parser_ready
 
     subroutine register_parse_do_loop(proc)
         procedure(parse_do_loop_interface) :: proc
@@ -116,6 +127,7 @@ contains
                 stmt_index = parse_if(parser, arena, parent_index)
             case ("do")
                 ! Handle nested do loops when registration provided
+                call ensure_do_parser_ready()
                 if (associated(parse_do_loop_proc)) then
                     stmt_index = parse_do_loop_proc(parser, arena)
                 else

--- a/test/parser/test_if_inside_do_loop.f90
+++ b/test/parser/test_if_inside_do_loop.f90
@@ -1,0 +1,88 @@
+program test_if_inside_do_loop
+    ! Regression test for Issue #1324: ensure IF statements inside DO loops parse
+    use frontend, only: compile_source, compilation_options_t
+    use iso_fortran_env, only: error_unit
+    implicit none
+
+    character(len=:), allocatable :: input_path, output_path
+    character(len=256) :: error_msg, line
+    type(compilation_options_t) :: options
+    integer :: unit, iostat
+    integer :: inline_if_count
+    logical :: found_do_loop, found_unparsed, found_nested_if
+
+    print *, "=== Testing IF statements inside DO loops (Issue #1324) ==="
+
+    input_path = 'test_inline_if_in_do_input.f90'
+    output_path = 'test_inline_if_in_do_output.f90'
+
+    open(newunit=unit, file=input_path, status='replace', action='write', iostat=iostat)
+    if (iostat /= 0) then
+        write(error_unit, '(a)') 'ERROR: cannot create input file'
+        stop 1
+    end if
+    write(unit, '(a)') 'program inline_if_fixture'
+    write(unit, '(a)') '  implicit none'
+    write(unit, '(a)') '  real :: x'
+    write(unit, '(a)') '  integer :: i, n'
+    write(unit, '(a)') '  n = 3'
+    write(unit, '(a)') '  call random_number(x)'
+    write(unit, '(a)') '  do i = 1, n'
+    write(unit, '(a)') '    call random_number(x)'
+    write(unit, '(a)') '    print*, "x =", x'
+    write(unit, '(a)') '    if (x > 0.3) print*, "x larger than 0.3"'
+    write(unit, '(a)') '    if (x > 0.2) then'
+    write(unit, '(a)') '      print*, "x larger than 0.2"'
+    write(unit, '(a)') '    end if'
+    write(unit, '(a)') '  end do'
+    write(unit, '(a)') 'end program inline_if_fixture'
+    close(unit)
+
+    options%output_file = output_path
+    call compile_source(input_path, options, error_msg)
+    if (len_trim(error_msg) > 0) then
+        write(error_unit, '(a)') 'ERROR: '//trim(error_msg)
+        stop 1
+    end if
+
+    open(newunit=unit, file=output_path, status='old', action='read', iostat=iostat)
+    if (iostat /= 0) then
+        write(error_unit, '(a)') 'ERROR: cannot open output file'
+        stop 1
+    end if
+
+    inline_if_count = 0
+    found_do_loop = .false.
+    found_unparsed = .false.
+    found_nested_if = .false.
+
+    do
+        read(unit, '(a)', iostat=iostat) line
+        if (iostat /= 0) exit
+        if (index(line, '! Unparsed') > 0) found_unparsed = .true.
+        if (index(adjustl(line), 'do i = 1, n') > 0) found_do_loop = .true.
+        if (index(line, 'if (x > 0.3d0)') > 0) inline_if_count = inline_if_count + 1
+        if (index(line, 'if (x > 0.2d0) then') > 0) found_nested_if = .true.
+    end do
+    close(unit)
+
+    if (found_unparsed) then
+        write(error_unit, '(a)') 'ERROR: unexpected ! Unparsed placeholder emitted'
+        stop 1
+    end if
+    if (.not. found_do_loop) then
+        write(error_unit, '(a)') 'ERROR: DO loop missing from output'
+        stop 1
+    end if
+    if (inline_if_count < 1) then
+        write(error_unit, '(a)') 'ERROR: missing IF (x > 0.3d0) inside loop'
+        stop 1
+    end if
+    if (.not. found_nested_if) then
+        write(error_unit, '(a)') 'ERROR: nested IF (x > 0.2d0) block missing'
+        stop 1
+    end if
+
+    print *, 'PASS: parser retains IF statements inside DO loops without placeholders'
+    stop 0
+end program test_if_inside_do_loop

--- a/test/parser/test_parse_if_nested_do_direct.f90
+++ b/test/parser/test_parse_if_nested_do_direct.f90
@@ -1,0 +1,68 @@
+program test_parse_if_nested_do_direct
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use lexer_core, only: token_t, tokenize_core
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_if_constructs_module, only: parse_if
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_loops, only: do_loop_node
+    use ast_nodes_control, only: if_node
+    use ast_nodes_core, only: literal_node
+    implicit none
+
+    character(len=:), allocatable :: source
+    type(token_t), allocatable :: tokens(:)
+    type(parser_state_t) :: parser
+    type(ast_arena_t) :: arena
+    integer :: if_index, i
+    logical :: has_do_loop, has_unparsed
+
+    print *, '=== Test: direct parse_if handles nested DO without preregistration ==='
+
+    source = 'if (flag) then' // new_line('a') // &
+             '  do i = 1, 3' // new_line('a') // &
+             '    print *, i' // new_line('a') // &
+             '  end do' // new_line('a') // &
+             'end if'
+
+    call tokenize_core(source, tokens)
+    parser = create_parser_state(tokens)
+    arena = create_ast_arena(64)
+
+    if_index = parse_if(parser, arena)
+    if (if_index <= 0) then
+        write(error_unit, '(a)') 'ERROR: parse_if returned invalid index'
+        stop 1
+    end if
+
+    has_do_loop = .false.
+    has_unparsed = .false.
+
+    do i = 1, arena%size
+        if (.not. arena%has_node_at(i)) cycle
+        select type (node => arena%entries(i)%node)
+        type is (do_loop_node)
+            has_do_loop = .true.
+        type is (literal_node)
+            if (allocated(node%value)) then
+                if (index(node%value, '! Unparsed') > 0) has_unparsed = .true.
+            end if
+        type is (if_node)
+            cycle
+        class default
+            cycle
+        end select
+    end do
+
+    if (.not. has_do_loop) then
+        write(error_unit, '(a)') 'ERROR: nested DO loop node not created'
+        stop 1
+    end if
+
+    if (has_unparsed) then
+        write(error_unit, '(a)') 'ERROR: unexpected ! Unparsed literal emitted'
+        stop 1
+    end if
+
+    print *, 'PASS: parse_if registers DO parser lazily'
+
+end program test_parse_if_nested_do_direct


### PR DESCRIPTION
## Summary
- allow the do loop parser to reuse the IF parser without introducing a module cycle
- capture multi-line IF/THEN blocks inside DO bodies so nested IFs no longer fall back to `! Unparsed`
- add a regression test that exercises inline and block IF statements inside a loop

## Verification
- `make test`
