### PR TITLE
fix(parser): share statement boundary finder

### DIFF
--- a/src/parser/parser_array_constructs.f90
+++ b/src/parser/parser_array_constructs.f90
@@ -1,22 +1,15 @@
 module parser_array_constructs_module
     ! Parser module for WHERE and ASSOCIATE constructs
-    use, intrinsic :: iso_fortran_env, only: error_unit
-    use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_NUMBER, TK_STRING, &
-                          TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, TK_COMMENT, TK_WHITESPACE, &
-                          to_lower
-    use ast_types, only: LITERAL_STRING
+    use lexer_core, only: token_t, TK_EOF, TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, &
+                          TK_COMMENT, TK_WHITESPACE, TK_IDENTIFIER
     use parser_state_module
     use parser_expressions_module, only: parse_expression
-    use parser_io_statements_module, only: parse_print_statement, parse_write_statement, &
-                                           parse_read_statement
-    use parser_control_statements_module, only: parse_cycle_statement, parse_exit_statement, &
-                                                parse_return_statement, parse_stop_statement, &
-                                                parse_goto_statement, parse_error_stop_statement
-    use parser_call_module, only: parse_call_statement
-    use parser_declarations, only: parse_declaration, parse_multi_declaration
-    use parser_utils, only: analyze_declaration_structure
+    use parser_statement_core_module, only: parse_basic_statement_core, &
+        statement_callbacks_t, null_statement_callbacks, find_statement_end
+    use parser_if_constructs_module, only: parse_if, parse_if_condition
+    use parser_select_constructs_module, only: parse_select_case
     use ast_arena_modern, only: ast_arena_t
-    use ast_factory, only: push_where, push_associate, push_identifier, push_literal, push_assignment
+    use ast_factory, only: push_where, push_associate
     implicit none
     private
 
@@ -25,164 +18,23 @@ module parser_array_constructs_module
 contains
 
     ! Local implementation to avoid circular dependency
-    function parse_basic_stmt_local(tokens, arena, parent_index) result(stmt_indices)
-        type(token_t), intent(in) :: tokens(:)
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in), optional :: parent_index
-        integer, allocatable :: stmt_indices(:)
-        type(parser_state_t) :: parser
-        type(token_t) :: first_token
-        integer :: stmt_index
+    function build_where_callbacks() result(callbacks)
+        type(statement_callbacks_t) :: callbacks
 
-        parser = create_parser_state(tokens)
-        first_token = parser%peek()
+        callbacks = null_statement_callbacks()
+        callbacks%parse_if => parse_if
+        callbacks%parse_where => parse_where_construct
+        callbacks%parse_associate => parse_associate
+        callbacks%parse_select_case => parse_select_case
+    end function build_where_callbacks
 
-        ! Check if this is a declaration that might have multiple variables
-        if (first_token%kind == TK_KEYWORD) then
-            if (first_token%text == "real" .or. first_token%text == "integer" .or. &
-                first_token%text == "logical" .or. first_token%text == "character") then
-                ! Check if this is a single declaration with initializer
-                ! If so, use parse_declaration for proper initializer handling
-                block
-                    logical :: has_initializer, has_comma
-                    
-                    ! Look ahead to check for = (initializer) and comma (multi-var)
-                    has_initializer = .false.
-                    has_comma = .false.
-                    
-                    call analyze_declaration_structure(parser, has_initializer, has_comma)
-                    
-                    if (has_initializer .and. .not. has_comma) then
-                        ! Single variable with initializer - use parse_declaration
-                        if (.not. allocated(stmt_indices)) allocate (stmt_indices(1))
-                        stmt_indices(1) = parse_declaration(parser, arena)
-                        return
-                    else
-                        ! Multi-variable declaration - use parse_multi_declaration
-                        stmt_indices = parse_multi_declaration(parser, arena)
-                        return
-                    end if
-                end block
-            end if
-        end if
-
-        ! For all other statements, parse as single statement
-        if (.not. allocated(stmt_indices)) allocate (stmt_indices(1))
-        stmt_index = 0
-
-        ! Handle different statement types (excluding control flow to avoid circular deps)
-        if (first_token%kind == TK_KEYWORD) then
-            select case (first_token%text)
-            case ("print")
-                stmt_index = parse_print_statement(parser, arena)
-            case ("write")
-                stmt_index = parse_write_statement(parser, arena)
-            case ("read")
-                stmt_index = parse_read_statement(parser, arena)
-            case ("cycle")
-                stmt_index = parse_cycle_statement(parser, arena)
-            case ("exit")
-                stmt_index = parse_exit_statement(parser, arena)
-            case ("return")
-                stmt_index = parse_return_statement(parser, arena, parent_index)
-            case ("call")
-                stmt_index = parse_call_statement(parser, arena)
-            case ("stop")
-                stmt_index = parse_stop_statement(parser, arena)
-            case ("go")
-                stmt_index = parse_goto_statement(parser, arena)
-            case ("error")
-                stmt_index = parse_error_stop_statement(parser, arena)
-            case default
-                ! Unknown or control flow keyword - create placeholder
-                stmt_index = 0
-            end select
-        else if (first_token%kind == TK_IDENTIFIER) then
-            block
-                type(token_t) :: id_token, op_token
-                integer :: target_index, value_index
-
-                id_token = parser%consume()
-                op_token = parser%peek()
-
-                if (op_token%kind == TK_OPERATOR .and. op_token%text == "=") then
-                    op_token = parser%consume()  ! consume '='
-                    target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column, parent_index)
-                    ! Get remaining tokens for expression parsing
-                    block
-                        type(token_t), allocatable, target :: expr_tokens(:)
-                        integer :: remaining_count
-                        remaining_count = size(tokens) - parser%current_token + 1
-                        if (remaining_count > 0) then
-                            allocate (expr_tokens(remaining_count))
-                            expr_tokens = tokens(parser%current_token:)
-                            value_index = parse_expression(expr_tokens, arena)
-                            if (value_index > 0) then
-                                stmt_index = push_assignment(arena, target_index, value_index, &
-                                                             id_token%line, id_token%column, &
-                                                             parent_index)
-                            end if
-                        end if
-                    end block
-                end if
-            end block
-        end if
-
-        ! If we couldn't parse it, create a placeholder with debug info
-        if (stmt_index == 0) then
-            block
-                logical :: is_terminator
-                character(len=:), allocatable :: lowered
-                character(len=256) :: debug_msg
-                character(len=64) :: token_text
-                integer :: debug_len, i
-
-                is_terminator = .false.
-                if (first_token%kind == TK_KEYWORD) then
-                    lowered = to_lower(first_token%text)
-                    select case (lowered)
-                    case ("end")
-                        if (size(tokens) >= 2) then
-                            select case (to_lower(tokens(2)%text))
-                            case ("where", "forall", "select")
-                                is_terminator = .true.
-                            end select
-                        else
-                            is_terminator = .true.
-                        end if
-                    case ("endwhere", "endforall", "endselect", "elsewhere")
-                        is_terminator = .true.
-                    end select
-                end if
-
-                if (.not. is_terminator) then
-                    debug_msg = "! Unparsed: "
-                    debug_len = len_trim(debug_msg)
-
-                    ! Add first few tokens for debugging
-                    do i = 1, min(3, size(tokens))
-                        if (tokens(i)%kind == TK_EOF) exit
-                        if (len_trim(tokens(i)%text) > 0) then
-                            token_text = trim(tokens(i)%text)
-                            if (debug_len + len_trim(token_text) + 1 < 250) then
-                                debug_msg = debug_msg(1:debug_len)//" "//trim(token_text)
-                                debug_len = len_trim(debug_msg)
-                            end if
-                        end if
-                    end do
-
-                    stmt_index = push_literal(arena, trim(debug_msg), LITERAL_STRING, &
-                                              first_token%line, first_token%column)
-                end if
-            end block
-        end if
-
-        stmt_indices(1) = stmt_index
-    end function parse_basic_stmt_local
+    function build_associate_callbacks() result(callbacks)
+        type(statement_callbacks_t) :: callbacks
+        callbacks = build_where_callbacks()
+    end function build_associate_callbacks
     
     ! Parse WHERE construct (enhanced version)
     function parse_where_construct(parser, arena) result(where_index)
-        use parser_if_constructs_module, only: parse_if_condition
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         integer :: where_index
@@ -220,7 +72,6 @@ contains
                 token%text == "end" .or. parser%is_at_end()) then
                 ! Single-line WHERE - parse single statement
                 block
-                    integer :: stmt_index
                     type(token_t), allocatable, target :: remaining_tokens(:)
                     integer, allocatable :: stmt_indices(:)
                     integer :: j, n
@@ -234,12 +85,17 @@ contains
                     ! Extract remaining tokens
                     allocate(remaining_tokens(n))
                     do j = 1, n
-                        remaining_tokens(j) = parser%tokens(&
-                            parser%current_token + j - 1)
+                        remaining_tokens(j) = &
+                            parser%tokens(parser%current_token + j - 1)
                     end do
                     
                     ! Parse statement
-                    stmt_indices = parse_basic_stmt_local(remaining_tokens, arena)
+                    block
+                        type(statement_callbacks_t) :: callbacks
+                        callbacks = build_where_callbacks()
+                        stmt_indices = parse_basic_statement_core( &
+                            remaining_tokens, arena, callbacks=callbacks)
+                    end block
                     
                     if (allocated(stmt_indices) .and. size(stmt_indices) > 0) then
                         allocate(where_body_indices(size(stmt_indices)))
@@ -253,8 +109,8 @@ contains
                 
                 ! Create WHERE node with single statement
                 block
-                    where_index = push_where(arena, mask_expr_index, where_body_indices, &
-                                     line=line, column=column)
+                    where_index = push_where(arena, mask_expr_index, &
+                                     where_body_indices, line=line, column=column)
                 end block
                 
                 deallocate(where_body_indices)
@@ -295,6 +151,7 @@ contains
                             type(token_t), allocatable, target :: stmt_tokens(:)
                             integer, allocatable :: stmt_indices(:)
                             integer :: j, n, k
+                            integer :: last_token_index
                             
                             ! Extract tokens for current statement
                             n = 0
@@ -307,15 +164,23 @@ contains
                             end do
                             
                             if (n > 0) then
-                                allocate(stmt_tokens(n))
+                                allocate(stmt_tokens(n + 1))
                                 do j = 1, n
-                                    stmt_tokens(j) = parser%tokens(&
-                                        parser%current_token + j - 1)
+                                    stmt_tokens(j) = &
+                                        parser%tokens(parser%current_token + j - 1)
                                 end do
-                                
-                                stmt_indices = &
-                                    parse_basic_stmt_local(stmt_tokens, arena)
-                                
+                                stmt_tokens(n + 1)%kind = TK_EOF
+                                stmt_tokens(n + 1)%text = ""
+                                last_token_index = parser%current_token + n - 1
+                                stmt_tokens(n + 1)%line = &
+                                    parser%tokens(last_token_index)%line
+                                stmt_tokens(n + 1)%column = &
+                                    parser%tokens(last_token_index)%column + 1
+
+                                stmt_indices = parse_basic_statement_core( &
+                                    stmt_tokens, arena, callbacks= &
+                                    build_where_callbacks())
+
                                 ! Add all parsed statements
                                 do k = 1, size(stmt_indices)
                                     if (stmt_indices(k) > 0) then
@@ -324,9 +189,10 @@ contains
                                             [elsewhere_body_indices, stmt_indices(k)]
                                     end if
                                 end do
-                                
+
                                 ! Advance parser position
                                 parser%current_token = parser%current_token + n
+                                deallocate(stmt_tokens)
                             end if
                         end block
                     end do
@@ -342,6 +208,7 @@ contains
                 type(token_t), allocatable, target :: stmt_tokens(:)
                 integer, allocatable :: stmt_indices(:)
                 integer :: j, n, k
+                integer :: last_token_index
                 
                 ! Extract tokens for current statement
                 n = 0
@@ -354,13 +221,21 @@ contains
                 end do
                 
                 if (n > 0) then
-                    allocate(stmt_tokens(n))
+                    allocate(stmt_tokens(n + 1))
                     do j = 1, n
-                        stmt_tokens(j) = parser%tokens(parser%current_token + j - 1)
+                        stmt_tokens(j) = &
+                            parser%tokens(parser%current_token + j - 1)
                     end do
-                    
-                    stmt_indices = parse_basic_stmt_local(stmt_tokens, arena)
-                    
+                    stmt_tokens(n + 1)%kind = TK_EOF
+                    stmt_tokens(n + 1)%text = ""
+                    last_token_index = parser%current_token + n - 1
+                    stmt_tokens(n + 1)%line = parser%tokens(last_token_index)%line
+                    stmt_tokens(n + 1)%column = &
+                        parser%tokens(last_token_index)%column + 1
+
+                    stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
+                        callbacks=build_where_callbacks())
+
                     ! Add all parsed statements
                     do k = 1, size(stmt_indices)
                         if (stmt_indices(k) > 0) then
@@ -368,9 +243,10 @@ contains
                             where_body_indices = [where_body_indices, stmt_indices(k)]
                         end if
                     end do
-                    
+
                     ! Advance parser position
                     parser%current_token = parser%current_token + n
+                    deallocate(stmt_tokens)
                 end if
             end block
         end do
@@ -418,7 +294,7 @@ contains
         
         ! Consume 'associate'
         token = parser%consume()
-        
+
         ! Expect opening parenthesis
         token = parser%peek()
         if (token%kind /= TK_OPERATOR .or. token%text /= "(") then
@@ -445,12 +321,31 @@ contains
                 
                 ! Expect '=>'
                 token = parser%peek()
-                if (token%kind /= TK_OPERATOR .or. token%text /= "=>") then
+                if (token%kind == TK_OPERATOR .and. token%text == "=>") then
+                    token = parser%consume()
+                else if (token%kind == TK_OPERATOR .and. token%text == "=") then
+                    if (parser%current_token + 1 > size(parser%tokens)) then
+                        deallocate(associations)
+                        assoc_index = 0
+                        return
+                    end if
+                    block
+                        type(token_t) :: next_token
+                        next_token = parser%tokens(parser%current_token + 1)
+                        if (next_token%kind /= TK_OPERATOR .or. &
+                            next_token%text /= ">") then
+                            deallocate(associations)
+                            assoc_index = 0
+                            return
+                        end if
+                    end block
+                    token = parser%consume()
+                    token = parser%consume()
+                else
                     deallocate(associations)
                     assoc_index = 0
                     return
                 end if
-                token = parser%consume()
                 
                 ! Parse expression
                 expr_index = parse_expression(&
@@ -521,11 +416,11 @@ contains
             else if (token%kind == TK_OPERATOR .and. token%text == ")") then
                 token = parser%consume()
                 exit
-            else
-                deallocate(associations)
-                assoc_index = 0
-                return
-            end if
+                else
+                    deallocate(associations)
+                    assoc_index = 0
+                    return
+                end if
         end do
         
         ! Parse body statements until 'end associate'
@@ -533,6 +428,22 @@ contains
         allocate(body_indices(100))  ! Initial allocation
         
         do while (.not. parser%is_at_end())
+            do while (parser%current_token <= size(parser%tokens))
+                select case (parser%tokens(parser%current_token)%kind)
+                case (TK_NEWLINE, TK_COMMENT, TK_WHITESPACE)
+                    parser%current_token = parser%current_token + 1
+                case (TK_OPERATOR)
+                    if (parser%tokens(parser%current_token)%text == ";") then
+                        parser%current_token = parser%current_token + 1
+                    else
+                        exit
+                    end if
+                case default
+                    exit
+                end select
+            end do
+            if (parser%current_token > size(parser%tokens)) exit
+
             token = parser%peek()
             
             ! Check for 'end associate'
@@ -554,127 +465,58 @@ contains
                 exit
             end if
             
-            ! Parse a single statement by trying to identify its end
             block
-                integer :: stmt_start, stmt_end, j
                 type(token_t), allocatable, target :: stmt_tokens(:)
                 integer, allocatable :: stmt_indices(:)
-                
-                stmt_start = parser%current_token
-                stmt_end = stmt_start
-                
-                ! Find end of current statement 
-                ! Since we don't have newlines, we need to use heuristics:
-                ! 1. Look for certain keywords that indicate a new statement
-                ! 2. Look for assignment patterns
-                ! 3. Use a reasonable token limit for simple statements
-                
-                do j = stmt_start, size(parser%tokens)
-                    if (j > stmt_start) then
-                        ! Check if we've hit an end condition
-                        if (parser%tokens(j)%kind == TK_EOF) then
-                            stmt_end = j - 1
-                            exit
-                        end if
-                        
-                        ! Check for keywords that typically start new statements
-                        if (parser%tokens(j)%kind == TK_KEYWORD) then
-                            if (parser%tokens(j)%text == "print" .or. &
-                                parser%tokens(j)%text == "write" .or. &
-                                parser%tokens(j)%text == "read" .or. &
-                                parser%tokens(j)%text == "call" .or. &
-                                parser%tokens(j)%text == "if" .or. &
-                                parser%tokens(j)%text == "do" .or. &
-                                parser%tokens(j)%text == "associate" .or. &
-                                parser%tokens(j)%text == "end") then
-                                stmt_end = j - 1
-                                exit
-                            end if
-                        end if
-                        
-                        ! Check for identifier followed by = (assignment)
-                        if (j + 1 <= size(parser%tokens)) then
-                            if (parser%tokens(j)%kind == TK_IDENTIFIER .and. &
-                                parser%tokens(j + 1)%kind == TK_OPERATOR .and. &
-                                parser%tokens(j + 1)%text == "=" .and. &
-                                j > stmt_start + 2) then  ! Ensure it's not &
-                                                           ! the first assignment
-                                stmt_end = j - 1
-                                exit
-                            end if
-                        end if
-                    end if
-                    stmt_end = j
-                end do
-                
-                ! Extract statement tokens
-                if (stmt_end >= stmt_start) then
-                    allocate(stmt_tokens(stmt_end - stmt_start + 1))
-                    do j = 1, stmt_end - stmt_start + 1
-                        stmt_tokens(j) = parser%tokens(stmt_start + j - 1)
-                    end do
-                    
-                    ! Parse the statement - handle ASSOCIATE constructs specially
-                    block
-                        integer :: single_stmt_index
-                        
-                        ! Check if this is an ASSOCIATE construct
-                        if (size(stmt_tokens) > 0 .and. &
-                            stmt_tokens(1)%kind == TK_KEYWORD .and. &
-                            stmt_tokens(1)%text == "associate") then
-                            ! Parse as ASSOCIATE construct
-                            block
-                                type(parser_state_t) :: stmt_parser
-                                stmt_parser = create_parser_state(stmt_tokens)
-                                single_stmt_index = parse_associate(stmt_parser, arena)
-                            end block
-                        else
-                            ! Parse as basic statement
-                            stmt_indices = &
-                                parse_basic_stmt_local(stmt_tokens, arena)
-                            if (allocated(stmt_indices) .and. &
-                                size(stmt_indices) > 0) then
-                                single_stmt_index = stmt_indices(1)
-                            else
-                                single_stmt_index = 0
-                            end if
-                        end if
-                        
-                        ! Convert to array format
-                        if (single_stmt_index > 0) then
-                            if (.not. allocated(stmt_indices)) allocate(stmt_indices(1))
-                            stmt_indices(1) = single_stmt_index
-                        else
-                            if (.not. allocated(stmt_indices)) allocate(stmt_indices(0))
-                        end if
-                    end block
-                    
-                    ! Add successful statements to body
-                    if (allocated(stmt_indices) .and. size(stmt_indices) > 0) then
-                        do j = 1, size(stmt_indices)
-                            if (stmt_indices(j) > 0) then
-                                body_count = body_count + 1
-                                if (body_count > size(body_indices)) then
-                                    ! Resize array - extend by 100 elements
-                                    block
-                                        integer, allocatable :: temp(:)
-                                        allocate(temp(size(body_indices) + 100))
-                                        temp(1:size(body_indices)) = body_indices
-                                        temp(size(body_indices)+1:) = 0
-                                        call move_alloc(temp, body_indices)
-                                    end block
-                                end if
-                                body_indices(body_count) = stmt_indices(j)
-                            end if
-                        end do
-                    end if
-                    
-                    ! Advance parser
-                    parser%current_token = stmt_end + 1
-                else
-                    ! Safety: advance by one token if we can't parse
-                    parser%current_token = parser%current_token + 1
+                integer :: remaining_count, consumed_tokens, k
+                integer :: stmt_end, last_token_index
+                type(statement_callbacks_t) :: callbacks
+
+                stmt_end = find_statement_end(parser%tokens, parser%current_token)
+                if (stmt_end < parser%current_token) then
+                    stmt_end = parser%current_token
                 end if
+
+                remaining_count = stmt_end - parser%current_token + 1
+                if (remaining_count <= 0) exit
+
+                allocate(stmt_tokens(remaining_count + 1))
+                stmt_tokens(1:remaining_count) = &
+                    parser%tokens(parser%current_token:stmt_end)
+                stmt_tokens(remaining_count + 1)%kind = TK_EOF
+                stmt_tokens(remaining_count + 1)%text = ""
+                last_token_index = stmt_end
+                stmt_tokens(remaining_count + 1)%line = &
+                    parser%tokens(last_token_index)%line
+                stmt_tokens(remaining_count + 1)%column = &
+                    parser%tokens(last_token_index)%column + 1
+
+                callbacks = build_associate_callbacks()
+                stmt_indices = parse_basic_statement_core( &
+                    stmt_tokens, arena, callbacks=callbacks, &
+                    consumed_count=consumed_tokens)
+
+                if (allocated(stmt_indices) .and. size(stmt_indices) > 0) then
+                    do k = 1, size(stmt_indices)
+                        if (stmt_indices(k) > 0) then
+                            body_count = body_count + 1
+                            if (body_count > size(body_indices)) then
+                                block
+                                    integer, allocatable :: temp(:)
+                                    allocate(temp(size(body_indices) + 100))
+                                    temp(1:size(body_indices)) = body_indices
+                                    temp(size(body_indices)+1:) = 0
+                                    call move_alloc(temp, body_indices)
+                                end block
+                            end if
+                            body_indices(body_count) = stmt_indices(k)
+                        end if
+                    end do
+                end if
+
+                parser%current_token = stmt_end + 1
+
+                deallocate(stmt_tokens)
             end block
         end do
         

--- a/src/parser/parser_basic_statement_module.f90
+++ b/src/parser/parser_basic_statement_module.f90
@@ -1,6 +1,7 @@
 module parser_basic_statement_module
     ! Parser module for basic statement parsing and utilities
-    use lexer_core, only: token_t, TK_EOF, TK_KEYWORD
+    use lexer_core, only: token_t, TK_EOF, TK_KEYWORD, TK_OPERATOR, TK_NEWLINE, &
+                          TK_COMMENT, TK_WHITESPACE
     use parser_state_module, only: parser_state_t
     use parser_expressions_module, only: parse_range
     use parser_statement_core_module, only: parse_basic_statement_core, &
@@ -16,12 +17,13 @@ module parser_basic_statement_module
 contains
 
     ! Parse basic statement with support for multi-variable declarations
-    function parse_basic_statement_multi(tokens, arena, parent_index, callbacks) &
-            result(stmt_indices)
+    function parse_basic_statement_multi(tokens, arena, parent_index, callbacks, &
+                                         consumed_count) result(stmt_indices)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in), optional :: parent_index
         type(statement_callbacks_t), intent(in), optional :: callbacks
+        integer, intent(out), optional :: consumed_count
         integer, allocatable :: stmt_indices(:)
         type(statement_callbacks_t) :: local_callbacks
 
@@ -31,18 +33,35 @@ contains
             local_callbacks = null_statement_callbacks()
         end if
 
-        stmt_indices = parse_basic_statement_core(tokens, arena, parent_index, &
-                                                 local_callbacks)
+        if (present(parent_index)) then
+            if (present(consumed_count)) then
+                stmt_indices = parse_basic_statement_core(tokens, arena, &
+                    parent_index=parent_index, callbacks=local_callbacks, &
+                    consumed_count=consumed_count)
+            else
+                stmt_indices = parse_basic_statement_core(tokens, arena, &
+                    parent_index=parent_index, callbacks=local_callbacks)
+            end if
+        else
+            if (present(consumed_count)) then
+                stmt_indices = parse_basic_statement_core(tokens, arena, &
+                    callbacks=local_callbacks, consumed_count=consumed_count)
+            else
+                stmt_indices = parse_basic_statement_core(tokens, arena, &
+                    callbacks=local_callbacks)
+            end if
+        end if
     end function parse_basic_statement_multi
 
     ! Unified function for parsing statement bodies (used by if blocks, &
     ! do while loops, etc.)
-    function parse_statement_body(parser, arena, end_keywords, callbacks) &
-            result(body_indices)
+    function parse_statement_body(parser, arena, end_keywords, callbacks, &
+                                   parent_index) result(body_indices)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: end_keywords(:)
         type(statement_callbacks_t), intent(in), optional :: callbacks
+        integer, intent(in), optional :: parent_index
         integer, allocatable :: body_indices(:)
 
         type(token_t) :: token
@@ -51,6 +70,8 @@ contains
         type(token_t), allocatable, target :: stmt_tokens(:)
         logical :: found_end
         type(statement_callbacks_t) :: local_callbacks
+        logical :: has_meaningful
+        integer :: next_index
 
         allocate (body_indices(0))
         stmt_count = 0
@@ -68,6 +89,27 @@ contains
                 safety_counter = safety_counter + 1
                 token = parser%peek()
 
+                ! Skip whitespace, comments, and standalone semicolons
+                do while (.not. parser%is_at_end())
+                    select case (token%kind)
+                    case (TK_NEWLINE, TK_COMMENT, TK_WHITESPACE)
+                        token = parser%consume()
+                    case (TK_OPERATOR)
+                        if (token%text == ";") then
+                            token = parser%consume()
+                        else
+                            exit
+                        end if
+                    case default
+                        exit
+                    end select
+                    if (parser%is_at_end()) exit
+                    token = parser%peek()
+                end do
+
+                if (parser%is_at_end()) exit
+                token = parser%peek()
+
                 ! Check for end keywords
                 found_end = .false.
                 if (token%kind == TK_KEYWORD) then
@@ -83,20 +125,49 @@ contains
                 ! Parse statement until end of line
                 stmt_start = parser%current_token
                 stmt_end = stmt_start
+                has_meaningful = .false.
 
-                ! Find end of current statement (same line)
+                ! Find end of current statement, respecting semicolons
                 do j = stmt_start, size(parser%tokens)
-                    if (parser%tokens(j)%kind == TK_EOF) then
+                    select case (parser%tokens(j)%kind)
+                    case (TK_EOF)
                         stmt_end = j
                         exit
-                    end if
+                    case (TK_NEWLINE)
+                        stmt_end = j - 1
+                        exit
+                    case (TK_OPERATOR)
+                        if (parser%tokens(j)%text == ";") then
+                            stmt_end = j - 1
+                            exit
+                        end if
+                    end select
+
                     if (j > stmt_start .and. parser%tokens(j)%line > &
                             parser%tokens(stmt_start)%line) then
                         stmt_end = j - 1
                         exit
                     end if
+
                     stmt_end = j
+                    select case (parser%tokens(j)%kind)
+                    case (TK_EOF, TK_NEWLINE, TK_COMMENT, TK_WHITESPACE)
+                        cycle
+                    case default
+                        if (len_trim(parser%tokens(j)%text) > 0) then
+                            has_meaningful = .true.
+                        end if
+                    end select
                 end do
+
+                if (.not. has_meaningful) then
+                    if (stmt_end < stmt_start) then
+                        parser%current_token = parser%current_token + 1
+                    else
+                        parser%current_token = stmt_end + 1
+                    end if
+                    cycle
+                end if
 
                 ! Extract and parse statement tokens
                 if (stmt_end >= stmt_start) then
@@ -114,8 +185,13 @@ contains
                     block
                         integer, allocatable :: stmt_indices(:)
                         integer :: k
-                        stmt_indices = parse_basic_statement_multi( &
-                            stmt_tokens, arena, callbacks=local_callbacks)
+                        if (present(parent_index)) then
+                            stmt_indices = parse_basic_statement_multi( &
+                                stmt_tokens, arena, parent_index, local_callbacks)
+                        else
+                            stmt_indices = parse_basic_statement_multi( &
+                                stmt_tokens, arena, callbacks=local_callbacks)
+                        end if
 
                         ! Add all parsed statements to body
                         do k = 1, size(stmt_indices)
@@ -129,7 +205,14 @@ contains
                     deallocate (stmt_tokens)
                 end if
 
-                parser%current_token = stmt_end + 1
+                next_index = stmt_end + 1
+                if (next_index <= size(parser%tokens)) then
+                    if (parser%tokens(next_index)%kind == TK_OPERATOR .and. &
+                        parser%tokens(next_index)%text == ";") then
+                        next_index = next_index + 1
+                    end if
+                end if
+                parser%current_token = next_index
             end do
         end block
     end function parse_statement_body

--- a/src/parser/parser_if_constructs.f90
+++ b/src/parser/parser_if_constructs.f90
@@ -1,23 +1,15 @@
 module parser_if_constructs_module
     ! Parser module for IF constructs (if/then/else/elseif/endif)
-    use, intrinsic :: iso_fortran_env, only: error_unit
-    use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_NUMBER, TK_STRING, &
-                          TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, TK_COMMENT, TK_WHITESPACE, &
-                          to_lower
-    use ast_types, only: LITERAL_STRING
+    use lexer_core, only: token_t, TK_EOF, TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, &
+                          TK_COMMENT, TK_WHITESPACE
     use parser_state_module
     use parser_expressions_module, only: parse_expression
-    use parser_io_statements_module, only: parse_print_statement, parse_write_statement, &
-                                           parse_read_statement
-    use parser_control_statements_module, only: parse_cycle_statement, parse_exit_statement, &
-                                                parse_return_statement, parse_stop_statement, &
-                                                parse_goto_statement, parse_error_stop_statement
-    use parser_call_module, only: parse_call_statement
-    use parser_declarations, only: parse_declaration, parse_multi_declaration
-    use parser_utils, only: analyze_declaration_structure
+    use parser_statement_core_module, only: parse_basic_statement_core, &
+        statement_callbacks_t, null_statement_callbacks, find_statement_end
+    use parser_select_constructs_module, only: parse_select_case
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_control, only: if_node
-    use ast_factory, only: push_if, push_identifier, push_literal, push_assignment
+    use ast_factory, only: push_if
     implicit none
     private
 
@@ -53,174 +45,25 @@ contains
         parse_do_loop_proc => proc
     end subroutine register_parse_do_loop
 
-    ! Local implementation to avoid circular dependency
-    function parse_basic_stmt_local(tokens, arena, parent_index) result(stmt_indices)
-        type(token_t), intent(in) :: tokens(:)
+    function build_if_body_callbacks() result(callbacks)
+        type(statement_callbacks_t) :: callbacks
+
+        callbacks = null_statement_callbacks()
+        callbacks%parse_if => parse_if
+        callbacks%parse_do_loop => parse_do_loop_callback
+        callbacks%parse_select_case => parse_select_case
+    end function build_if_body_callbacks
+
+    integer function parse_do_loop_callback(parser, arena) result(loop_index)
+        type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in), optional :: parent_index
-        integer, allocatable :: stmt_indices(:)
-        type(parser_state_t) :: parser
-        type(token_t) :: first_token
-        integer :: stmt_index
 
-        parser = create_parser_state(tokens)
-        first_token = parser%peek()
-
-        ! Check if this is a declaration that might have multiple variables
-        if (first_token%kind == TK_KEYWORD) then
-            if (first_token%text == "real" .or. first_token%text == "integer" .or. &
-                first_token%text == "logical" .or. first_token%text == "character") then
-                ! Check if this is a single declaration with initializer
-                ! If so, use parse_declaration for proper initializer handling
-                block
-                    logical :: has_initializer, has_comma
-                    
-                    ! Look ahead to check for = (initializer) and comma (multi-var)
-                    has_initializer = .false.
-                    has_comma = .false.
-                    
-                    call analyze_declaration_structure(parser, has_initializer, has_comma)
-                    
-                    if (has_initializer .and. .not. has_comma) then
-                        ! Single variable with initializer - use parse_declaration
-                        if (.not. allocated(stmt_indices)) allocate (stmt_indices(1))
-                        stmt_indices(1) = parse_declaration(parser, arena)
-                        return
-                    else
-                        ! Multi-variable declaration - use parse_multi_declaration
-                        stmt_indices = parse_multi_declaration(parser, arena)
-                        return
-                    end if
-                end block
-            end if
+        loop_index = 0
+        call ensure_do_parser_ready()
+        if (associated(parse_do_loop_proc)) then
+            loop_index = parse_do_loop_proc(parser, arena)
         end if
-
-        ! For all other statements, parse as single statement
-        if (.not. allocated(stmt_indices)) allocate (stmt_indices(1))
-        stmt_index = 0
-
-        ! Handle different statement types (excluding control flow to avoid circular deps)
-        if (first_token%kind == TK_KEYWORD) then
-            select case (first_token%text)
-            case ("print")
-                stmt_index = parse_print_statement(parser, arena)
-            case ("write")
-                stmt_index = parse_write_statement(parser, arena)
-            case ("read")
-                stmt_index = parse_read_statement(parser, arena)
-            case ("cycle")
-                stmt_index = parse_cycle_statement(parser, arena)
-            case ("exit")
-                stmt_index = parse_exit_statement(parser, arena)
-            case ("return")
-                stmt_index = parse_return_statement(parser, arena, parent_index)
-            case ("call")
-                stmt_index = parse_call_statement(parser, arena)
-            case ("stop")
-                stmt_index = parse_stop_statement(parser, arena)
-            case ("go")
-                stmt_index = parse_goto_statement(parser, arena)
-            case ("error")
-                stmt_index = parse_error_stop_statement(parser, arena)
-            case ("if")
-                ! Handle nested if statements
-                stmt_index = parse_if(parser, arena, parent_index)
-            case ("do")
-                ! Handle nested do loops when registration provided
-                call ensure_do_parser_ready()
-                if (associated(parse_do_loop_proc)) then
-                    stmt_index = parse_do_loop_proc(parser, arena)
-                else
-                    stmt_index = 0
-                end if
-            case default
-                ! Unknown or control flow keyword - create placeholder
-                stmt_index = 0
-            end select
-        else if (first_token%kind == TK_IDENTIFIER) then
-            block
-                type(token_t) :: id_token, op_token
-                integer :: target_index, value_index
-
-                id_token = parser%consume()
-                op_token = parser%peek()
-
-                if (op_token%kind == TK_OPERATOR .and. op_token%text == "=") then
-                    op_token = parser%consume()  ! consume '='
-                    target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column, parent_index)
-                    ! Get remaining tokens for expression parsing
-                    block
-                        type(token_t), allocatable, target :: expr_tokens(:)
-                        integer :: remaining_count
-                        remaining_count = size(tokens) - parser%current_token + 1
-                        if (remaining_count > 0) then
-                            allocate (expr_tokens(remaining_count))
-                            expr_tokens = tokens(parser%current_token:)
-                            value_index = parse_expression(expr_tokens, arena)
-                            if (value_index > 0) then
-                                stmt_index = push_assignment(arena, target_index, value_index, &
-                                                             id_token%line, id_token%column, &
-                                                             parent_index)
-                            end if
-                        end if
-                    end block
-                end if
-            end block
-        end if
-
-        ! If we couldn't parse it, create a placeholder with debug info
-        if (stmt_index == 0) then
-            block
-                logical :: is_terminator
-                character(len=:), allocatable :: lowered
-                character(len=256) :: debug_msg
-                character(len=64) :: token_text
-                integer :: debug_len, i
-
-                is_terminator = .false.
-                if (first_token%kind == TK_KEYWORD) then
-                    lowered = to_lower(first_token%text)
-                    select case (lowered)
-                    case ("else", "elseif")
-                        is_terminator = .true.
-                    case ("end")
-                        if (size(tokens) >= 2) then
-                            select case (to_lower(tokens(2)%text))
-                            case ("if", "do", "select", "where", "forall")
-                                is_terminator = .true.
-                            end select
-                        else
-                            is_terminator = .true.
-                        end if
-                    case ("endif", "enddo", "endselect")
-                        is_terminator = .true.
-                    end select
-                end if
-
-                if (.not. is_terminator) then
-                    debug_msg = "! Unparsed: "
-                    debug_len = len_trim(debug_msg)
-
-                    ! Add first few tokens for debugging
-                    do i = 1, min(3, size(tokens))
-                        if (tokens(i)%kind == TK_EOF) exit
-                        if (len_trim(tokens(i)%text) > 0) then
-                            token_text = trim(tokens(i)%text)
-                            if (debug_len + len_trim(token_text) + 1 < 250) then
-                                debug_msg = debug_msg(1:debug_len)//" "//trim(token_text)
-                                debug_len = len_trim(debug_msg)
-                            end if
-                        end if
-                    end do
-
-                    stmt_index = push_literal(arena, trim(debug_msg), LITERAL_STRING, &
-                                              first_token%line, first_token%column)
-                end if
-            end block
-        end if
-
-        stmt_indices(1) = stmt_index
-    end function parse_basic_stmt_local
+    end function parse_do_loop_callback
 
     ! Parse if statement
     function parse_if(parser, arena, parent_index) result(if_index)
@@ -304,7 +147,8 @@ contains
                         ! Skip optional semicolon after 'else'
                         if (.not. parser%is_at_end()) then
                             then_token = parser%peek()
-                            if (then_token%kind == TK_OPERATOR .and. then_token%text == ";") then
+                            if (then_token%kind == TK_OPERATOR .and. &
+                                then_token%text == ";") then
                                 then_token = parser%consume()  ! Skip the semicolon
                             end if
                         end if
@@ -337,11 +181,14 @@ contains
                         node%else_body_indices = else_body_indices  
                     end if
                     if (allocated(elseif_indices)) then
-                        if (size(elseif_indices) > 0 .and. mod(size(elseif_indices), 2) == 0) then
+                if (size(elseif_indices) > 0 .and. &
+                    mod(size(elseif_indices), 2) == 0) then
                             allocate (node%elseif_blocks(size(elseif_indices)/2))
                             do elseif_count = 1, size(elseif_indices)/2
-                                node%elseif_blocks(elseif_count)%condition_index = elseif_indices(2*elseif_count - 1)
-                                node%elseif_blocks(elseif_count)%body_indices = [elseif_indices(2*elseif_count)]
+                    node%elseif_blocks(elseif_count)%condition_index = &
+                        elseif_indices(2*elseif_count - 1)
+                    node%elseif_blocks(elseif_count)%body_indices = &
+                        [elseif_indices(2*elseif_count)]
                             end do
                         end if
                     end if
@@ -353,7 +200,6 @@ contains
 
             ! Parse the single statement
             block
-                integer :: stmt_index
                 type(token_t), allocatable, target :: remaining_tokens(:)
                 integer :: i, n
 
@@ -367,10 +213,14 @@ contains
                 allocate (remaining_tokens(n))
                 remaining_tokens = parser%tokens(parser%current_token:)
 
-                ! Use local basic statement parser
+                ! Parse single statement using shared core
                 block
                     integer, allocatable :: stmt_indices(:)
-                    stmt_indices = parse_basic_stmt_local(remaining_tokens, arena)
+                    type(statement_callbacks_t) :: callbacks
+
+                    callbacks = build_if_body_callbacks()
+                    stmt_indices = parse_basic_statement_core(remaining_tokens, arena, &
+                        callbacks=callbacks)
                     if (size(stmt_indices) > 0 .and. stmt_indices(1) > 0) then
                         then_body_indices(1) = stmt_indices(1)
                     end if
@@ -472,7 +322,24 @@ contains
             
             do while (.not. parser%is_at_end() .and. safety_counter < 10000)
                 safety_counter = safety_counter + 1
-            token = parser%peek()
+
+                do while (parser%current_token <= size(parser%tokens))
+                    select case (parser%tokens(parser%current_token)%kind)
+                    case (TK_NEWLINE, TK_COMMENT, TK_WHITESPACE)
+                        parser%current_token = parser%current_token + 1
+                    case (TK_OPERATOR)
+                        if (parser%tokens(parser%current_token)%text == ";") then
+                            parser%current_token = parser%current_token + 1
+                        else
+                            exit
+                        end if
+                    case default
+                        exit
+                    end select
+                end do
+                if (parser%current_token > size(parser%tokens)) exit
+
+                token = parser%peek()
 
             ! Check for end of body
             if (token%kind == TK_KEYWORD) then
@@ -482,234 +349,81 @@ contains
                 else if (token%text == "else") then
                     ! Check if next token is "if" (for "else if")
                     if (parser%current_token + 1 <= size(parser%tokens)) then
-                        if (parser%tokens(parser%current_token + 1)%kind == TK_KEYWORD .and. &
-                            parser%tokens(parser%current_token + 1)%text == "if") then
-                            exit  ! Found "else if"
-                        end if
+                        block
+                            type(token_t) :: lookahead
+                            lookahead = parser%tokens(parser%current_token + 1)
+                            if (lookahead%kind == TK_KEYWORD .and. &
+                                lookahead%text == "if") then
+                                exit  ! Found "else if"
+                            end if
+                        end block
                     end if
                     ! If not "else if", it's just "else" - also exit
                     exit
                 else if (token%text == "end") then
                     ! Check if next token is "if"
                     if (parser%current_token + 1 <= size(parser%tokens)) then
-                        if (parser%tokens(parser%current_token + 1)%kind == TK_KEYWORD .and. &
-                            parser%tokens(parser%current_token + 1)%text == "if") then
-                            exit  ! Found "end if"
-                        end if
+                        block
+                            type(token_t) :: lookahead
+                            lookahead = parser%tokens(parser%current_token + 1)
+                            if (lookahead%kind == TK_KEYWORD .and. &
+                                lookahead%text == "if") then
+                                exit  ! Found "end if"
+                            end if
+                        end block
                     end if
                 end if
             end if
 
             ! Parse statement until end of line (same approach as do loop)
             block
-                integer :: stmt_start, stmt_end, j
                 type(token_t), allocatable, target :: stmt_tokens(:)
+                integer, allocatable :: stmt_indices(:)
+                integer :: remaining_count, consumed_tokens, k
+                integer :: stmt_end, last_token_index
+                type(statement_callbacks_t) :: callbacks
 
-                stmt_start = parser%current_token
-                
-                ! Skip leading semicolons and newlines to get to actual statement
-                do while (stmt_start <= size(parser%tokens) .and. &
-                         ((parser%tokens(stmt_start)%kind == TK_OPERATOR .and. &
-                          parser%tokens(stmt_start)%text == ";") .or. &
-                          parser%tokens(stmt_start)%kind == TK_NEWLINE))
-                    stmt_start = stmt_start + 1
-                end do
-                
-                ! Check if we've gone past the end of tokens
-                if (stmt_start > size(parser%tokens)) then
-                    parser%current_token = stmt_start
-                    exit  ! Exit the main body parsing loop
+                stmt_end = find_statement_end(parser%tokens, parser%current_token)
+                if (stmt_end < parser%current_token) then
+                    stmt_end = parser%current_token
                 end if
 
-                ! After skipping leading delimiters, bail out if we hit a terminator
-                token = parser%tokens(stmt_start)
-                if (token%kind == TK_KEYWORD) then
-                    select case (token%text)
-                    case ("else", "elseif", "else if", "endif", "end if")
-                        parser%current_token = stmt_start
-                        exit  ! Let caller handle control-flow keyword
-                    case ("end")
-                        if (stmt_start + 1 <= size(parser%tokens)) then
-                            if (parser%tokens(stmt_start + 1)%kind == TK_KEYWORD .and. &
-                                parser%tokens(stmt_start + 1)%text == "if") then
-                                parser%current_token = stmt_start
-                                exit
-                            end if
-                        else
-                            parser%current_token = stmt_start
-                            exit
-                        end if
-                    end select
-                end if
+                remaining_count = stmt_end - parser%current_token + 1
+                if (remaining_count <= 0) exit
 
-                stmt_end = stmt_start
+                allocate (stmt_tokens(remaining_count + 1))
+                stmt_tokens(1:remaining_count) = &
+                    parser%tokens(parser%current_token:stmt_end)
+                stmt_tokens(remaining_count + 1)%kind = TK_EOF
+                stmt_tokens(remaining_count + 1)%text = ""
+                last_token_index = stmt_end
+                stmt_tokens(remaining_count + 1)%line = &
+                    parser%tokens(last_token_index)%line
+                stmt_tokens(remaining_count + 1)%column = &
+                    parser%tokens(last_token_index)%column + 1
 
-                ! Find end of current statement (handle multi-line properly)
-                block
-                    logical :: is_nested_if
-                    integer :: nesting_depth
-                    
-                    is_nested_if = .false.
-                    nesting_depth = 0
-                    
-                    ! Check if statement starts with 'if' (for same-line nested ifs only)
-                    if (parser%tokens(stmt_start)%kind == TK_KEYWORD .and. &
-                        parser%tokens(stmt_start)%text == "if") then
-                        ! Check if there are semicolons on the same line (same-line nesting)
-                        block
-                            integer :: k
-                            logical :: has_semicolon
-                            has_semicolon = .false.
-                            do k = stmt_start + 1, min(stmt_start + 20, size(parser%tokens))
-                                if (parser%tokens(k)%line > parser%tokens(stmt_start)%line) exit
-                                if (parser%tokens(k)%kind == TK_OPERATOR .and. &
-                                    parser%tokens(k)%text == ";") then
-                                    has_semicolon = .true.
-                                    exit
-                                end if
-                            end do
-                            if (has_semicolon) then
-                                is_nested_if = .true.
-                                nesting_depth = 1
-                            end if
-                        end block
-                    end if
-                    
-                    do j = stmt_start, size(parser%tokens)
-                        ! For nested if, need to find matching end if
-                        if (is_nested_if .and. j > stmt_start) then
-                            if (parser%tokens(j)%kind == TK_KEYWORD) then
-                                if (parser%tokens(j)%text == "if") then
-                                    ! Check if it's a new if (has 'then' later)
-                                    block
-                                        integer :: k
-                                        logical :: has_then
-                                        has_then = .false.
-                                        do k = j + 1, min(j + 10, size(parser%tokens))
-                                            if (parser%tokens(k)%kind == TK_KEYWORD .and. &
-                                                parser%tokens(k)%text == "then") then
-                                                has_then = .true.
-                                                exit
-                                            else if (parser%tokens(k)%kind == TK_NEWLINE .or. &
-                                                    parser%tokens(k)%kind == TK_EOF) then
-                                                exit
-                                            end if
-                                        end do
-                                        if (has_then) then
-                                            nesting_depth = nesting_depth + 1
-                                        end if
-                                    end block
-                                else if (parser%tokens(j)%text == "endif" .or. &
-                                        parser%tokens(j)%text == "end") then
-                                    if (parser%tokens(j)%text == "endif") then
-                                        nesting_depth = nesting_depth - 1
-                                        if (nesting_depth == 0) then
-                                            stmt_end = j
-                                            exit
-                                        end if
-                                    else if (j + 1 <= size(parser%tokens) .and. &
-                                            parser%tokens(j+1)%kind == TK_KEYWORD .and. &
-                                            parser%tokens(j+1)%text == "if") then
-                                        nesting_depth = nesting_depth - 1
-                                        if (nesting_depth == 0) then
-                                            stmt_end = j + 1
-                                            exit
-                                        end if
-                                    end if
-                                end if
-                            end if
-                        else if (.not. is_nested_if) then
-                            ! Non-nested statement - original logic
-                            ! Treat control-flow keywords as hard boundaries
-                            if (parser%tokens(j)%kind == TK_KEYWORD) then
-                                select case (parser%tokens(j)%text)
-                                case ("else", "elseif", "else if")
-                                    if (j > stmt_start) then
-                                        stmt_end = j - 1
-                                        exit
-                                    end if
-                                case ("endif", "end if")
-                                    if (j > stmt_start) then
-                                        stmt_end = j - 1
-                                        exit
-                                    end if
-                                case ("end")
-                                    if (j + 1 <= size(parser%tokens)) then
-                                        if (parser%tokens(j+1)%kind == TK_KEYWORD .and. &
-                                            parser%tokens(j+1)%text == "if") then
-                                            if (j > stmt_start) then
-                                                stmt_end = j - 1
-                                                exit
-                                            end if
-                                        end if
-                                    end if
-                                end select
-                            end if
-                        end if
-                        if (parser%tokens(j)%kind == TK_EOF) then
-                            stmt_end = j
-                            exit
-                        end if
-                        ! For non-nested statements, check for newlines and semicolons
-                        if (.not. is_nested_if) then
-                            ! For multi-line control flow bodies, treat NEWLINE as a statement boundary
-                            ! but only after we've seen some content
-                            if (j > stmt_start .and. parser%tokens(j)%kind == TK_NEWLINE) then
-                                stmt_end = j - 1
-                                exit
-                            end if
-                            ! Check for semicolon as statement separator
-                            if (j > stmt_start .and. parser%tokens(j)%kind == TK_OPERATOR .and. &
-                                parser%tokens(j)%text == ";") then
-                                stmt_end = j - 1
-                                exit
-                            end if
-                        end if
-                        stmt_end = j
-                    end do
-                end block
-
-                ! Extract statement tokens
-                if (stmt_end >= stmt_start) then
-                    allocate (stmt_tokens(stmt_end - stmt_start + 2))
-                    stmt_tokens(1:stmt_end - stmt_start + 1) = parser%tokens(stmt_start:stmt_end)
-                    ! Add EOF token
-                    stmt_tokens(stmt_end - stmt_start + 2)%kind = TK_EOF
-                    stmt_tokens(stmt_end - stmt_start + 2)%text = ""
-                    stmt_tokens(stmt_end - stmt_start + 2)%line = parser%tokens(stmt_end)%line
-                    stmt_tokens(stmt_end - stmt_start + 2)%column = parser%tokens(stmt_end)%column + 1
-
-                    ! Parse the statement (may return multiple indices for &
-                    ! multi-variable declarations)
-                    block
-                        integer, allocatable :: stmt_indices(:)
-                        integer :: k
-                        stmt_indices = parse_basic_stmt_local(stmt_tokens, arena, parent_index)
-
-                        ! Add all parsed statements to body
-                        do k = 1, size(stmt_indices)
-                            if (stmt_indices(k) > 0) then
-                                body_indices = [body_indices, stmt_indices(k)]
-                                stmt_count = stmt_count + 1
-                            end if
-                        end do
-                    end block
-
-                    deallocate (stmt_tokens)
-                end if
-
-                ! Move to next statement
-                ! If we stopped at a semicolon, skip over it
-                if (stmt_end + 1 <= size(parser%tokens)) then
-                    if (parser%tokens(stmt_end + 1)%kind == TK_OPERATOR .and. &
-                        parser%tokens(stmt_end + 1)%text == ";") then
-                        parser%current_token = stmt_end + 2
-                    else
-                        parser%current_token = stmt_end + 1
-                    end if
+                callbacks = build_if_body_callbacks()
+                if (present(parent_index)) then
+                    stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
+                        parent_index=parent_index, callbacks=callbacks, &
+                        consumed_count=consumed_tokens)
                 else
-                    parser%current_token = stmt_end + 1
+                    stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
+                        callbacks=callbacks, consumed_count=consumed_tokens)
                 end if
+
+                if (allocated(stmt_indices) .and. size(stmt_indices) > 0) then
+                    do k = 1, size(stmt_indices)
+                        if (stmt_indices(k) > 0) then
+                            body_indices = [body_indices, stmt_indices(k)]
+                            stmt_count = stmt_count + 1
+                        end if
+                    end do
+                end if
+
+                parser%current_token = stmt_end + 1
+
+                deallocate (stmt_tokens)
             end block
             end do
         end block

--- a/src/parser/parser_statement_core.f90
+++ b/src/parser/parser_statement_core.f90
@@ -1,6 +1,6 @@
 module parser_statement_core_module
     use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_OPERATOR, TK_KEYWORD, &
-                          TK_NEWLINE, to_lower
+                          TK_NEWLINE, TK_COMMENT, TK_WHITESPACE, to_lower
     use ast_types, only: LITERAL_STRING
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_expressions_module, only: parse_expression
@@ -18,7 +18,7 @@ module parser_statement_core_module
     private
 
     public :: statement_callbacks_t, parse_basic_statement_core, &
-              null_statement_callbacks
+              null_statement_callbacks, find_statement_end
 
     abstract interface
         function parse_with_parent_interface(parser, arena, parent_index) &
@@ -58,12 +58,374 @@ contains
         type(statement_callbacks_t) :: callbacks
     end function null_statement_callbacks
 
-    function parse_basic_statement_core(tokens, arena, parent_index, callbacks) &
-            result(stmt_indices)
+    logical function is_block_if(tokens, start_index) result(is_block)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_index
+        integer :: i
+
+        is_block = .false.
+        do i = start_index + 1, size(tokens)
+            select case (tokens(i)%kind)
+            case (TK_KEYWORD)
+                if (tokens(i)%text == "then") then
+                    is_block = .true.
+                    return
+                else
+                    return
+                end if
+            case (TK_OPERATOR)
+                if (tokens(i)%text == ";") return
+            case (TK_NEWLINE, TK_EOF)
+                return
+            case (TK_COMMENT, TK_WHITESPACE)
+                cycle
+            case default
+                cycle
+            end select
+        end do
+    end function is_block_if
+
+    pure logical function at_top_level(if_depth, select_depth, do_depth, &
+            where_depth, assoc_depth, forall_depth) result(is_top_level)
+        integer, intent(in) :: if_depth, select_depth, do_depth
+        integer, intent(in) :: where_depth, assoc_depth, forall_depth
+
+        is_top_level = (if_depth == 0 .and. select_depth == 0 .and. &
+            do_depth == 0 .and. where_depth == 0 .and. &
+            assoc_depth == 0 .and. forall_depth == 0)
+    end function at_top_level
+
+    integer function find_statement_end(tokens, start_index) result(end_index)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_index
+
+        integer :: idx
+        integer :: if_depth, select_depth, do_depth, where_depth, assoc_depth
+        integer :: forall_depth
+        logical :: first_processed, block_if
+        character(len=16) :: first_keyword
+        type(token_t) :: token, next_token
+
+        end_index = start_index
+        if (start_index > size(tokens)) return
+
+        if_depth = 0
+        select_depth = 0
+        do_depth = 0
+        where_depth = 0
+        assoc_depth = 0
+        forall_depth = 0
+        first_processed = .false.
+        block_if = .false.
+        first_keyword = ""
+
+        idx = start_index
+        do while (idx <= size(tokens))
+            token = tokens(idx)
+
+            select case (token%kind)
+            case (TK_EOF)
+                end_index = idx - 1
+                exit
+            case (TK_NEWLINE)
+                        if (at_top_level( &
+                            if_depth, select_depth, do_depth, where_depth, &
+                            assoc_depth, forall_depth)) then
+                    end_index = idx - 1
+                    exit
+                end if
+            case (TK_OPERATOR)
+                if (token%text == ";") then
+                        if (at_top_level( &
+                            if_depth, select_depth, do_depth, where_depth, &
+                            assoc_depth, forall_depth)) then
+                        end_index = idx - 1
+                        exit
+                    end if
+                end if
+            case (TK_COMMENT, TK_WHITESPACE)
+                ! Ignore spacing tokens
+            case (TK_KEYWORD)
+                select case (token%text)
+                case ("if")
+                    if (.not. first_processed) then
+                        first_processed = .true.
+                        block_if = is_block_if(tokens, idx)
+                        if (block_if) if_depth = if_depth + 1
+                        first_keyword = "if"
+                    else
+                        if (is_block_if(tokens, idx)) then
+                            if_depth = if_depth + 1
+                        end if
+                    end if
+                case ("select")
+                    if (.not. first_processed) then
+                        first_processed = .true.
+                        first_keyword = "select"
+                    end if
+                    select_depth = select_depth + 1
+                case ("do")
+                    if (.not. first_processed) then
+                        first_processed = .true.
+                        first_keyword = "do"
+                    end if
+                    do_depth = do_depth + 1
+                case ("where")
+                    if (.not. first_processed) then
+                        first_processed = .true.
+                        first_keyword = "where"
+                    end if
+                    where_depth = where_depth + 1
+                case ("forall")
+                    if (.not. first_processed) then
+                        first_processed = .true.
+                        first_keyword = "forall"
+                    end if
+                    forall_depth = forall_depth + 1
+                case ("associate")
+                    if (.not. first_processed) then
+                        first_processed = .true.
+                        first_keyword = "associate"
+                    end if
+                    assoc_depth = assoc_depth + 1
+               case ("else")
+                   if (block_if) then
+                       if (idx + 1 <= size(tokens)) then
+                           if (tokens(idx + 1)%kind == TK_KEYWORD .and. &
+                               tokens(idx + 1)%text == "if") then
+                               if (if_depth == 1) then
+                                   end_index = idx - 1
+                                   exit
+                               end if
+                           else
+                               if (if_depth == 1) then
+                                   end_index = idx - 1
+                                   exit
+                               end if
+                           end if
+                       else
+                           if (if_depth == 1) then
+                               end_index = idx - 1
+                               exit
+                           end if
+                       end if
+                    else if (at_top_level( &
+                             if_depth, select_depth, do_depth, where_depth, &
+                             assoc_depth, forall_depth)) then
+                        end_index = idx - 1
+                        exit
+                    end if
+                case ("elseif", "else if")
+                    if (block_if .and. if_depth == 1) then
+                        end_index = idx - 1
+                        exit
+                    else if (at_top_level( &
+                             if_depth, select_depth, do_depth, where_depth, &
+                             assoc_depth, forall_depth)) then
+                        end_index = idx - 1
+                        exit
+                    end if
+                case ("endif")
+                    if (if_depth > 0) then
+                        if_depth = if_depth - 1
+                        if (if_depth == 0 .and. block_if) then
+                            end_index = idx
+                            exit
+                        end if
+                    else
+                        end_index = idx - 1
+                        exit
+                    end if
+                case ("endselect")
+                    if (select_depth > 0) then
+                        select_depth = select_depth - 1
+                        if (select_depth == 0 .and. first_keyword == "select") then
+                            end_index = idx
+                            exit
+                        end if
+                    else
+                        end_index = idx - 1
+                        exit
+                    end if
+                case ("enddo")
+                    if (do_depth > 0) then
+                        do_depth = do_depth - 1
+                        if (do_depth == 0 .and. first_keyword == "do") then
+                            end_index = idx
+                            exit
+                        end if
+                    else
+                        end_index = idx - 1
+                        exit
+                    end if
+                case ("endwhere")
+                    if (where_depth > 0) then
+                        where_depth = where_depth - 1
+                        if (where_depth == 0 .and. first_keyword == "where") then
+                            end_index = idx
+                            exit
+                        end if
+                    else
+                        end_index = idx - 1
+                        exit
+                    end if
+                case ("endforall")
+                    if (forall_depth > 0) then
+                        forall_depth = forall_depth - 1
+                        if (forall_depth == 0 .and. first_keyword == "forall") then
+                            end_index = idx
+                            exit
+                        end if
+                    else
+                        end_index = idx - 1
+                        exit
+                    end if
+                case ("endassociate")
+                    if (assoc_depth > 0) then
+                        assoc_depth = assoc_depth - 1
+                        if (assoc_depth == 0 .and. first_keyword == "associate") then
+                            end_index = idx
+                            exit
+                        end if
+                    else
+                        end_index = idx - 1
+                        exit
+                    end if
+                case ("end")
+                    if (idx + 1 <= size(tokens)) then
+                        if (tokens(idx + 1)%kind == TK_KEYWORD) then
+                            next_token = tokens(idx + 1)
+                            select case (next_token%text)
+                            case ("if")
+                                if (if_depth > 0) then
+                                    if_depth = if_depth - 1
+                                    if (if_depth == 0 .and. block_if) then
+                                        end_index = idx + 1
+                                        exit
+                                    end if
+                                else
+                                    end_index = idx - 1
+                                    exit
+                                end if
+                                idx = idx + 1
+                                cycle
+                            case ("select")
+                                if (select_depth > 0) then
+                                    select_depth = select_depth - 1
+                                    if (select_depth == 0 .and. &
+                                        first_keyword == "select") then
+                                        end_index = idx + 1
+                                        exit
+                                    end if
+                                else
+                                    end_index = idx - 1
+                                    exit
+                                end if
+                                idx = idx + 1
+                                cycle
+                            case ("do")
+                                if (do_depth > 0) then
+                                    do_depth = do_depth - 1
+                                    if (do_depth == 0 .and. first_keyword == "do") then
+                                        end_index = idx + 1
+                                        exit
+                                    end if
+                                else
+                                    end_index = idx - 1
+                                    exit
+                                end if
+                                idx = idx + 1
+                                cycle
+                            case ("associate")
+                                if (assoc_depth > 0) then
+                                    assoc_depth = assoc_depth - 1
+                                    if (assoc_depth == 0 .and. &
+                                        first_keyword == "associate") then
+                                        end_index = idx + 1
+                                        exit
+                                    end if
+                                else
+                                    end_index = idx - 1
+                                    exit
+                                end if
+                                idx = idx + 1
+                                cycle
+                            case ("where")
+                                if (where_depth > 0) then
+                                    where_depth = where_depth - 1
+                                    if (where_depth == 0 .and. &
+                                        first_keyword == "where") then
+                                        end_index = idx + 1
+                                        exit
+                                    end if
+                                else
+                                    end_index = idx - 1
+                                    exit
+                                end if
+                                idx = idx + 1
+                                cycle
+                            case ("forall")
+                                if (forall_depth > 0) then
+                                    forall_depth = forall_depth - 1
+                                    if (forall_depth == 0 .and. &
+                                        first_keyword == "forall") then
+                                        end_index = idx + 1
+                                        exit
+                                    end if
+                                else
+                                    end_index = idx - 1
+                                    exit
+                                end if
+                                idx = idx + 1
+                                cycle
+                            case default
+                                if (at_top_level( &
+                                    if_depth, select_depth, do_depth, where_depth, &
+                                    assoc_depth, forall_depth)) then
+                                    end_index = idx - 1
+                                    exit
+                                end if
+                            end select
+                        else
+                            if (at_top_level( &
+                                if_depth, select_depth, do_depth, where_depth, &
+                                assoc_depth, forall_depth)) then
+                                end_index = idx - 1
+                                exit
+                            end if
+                        end if
+                    else
+                        if (at_top_level( &
+                            if_depth, select_depth, do_depth, where_depth, &
+                            assoc_depth, forall_depth)) then
+                            end_index = idx - 1
+                            exit
+                        end if
+                    end if
+                case default
+                    if (.not. first_processed) then
+                        first_processed = .true.
+                        first_keyword = to_lower(token%text)
+                    end if
+                end select
+            case default
+                if (.not. first_processed) then
+                    first_processed = .true.
+                end if
+            end select
+
+            end_index = idx
+            idx = idx + 1
+        end do
+    end function find_statement_end
+
+    function parse_basic_statement_core(tokens, arena, parent_index, callbacks, &
+                                        consumed_count) result(stmt_indices)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in), optional :: parent_index
         type(statement_callbacks_t), intent(in), optional :: callbacks
+        integer, intent(out), optional :: consumed_count
         integer, allocatable :: stmt_indices(:)
         type(parser_state_t) :: parser
         type(token_t) :: first_token
@@ -81,7 +443,12 @@ contains
         first_token = parser%peek()
 
         handled = try_handle_declaration(parser, arena, first_token, stmt_indices)
-        if (handled) return
+        if (handled) then
+            if (present(consumed_count)) then
+                consumed_count = parser%current_token - 1
+            end if
+            return
+        end if
 
         stmt_index = 0
         select case (first_token%kind)
@@ -100,6 +467,10 @@ contains
             allocate (stmt_indices(1))
         end if
         stmt_indices(1) = stmt_index
+
+        if (present(consumed_count)) then
+            consumed_count = parser%current_token - 1
+        end if
     end function parse_basic_statement_core
 
     logical function try_handle_declaration(parser, arena, first_token, stmt_indices) &

--- a/test/parser/test_associate_nested_select_case.f90
+++ b/test/parser/test_associate_nested_select_case.f90
@@ -1,0 +1,70 @@
+program test_associate_nested_select_case
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use lexer_core, only: token_t, tokenize_core
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_array_constructs_module, only: parse_associate
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_control, only: associate_node, select_case_node
+    use ast_nodes_core, only: literal_node
+    implicit none
+
+    character(len=:), allocatable :: source
+    type(token_t), allocatable :: tokens(:)
+    type(parser_state_t) :: parser
+    type(ast_arena_t) :: arena
+    integer :: assoc_index, i
+    logical :: has_select_case, has_unparsed
+
+    print *, '=== Test: parse_associate handles nested SELECT CASE blocks ==='
+
+    source = 'associate (foo => bar)' // new_line('a') // &
+             '  select case(kind)' // new_line('a') // &
+             '  case (1)' // new_line('a') // &
+             '    print *, 1' // new_line('a') // &
+             '  case default' // new_line('a') // &
+             '    print *, 2' // new_line('a') // &
+             '  end select' // new_line('a') // &
+             'end associate'
+
+    call tokenize_core(source, tokens)
+    parser = create_parser_state(tokens)
+    arena = create_ast_arena(128)
+
+    assoc_index = parse_associate(parser, arena)
+    if (assoc_index <= 0) then
+        write(error_unit, '(a)') 'ERROR: parse_associate returned invalid index'
+        stop 1
+    end if
+
+    has_select_case = .false.
+    has_unparsed = .false.
+
+    do i = 1, arena%size
+        if (.not. arena%has_node_at(i)) cycle
+        select type (node => arena%entries(i)%node)
+        type is (select_case_node)
+            has_select_case = .true.
+        type is (literal_node)
+            if (allocated(node%value)) then
+                if (index(node%value, '! Unparsed') > 0) has_unparsed = .true.
+            end if
+        type is (associate_node)
+            cycle
+        class default
+            cycle
+        end select
+    end do
+
+    if (.not. has_select_case) then
+        write(error_unit, '(a)') 'ERROR: nested SELECT CASE node missing'
+        stop 1
+    end if
+
+    if (has_unparsed) then
+        write(error_unit, '(a)') 'ERROR: unexpected ! Unparsed literal emitted'
+        stop 1
+    end if
+
+    print *, 'PASS: nested SELECT CASE parsed without placeholders'
+
+end program test_associate_nested_select_case

--- a/test/parser/test_if_nested_select_case.f90
+++ b/test/parser/test_if_nested_select_case.f90
@@ -1,0 +1,70 @@
+program test_if_nested_select_case
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use lexer_core, only: token_t, tokenize_core
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_if_constructs_module, only: parse_if
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_control, only: if_node, select_case_node
+    use ast_nodes_core, only: literal_node
+    implicit none
+
+    character(len=:), allocatable :: source
+    type(token_t), allocatable :: tokens(:)
+    type(parser_state_t) :: parser
+    type(ast_arena_t) :: arena
+    integer :: if_index, i
+    logical :: has_select_case, has_unparsed
+
+    print *, '=== Test: parse_if handles nested SELECT CASE blocks ==='
+
+    source = 'if (flag) then' // new_line('a') // &
+             '  select case(value)' // new_line('a') // &
+             '  case (1)' // new_line('a') // &
+             '    print *, 1' // new_line('a') // &
+             '  case default' // new_line('a') // &
+             '    print *, 2' // new_line('a') // &
+             '  end select' // new_line('a') // &
+             'end if'
+
+    call tokenize_core(source, tokens)
+    parser = create_parser_state(tokens)
+    arena = create_ast_arena(128)
+
+    if_index = parse_if(parser, arena)
+    if (if_index <= 0) then
+        write(error_unit, '(a)') 'ERROR: parse_if returned invalid index'
+        stop 1
+    end if
+
+    has_select_case = .false.
+    has_unparsed = .false.
+
+    do i = 1, arena%size
+        if (.not. arena%has_node_at(i)) cycle
+        select type (node => arena%entries(i)%node)
+        type is (select_case_node)
+            has_select_case = .true.
+        type is (literal_node)
+            if (allocated(node%value)) then
+                if (index(node%value, '! Unparsed') > 0) has_unparsed = .true.
+            end if
+        type is (if_node)
+            cycle
+        class default
+            cycle
+        end select
+    end do
+
+    if (.not. has_select_case) then
+        write(error_unit, '(a)') 'ERROR: nested SELECT CASE node missing'
+        stop 1
+    end if
+
+    if (has_unparsed) then
+        write(error_unit, '(a)') 'ERROR: unexpected ! Unparsed literal emitted'
+        stop 1
+    end if
+
+    print *, 'PASS: nested SELECT CASE parsed without placeholders'
+
+end program test_if_nested_select_case


### PR DESCRIPTION
## Summary
- centralize statement boundary detection so nested control flow no longer produces ! Unparsed placeholders
- update ASSOCIATE/IF parsers to reuse shared callbacks and respect statement separators
- add parser regression tests covering nested SELECT CASE inside ASSOCIATE and IF constructs

## Testing
- make test
- fpm test --target test_issue_653_semicolon_parsing
