### PR TITLE
fix: Missing declarations (fixes #1330)

### DIFF
--- a/src/standardizers/standardizer_declarations_core.f90
+++ b/src/standardizers/standardizer_declarations_core.f90
@@ -85,7 +85,8 @@ contains
         end if
 
         ! Collect and generate variable declarations for any missing variables
-        call generate_and_insert_declarations(arena, prog, prog_index, declaration_indices)
+        call generate_and_insert_declarations(arena, prog, prog_index, &
+            declaration_indices)
         n_declarations = 0
         if (allocated(declaration_indices)) n_declarations = size(declaration_indices)
 
@@ -259,8 +260,12 @@ contains
                     select type (stmt => arena%entries(prog%body_indices(i))%node)
                     type is (use_statement_node)
                         pos = i + 1  ! Insert after this use statement
+                    type is (comment_node)
+                        cycle
+                    type is (blank_line_node)
+                        cycle
                     class default
-                        ! First non-use statement, stop looking
+                        ! First non-use, non-comment statement, stop looking
                         exit
                     end select
                 end if

--- a/src/standardizers/standardizer_declarations_core.f90
+++ b/src/standardizers/standardizer_declarations_core.f90
@@ -60,6 +60,7 @@ contains
         integer, allocatable :: declaration_indices(:)
         integer :: i, j, implicit_insert_pos, header_insert_pos
         integer :: n_declarations, total_extra
+        integer :: header_copy_end, separator_start
 
         if (.not. allocated(prog%body_indices)) return
 
@@ -103,9 +104,22 @@ contains
             j = j + 1
         end if
 
-        ! Copy existing header statements (implicit none, declarations, comments) that should stay before new declarations
-        if (header_insert_pos > implicit_insert_pos) then
-            do i = implicit_insert_pos, header_insert_pos - 1
+        ! Determine header statements to retain before new declarations
+        header_copy_end = header_insert_pos - 1
+        if (header_copy_end >= implicit_insert_pos) then
+            do while (header_copy_end >= implicit_insert_pos)
+                if (.not. is_header_separator(header_copy_end)) exit
+                header_copy_end = header_copy_end - 1
+            end do
+        else
+            header_copy_end = implicit_insert_pos - 1
+        end if
+        separator_start = header_copy_end + 1
+        if (separator_start < implicit_insert_pos) separator_start = implicit_insert_pos
+
+        ! Copy retained header statements (uses are already handled)
+        if (header_copy_end >= implicit_insert_pos) then
+            do i = implicit_insert_pos, header_copy_end
                 new_body_indices(j) = prog%body_indices(i)
                 j = j + 1
             end do
@@ -116,6 +130,14 @@ contains
             new_body_indices(j) = declaration_indices(i)
             j = j + 1
         end do
+
+        ! Reinsert trailing separators (comments/blank lines) between header and body
+        if (separator_start <= header_insert_pos - 1) then
+            do i = separator_start, header_insert_pos - 1
+                new_body_indices(j) = prog%body_indices(i)
+                j = j + 1
+            end do
+        end if
 
         ! Copy remaining statements
         if (header_insert_pos <= size(prog%body_indices)) then
@@ -130,6 +152,30 @@ contains
 
         ! Update the arena entry
         arena%entries(prog_index)%node = prog
+
+    contains
+
+        logical function is_header_separator(pos)
+            integer, intent(in) :: pos
+            integer :: node_index
+
+            is_header_separator = .false.
+            if (.not. allocated(prog%body_indices)) return
+            if (pos < 1 .or. pos > size(prog%body_indices)) return
+
+            node_index = prog%body_indices(pos)
+            if (node_index <= 0 .or. node_index > arena%size) return
+            if (.not. allocated(arena%entries(node_index)%node)) return
+
+            select type (stmt => arena%entries(node_index)%node)
+            type is (comment_node)
+                is_header_separator = .true.
+            type is (blank_line_node)
+                is_header_separator = .true.
+            class default
+                is_header_separator = .false.
+            end select
+        end function is_header_separator
 
     end subroutine insert_variable_declarations
 

--- a/src/standardizers/standardizer_declarations_core.f90
+++ b/src/standardizers/standardizer_declarations_core.f90
@@ -66,15 +66,20 @@ contains
 
         ! Find insertion point (after use statements, before executable statements)
         implicit_insert_pos = find_declaration_insertion_point(arena, prog)
-        if (implicit_insert_pos == 0) implicit_insert_pos = 1  ! Default to beginning if no use statements
+        ! Default to beginning when no use statements are present
+        if (implicit_insert_pos == 0) then
+            implicit_insert_pos = 1
+        end if
         header_insert_pos = find_declaration_header_end(arena, prog)
-        if (header_insert_pos < implicit_insert_pos) header_insert_pos = implicit_insert_pos
+        if (header_insert_pos < implicit_insert_pos) then
+            header_insert_pos = implicit_insert_pos
+        end if
 
         ! Check if implicit none already exists
         if (.not. has_implicit_none(arena, prog)) then
             ! Create implicit none statement node
             implicit_none_index = push_implicit_statement(arena, .true., &
-                                                         line=1, column=1, parent_index=prog_index)
+                line=1, column=1, parent_index=prog_index)
         else
             implicit_none_index = 0  ! Don't add duplicate
         end if

--- a/src/standardizers/standardizer_declarations_core.f90
+++ b/src/standardizers/standardizer_declarations_core.f90
@@ -58,13 +58,16 @@ contains
         integer, allocatable :: new_body_indices(:)
         integer :: implicit_none_index
         integer, allocatable :: declaration_indices(:)
-        integer :: i, j, insert_pos, n_declarations
+        integer :: i, j, implicit_insert_pos, header_insert_pos
+        integer :: n_declarations, total_extra
 
         if (.not. allocated(prog%body_indices)) return
 
         ! Find insertion point (after use statements, before executable statements)
-        insert_pos = find_declaration_insertion_point(arena, prog)
-        if (insert_pos == 0) insert_pos = 1  ! Default to beginning if no use statements
+        implicit_insert_pos = find_declaration_insertion_point(arena, prog)
+        if (implicit_insert_pos == 0) implicit_insert_pos = 1  ! Default to beginning if no use statements
+        header_insert_pos = find_declaration_header_end(arena, prog)
+        if (header_insert_pos < implicit_insert_pos) header_insert_pos = implicit_insert_pos
 
         ! Check if implicit none already exists
         if (.not. has_implicit_none(arena, prog)) then
@@ -75,30 +78,24 @@ contains
             implicit_none_index = 0  ! Don't add duplicate
         end if
 
-        ! Check if program already has variable declarations (is already standardized)
-        if (program_has_variable_declarations(arena, prog)) then
-            ! Program already standardized, don't add more declarations
-            allocate(declaration_indices(0))
-        else
-            ! Collect and generate variable declarations
-            call generate_and_insert_declarations(arena, prog, prog_index, declaration_indices)
-        end if
+        ! Collect and generate variable declarations for any missing variables
+        call generate_and_insert_declarations(arena, prog, prog_index, declaration_indices)
         n_declarations = 0
         if (allocated(declaration_indices)) n_declarations = size(declaration_indices)
 
         ! Create new body indices with optional implicit none and declarations
-        if (implicit_none_index > 0) then
-            allocate (new_body_indices(size(prog%body_indices) + 1 + n_declarations))
-        else
-            allocate (new_body_indices(size(prog%body_indices) + n_declarations))
-        end if
+        total_extra = n_declarations
+        if (implicit_none_index > 0) total_extra = total_extra + 1
+        allocate (new_body_indices(size(prog%body_indices) + total_extra))
 
         ! Copy use statements
         j = 1
-        do i = 1, insert_pos - 1
-            new_body_indices(j) = prog%body_indices(i)
-            j = j + 1
-        end do
+        if (implicit_insert_pos > 1) then
+            do i = 1, implicit_insert_pos - 1
+                new_body_indices(j) = prog%body_indices(i)
+                j = j + 1
+            end do
+        end if
 
         ! Insert implicit none if we created one
         if (implicit_none_index > 0) then
@@ -106,17 +103,27 @@ contains
             j = j + 1
         end if
 
-        ! Insert declarations
+        ! Copy existing header statements (implicit none, declarations, comments) that should stay before new declarations
+        if (header_insert_pos > implicit_insert_pos) then
+            do i = implicit_insert_pos, header_insert_pos - 1
+                new_body_indices(j) = prog%body_indices(i)
+                j = j + 1
+            end do
+        end if
+
+        ! Insert newly generated declarations, if any
         do i = 1, n_declarations
             new_body_indices(j) = declaration_indices(i)
             j = j + 1
         end do
 
         ! Copy remaining statements
-        do i = insert_pos, size(prog%body_indices)
-            new_body_indices(j) = prog%body_indices(i)
-            j = j + 1
-        end do
+        if (header_insert_pos <= size(prog%body_indices)) then
+            do i = header_insert_pos, size(prog%body_indices)
+                new_body_indices(j) = prog%body_indices(i)
+                j = j + 1
+            end do
+        end if
 
         ! Update program body
         prog%body_indices = new_body_indices
@@ -210,6 +217,40 @@ contains
         end do
 
     end function find_declaration_insertion_point
+
+    ! Find the position after existing declaration header statements
+    function find_declaration_header_end(arena, prog) result(pos)
+        type(ast_arena_t), intent(in) :: arena
+        type(program_node), intent(in) :: prog
+        integer :: pos
+        integer :: i
+
+        pos = 1
+        if (.not. allocated(prog%body_indices)) return
+
+        do i = 1, size(prog%body_indices)
+            if (prog%body_indices(i) > 0 .and. prog%body_indices(i) <= arena%size) then
+                if (allocated(arena%entries(prog%body_indices(i))%node)) then
+                    select type (stmt => arena%entries(prog%body_indices(i))%node)
+                    type is (use_statement_node)
+                        pos = i + 1
+                    type is (implicit_statement_node)
+                        pos = i + 1
+                    type is (declaration_node)
+                        pos = i + 1
+                    type is (parameter_declaration_node)
+                        pos = i + 1
+                    type is (comment_node)
+                        pos = i + 1
+                    type is (blank_line_node)
+                        pos = i + 1
+                    class default
+                        exit
+                    end select
+                end if
+            end if
+        end do
+    end function find_declaration_header_end
 
     ! Standardize existing declarations (e.g., real -> real(8))
     subroutine standardize_declarations(arena, prog)

--- a/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
+++ b/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
@@ -60,11 +60,14 @@ contains
             if (real_decl_pos > 0) then
                 existing_decl_line = 'real(8) :: x, y'
             else
-                real_decl_pos = index(output, 'real :: x, y')
-                existing_decl_line = 'real :: x, y'
+                print *, 'FAIL: missing explicit real(kind=8) declaration for x,y'
+                print *, 'Output:'
+                print *, trim(output)
+                error stop 1
             end if
         end if
-        call assert_contains(output, existing_decl_line, 'missing real decl for x,y')
+        call assert_contains(output, existing_decl_line, &
+            'missing explicit real declaration for x,y')
 
         has_real_kind = index(output, 'real :: pi_estimate') > 0
         if (.not. has_real_kind) then

--- a/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
+++ b/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
@@ -12,6 +12,12 @@ contains
 
     subroutine test_missing_variable_declarations()
         logical :: has_real_kind
+        integer :: real_decl_pos
+        integer :: pos_n
+        integer :: pos_count
+        integer :: pos_i
+        integer :: first_new_pos
+        integer :: output_len
 
         input = 'real(kind=8) :: x, y' // new_line('a') // &
                 'n = 1000000' // new_line('a') // &
@@ -38,12 +44,32 @@ contains
         call assert_contains(output, 'integer :: count', 'missing integer declaration for count')
         call assert_contains(output, 'integer :: i', 'missing integer declaration for i')
 
+        real_decl_pos = index(output, 'real(kind=8) :: x, y')
+        if (real_decl_pos == 0) real_decl_pos = index(output, 'real(8) :: x, y')
+        if (real_decl_pos == 0) real_decl_pos = index(output, 'real :: x, y')
+
         has_real_kind = index(output, 'real :: pi_estimate') > 0
         if (.not. has_real_kind) then
             has_real_kind = index(output, 'real(8) :: pi_estimate') > 0
         end if
         if (.not. has_real_kind) then
             print *, 'FAIL: missing real declaration for pi_estimate'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+
+        output_len = len(output)
+        first_new_pos = output_len + 1
+        pos_n = index(output, 'integer :: n')
+        if (pos_n > 0 .and. pos_n < first_new_pos) first_new_pos = pos_n
+        pos_count = index(output, 'integer :: count')
+        if (pos_count > 0 .and. pos_count < first_new_pos) first_new_pos = pos_count
+        pos_i = index(output, 'integer :: i')
+        if (pos_i > 0 .and. pos_i < first_new_pos) first_new_pos = pos_i
+
+        if (real_decl_pos > 0 .and. first_new_pos <= real_decl_pos) then
+            print *, 'FAIL: inferred declarations inserted before existing declarations'
             print *, 'Output:'
             print *, trim(output)
             error stop 1

--- a/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
+++ b/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
@@ -17,9 +17,16 @@ contains
         integer :: pos_count
         integer :: pos_i
         integer :: first_new_pos
+        integer :: last_new_pos
         integer :: output_len
+        integer :: comment_pos
+        integer :: body_pos
+        integer :: next_real_pos
+        integer :: search_start
+        character(len=:), allocatable :: existing_decl_line
 
-        input = 'real(kind=8) :: x, y' // new_line('a') // &
+        input = 'real(kind=8) :: x, y' // new_line('a') // new_line('a') // &
+                '! header comment before loop' // new_line('a') // &
                 'n = 1000000' // new_line('a') // &
                 'count = 0' // new_line('a') // &
                 'do i = 1, n' // new_line('a') // &
@@ -40,25 +47,24 @@ contains
             end if
         end if
 
-        call assert_contains(output, 'integer :: n', 'missing integer declaration for n')
-        call assert_contains(output, 'integer :: count', 'missing integer declaration for count')
-        call assert_contains(output, 'integer :: i', 'missing integer declaration for i')
+        call assert_contains(output, 'integer :: n', 'missing integer decl for n')
+        call assert_contains(output, 'integer :: count', &
+            'missing integer decl for count')
+        call assert_contains(output, 'integer :: i', 'missing integer decl for i')
 
         real_decl_pos = index(output, 'real(kind=8) :: x, y')
         if (real_decl_pos > 0) then
-            call assert_contains(output, 'real(kind=8) :: x, y', &
-                'missing real declaration for x and y')
+            existing_decl_line = 'real(kind=8) :: x, y'
         else
             real_decl_pos = index(output, 'real(8) :: x, y')
             if (real_decl_pos > 0) then
-                call assert_contains(output, 'real(8) :: x, y', &
-                    'missing real declaration for x and y')
+                existing_decl_line = 'real(8) :: x, y'
             else
                 real_decl_pos = index(output, 'real :: x, y')
-                call assert_contains(output, 'real :: x, y', &
-                    'missing real declaration for x and y')
+                existing_decl_line = 'real :: x, y'
             end if
         end if
+        call assert_contains(output, existing_decl_line, 'missing real decl for x,y')
 
         has_real_kind = index(output, 'real :: pi_estimate') > 0
         if (.not. has_real_kind) then
@@ -73,18 +79,64 @@ contains
 
         output_len = len(output)
         first_new_pos = output_len + 1
+        last_new_pos = 0
         pos_n = index(output, 'integer :: n')
-        if (pos_n > 0 .and. pos_n < first_new_pos) first_new_pos = pos_n
+        if (pos_n > 0) then
+            if (pos_n < first_new_pos) first_new_pos = pos_n
+            if (pos_n > last_new_pos) last_new_pos = pos_n
+        end if
         pos_count = index(output, 'integer :: count')
-        if (pos_count > 0 .and. pos_count < first_new_pos) first_new_pos = pos_count
+        if (pos_count > 0) then
+            if (pos_count < first_new_pos) first_new_pos = pos_count
+            if (pos_count > last_new_pos) last_new_pos = pos_count
+        end if
         pos_i = index(output, 'integer :: i')
-        if (pos_i > 0 .and. pos_i < first_new_pos) first_new_pos = pos_i
+        if (pos_i > 0) then
+            if (pos_i < first_new_pos) first_new_pos = pos_i
+            if (pos_i > last_new_pos) last_new_pos = pos_i
+        end if
 
         if (real_decl_pos > 0 .and. first_new_pos <= real_decl_pos) then
             print *, 'FAIL: inferred declarations inserted before existing declarations'
             print *, 'Output:'
             print *, trim(output)
             error stop 1
+        end if
+
+        comment_pos = index(output, 'header comment before loop')
+        if (comment_pos == 0) then
+            print *, 'FAIL: header comment missing after transformation'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+        if (comment_pos <= last_new_pos) then
+            print *, 'FAIL: header comment moved ahead of inferred declarations'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+        body_pos = index(output, 'n = 1000000')
+        if (body_pos > 0 .and. comment_pos >= body_pos) then
+            print *, 'FAIL: header comment moved into executable section'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+
+        if (real_decl_pos > 0) then
+            if (real_decl_pos + len(existing_decl_line) <= output_len) then
+                search_start = real_decl_pos + len(existing_decl_line)
+                next_real_pos = index(output(search_start:), existing_decl_line)
+            else
+                next_real_pos = 0
+            end if
+            if (next_real_pos > 0) then
+                print *, 'FAIL: explicit declarations duplicated'
+                print *, 'Output:'
+                print *, trim(output)
+                error stop 1
+            end if
         end if
     end subroutine test_missing_variable_declarations
 

--- a/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
+++ b/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
@@ -45,8 +45,20 @@ contains
         call assert_contains(output, 'integer :: i', 'missing integer declaration for i')
 
         real_decl_pos = index(output, 'real(kind=8) :: x, y')
-        if (real_decl_pos == 0) real_decl_pos = index(output, 'real(8) :: x, y')
-        if (real_decl_pos == 0) real_decl_pos = index(output, 'real :: x, y')
+        if (real_decl_pos > 0) then
+            call assert_contains(output, 'real(kind=8) :: x, y', &
+                'missing real declaration for x and y')
+        else
+            real_decl_pos = index(output, 'real(8) :: x, y')
+            if (real_decl_pos > 0) then
+                call assert_contains(output, 'real(8) :: x, y', &
+                    'missing real declaration for x and y')
+            else
+                real_decl_pos = index(output, 'real :: x, y')
+                call assert_contains(output, 'real :: x, y', &
+                    'missing real declaration for x and y')
+            end if
+        end if
 
         has_real_kind = index(output, 'real :: pi_estimate') > 0
         if (.not. has_real_kind) then

--- a/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
+++ b/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
@@ -1,0 +1,67 @@
+program test_issue_1330_missing_declarations
+    use frontend, only: transform_lazy_fortran_string
+    implicit none
+    character(len=:), allocatable :: input
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+
+    call test_missing_variable_declarations()
+    print *, 'Issue #1330 regression test passed.'
+
+contains
+
+    subroutine test_missing_variable_declarations()
+        logical :: has_real_kind
+
+        input = 'real(kind=8) :: x, y' // new_line('a') // &
+                'n = 1000000' // new_line('a') // &
+                'count = 0' // new_line('a') // &
+                'do i = 1, n' // new_line('a') // &
+                '    call random_number(x)' // new_line('a') // &
+                '    call random_number(y)' // new_line('a') // &
+                '    if (x*x + y*y <= 1.0) count = count + 1' // new_line('a') // &
+                'end do' // new_line('a') // &
+                'pi_estimate = 4.0 * real(count) / real(n)' // new_line('a') // &
+                'print *, "Number of points:", n' // new_line('a') // &
+                'print *, "Estimated value of pi:", pi_estimate'
+
+        call transform_lazy_fortran_string(input, output, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'FAIL: transform error:', trim(error_msg)
+                error stop 1
+            end if
+        end if
+
+        call assert_contains(output, 'integer :: n', 'missing integer declaration for n')
+        call assert_contains(output, 'integer :: count', 'missing integer declaration for count')
+        call assert_contains(output, 'integer :: i', 'missing integer declaration for i')
+
+        has_real_kind = index(output, 'real :: pi_estimate') > 0
+        if (.not. has_real_kind) then
+            has_real_kind = index(output, 'real(8) :: pi_estimate') > 0
+        end if
+        if (.not. has_real_kind) then
+            print *, 'FAIL: missing real declaration for pi_estimate'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+    end subroutine test_missing_variable_declarations
+
+    subroutine assert_contains(text, pattern, message)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: pattern
+        character(len=*), intent(in) :: message
+
+        if (index(text, pattern) == 0) then
+            print *, 'FAIL:', trim(message)
+            print *, 'Pattern:', trim(pattern)
+            print *, 'Output:'
+            print *, trim(text)
+            error stop 1
+        end if
+    end subroutine assert_contains
+
+end program test_issue_1330_missing_declarations

--- a/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
+++ b/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
@@ -19,13 +19,20 @@ contains
         integer :: first_new_pos
         integer :: last_new_pos
         integer :: output_len
-        integer :: comment_pos
+        integer :: header_comment_pos
         integer :: body_pos
         integer :: next_real_pos
         integer :: search_start
+        integer :: use1_pos
+        integer :: use2_pos
+        integer :: use_comment_pos
+        integer :: implicit_pos
         character(len=:), allocatable :: existing_decl_line
 
-        input = 'real(kind=8) :: x, y' // new_line('a') // new_line('a') // &
+        input = 'use iso_fortran_env' // new_line('a') // &
+                '! comment between use statements' // new_line('a') // &
+                'use iso_c_binding' // new_line('a') // &
+                'real(kind=8) :: x, y' // new_line('a') // new_line('a') // &
                 '! header comment before loop' // new_line('a') // &
                 'n = 1000000' // new_line('a') // &
                 'count = 0' // new_line('a') // &
@@ -47,10 +54,49 @@ contains
             end if
         end if
 
+        call assert_contains(output, 'use iso_fortran_env', &
+            'missing iso_fortran_env use statement')
+        call assert_contains(output, 'use iso_c_binding', &
+            'missing iso_c_binding use statement')
         call assert_contains(output, 'integer :: n', 'missing integer decl for n')
         call assert_contains(output, 'integer :: count', &
             'missing integer decl for count')
         call assert_contains(output, 'integer :: i', 'missing integer decl for i')
+
+        use1_pos = index(output, 'use iso_fortran_env')
+        use2_pos = index(output, 'use iso_c_binding')
+        use_comment_pos = index(output, 'comment between use statements')
+        if (use1_pos == 0 .or. use2_pos == 0) then
+            print *, 'FAIL: use statements missing after transformation'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+        if (use1_pos >= use2_pos) then
+            print *, 'FAIL: use statements reordered'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+        if (use_comment_pos == 0) then
+            print *, 'FAIL: use block comment missing'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+        implicit_pos = index(output, 'implicit none')
+        if (implicit_pos == 0) then
+            print *, 'FAIL: implicit none missing from output'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+        if (.not. (use_comment_pos > use1_pos .and. use_comment_pos < implicit_pos)) then
+            print *, 'FAIL: use block comment moved out of declaration header'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
 
         real_decl_pos = index(output, 'real(kind=8) :: x, y')
         if (real_decl_pos > 0) then
@@ -106,21 +152,28 @@ contains
             error stop 1
         end if
 
-        comment_pos = index(output, 'header comment before loop')
-        if (comment_pos == 0) then
+        if (implicit_pos <= use2_pos) then
+            print *, 'FAIL: implicit none inserted before use block'
+            print *, 'Output:'
+            print *, trim(output)
+            error stop 1
+        end if
+
+        header_comment_pos = index(output, 'header comment before loop')
+        if (header_comment_pos == 0) then
             print *, 'FAIL: header comment missing after transformation'
             print *, 'Output:'
             print *, trim(output)
             error stop 1
         end if
-        if (comment_pos <= last_new_pos) then
+        if (header_comment_pos <= last_new_pos) then
             print *, 'FAIL: header comment moved ahead of inferred declarations'
             print *, 'Output:'
             print *, trim(output)
             error stop 1
         end if
         body_pos = index(output, 'n = 1000000')
-        if (body_pos > 0 .and. comment_pos >= body_pos) then
+        if (body_pos > 0 .and. header_comment_pos >= body_pos) then
             print *, 'FAIL: header comment moved into executable section'
             print *, 'Output:'
             print *, trim(output)

--- a/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
+++ b/test/integration/issue_tests/test_issue_1330_missing_declarations.f90
@@ -28,6 +28,7 @@ contains
         integer :: use_comment_pos
         integer :: implicit_pos
         character(len=:), allocatable :: existing_decl_line
+        character(len=32) :: real_decl_variants(2)
 
         input = 'use iso_fortran_env' // new_line('a') // &
                 '! comment between use statements' // new_line('a') // &
@@ -98,22 +99,18 @@ contains
             error stop 1
         end if
 
-        real_decl_pos = index(output, 'real(kind=8) :: x, y')
-        if (real_decl_pos > 0) then
-            existing_decl_line = 'real(kind=8) :: x, y'
-        else
-            real_decl_pos = index(output, 'real(8) :: x, y')
-            if (real_decl_pos > 0) then
-                existing_decl_line = 'real(8) :: x, y'
-            else
-                print *, 'FAIL: missing explicit real(kind=8) declaration for x,y'
-                print *, 'Output:'
-                print *, trim(output)
-                error stop 1
-            end if
-        end if
-        call assert_contains(output, existing_decl_line, &
+        real_decl_variants = [ character(len=32) :: &
+            'real(kind=8) :: x, y', &
+            'real(8) :: x, y' ]
+        call assert_contains_any(output, real_decl_variants, &
             'missing explicit real declaration for x,y')
+
+        real_decl_pos = index(output, 'real(kind=8) :: x, y')
+        existing_decl_line = 'real(kind=8) :: x, y'
+        if (real_decl_pos == 0) then
+            real_decl_pos = index(output, 'real(8) :: x, y')
+            existing_decl_line = 'real(8) :: x, y'
+        end if
 
         has_real_kind = index(output, 'real :: pi_estimate') > 0
         if (.not. has_real_kind) then
@@ -209,5 +206,26 @@ contains
             error stop 1
         end if
     end subroutine assert_contains
+
+    subroutine assert_contains_any(text, patterns, message)
+        character(len=*), intent(in) :: text
+        character(len=*), dimension(:), intent(in) :: patterns
+        character(len=*), intent(in) :: message
+        integer :: i
+
+        do i = 1, size(patterns)
+            if (len_trim(patterns(i)) == 0) cycle
+            if (index(text, trim(patterns(i))) > 0) return
+        end do
+
+        print *, 'FAIL:', trim(message)
+        print *, 'Patterns:'
+        do i = 1, size(patterns)
+            print *, trim(patterns(i))
+        end do
+        print *, 'Output:'
+        print *, trim(text)
+        error stop 1
+    end subroutine assert_contains_any
 
 end program test_issue_1330_missing_declarations


### PR DESCRIPTION
## Summary
- continue declaration generation even when explicit declarations are present
- append inferred declarations after existing header statements to preserve layout
- add regression for issue #1330 covering mixed explicit/implicit declarations

## Verification
- `make test` (PASS; exercises `test/integration/issue_tests/test_issue_1330_missing_declarations.f90`)
