### PR TITLE
Fix parser multi-index FORALL support

### DIFF
--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -128,7 +128,9 @@ program fortfront_cli
 
             deallocate(arg_str, stat=alloc_stat)
             if (alloc_stat /= 0) then
-                write(error_unit, '(A,I0,A)') 'Memory deallocation failed for command argument (stat=', alloc_stat, ')'
+                write(error_unit, '(A,I0,A)') &
+                    'Memory deallocation failed for command argument (stat=', &
+                    alloc_stat, ')'
                 call exit_quiet(EXIT_FAILURE)
             end if
             i = i + 1

--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -15,7 +15,6 @@ external_tool_example.f90       # Gfortran compilation failure
 tooling_lightweight_ast.f90     # Gfortran compilation failure
 
 # F95 features
-issue_1337_forall.f90           # Issue #1337: FORALL body assignments dropped
 
 # Lazy Fortran type inference
 issue_1343_lazy_function.lf     # Issue #1343: Functions missing type inference

--- a/src/ast/factory/ast_factory_control.f90
+++ b/src/ast/factory/ast_factory_control.f90
@@ -194,16 +194,24 @@ contains
 
     ! Create forall construct node and add to stack
     function push_forall(arena, index_var, start_index, end_index, step_index, &
-              mask_index, body_indices, line, column, parent_index) result(forall_index)
+              mask_index, body_indices, line, column, parent_index, &
+              index_vars_all, start_indices_all, end_indices_all, &
+              stride_indices_all) result(forall_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: index_var
         integer, intent(in) :: start_index, end_index
         integer, intent(in), optional :: step_index, mask_index
         integer, intent(in), optional :: body_indices(:)
         integer, intent(in), optional :: line, column, parent_index
+        character(len=*), intent(in), optional :: index_vars_all(:)
+        integer, intent(in), optional :: start_indices_all(:)
+        integer, intent(in), optional :: end_indices_all(:)
+        integer, intent(in), optional :: stride_indices_all(:)
         integer :: forall_index
         type(forall_node) :: forall_stmt
-        integer :: i, index_var_len
+        integer :: i, index_var_len, num_indices, max_index_len, stride_val
+        logical :: use_multi
+        integer, allocatable :: lower_vals(:), upper_vals(:), stride_vals(:)
         type(result_t) :: validation
 
         forall_stmt%uid = generate_uid()
@@ -216,45 +224,103 @@ contains
             return
         end if
 
-        ! Validate index variable name
-        index_var_len = len_trim(index_var)
-        if (index_var_len == 0) then
-            write(error_unit, '(A)') "ERROR [ast_factory_control]: FORALL index variable name cannot be empty"
-            forall_index = 0
-            return
-        end if
-        if (index_var_len > MAX_INDEX_NAME_LENGTH) then
-            write(error_unit, '(A)') "ERROR [ast_factory_control]: FORALL index variable name exceeds maximum length"
-            forall_index = 0
-            return
+        use_multi = present(index_vars_all) .and. present(start_indices_all) .and. &
+            present(end_indices_all)
+
+        if (use_multi) then
+            num_indices = size(index_vars_all)
+            if (num_indices <= 0) then
+                write(error_unit, '(A)') "ERROR [ast_factory_control]: FORALL requires at least one index"
+                forall_index = 0
+                return
+            end if
+            if (size(start_indices_all) /= num_indices .or. &
+                size(end_indices_all) /= num_indices) then
+                write(error_unit, '(A)') "ERROR [ast_factory_control]: FORALL index arrays must be the same size"
+                forall_index = 0
+                return
+            end if
+            if (present(stride_indices_all)) then
+                if (size(stride_indices_all) /= num_indices) then
+                    write(error_unit, '(A)') &
+                        "ERROR [ast_factory_control]: FORALL stride array must match index count"
+                    forall_index = 0
+                    return
+                end if
+            end if
+        else
+            num_indices = 1
         end if
 
-        ! Validate required indices
-        validation = validate_node_index(arena, start_index, "push_forall start")
-        if (validation%is_failure()) then
-            write(error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
-            forall_index = 0
-            return
-        end if
+        allocate(lower_vals(num_indices))
+        allocate(upper_vals(num_indices))
+        allocate(stride_vals(num_indices))
 
-        validation = validate_node_index(arena, end_index, "push_forall end")
-        if (validation%is_failure()) then
-            write(error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
-            forall_index = 0
-            return
-        end if
+        max_index_len = 0
+        do i = 1, num_indices
+            if (use_multi) then
+                index_var_len = len_trim(index_vars_all(i))
+                lower_vals(i) = start_indices_all(i)
+                upper_vals(i) = end_indices_all(i)
+                if (present(stride_indices_all)) then
+                    stride_val = stride_indices_all(i)
+                else
+                    stride_val = 0
+                end if
+            else
+                index_var_len = len_trim(index_var)
+                lower_vals(i) = start_index
+                upper_vals(i) = end_index
+                if (present(step_index)) then
+                    stride_val = step_index
+                else
+                    stride_val = 0
+                end if
+            end if
 
-        ! Validate optional step index
-        if (present(step_index)) then
-            if (step_index > 0) then
-                validation = validate_node_index(arena, step_index, "push_forall step")
+            if (index_var_len == 0) then
+                write(error_unit, '(A)') &
+                    "ERROR [ast_factory_control]: FORALL index variable name cannot be empty"
+                forall_index = 0
+                return
+            end if
+            if (index_var_len > MAX_INDEX_NAME_LENGTH) then
+                write(error_unit, '(A)') &
+                    "ERROR [ast_factory_control]: FORALL index variable name exceeds maximum length"
+                forall_index = 0
+                return
+            end if
+
+            max_index_len = max(max_index_len, index_var_len)
+
+            validation = validate_node_index(arena, lower_vals(i), "push_forall start")
+            if (validation%is_failure()) then
+                write(error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
+                forall_index = 0
+                return
+            end if
+
+            validation = validate_node_index(arena, upper_vals(i), "push_forall end")
+            if (validation%is_failure()) then
+                write(error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
+                forall_index = 0
+                return
+            end if
+
+            if (stride_val > 0) then
+                validation = validate_node_index(arena, stride_val, "push_forall step")
                 if (validation%is_failure()) then
                     write(error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
                     forall_index = 0
                     return
                 end if
+                stride_vals(i) = stride_val
+            else
+                stride_vals(i) = 0
             end if
-        end if
+        end do
+
+        if (max_index_len <= 0) max_index_len = 1
 
         ! Validate optional mask index
         if (present(mask_index)) then
@@ -280,29 +346,22 @@ contains
             end do
         end if
 
-        ! For simple single-index FORALL, use first element of arrays
-        forall_stmt%num_indices = 1
-        allocate(character(len=len(index_var)) :: forall_stmt%index_names(1))
-        forall_stmt%index_names(1) = index_var
+        forall_stmt%num_indices = num_indices
+        allocate(character(len=max_index_len) :: forall_stmt%index_names(num_indices))
+        allocate(forall_stmt%lower_bound_indices(num_indices))
+        allocate(forall_stmt%upper_bound_indices(num_indices))
+        allocate(forall_stmt%stride_indices(num_indices))
 
-        ! Set start and end expression indices
-        allocate(forall_stmt%lower_bound_indices(1))
-        allocate(forall_stmt%upper_bound_indices(1))
-        allocate(forall_stmt%stride_indices(1))
-        
-        forall_stmt%lower_bound_indices(1) = start_index
-        forall_stmt%upper_bound_indices(1) = end_index
-
-        ! Set optional step expression index
-        if (present(step_index)) then
-            if (step_index > 0) then
-                forall_stmt%stride_indices(1) = step_index
+        do i = 1, num_indices
+            if (use_multi) then
+                forall_stmt%index_names(i) = trim(index_vars_all(i))
             else
-                forall_stmt%stride_indices(1) = 0
+                forall_stmt%index_names(i) = trim(index_var)
             end if
-        else
-            forall_stmt%stride_indices(1) = 0
-        end if
+            forall_stmt%lower_bound_indices(i) = lower_vals(i)
+            forall_stmt%upper_bound_indices(i) = upper_vals(i)
+            forall_stmt%stride_indices(i) = stride_vals(i)
+        end do
 
         ! Set optional mask expression index
         if (present(mask_index)) then
@@ -326,7 +385,11 @@ contains
         if (present(line)) forall_stmt%line = line
         if (present(column)) forall_stmt%column = column
 
-        call arena%push(forall_stmt, "forall", parent_index)
+        if (present(parent_index)) then
+            call arena%push(forall_stmt, "forall", parent_index)
+        else
+            call arena%push(forall_stmt, "forall")
+        end if
         forall_index = arena%size
     end function push_forall
 

--- a/src/parser/parser_forall.f90
+++ b/src/parser/parser_forall.f90
@@ -102,7 +102,10 @@ contains
         integer, allocatable :: body_indices(:)
         integer, allocatable :: stmt_indices(:)
         type(token_t), allocatable, target :: stmt_tokens(:)
+        character(len=:), allocatable :: index_names(:)
+        integer, allocatable :: lower_bounds(:), upper_bounds(:), stride_bounds(:)
         integer :: triplet_count
+        integer :: max_name_len
         integer :: line, column
         integer :: stmt_start, stmt_end, token_count, k
         logical :: is_inline
@@ -362,8 +365,6 @@ contains
         
         ! Create FORALL node
         if (triplet_count > 0) then
-            ! For now, only handle single-index FORALL using existing push_forall
-            ! Multi-index support requires extending push_forall
             if (triplet_count == 1) then
                 forall_index = push_forall(arena, triplets(1)%index_name, &
                                           triplets(1)%lower_expr_index, &
@@ -371,15 +372,56 @@ contains
                                           triplets(1)%stride_expr_index, &
                                           mask_index, body_indices, line, column)
             else
-                ! For multi-index, emit error since body will be dropped
-                write(error_unit, '(A)') "ERROR: Multi-index FORALL not yet supported - body will be lost"
-                forall_index = 0
+                max_name_len = 0
+                do k = 1, triplet_count
+                    max_name_len = max(max_name_len, len_trim(triplets(k)%index_name))
+                end do
+                if (max_name_len <= 0) max_name_len = 1
+
+                allocate(character(len=max_name_len) :: index_names(triplet_count))
+                allocate(lower_bounds(triplet_count))
+                allocate(upper_bounds(triplet_count))
+                allocate(stride_bounds(triplet_count))
+
+                do k = 1, triplet_count
+                    index_names(k) = triplets(k)%index_name
+                    lower_bounds(k) = triplets(k)%lower_expr_index
+                    upper_bounds(k) = triplets(k)%upper_expr_index
+                    stride_bounds(k) = triplets(k)%stride_expr_index
+                end do
+
+                if (allocated(body_indices)) then
+                    forall_index = push_forall(arena, triplets(1)%index_name, &
+                                              triplets(1)%lower_expr_index, &
+                                              triplets(1)%upper_expr_index, &
+                                              triplets(1)%stride_expr_index, &
+                                              mask_index=mask_index, &
+                                              body_indices=body_indices, line=line, column=column, &
+                                              index_vars_all=index_names, &
+                                              start_indices_all=lower_bounds, &
+                                              end_indices_all=upper_bounds, &
+                                              stride_indices_all=stride_bounds)
+                else
+                    forall_index = push_forall(arena, triplets(1)%index_name, &
+                                              triplets(1)%lower_expr_index, &
+                                              triplets(1)%upper_expr_index, &
+                                              triplets(1)%stride_expr_index, &
+                                              mask_index=mask_index, line=line, column=column, &
+                                              index_vars_all=index_names, &
+                                              start_indices_all=lower_bounds, &
+                                              end_indices_all=upper_bounds, &
+                                              stride_indices_all=stride_bounds)
+                end if
             end if
         end if
-        
+
         deallocate(triplets)
         if (allocated(body_indices)) deallocate(body_indices)
-        
+        if (allocated(index_names)) deallocate(index_names)
+        if (allocated(lower_bounds)) deallocate(lower_bounds)
+        if (allocated(upper_bounds)) deallocate(upper_bounds)
+        if (allocated(stride_bounds)) deallocate(stride_bounds)
+
     end function parse_forall
     
 end module parser_forall_module

--- a/test/ast/test_where_forall_validation.f90
+++ b/test/ast/test_where_forall_validation.f90
@@ -14,6 +14,7 @@ contains
         call test_arena_initialization_validation()
         call test_node_allocation_validation()
         call test_empty_index_name_validation()
+        call test_multi_index_forall_creation()
         
         print *, ""
         print *, "All WHERE/FORALL validation tests passed!"
@@ -133,6 +134,53 @@ contains
         print *, "  ✓ Empty index name validation implemented"
         print *, "    (Error handling would trigger for empty index names)"
     end subroutine test_empty_index_name_validation
+
+    subroutine test_multi_index_forall_creation()
+        type(ast_arena_t) :: arena
+        integer :: lower_ids(2), upper_ids(2), stride_ids(2)
+        integer :: body_idx, forall_idx
+        character(len=1) :: index_names(2)
+
+        print *, "Testing multi-index FORALL creation..."
+
+        arena = create_ast_arena()
+
+        lower_ids(1) = push_literal(arena, "1", 1)
+        lower_ids(2) = push_literal(arena, "1", 1)
+        upper_ids(1) = push_identifier(arena, "n")
+        upper_ids(2) = push_identifier(arena, "m")
+        stride_ids = [0, 0]
+        body_idx = push_identifier(arena, "stmt")
+        index_names = ['i', 'j']
+
+        forall_idx = push_forall(arena, 'i', lower_ids(1), upper_ids(1), 0, 0, [body_idx], &
+                                 index_vars_all=index_names, &
+                                 start_indices_all=lower_ids, &
+                                 end_indices_all=upper_ids, &
+                                 stride_indices_all=stride_ids)
+
+        if (forall_idx <= 0) then
+            print *, "Failed to create multi-index FORALL"
+            stop 1
+        end if
+
+        select type(node => arena%entries(forall_idx)%node)
+        type is (forall_node)
+            if (node%num_indices /= 2) then
+                print *, "Multi-index FORALL did not record both indices"
+                stop 1
+            end if
+            if (trim(node%index_names(1)) /= 'i' .or. trim(node%index_names(2)) /= 'j') then
+                print *, "FORALL index names not preserved for multi-index case"
+                stop 1
+            end if
+        class default
+            print *, "Wrong node type when verifying multi-index FORALL"
+            stop 1
+        end select
+
+        print *, "  ✓ Multi-index FORALL creation successful"
+    end subroutine test_multi_index_forall_creation
 
 end module test_where_forall_validation
 

--- a/test/codegen/test_where_forall_codegen.f90
+++ b/test/codegen/test_where_forall_codegen.f90
@@ -12,6 +12,7 @@ program test_where_forall_codegen
 
     if (.not. test_where_codegen()) all_passed = .false.
     if (.not. test_forall_codegen()) all_passed = .false.
+    if (.not. test_forall_multi_codegen()) all_passed = .false.
 
     if (all_passed) then
         print *, 'All WHERE/FORALL codegen tests passed!'
@@ -145,5 +146,62 @@ contains
             test_forall_codegen = .false.
         end if
     end function test_forall_codegen
+
+    logical function test_forall_multi_codegen()
+        type(ast_arena_t) :: arena
+        integer :: one_id, n_id, m_id
+        integer :: value_id, assign_idx, forall_idx, prog_idx
+        character(len=:), allocatable :: code
+        character(len=1) :: index_list(2)
+        integer :: lower_ids(2), upper_ids(2), stride_ids(2)
+
+        test_forall_multi_codegen = .true.
+        print *, 'Testing multi-index FORALL code generation...'
+
+        arena = create_ast_arena()
+
+        one_id = push_literal(arena, '1', LITERAL_INTEGER)
+        n_id = push_identifier(arena, 'n')
+        m_id = push_identifier(arena, 'm')
+
+        value_id = push_identifier(arena, 'value')
+        assign_idx = push_assignment(arena, value_id, one_id)
+
+        index_list = ['i', 'j']
+        lower_ids = [one_id, one_id]
+        upper_ids = [n_id, m_id]
+        stride_ids = [0, 0]
+
+        forall_idx = push_forall(arena, 'i', one_id, n_id, 0, 0, [assign_idx], &
+                                 index_vars_all=index_list, &
+                                 start_indices_all=lower_ids, &
+                                 end_indices_all=upper_ids, &
+                                 stride_indices_all=stride_ids)
+
+        prog_idx = push_program(arena, 'main', [forall_idx])
+
+        call emit_fortran(arena, prog_idx, code)
+
+        if (.not. allocated(code)) then
+            print *, '  FAIL: No code generated for multi-index FORALL'
+            test_forall_multi_codegen = .false.
+            return
+        end if
+
+        if (index(code, 'forall (i = 1:n, j = 1:m)') == 0) then
+            print *, '  FAIL: Multi-index FORALL header missing'
+            test_forall_multi_codegen = .false.
+        end if
+
+        if (index(code, 'value = 1') == 0) then
+            print *, '  FAIL: Multi-index FORALL body assignment missing'
+            test_forall_multi_codegen = .false.
+        end if
+
+        if (index(code, 'end forall') == 0) then
+            print *, '  FAIL: Missing END FORALL for multi-index construct'
+            test_forall_multi_codegen = .false.
+        end if
+    end function test_forall_multi_codegen
 
 end program test_where_forall_codegen


### PR DESCRIPTION
### **User description**
## Summary
- extend `push_forall` to accept multiple index specifications and update the parser to populate them
- remove the Issue #1337 FORALL example from expected failures and add regression coverage in validation/codegen tests
- tidy long diagnostics in CLI/tests to satisfy gfortran line-length checks

## Testing
- `fpm test --target test_where_forall_codegen`
- `fpm test --target test_where_forall_validation`
- `fpm test --target test_all_examples`


------
https://chatgpt.com/codex/tasks/task_e_68e96496337483249ea3bda0f827d510


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix multi-index FORALL parser support and AST factory

- Add regression tests for multi-index FORALL validation/codegen

- Remove resolved issue from expected failures list

- Format long diagnostic lines for gfortran compliance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parser"] --> B["Multi-index FORALL"]
  B --> C["AST Factory"]
  C --> D["Code Generation"]
  D --> E["Tests"]
  F["Expected Failures"] --> G["Remove Issue #1337"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortfront.f90</strong><dd><code>Format long diagnostic messages for gfortran</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/fortfront.f90

<ul><li>Split long diagnostic error messages across multiple lines<br> <li> Ensure gfortran line-length compliance for memory deallocation errors</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1358/files#diff-832f17e145dd906bbff1704d5dd7789bbb567e16c93b41913a1901f6494778a0">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_select_case_codegen.f90</strong><dd><code>Format long test assertion message</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/codegen/test_select_case_codegen.f90

<ul><li>Split long assertion message across multiple lines<br> <li> Maintain gfortran line-length compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1358/files#diff-d89468ac0cbd77d605a01ce0988e85902ca5ca524b9919767ed9864f3afeb11c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_issue_508_module_comment_multi.f90</strong><dd><code>Format long conditional expression</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/module/test_issue_508_module_comment_multi.f90

<ul><li>Split long conditional expression across multiple lines<br> <li> Ensure gfortran line-length compliance</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1358/files#diff-319567eaa5968706212ae83ba7cb44a2d5cac4bf9b7dbf4bc040a0b6d92a46ae">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ast_factory_control.f90</strong><dd><code>Extend push_forall for multi-index support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/factory/ast_factory_control.f90

<ul><li>Extend <code>push_forall</code> function to accept multiple index specifications<br> <li> Add optional parameters for multi-index arrays (names, bounds, <br>strides)<br> <li> Implement validation and allocation logic for multiple indices<br> <li> Maintain backward compatibility with single-index FORALL</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1358/files#diff-9520651522b998474ec02a2922f277dc7713df8468abfa9ec298fe33fa524ddf">+116/-53</a></td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser_forall.f90</strong><dd><code>Enable multi-index FORALL parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_forall.f90

<ul><li>Remove error for multi-index FORALL constructs<br> <li> Populate multi-index arrays and pass to <code>push_forall</code><br> <li> Add proper memory management for allocated arrays<br> <li> Handle both single and multi-index cases</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1358/files#diff-ef6e0fd82a28881281e8664cd6cadae552b58e386cb9442f98d99200a0ac9997">+49/-7</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>expected_failures.txt</strong><dd><code>Remove resolved FORALL issue from failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/expected_failures.txt

<ul><li>Remove <code>issue_1337_forall.f90</code> from expected failures<br> <li> Issue #1337 resolved with multi-index FORALL support</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1358/files#diff-f5e7f1a27130e10c3fa158ab22b6d673c4cb6e666a708bb1b9f0b312b4abc497">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_where_forall_validation.f90</strong><dd><code>Add multi-index FORALL validation tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/ast/test_where_forall_validation.f90

<ul><li>Add <code>test_multi_index_forall_creation</code> test function<br> <li> Validate multi-index FORALL node creation and structure<br> <li> Verify index names preservation in multi-index case</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1358/files#diff-8407864c477c239486830b848d68d3ab87a113162d4974ff9b29d9def1b81e49">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_where_forall_codegen.f90</strong><dd><code>Add multi-index FORALL codegen tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/codegen/test_where_forall_codegen.f90

<ul><li>Add <code>test_forall_multi_codegen</code> function for multi-index testing<br> <li> Verify multi-index FORALL code generation output<br> <li> Test proper header format and body assignment generation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1358/files#diff-468e730309d413c5cf94438aa37e8fa3f590c04f895500c10d836b54a4c71e88">+58/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

