### PR TITLE
Fix character length handling in declarations

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -28,5 +28,4 @@ issue_1353_derived_type.f90     # Issue #1353: Derived type definitions mangled
 
 # Silent bugs (compile successfully but produce wrong code - cannot be detected by test)
 # These are commented out to avoid XPASS, but documented here for reference:
-# issue_1344_character_length.f90 # Issue #1344: Character lengths wrong (silent data corruption)
 # issue_1349_select_case.f90      # Issue #1349: CASE bodies outside SELECT (wrong logic)

--- a/src/codegen/codegen_declarations.f90
+++ b/src/codegen/codegen_declarations.f90
@@ -17,6 +17,7 @@ module codegen_declarations
         generate_grouped_body_context, find_parameter_info
     use codegen_arena_interface, only: generate_code_from_arena
     use codegen_type_utils, only: get_type_standardization
+    use lexer_core, only: to_lower
     implicit none
     private
 
@@ -289,15 +290,28 @@ contains
         integer, intent(in) :: node_index
         character(len=:), allocatable :: code
         character(len=:), allocatable :: init_code, type_str
-        integer :: i, j
+        character(len=:), allocatable :: base_type, trimmed_type, paren_content
+        integer :: i, j, special_pos, read_len, io_stat
         logical :: standardize_types_enabled
 
         ! Get type standardization setting
         call get_type_standardization(standardize_types_enabled)
 
         ! Determine the type string
+        trimmed_type = trim(adjustl(node%type_name))
+        base_type = trimmed_type
+        special_pos = index(base_type, '(')
+        if (special_pos > 0) base_type = base_type(1:special_pos-1)
+        special_pos = index(base_type, '*')
+        if (special_pos > 0) base_type = base_type(1:special_pos-1)
+        base_type = to_lower(trim(base_type))
+
         if (len_trim(node%type_name) > 0) then
-            type_str = node%type_name
+            if (base_type == "character") then
+                type_str = "character"
+            else
+                type_str = node%type_name
+            end if
         else if (node%inferred_type%kind > 0) then
             ! Handle type inference
             select case (node%inferred_type%kind)
@@ -344,11 +358,38 @@ contains
         code = type_str
 
         ! Add kind if present and valid (>0) (but not for character which uses len)
-        if (node%has_kind .and. node%kind_value > 0 .and. node%type_name /= "character") then
+        if (node%has_kind .and. node%kind_value > 0 .and. base_type /= "character") then
             code = code // "(" // trim(adjustl(int_to_string(node%kind_value))) // ")"
-        else if (node%type_name == "character" .and. node%has_kind .and. node%kind_value > 0) then
-            ! For character, kind_value is actually the length
-            code = "character(len=" // trim(adjustl(int_to_string(node%kind_value))) // ")"
+        else if (base_type == "character") then
+            if (node%has_kind) then
+                if (node%kind_value == -1) then
+                    code = "character(len=*)"
+                else if (node%kind_value > 0) then
+                    code = "character(len=" // trim(adjustl(int_to_string(node%kind_value))) // ")"
+                end if
+            else
+                special_pos = index(trimmed_type, '(')
+                if (special_pos > 0) then
+                    read_len = 0
+                    io_stat = 0
+                    if (index(trimmed_type, ')') > special_pos) then
+                        paren_content = trim(trimmed_type(special_pos+1:index(trimmed_type, ')')-1))
+                        if (len(paren_content) > 0) then
+                            if (index(to_lower(paren_content), "len=") == 1) then
+                                paren_content = trim(paren_content(5:))
+                            end if
+                            if (paren_content == "*") then
+                                code = "character(len=*)"
+                            else
+                                read(paren_content, *, iostat=io_stat) read_len
+                                if (io_stat == 0 .and. read_len > 0) then
+                                    code = "character(len=" // trim(adjustl(int_to_string(read_len))) // ")"
+                                end if
+                            end if
+                        end if
+                    end if
+                end if
+            end if
         end if
 
         ! Add intent if present

--- a/src/parser/parser_declarations.f90
+++ b/src/parser/parser_declarations.f90
@@ -63,14 +63,89 @@ contains
             end if
         end if
 
-        ! Check for kind specification
+        ! Handle old-style character*len notation
+        if (trim(type_spec%type_name) == "character" .and. .not. parser%is_at_end()) then
+            token = parser%peek()
+            if (token%text == "*") then
+                token = parser%consume()
+                if (.not. parser%is_at_end()) then
+                    token = parser%peek()
+                    if (token%text == "*") then
+                        type_spec%has_kind = .true.
+                        type_spec%kind_value = -1
+                        token = parser%consume()
+                    else if (token%kind == TK_NUMBER) then
+                        read(token%text, *) type_spec%kind_value
+                        type_spec%has_kind = .true.
+                        token = parser%consume()
+                    end if
+                end if
+            end if
+        end if
+
+        ! Check for parenthesized specification (len/kind)
         if (.not. parser%is_at_end()) then
             token = parser%peek()
             if (token%text == "(") then
-                ! Skip kind specifications for simplicity
+                token = parser%consume()
                 do while (.not. parser%is_at_end())
-                    token = parser%consume()
-                    if (token%text == ")") exit
+                    token = parser%peek()
+
+                    if (token%text == ")") then
+                        token = parser%consume()
+                        exit
+                    end if
+
+                    if (trim(type_spec%type_name) == "character") then
+                        if (trim(token%text) == "len") then
+                            token = parser%consume()
+                            if (.not. parser%is_at_end()) then
+                                token = parser%peek()
+                                if (token%text == "=") then
+                                    token = parser%consume()
+                                    token = parser%peek()
+                                end if
+                                if (token%text == "*") then
+                                    type_spec%has_kind = .true.
+                                    type_spec%kind_value = -1
+                                    token = parser%consume()
+                                else if (token%kind == TK_NUMBER) then
+                                    read(token%text, *) type_spec%kind_value
+                                    type_spec%has_kind = .true.
+                                    token = parser%consume()
+                                end if
+                            end if
+                        else if (trim(token%text) == "kind") then
+                            ! Skip explicit character kind for now
+                            token = parser%consume()
+                            if (.not. parser%is_at_end()) then
+                                token = parser%peek()
+                                if (token%text == "=") then
+                                    token = parser%consume()
+                                end if
+                                if (.not. parser%is_at_end()) token = parser%consume()
+                            end if
+                        else if (token%kind == TK_NUMBER) then
+                            read(token%text, *) type_spec%kind_value
+                            type_spec%has_kind = .true.
+                            token = parser%consume()
+                        else if (token%text == "*") then
+                            type_spec%has_kind = .true.
+                            type_spec%kind_value = -1
+                            token = parser%consume()
+                        else
+                            token = parser%consume()
+                        end if
+                    else
+                        ! Non-character types: skip content
+                        token = parser%consume()
+                    end if
+
+                    if (parser%is_at_end()) exit
+                    token = parser%peek()
+                    if (token%text == ",") then
+                        token = parser%consume()
+                    end if
                 end do
             end if
         end if
@@ -360,46 +435,96 @@ contains
 
             ! Create declaration node
             if (attr_info%has_global_dimensions) then
-                decl_index = push_declaration( &
-                    arena, &
-                    type_spec%type_name, &
-                    var_name, &
-                    dimension_indices=attr_info%global_dimension_indices, &
-                    initializer_index=initializer_index, &
-                    is_allocatable=attr_info%is_allocatable, &
-                    is_pointer=attr_info%is_pointer, &
-                    is_target=attr_info%is_target, &
-                    intent_value=attr_info%intent, &
-                    is_optional=attr_info%is_optional, &
-                    is_parameter=attr_info%is_parameter &
-                )
+                if (type_spec%has_kind) then
+                    decl_index = push_declaration( &
+                        arena, &
+                        type_spec%type_name, &
+                        var_name, &
+                        kind_value=type_spec%kind_value, &
+                        dimension_indices=attr_info%global_dimension_indices, &
+                        initializer_index=initializer_index, &
+                        is_allocatable=attr_info%is_allocatable, &
+                        is_pointer=attr_info%is_pointer, &
+                        is_target=attr_info%is_target, &
+                        intent_value=attr_info%intent, &
+                        is_optional=attr_info%is_optional, &
+                        is_parameter=attr_info%is_parameter &
+                    )
+                else
+                    decl_index = push_declaration( &
+                        arena, &
+                        type_spec%type_name, &
+                        var_name, &
+                        dimension_indices=attr_info%global_dimension_indices, &
+                        initializer_index=initializer_index, &
+                        is_allocatable=attr_info%is_allocatable, &
+                        is_pointer=attr_info%is_pointer, &
+                        is_target=attr_info%is_target, &
+                        intent_value=attr_info%intent, &
+                        is_optional=attr_info%is_optional, &
+                        is_parameter=attr_info%is_parameter &
+                    )
+                end if
             else if (has_local_dimensions) then
-                decl_index = push_declaration( &
-                    arena, &
-                    type_spec%type_name, &
-                    var_name, &
-                    dimension_indices=local_dimension_indices, &
-                    initializer_index=initializer_index, &
-                    is_allocatable=attr_info%is_allocatable, &
-                    is_pointer=attr_info%is_pointer, &
-                    is_target=attr_info%is_target, &
-                    intent_value=attr_info%intent, &
-                    is_optional=attr_info%is_optional, &
-                    is_parameter=attr_info%is_parameter &
-                )
+                if (type_spec%has_kind) then
+                    decl_index = push_declaration( &
+                        arena, &
+                        type_spec%type_name, &
+                        var_name, &
+                        kind_value=type_spec%kind_value, &
+                        dimension_indices=local_dimension_indices, &
+                        initializer_index=initializer_index, &
+                        is_allocatable=attr_info%is_allocatable, &
+                        is_pointer=attr_info%is_pointer, &
+                        is_target=attr_info%is_target, &
+                        intent_value=attr_info%intent, &
+                        is_optional=attr_info%is_optional, &
+                        is_parameter=attr_info%is_parameter &
+                    )
+                else
+                    decl_index = push_declaration( &
+                        arena, &
+                        type_spec%type_name, &
+                        var_name, &
+                        dimension_indices=local_dimension_indices, &
+                        initializer_index=initializer_index, &
+                        is_allocatable=attr_info%is_allocatable, &
+                        is_pointer=attr_info%is_pointer, &
+                        is_target=attr_info%is_target, &
+                        intent_value=attr_info%intent, &
+                        is_optional=attr_info%is_optional, &
+                        is_parameter=attr_info%is_parameter &
+                    )
+                end if
             else
-                decl_index = push_declaration( &
-                arena, &
-                type_spec%type_name, &
-                var_name, &
-                initializer_index=initializer_index, &
-                is_allocatable=attr_info%is_allocatable, &
-                is_pointer=attr_info%is_pointer, &
-                is_target=attr_info%is_target, &
-                intent_value=attr_info%intent, &
-                is_optional=attr_info%is_optional, &
-                is_parameter=attr_info%is_parameter &
-            )
+                if (type_spec%has_kind) then
+                    decl_index = push_declaration( &
+                        arena, &
+                        type_spec%type_name, &
+                        var_name, &
+                        kind_value=type_spec%kind_value, &
+                        initializer_index=initializer_index, &
+                        is_allocatable=attr_info%is_allocatable, &
+                        is_pointer=attr_info%is_pointer, &
+                        is_target=attr_info%is_target, &
+                        intent_value=attr_info%intent, &
+                        is_optional=attr_info%is_optional, &
+                        is_parameter=attr_info%is_parameter &
+                    )
+                else
+                    decl_index = push_declaration( &
+                        arena, &
+                        type_spec%type_name, &
+                        var_name, &
+                        initializer_index=initializer_index, &
+                        is_allocatable=attr_info%is_allocatable, &
+                        is_pointer=attr_info%is_pointer, &
+                        is_target=attr_info%is_target, &
+                        intent_value=attr_info%intent, &
+                        is_optional=attr_info%is_optional, &
+                        is_parameter=attr_info%is_parameter &
+                    )
+                end if
             end if
         end block
     end function parse_declaration

--- a/src/parser/parser_type_specifications.f90
+++ b/src/parser/parser_type_specifications.f90
@@ -113,7 +113,11 @@ contains
                 token = parser%peek()
             end if
         end if
-        if (token%kind == TK_NUMBER) then
+        if (token%text == "*") then
+            length_value = -1
+            has_length = .true.
+            token = parser%consume()
+        else if (token%kind == TK_NUMBER) then
             read(token%text, *) length_value
             has_length = .true.
             token = parser%consume()

--- a/src/semantic/semantic_inference_helpers.f90
+++ b/src/semantic/semantic_inference_helpers.f90
@@ -137,10 +137,17 @@ contains
         
         ! Create mono type
         var_type = create_mono_type(var_type_kind)
-        
+
         ! Handle kind parameter if present
         if (decl%has_kind) then
             var_type%kind = var_type_kind
+            if (var_type_kind == TCHAR) then
+                if (decl%kind_value > 0) then
+                    var_type%size = decl%kind_value
+                else if (decl%kind_value == -1) then
+                    var_type%size = -1
+                end if
+            end if
         end if
     end subroutine process_declaration_variables
 


### PR DESCRIPTION
### **User description**
## Summary
- preserve character length information throughout parsing, semantic inference, and code generation so Lazy Fortran character declarations emit the correct `len=` (including `len=*` and old-style `character*` forms)
- split long CLI diagnostic writes to avoid line truncation warnings and clean up a pair of tests that relied on overlong lines
- drop the `issue_1344_character_length.f90` example from the expected-failures list now that it passes

## Testing
- `CI=1 fpm test`


------
https://chatgpt.com/codex/tasks/task_e_68e964b4a8648324adf7575b0bf34e63


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix character length handling in declarations and code generation

- Preserve character length information (`len=*`, `len=N`) throughout parsing

- Split long CLI diagnostic writes to avoid line truncation

- Remove fixed issue from expected failures list


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parser"] --> B["Type Specifier"]
  B --> C["Character Length Detection"]
  C --> D["AST Declaration Node"]
  D --> E["Semantic Inference"]
  E --> F["Code Generation"]
  F --> G["Correct len= Output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>fortfront.f90</strong><dd><code>Split long CLI diagnostic messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/fortfront.f90

<ul><li>Split long error message writes across multiple lines<br> <li> Avoid line truncation warnings in CLI diagnostics</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1365/files#diff-832f17e145dd906bbff1704d5dd7789bbb567e16c93b41913a1901f6494778a0">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_select_case_codegen.f90</strong><dd><code>Fix long line in test assertion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/codegen/test_select_case_codegen.f90

- Split long assertion line to avoid truncation warning


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1365/files#diff-d89468ac0cbd77d605a01ce0988e85902ca5ca524b9919767ed9864f3afeb11c">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_issue_508_module_comment_multi.f90</strong><dd><code>Fix long line in test condition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/module/test_issue_508_module_comment_multi.f90

- Split long conditional expression across multiple lines


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1365/files#diff-319567eaa5968706212ae83ba7cb44a2d5cac4bf9b7dbf4bc040a0b6d92a46ae">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen_declarations.f90</strong><dd><code>Implement character length code generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_declarations.f90

<ul><li>Add character length handling in code generation<br> <li> Support <code>len=*</code> and <code>len=N</code> formats for character declarations<br> <li> Parse parenthesized content to extract length specifications<br> <li> Import <code>to_lower</code> utility for case-insensitive type checking</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1365/files#diff-2f2aaf5d275f4e51553e5ce93f4fab08d9e6dd89a92a8566ff57eb6aab61fa0e">+47/-6</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_declarations.f90</strong><dd><code>Parse character length specifications</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_declarations.f90

<ul><li>Add support for old-style <code>character*N</code> and <code>character*</code> syntax<br> <li> Parse parenthesized <code>len=</code> specifications for character types<br> <li> Pass kind/length values to declaration node creation<br> <li> Handle both explicit and implicit character length formats</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1365/files#diff-ebbd95623c5af37d8eae5f4f3ecd04bf32a8e1999d49a458a79fc7552409869b">+167/-42</a></td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_type_specifications.f90</strong><dd><code>Support assumed length character parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_type_specifications.f90

<ul><li>Add support for <code>len=*</code> (assumed length) character specification<br> <li> Handle asterisk token as special length value (-1)</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1365/files#diff-eecad2d20d08d65d8cbd04f75ac1f1baa2588d4fcb7d608ac5c03350248992e0">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>semantic_inference_helpers.f90</strong><dd><code>Preserve character lengths in type inference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/semantic_inference_helpers.f90

<ul><li>Preserve character length information in type inference<br> <li> Set size field for character types with explicit lengths<br> <li> Handle assumed length (<code>*</code>) as special size value (-1)</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1365/files#diff-be6457e4b29e7c2295eb1a3522bfd3b38c560128bc8eec5635871b93bd3fc761">+8/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected_failures.txt</strong><dd><code>Remove fixed character length issue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/expected_failures.txt

<ul><li>Remove <code>issue_1344_character_length.f90</code> from expected failures<br> <li> Issue is now fixed and test passes</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1365/files#diff-f5e7f1a27130e10c3fa158ab22b6d673c4cb6e666a708bb1b9f0b312b4abc497">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

