### PR TITLE
fix(parser): preserve optional parameter control flow

### DIFF
--- a/src/codegen/codegen_utilities.f90
+++ b/src/codegen/codegen_utilities.f90
@@ -443,7 +443,10 @@ contains
                                     if (found_params) then
                                         ! Generate declaration for all parameters in this multi-declaration
                                         type_name = trim(node%type_name)
-                                        append_kind = node%has_kind
+                                        if (is_character_type_string(type_name)) then
+                                            type_name = normalize_character_type(node, type_name)
+                                        end if
+                                        append_kind = node%has_kind .and. .not. is_character_type_string(type_name)
                                         code = code // indent_str // type_name
 
                                         if (append_kind) then
@@ -490,7 +493,8 @@ contains
                                             do j = 1, size(node%var_names)
                                                 if (.not. is_param(j)) then
                                                     if (have_nonparam) then
-                                                        nonparam_list = nonparam_list // ", " // trim(node%var_names(j))
+                                                        nonparam_list = nonparam_list // ", " // &
+                                                                        trim(node%var_names(j))
                                                     else
                                                         nonparam_list = trim(node%var_names(j))
                                                     end if
@@ -500,7 +504,10 @@ contains
 
                                             if (have_nonparam) then
                                                 local_type = trim(node%type_name)
-                                                local_append_kind = node%has_kind
+                                                if (is_character_type_string(local_type)) then
+                                                    local_type = normalize_character_type(node, local_type)
+                                                end if
+                                                local_append_kind = node%has_kind .and. .not. is_character_type_string(local_type)
                                                 if (local_type == 'real' .and. .not. local_append_kind) then
                                                     local_type = 'real(8)'
                                                 end if
@@ -522,7 +529,10 @@ contains
                                 if (param_idx > 0) then
                                     ! Generate the declaration with parameter attributes from the declaration node
                                     type_name = trim(node%type_name)
-                                    append_kind_single = node%has_kind
+                                    if (is_character_type_string(type_name)) then
+                                        type_name = normalize_character_type(node, type_name)
+                                    end if
+                                    append_kind_single = node%has_kind .and. .not. is_character_type_string(type_name)
                                     code = code // indent_str // type_name
 
                                     if (append_kind_single) then
@@ -565,7 +575,11 @@ contains
                             if (param_idx > 0) then
                                 ! Generate the declaration with attributes from parameter_declaration_node
                                 type_name = trim(node%type_name)
-                                append_kind_param = node%has_kind
+                                if (is_character_type_string(type_name)) then
+                                    type_name = normalize_character_type_param(type_name, node%has_kind, &
+                                                                              node%kind_value)
+                                end if
+                                append_kind_param = node%has_kind .and. .not. is_character_type_string(type_name)
                                 ! Debug: print if type_name is empty
                                 if (len_trim(type_name) == 0) then
                                     ! Skip if no type name - will be handled elsewhere
@@ -1113,6 +1127,16 @@ contains
             end if
         end if
 
+        if (has_length) then
+            lowered_len = to_lower_ascii(trim(length_spec))
+            select case (trim(lowered_len))
+            case ("-1")
+                length_spec = "*"
+            case ("len=-1")
+                length_spec = "len=*"
+            end select
+        end if
+
         if (.not. has_length) then
             type_str = "character"
         else
@@ -1180,6 +1204,16 @@ contains
             if (len_trim(length_spec) == 0) then
                 has_length = .false.
             end if
+        end if
+
+        if (has_length) then
+            lowered_len = to_lower_ascii(trim(length_spec))
+            select case (trim(lowered_len))
+            case ("-1")
+                length_spec = "*"
+            case ("len=-1")
+                length_spec = "len=*"
+            end select
         end if
 
         if (.not. has_length) then

--- a/src/parser/parser_procedure_definitions.f90
+++ b/src/parser/parser_procedure_definitions.f90
@@ -11,7 +11,7 @@ module parser_procedure_definitions_module
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_function_def, push_subroutine_def, push_interface_block, &
-                           push_module_procedure
+                           push_module_procedure, push_if
     use ast_factory
     use ast_base, only: string_t
     implicit none
@@ -292,16 +292,48 @@ contains
                     end if
 
                     ! Parse the statement (handle multi-line IF blocks)
-     if (token%kind == TK_KEYWORD .and. (token%text == "if" .or. token%text == "IF")) then
-                        stmt_index = parse_if_statement_tokens(stmt_tokens, arena)
+                    block
+                        integer :: first_token
+                        character(len=:), allocatable :: token_lower
+
+                        stmt_index = 0
+
+                        first_token = 1
+                        do while (first_token <= stmt_size)
+                            select case (stmt_tokens(first_token)%kind)
+                            case (TK_WHITESPACE, TK_NEWLINE)
+                                first_token = first_token + 1
+                            case default
+                                exit
+                            end select
+                        end do
+
+                        if (first_token <= stmt_size) then
+                            if (stmt_tokens(first_token)%kind == TK_KEYWORD) then
+                                token_lower = to_lower_local( &
+     &                                    stmt_tokens(first_token)%text)
+                                if (trim(token_lower) == "if") then
+                                    stmt_index = parse_if_statement_tokens( &
+     &                                        stmt_tokens, arena)
+                                end if
+                            end if
+                        end if
+
                         if (stmt_index <= 0) then
                             block_parser = create_parser_state(stmt_tokens)
-             stmt_index = parse_statement_in_if_block(block_parser, arena, stmt_tokens(1))
+                            do while (block_parser%current_token < first_token .and. &
+     &                                  .not. block_parser%is_at_end())
+                                token = block_parser%consume()
+                            end do
+                            if (.not. block_parser%is_at_end()) then
+                                stmt_index = parse_statement_in_if_block( &
+     &                                    block_parser, arena, &
+     &                                    stmt_tokens(max(1, first_token)))
+                            else
+                                stmt_index = 0
+                            end if
                         end if
-                    else
-                        block_parser = create_parser_state(stmt_tokens)
-             stmt_index = parse_statement_in_if_block(block_parser, arena, stmt_tokens(1))
-                    end if
+                    end block
 
                     ! Add to body
                     if (stmt_index > 0) then
@@ -346,6 +378,7 @@ contains
         integer :: condition_index
         integer, allocatable :: then_body_indices(:), else_body_indices(:)
         integer :: then_start, then_end, else_start, else_end
+        character(len=:), allocatable :: token_lower
 
         token_count = size(stmt_tokens)
         if (token_count <= 1) then
@@ -360,17 +393,20 @@ contains
 
         do i = 2, token_count
             if (stmt_tokens(i)%kind == TK_KEYWORD) then
-                select case (stmt_tokens(i)%text)
-                case ("then", "THEN")
+                token_lower = to_lower_local(stmt_tokens(i)%text)
+                select case (trim(token_lower))
+                case ("then")
                     if (then_pos < 0) then_pos = i
-                case ("else", "ELSE")
+                case ("else")
                     if (else_pos < 0) else_pos = i
-                case ("end", "END")
+                case ("end")
                     if (i < token_count) then
-                        if (stmt_tokens(i + 1)%kind == TK_KEYWORD .and. &
-              (stmt_tokens(i + 1)%text == "if" .or. stmt_tokens(i + 1)%text == "IF")) then
-                            end_pos = i
-                            exit
+                        if (stmt_tokens(i + 1)%kind == TK_KEYWORD) then
+                            token_lower = to_lower_local(stmt_tokens(i + 1)%text)
+                            if (trim(token_lower) == "if") then
+                                end_pos = i
+                                exit
+                            end if
                         end if
                     end if
                 end select
@@ -409,7 +445,8 @@ contains
         if (else_pos > 0) then
             else_start = else_pos + 1
             else_end = end_pos - 1
-        else_body_indices = parse_if_body_tokens(stmt_tokens, else_start, else_end, arena)
+            else_body_indices = parse_if_body_tokens(stmt_tokens, else_start, &
+     &                                              else_end, arena)
         else
             allocate (else_body_indices(0))
         end if
@@ -419,8 +456,7 @@ contains
                            line=stmt_tokens(1)%line, column=stmt_tokens(1)%column)
     end function parse_if_statement_tokens
 
-    function parse_if_body_tokens(stmt_tokens, start_idx, end_idx, arena) &
-        result(body_indices)
+    function parse_if_body_tokens(stmt_tokens, start_idx, end_idx, arena) result(body_indices)
         type(token_t), intent(in) :: stmt_tokens(:)
         integer, intent(in) :: start_idx, end_idx
         type(ast_arena_t), intent(inout) :: arena
@@ -478,9 +514,21 @@ contains
                 line_tokens(stmt_size + 1)%column = token%column
 
                 line_parser = create_parser_state(line_tokens)
-              stmt_index = parse_statement_in_if_block(line_parser, arena, line_tokens(1))
-                if (stmt_index > 0) then
-                    body_indices = [body_indices, stmt_index]
+                do while (.not. line_parser%is_at_end())
+                    token = line_parser%peek()
+                    if (token%kind == TK_WHITESPACE .or. token%kind == TK_NEWLINE) then
+                        token = line_parser%consume()
+                    else
+                        exit
+                    end if
+                end do
+
+                if (.not. line_parser%is_at_end()) then
+                    stmt_index = parse_statement_in_if_block(line_parser, arena, &
+     &                                                     line_parser%peek())
+                    if (stmt_index > 0) then
+                        body_indices = [body_indices, stmt_index]
+                    end if
                 end if
                 deallocate (line_tokens)
                 body_parser%current_token = stmt_end + 1
@@ -675,9 +723,48 @@ contains
                     stmt_tokens(stmt_size + 1)%line = token%line
                     stmt_tokens(stmt_size + 1)%column = token%column + 1
 
-                    ! Parse the statement
-                    block_parser = create_parser_state(stmt_tokens)
-             stmt_index = parse_statement_in_if_block(block_parser, arena, stmt_tokens(1))
+                    block
+                        integer :: first_token
+                        character(len=:), allocatable :: token_lower
+
+                        stmt_index = 0
+
+                        first_token = 1
+                        do while (first_token <= stmt_size)
+                            select case (stmt_tokens(first_token)%kind)
+                            case (TK_WHITESPACE, TK_NEWLINE)
+                                first_token = first_token + 1
+                            case default
+                                exit
+                            end select
+                        end do
+
+                        if (first_token <= stmt_size) then
+                            if (stmt_tokens(first_token)%kind == TK_KEYWORD) then
+                                token_lower = to_lower_local( &
+     &                                    stmt_tokens(first_token)%text)
+                                if (trim(token_lower) == "if") then
+                                    stmt_index = parse_if_statement_tokens( &
+     &                                        stmt_tokens, arena)
+                                end if
+                            end if
+                        end if
+
+                        if (stmt_index <= 0) then
+                            block_parser = create_parser_state(stmt_tokens)
+                            do while (block_parser%current_token < first_token .and. &
+     &                                  .not. block_parser%is_at_end())
+                                token = block_parser%consume()
+                            end do
+                            if (.not. block_parser%is_at_end()) then
+                                stmt_index = parse_statement_in_if_block( &
+     &                                    block_parser, arena, &
+     &                                    stmt_tokens(max(1, first_token)))
+                            else
+                                stmt_index = 0
+                            end if
+                        end if
+                    end block
 
                     ! Add to body
                     if (stmt_index > 0) then

--- a/test/frontend/test_issue_1352_optional_if.f90
+++ b/test/frontend/test_issue_1352_optional_if.f90
@@ -1,0 +1,70 @@
+program test_issue_1352_optional_if
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use frontend, only: transform_lazy_fortran_string
+    implicit none
+
+    call test_optional_parameter_if_control()
+    print *, ''
+    print *, 'All tests passed for issue 1352.'
+
+contains
+
+    subroutine test_optional_parameter_if_control()
+        character(len=:), allocatable :: input_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        integer :: idx_if, idx_then_stmt, idx_else, idx_else_stmt, idx_end_if
+
+        input_code = 'module optional_mod' // new_line('a') // &
+                     '    implicit none' // new_line('a') // &
+                     'contains' // new_line('a') // &
+                     '    subroutine greet(name, title)' // new_line('a') // &
+                     '        character(len=*), intent(in) :: name' // new_line('a') // &
+                     '        character(len=*), intent(in), optional :: title' // new_line('a') // &
+                     '        if (present(title)) then' // new_line('a') // &
+                     "            print *, title, ' ', name" // new_line('a') // &
+                     '        else' // new_line('a') // &
+                     '            print *, name' // new_line('a') // &
+                     '        end if' // new_line('a') // &
+                     '    end subroutine greet' // new_line('a') // &
+                     'end module optional_mod'
+
+        call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            write (error_unit, '(a)') 'FAIL: unexpected error for issue 1352 sample:'
+            write (error_unit, '(a)') trim(error_msg)
+            error stop 1
+        end if
+
+        if (index(output_code, 'character(len=*), intent(in) :: name') <= 0) then
+            write (error_unit, '(a)') 'FAIL: name parameter lost assumed length'
+            error stop 1
+        end if
+
+        if (index(output_code, 'character(len=*), intent(in), optional :: title') <= 0) then
+            write (error_unit, '(a)') 'FAIL: title parameter lost optional attribute or length'
+            error stop 1
+        end if
+
+        idx_if = index(output_code, 'if (present(title)) then')
+        idx_then_stmt = index(output_code, "print *, title, ' ', name")
+        idx_else = index(output_code, 'else')
+        idx_else_stmt = index(output_code, 'print *, name')
+        idx_end_if = index(output_code, 'end if')
+
+        if (idx_if <= 0 .or. idx_then_stmt <= 0 .or. idx_else <= 0 .or. idx_else_stmt <= 0 .or. idx_end_if <= 0) then
+            write (error_unit, '(a)') 'FAIL: expected IF/ELSE structure not found in output'
+            error stop 1
+        end if
+
+        if (.not. (idx_if < idx_then_stmt .and. idx_then_stmt < idx_else .and. &
+                   idx_else < idx_else_stmt .and. idx_else_stmt < idx_end_if)) then
+            write (error_unit, '(a)') 'FAIL: IF body or ELSE body emitted in wrong order'
+            error stop 1
+        end if
+
+        print *, 'PASS: Optional parameter IF control preserved'
+    end subroutine test_optional_parameter_if_control
+
+end program test_issue_1352_optional_if


### PR DESCRIPTION
### **User description**
## Summary
- ensure parser keeps multi-line IF/ELSE blocks when inferring recursive procedures so optional argument logic stays in place
- normalize character(len=*) declarations for parameters emitted from grouped declarations and assign the correct optional intent metadata
- add regression test covering issue #1352 to lock in the expected lazy-fortran output

## Testing
- make test


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fixed parser to preserve multi-line IF/ELSE blocks in recursive procedure inference

- Normalized `character(len=*)` declarations for optional parameters from grouped declarations

- Added regression test for issue #1352 to verify optional parameter control flow preservation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parser"] -- "detect IF blocks" --> B["parse_if_statement_tokens"]
  B -- "preserve structure" --> C["Multi-line IF/ELSE"]
  D["Codegen"] -- "normalize" --> E["character(len=*) declarations"]
  E -- "emit correct" --> F["Optional parameter metadata"]
  G["Test"] -- "verify" --> H["Issue #1352 fix"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen_utilities.f90</strong><dd><code>Normalize character type declarations for optional parameters</code></dd></summary>
<hr>

src/codegen/codegen_utilities.f90

<ul><li>Added normalization for <code>character(len=*)</code> type declarations in <br>parameter handling<br> <li> Converted <code>-1</code> length specifiers to <code>*</code> for assumed-length character <br>parameters<br> <li> Fixed kind attribute handling to exclude character types from kind <br>processing<br> <li> Applied normalization across grouped, single, and parameter <br>declaration nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1378/files#diff-b0a2107e70b99a22eb33987c481147208821fd4fd9b203e7186c751f92d44c46">+39/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_procedure_definitions.f90</strong><dd><code>Preserve multi-line IF/ELSE blocks in procedure parsing</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_procedure_definitions.f90

<ul><li>Enhanced IF statement parsing to preserve multi-line IF/ELSE block <br>structure<br> <li> Added token skipping logic to handle leading whitespace before <br>statement parsing<br> <li> Improved case-insensitive keyword matching using <code>to_lower_local</code> helper<br> <li> Fixed IF body parsing to properly handle statement boundaries and <br>whitespace</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1378/files#diff-58c92c40c01509fbf0ae9bf23a07692851590611ed25fe37cf37a91db4cb32de">+112/-25</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1352_optional_if.f90</strong><dd><code>Add regression test for optional parameter IF control flow</code></dd></summary>
<hr>

test/frontend/test_issue_1352_optional_if.f90

<ul><li>Added regression test for issue #1352 covering optional parameter <br>control flow<br> <li> Verifies <code>character(len=*)</code> preservation for optional parameters<br> <li> Validates IF/ELSE block structure and statement ordering in output<br> <li> Tests <code>present()</code> intrinsic usage with optional parameters</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1378/files#diff-211ea722e2ef2928d47f2704c0fe31d0358f19b14e4596ba52a67c066b060fa1">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

