### PR TITLE
Refactor parser control flow routing and type hooks

### DIFF
--- a/src/ast/factory/ast_factory_core.f90
+++ b/src/ast/factory/ast_factory_core.f90
@@ -4,7 +4,7 @@ module ast_factory_core
                               identifier_node, literal_node, binary_op_node, &
                               call_or_subscript_node, array_literal_node, &
                               component_access_node, range_subscript_node, &
-                              create_array_literal, create_component_access, create_range_subscript, &
+                  create_array_literal, create_component_access, create_range_subscript, &
                               create_pointer_assignment
     use ast_nodes_misc, only: complex_literal_node
     use uid_generator, only: generate_uid
@@ -38,7 +38,7 @@ contains
                                 ERROR_MEMORY, &
                                 component="ast_factory_core", &
                                 context=context, &
-                                suggestion="Initialize arena with create_ast_arena() before use" &
+                        suggestion="Initialize arena with create_ast_arena() before use" &
                                 )
             return
         end if
@@ -49,7 +49,7 @@ contains
                                 ERROR_INTERNAL, &
                                 component="ast_factory_core", &
                                 context=context, &
-                                suggestion="Check for memory corruption or incorrect initialization" &
+                    suggestion="Check for memory corruption or incorrect initialization" &
                                 )
             return
         end if
@@ -80,7 +80,7 @@ contains
                                 ERROR_VALIDATION, &
                                 component="ast_factory_core", &
                                 context=context, &
-                                suggestion="Ensure node index comes from valid push_* operation" &
+                        suggestion="Ensure node index comes from valid push_* operation" &
                                 )
             return
         end if
@@ -91,7 +91,7 @@ contains
                                 ERROR_VALIDATION, &
                                 component="ast_factory_core", &
                                 context=context, &
-                                suggestion="Check that referenced node was created in this arena" &
+                       suggestion="Check that referenced node was created in this arena" &
                                 )
             return
         end if
@@ -102,7 +102,7 @@ contains
                                 ERROR_VALIDATION, &
                                 component="ast_factory_core", &
                                 context=context, &
-                                suggestion="Ensure referenced node is still valid and not deallocated" &
+                  suggestion="Ensure referenced node is still valid and not deallocated" &
                                 )
             return
         end if
@@ -206,7 +206,7 @@ contains
     end function push_identifier
 
     ! Create literal node and add to stack
-    function push_literal(arena, value, kind, line, column, parent_index) result(lit_index)
+   function push_literal(arena, value, kind, line, column, parent_index) result(lit_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: value
         integer, intent(in) :: kind
@@ -270,17 +270,12 @@ contains
 
         ! Validate inputs
         if (object_index <= 0 .or. object_index > arena%size) then
-            ! Create error node for invalid base
-            access_index = push_literal(arena, &
-                                        "!ERROR: Invalid base for component access", &
-                                        LITERAL_STRING, line, column)
+            access_index = 0
             return
         end if
 
         if (len_trim(component_name) == 0) then
-            ! Create error node for empty component name
-            access_index = push_literal(arena, "!ERROR: Empty component name", &
-                                        LITERAL_STRING, line, column)
+            access_index = 0
             return
         end if
 
@@ -305,10 +300,7 @@ contains
 
         ! Validate base expression index
         if (base_expr_index <= 0 .or. base_expr_index > arena%size) then
-            ! Create error node for invalid base expression
-            subscript_index = push_literal(arena, &
-                                           "!ERROR: Invalid base for range subscript", &
-                                           LITERAL_STRING, line, column)
+            subscript_index = 0
             return
         end if
 

--- a/src/parser/parser_control_flow_router.f90
+++ b/src/parser/parser_control_flow_router.f90
@@ -1,0 +1,115 @@
+module parser_control_flow_router_module
+    use lexer_core, only: token_t, TK_KEYWORD, to_lower
+    use parser_state_module, only: parser_state_t
+    use parser_statement_callbacks_module, only: statement_callbacks_t, &
+                                                 null_statement_callbacks, &
+                                                 parse_without_parent_interface
+    use ast_arena_modern, only: ast_arena_t
+    use parser_if_constructs_module, only: parse_if
+    use parser_do_constructs_module, only: parse_do_loop
+    use parser_select_constructs_module, only: parse_select_case
+    use parser_array_constructs_module, only: parse_where_construct, parse_associate
+    use parser_forall_module, only: parse_forall
+    implicit none
+    private
+
+    public :: route_control_flow
+    public :: is_control_flow_keyword
+    public :: default_control_flow_callbacks
+
+contains
+
+    pure function default_control_flow_callbacks() result(callbacks)
+        type(statement_callbacks_t) :: callbacks
+        callbacks = null_statement_callbacks()
+        callbacks%parse_if => parse_if
+        callbacks%parse_do_loop => parse_do_loop
+        callbacks%parse_select_case => parse_select_case
+        callbacks%parse_where => parse_where_construct
+        callbacks%parse_forall => parse_forall
+        callbacks%parse_associate => parse_associate
+    end function default_control_flow_callbacks
+
+    logical function is_control_flow_keyword(text) result(is_control)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: lowered
+
+        lowered = to_lower(trim(text))
+        select case (lowered)
+        case ("if", "do", "select", "where", "forall", "associate")
+            is_control = .true.
+        case default
+            is_control = .false.
+        end select
+    end function is_control_flow_keyword
+
+    function route_control_flow(parser, arena, callbacks, parent_index) result(node_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(statement_callbacks_t), intent(in), optional :: callbacks
+        integer, intent(in), optional :: parent_index
+        integer :: node_index
+        type(statement_callbacks_t) :: local_callbacks
+        type(token_t) :: token
+        character(len=:), allocatable :: lowered
+
+        node_index = 0
+        if (present(callbacks)) then
+            local_callbacks = callbacks
+        else
+            local_callbacks = default_control_flow_callbacks()
+        end if
+
+        token = parser%peek()
+        if (token%kind /= TK_KEYWORD) return
+        lowered = to_lower(trim(token%text))
+
+        select case (lowered)
+        case ("if")
+            node_index = invoke_if(local_callbacks, parser, arena, parent_index)
+        case ("do")
+            node_index = invoke_no_parent(local_callbacks%parse_do_loop, parser, arena)
+        case ("select")
+            node_index = invoke_no_parent(local_callbacks%parse_select_case, &
+                                          parser, arena)
+        case ("where")
+            node_index = invoke_no_parent(local_callbacks%parse_where, parser, arena)
+        case ("forall")
+            node_index = invoke_no_parent(local_callbacks%parse_forall, parser, arena)
+        case ("associate")
+            node_index = invoke_no_parent(local_callbacks%parse_associate, parser, arena)
+        case default
+            node_index = 0
+        end select
+    end function route_control_flow
+
+    function invoke_if(callbacks, parser, arena, parent_index) result(node_index)
+        type(statement_callbacks_t), intent(in) :: callbacks
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in), optional :: parent_index
+        integer :: node_index
+
+        node_index = 0
+        if (.not. associated(callbacks%parse_if)) return
+        if (present(parent_index)) then
+            node_index = callbacks%parse_if(parser, arena, parent_index)
+        else
+            node_index = callbacks%parse_if(parser, arena)
+        end if
+    end function invoke_if
+
+    function invoke_no_parent(proc, parser, arena) result(node_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        procedure(parse_without_parent_interface), pointer, intent(in) :: proc
+        integer :: node_index
+
+        if (.not. associated(proc)) then
+            node_index = 0
+        else
+            node_index = proc(parser, arena)
+        end if
+    end function invoke_no_parent
+
+end module parser_control_flow_router_module

--- a/src/parser/parser_declarations.f90
+++ b/src/parser/parser_declarations.f90
@@ -10,6 +10,7 @@ module parser_declarations
    use parser_result_types, only: parse_result_t, success_parse_result, error_parse_result
     use error_handling, only: ERROR_PARSER
     use ast_factory, only: push_multi_declaration, push_declaration, push_identifier
+    use parser_type_hooks_module, only: register_type_annotation
     implicit none
     private
 
@@ -1024,6 +1025,9 @@ contains
         type(type_specifier_t) :: type_spec
         type(declaration_attributes_t) :: attr_info
         integer :: initializer_index
+        character(len=:), allocatable :: var_name
+        integer, allocatable :: local_dimension_indices(:)
+        logical :: has_local_dimensions
 
         decl_index = 0
         initializer_index = 0
@@ -1168,14 +1172,27 @@ contains
                     end if
                 end if
                 decl_index = temp_index
+                if (temp_index > 0) then
+                    if (attr_info%has_global_dimensions) then
+                        call register_type_annotation(temp_index, type_spec%type_name, &
+                                    var_names(1:var_count), has_kind=type_spec%has_kind, &
+                                                      kind_value=type_spec%kind_value, &
+                                                    is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                                                      is_pointer=attr_info%is_pointer, &
+                                     dimension_indices=attr_info%global_dimension_indices)
+                    else
+                        call register_type_annotation(temp_index, type_spec%type_name, &
+                                    var_names(1:var_count), has_kind=type_spec%has_kind, &
+                                                      kind_value=type_spec%kind_value, &
+                                                    is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                                                      is_pointer=attr_info%is_pointer)
+                    end if
+                end if
                 return
             end if
-        end block
 
-        block
-            character(len=:), allocatable :: var_name
-            integer, allocatable :: local_dimension_indices(:)
-            logical :: has_local_dimensions
             var_name = token%text
             has_local_dimensions = .false.
 
@@ -1296,6 +1313,34 @@ contains
                                  )
                 end if
             end if
+
+            if (decl_index > 0) then
+                if (attr_info%has_global_dimensions) then
+                    call register_type_annotation(decl_index, type_spec%type_name, &
+                                 [adjustl(trim(var_name))], has_kind=type_spec%has_kind, &
+                                                  kind_value=type_spec%kind_value, &
+                                                  is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                                                  is_pointer=attr_info%is_pointer, &
+                                     dimension_indices=attr_info%global_dimension_indices)
+                else if (has_local_dimensions) then
+                    call register_type_annotation(decl_index, type_spec%type_name, &
+                                 [adjustl(trim(var_name))], has_kind=type_spec%has_kind, &
+                                                  kind_value=type_spec%kind_value, &
+                                                  is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                                                  is_pointer=attr_info%is_pointer, &
+                                                dimension_indices=local_dimension_indices)
+                else
+                    call register_type_annotation(decl_index, type_spec%type_name, &
+                                 [adjustl(trim(var_name))], has_kind=type_spec%has_kind, &
+                                                  kind_value=type_spec%kind_value, &
+                                                  is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                                                  is_pointer=attr_info%is_pointer)
+                end if
+            end if
+
         end block
     end function parse_declaration
 
@@ -1547,6 +1592,14 @@ contains
                                                   is_optional=attr_info%is_optional, &
                                                   is_parameter=attr_info%is_parameter &
                                                   )
+                                if (decl_indices(i) > 0) then
+                     call register_type_annotation(decl_indices(i), type_spec%type_name, &
+                             [adjustl(trim(var_names(i)))], has_kind=type_spec%has_kind, &
+                                                        kind_value=type_spec%kind_value, &
+                                                    is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                              is_pointer=attr_info%is_pointer, dimension_indices=var_dims)
+                                end if
                             end if
                         end block
                     else if (attr_info%has_global_dimensions) then
@@ -1564,6 +1617,15 @@ contains
                                           is_optional=attr_info%is_optional, &
                                           is_parameter=attr_info%is_parameter &
                                           )
+                        if (decl_indices(i) > 0) then
+                     call register_type_annotation(decl_indices(i), type_spec%type_name, &
+                             [adjustl(trim(var_names(i)))], has_kind=type_spec%has_kind, &
+                                                        kind_value=type_spec%kind_value, &
+                                                    is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                                                        is_pointer=attr_info%is_pointer, &
+                                     dimension_indices=attr_info%global_dimension_indices)
+                        end if
                     else
                         ! Variable without dimensions
                         decl_indices(i) = push_declaration( &
@@ -1578,8 +1640,17 @@ contains
                                           is_optional=attr_info%is_optional, &
                                           is_parameter=attr_info%is_parameter &
                                           )
+                        if (decl_indices(i) > 0) then
+                     call register_type_annotation(decl_indices(i), type_spec%type_name, &
+                             [adjustl(trim(var_names(i)))], has_kind=type_spec%has_kind, &
+                                                        kind_value=type_spec%kind_value, &
+                                                    is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                                                          is_pointer=attr_info%is_pointer)
+                        end if
                     end if
                 end do
+
             else
                 ! Use original multi-declaration approach when no per-var dims
                 if (type_spec%has_kind) then
@@ -1631,6 +1702,22 @@ contains
                 if (decl_index > 0) then
                     allocate (decl_indices(1))
                     decl_indices(1) = decl_index
+                    if (attr_info%has_global_dimensions) then
+                        call register_type_annotation(decl_index, type_spec%type_name, &
+                                    var_names(1:var_count), has_kind=type_spec%has_kind, &
+                                                      kind_value=type_spec%kind_value, &
+                                                    is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                                                      is_pointer=attr_info%is_pointer, &
+                                     dimension_indices=attr_info%global_dimension_indices)
+                    else
+                        call register_type_annotation(decl_index, type_spec%type_name, &
+                                    var_names(1:var_count), has_kind=type_spec%has_kind, &
+                                                      kind_value=type_spec%kind_value, &
+                                                    is_parameter=attr_info%is_parameter, &
+                                                is_allocatable=attr_info%is_allocatable, &
+                                                      is_pointer=attr_info%is_pointer)
+                    end if
                 else
                     allocate (decl_indices(0))
                 end if

--- a/src/parser/parser_dispatcher.f90
+++ b/src/parser/parser_dispatcher.f90
@@ -2,7 +2,8 @@ module parser_dispatcher_module
     ! Statement dispatcher that delegates to appropriate parsing modules
     ! This implements the SRP by separating the switch logic from the implementations
     use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_NUMBER, TK_STRING, &
-                  TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, TK_COMMENT, TK_WHITESPACE, to_lower
+                          TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, TK_COMMENT, &
+                          TK_WHITESPACE, to_lower
     use lexer_token_types, only: TK_IDENTIFIER, TK_OPERATOR, TK_KEYWORD
     use parser_state_module
     use parser_expressions_module
@@ -14,17 +15,17 @@ module parser_dispatcher_module
     use parser_io_statements_module, only: parse_print_statement, &
                                            parse_write_statement, parse_read_statement
     use parser_definition_statements_module, only: parse_function_definition, &
-                                        parse_subroutine_definition, parse_interface_block
-    use parser_control_statements_module, only: parse_stop_statement, &
-               parse_return_statement, parse_goto_statement, parse_error_stop_statement, &
-                          parse_cycle_statement, parse_exit_statement, parse_end_statement
+                                                   parse_subroutine_definition, &
+                                                   parse_interface_block
+    use parser_control_statements_module, only: &
+        parse_stop_statement, parse_return_statement, parse_goto_statement, &
+        parse_error_stop_statement, parse_cycle_statement, parse_exit_statement, &
+        parse_end_statement
     use parser_memory_statements_module, only: parse_allocate_statement, &
                                                parse_deallocate_statement
     use parser_execution_statements_module, only: parse_call_statement, &
                                                   parse_program_statement
-    use parser_control_flow_module, only: parse_if, parse_do_loop, parse_select_case, &
-                                          parse_where_construct, parse_associate
-    use parser_forall_module, only: parse_forall
+    use parser_control_flow_router_module, only: route_control_flow
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_misc, only: comment_node, blank_line_node
     use uid_generator, only: generate_uid
@@ -73,14 +74,8 @@ contains
                 stmt_index = parse_allocate_statement(parser, arena)
             case ("deallocate")
                 stmt_index = parse_deallocate_statement(parser, arena)
-            case ("if")
-                stmt_index = parse_if(parser, arena)
-            case ("do")
-                stmt_index = parse_do_loop(parser, arena)
-            case ("where")
-                stmt_index = parse_where_construct(parser, arena)
-            case ("select")
-                stmt_index = parse_select_case(parser, arena)
+            case ("if", "do", "where", "select", "forall", "associate")
+                stmt_index = route_control_flow(parser, arena)
             case ("function")
                 stmt_index = parse_function_definition(parser, arena, prefix_buffer)
             case ("subroutine")
@@ -110,14 +105,11 @@ contains
                 stmt_index = parse_cycle_statement(parser, arena)
             case ("exit")
                 stmt_index = parse_exit_statement(parser, arena)
-            case ("associate")
-                stmt_index = parse_associate(parser, arena)
-            case ("forall")
-                stmt_index = parse_forall(parser, arena)
             case ("end")
                 stmt_index = parse_end_statement(parser, arena)
             case default
-                if (.not. try_handle_prefix_sequence(parser, arena, prefix_buffer, stmt_index)) then
+                if (.not. try_handle_prefix_sequence(parser, arena, prefix_buffer, &
+                                                     stmt_index)) then
                     stmt_index = parse_as_expression(tokens, arena)
                 end if
             end select
@@ -125,7 +117,8 @@ contains
             if (to_lower(trim(first_token%text)) == "class") then
                 stmt_index = parse_type_or_declaration(parser, arena, prefix_buffer)
             else
-                if (.not. try_handle_prefix_sequence(parser, arena, prefix_buffer, stmt_index)) then
+                if (.not. try_handle_prefix_sequence(parser, arena, prefix_buffer, &
+                                                     stmt_index)) then
                     stmt_index = parse_assignment_or_expression(parser, arena)
                 end if
             end if
@@ -230,7 +223,8 @@ contains
                 op_token = parser%consume()
 
                 ! Create target identifier
-      target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column)
+                target_index = push_identifier(arena, id_token%text, id_token%line, &
+                                               id_token%column)
 
                 ! Parse value expression
                 value_index = parse_range(parser, arena)

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -23,13 +23,12 @@ module parser_execution_statements_module
                                                 parse_return_statement, &
                                                 parse_cycle_statement, &
                                                 parse_exit_statement
-    use parser_control_flow_module, only: parse_do_loop, parse_select_case, &
-                                          parse_where_construct, parse_associate
-    use parser_forall_module, only: parse_forall
+    use parser_control_flow_router_module, only: route_control_flow, &
+                                                 is_control_flow_keyword
     use parser_call_module, only: parse_call_statement
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_program, &
-                           push_declaration, push_if, push_implicit_statement
+                           push_declaration, push_implicit_statement
     use ast_types, only: LITERAL_STRING, LITERAL_INTEGER, LITERAL_REAL, LITERAL_LOGICAL
     implicit none
     private
@@ -130,186 +129,158 @@ contains
             ! Parse statements directly without complex boundary detection
             stmt_index = 0
 
-            select case (token%kind)
-            case (TK_KEYWORD)
-                select case (lowered)
-                case ("elemental", "pure", "impure", "recursive", "nonrecursive", &
-                      "non_recursive", "module")
-                    call append_prefix_token(pending_prefixes, lowered)
-                    token = parser%consume()
-                    stmt_index = 0
-                case ("contains")
-                    token = parser%consume()
-                    stmt_index = 0
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                    end if
-                    call prefix_buffer%clear()
-                case ("function")
-                    if (allocated(pending_prefixes)) then
-                        call prefix_buffer%set(pending_prefixes)
-                        deallocate (pending_prefixes)
-                    else
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_function_definition(parser, arena, prefix_buffer)
-                    call prefix_buffer%clear()
-                case ("subroutine")
-                    if (allocated(pending_prefixes)) then
-                        call prefix_buffer%set(pending_prefixes)
-                        deallocate (pending_prefixes)
-                    else
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_subroutine_definition(parser, arena, prefix_buffer)
-                    call prefix_buffer%clear()
-                case ("implicit")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    call parse_simple_implicit(parser, arena, stmt_index)
-                case ("real", "integer", "logical", "character", "complex", &
-                      "double", "class")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    call handle_variable_declaration(parser, arena, stmt_index)
-                case ("type")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    call handle_type_declaration(parser, arena, stmt_index)
-                case ("print")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_print_statement(parser, arena)
-                case ("write")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_write_statement(parser, arena)
-                case ("allocate")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_allocate_statement(parser, arena)
-                case ("deallocate")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_deallocate_statement(parser, arena)
-                case ("if")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_simple_if(parser, arena)
-                case ("stop")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_stop_statement(parser, arena)
-                case ("go", "goto")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_goto_statement(parser, arena)
-                case ("error")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_error_stop_statement(parser, arena)
-                case ("return")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_return_statement(parser, arena)
-                case ("cycle")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_cycle_statement(parser, arena)
-                case ("exit")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_exit_statement(parser, arena)
-                case ("call")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_call_statement(parser, arena)
-                case ("do")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_do_loop(parser, arena)
-                case ("select")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_select_case(parser, arena)
-                case ("where")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_where_construct(parser, arena)
-                case ("associate")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_associate(parser, arena)
-                case ("forall")
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    stmt_index = parse_forall(parser, arena)
-                case default
-                    if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
-                        call prefix_buffer%clear()
-                    end if
-                    token = parser%consume()
-                    stmt_index = 0
-                end select
-            case (TK_IDENTIFIER)
+            if (token%kind == TK_KEYWORD .and. is_control_flow_keyword(lowered)) then
                 if (allocated(pending_prefixes)) then
                     deallocate (pending_prefixes)
                     call prefix_buffer%clear()
                 end if
-                if (trim(to_lower(token%text)) == 'class') then
-                    call handle_variable_declaration(parser, arena, stmt_index)
-                else
-                    call parse_assignment_statement(parser, arena, stmt_index, &
-                                                    additional_execution_indices)
-                end if
-            case (TK_NEWLINE, TK_COMMENT)
-                token = parser%consume()
-                stmt_index = 0
-            case default
-                token = parser%consume()
-                stmt_index = 0
-            end select
+                stmt_index = route_control_flow(parser, arena)
+            else
+                select case (token%kind)
+                case (TK_KEYWORD)
+                    select case (lowered)
+                    case ("elemental", "pure", "impure", "recursive", "nonrecursive", &
+                          "non_recursive", "module")
+                        call append_prefix_token(pending_prefixes, lowered)
+                        token = parser%consume()
+                        stmt_index = 0
+                    case ("contains")
+                        token = parser%consume()
+                        stmt_index = 0
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                        end if
+                        call prefix_buffer%clear()
+                    case ("function")
+                        if (allocated(pending_prefixes)) then
+                            call prefix_buffer%set(pending_prefixes)
+                            deallocate (pending_prefixes)
+                        else
+                            call prefix_buffer%clear()
+                        end if
+                      stmt_index = parse_function_definition(parser, arena, prefix_buffer)
+                        call prefix_buffer%clear()
+                    case ("subroutine")
+                        if (allocated(pending_prefixes)) then
+                            call prefix_buffer%set(pending_prefixes)
+                            deallocate (pending_prefixes)
+                        else
+                            call prefix_buffer%clear()
+                        end if
+                    stmt_index = parse_subroutine_definition(parser, arena, prefix_buffer)
+                        call prefix_buffer%clear()
+                    case ("implicit")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        call parse_simple_implicit(parser, arena, stmt_index)
+                    case ("real", "integer", "logical", "character", "complex", &
+                          "double", "class")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        call handle_variable_declaration(parser, arena, stmt_index)
+                    case ("type")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        call handle_type_declaration(parser, arena, stmt_index)
+                    case ("print")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_print_statement(parser, arena)
+                    case ("write")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_write_statement(parser, arena)
+                    case ("allocate")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_allocate_statement(parser, arena)
+                    case ("deallocate")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_deallocate_statement(parser, arena)
+                    case ("stop")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_stop_statement(parser, arena)
+                    case ("go", "goto")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_goto_statement(parser, arena)
+                    case ("error")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_error_stop_statement(parser, arena)
+                    case ("return")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_return_statement(parser, arena)
+                    case ("cycle")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_cycle_statement(parser, arena)
+                    case ("exit")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_exit_statement(parser, arena)
+                    case ("call")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_call_statement(parser, arena)
+                    case default
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        token = parser%consume()
+                        stmt_index = 0
+                    end select
+                case (TK_IDENTIFIER)
+                    if (allocated(pending_prefixes)) then
+                        deallocate (pending_prefixes)
+                        call prefix_buffer%clear()
+                    end if
+                    if (trim(to_lower(token%text)) == 'class') then
+                        call handle_variable_declaration(parser, arena, stmt_index)
+                    else
+                        call parse_assignment_statement(parser, arena, stmt_index, &
+                                                        additional_execution_indices)
+                    end if
+                case (TK_NEWLINE, TK_COMMENT)
+                    token = parser%consume()
+                    stmt_index = 0
+                case default
+                    token = parser%consume()
+                    stmt_index = 0
+                end select
+            end if
 
             if (stmt_index > 0) then
                 body_indices = [body_indices, stmt_index]
@@ -326,245 +297,6 @@ contains
     end subroutine parse_program_body
 
     ! Parse a simple if statement with optional else block
-    function parse_simple_if(parser, arena) result(if_index)
-        use parser_expressions_module, only: parse_expression
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer :: if_index
-        type(token_t) :: token
-        integer :: condition_index, line, column
-        integer, allocatable :: then_body_indices(:)
-        integer, allocatable :: else_body_indices(:)
-        logical :: in_else, has_end_if
-
-        if_index = 0
-        allocate (then_body_indices(0))
-        allocate (else_body_indices(0))
-
-        ! Consume 'if' keyword
-        token = parser%consume()
-        line = token%line
-        column = token%column
-
-        ! Parse condition in parentheses
-        token = parser%peek()
-        if (token%kind == TK_OPERATOR .and. token%text == "(") then
-            token = parser%consume()  ! consume '('
-            block
-                type(token_t), allocatable, target :: expr_tokens(:)
-                integer :: start_pos, end_pos, paren_depth, expr_len
-                type(token_t) :: sentinel_location
-
-                start_pos = parser%current_token
-                end_pos = start_pos
-                paren_depth = 1
-
-                do while (end_pos <= size(parser%tokens) .and. paren_depth > 0)
-                    if (parser%tokens(end_pos)%text == "(") then
-                        paren_depth = paren_depth + 1
-                    else if (parser%tokens(end_pos)%text == ")") then
-                        paren_depth = paren_depth - 1
-                    end if
-                    if (paren_depth > 0) end_pos = end_pos + 1
-                end do
-
-                expr_len = max(end_pos - start_pos, 0)
-                if (end_pos <= size(parser%tokens)) then
-                    sentinel_location = parser%tokens(end_pos)
-                else
-                    sentinel_location%line = token%line
-                    sentinel_location%column = token%column
-                    sentinel_location%text = ""
-                    sentinel_location%kind = TK_EOF
-                end if
-
-                if (expr_len > 0) then
-                    allocate (expr_tokens(expr_len + 1))
-                    expr_tokens(1:expr_len) = parser%tokens(start_pos:end_pos - 1)
-                    expr_tokens(expr_len + 1)%kind = TK_EOF
-                    expr_tokens(expr_len + 1)%text = ""
-                    expr_tokens(expr_len + 1)%line = sentinel_location%line
-                    expr_tokens(expr_len + 1)%column = sentinel_location%column
-                    condition_index = parse_expression(expr_tokens, arena)
-                else
-                    allocate (expr_tokens(1))
-                    expr_tokens(1)%kind = TK_EOF
-                    expr_tokens(1)%text = ""
-                    expr_tokens(1)%line = sentinel_location%line
-                    expr_tokens(1)%column = sentinel_location%column
-                    condition_index = 0
-                end if
-                parser%current_token = end_pos
-            end block
-
-            token = parser%peek()
-            if (token%kind == TK_OPERATOR .and. token%text == ")") then
-                token = parser%consume()  ! consume ')'
-            end if
-        else
-            condition_index = 0
-        end if
-
-        ! Expect 'then'
-        token = parser%peek()
-        if (token%kind == TK_KEYWORD .and. token%text == "then") then
-            token = parser%consume()
-        end if
-
-        in_else = .false.
-        do while (.not. parser%is_at_end())
-            token = parser%peek()
-
-            if (token%kind == TK_KEYWORD) then
-                select case (token%text)
-                case ("end")
-                    has_end_if = .false.
-                    block
-                        type(token_t) :: next_token
-                        integer :: next_index
-
-                        next_index = parser%current_token + 1
-                        if (next_index <= size(parser%tokens)) then
-                            next_token = parser%tokens(next_index)
-                            has_end_if = next_token%kind == TK_KEYWORD
-                            if (has_end_if) then
-                                has_end_if = next_token%text == "if"
-                            end if
-                        end if
-                    end block
-                    if (has_end_if) then
-                        token = parser%consume()  ! consume 'end'
-                        token = parser%consume()  ! consume 'if'
-                        exit
-                    end if
-                case ("elseif")
-                    ! Fall back to original behavior: skip remainder of the block
-                    do while (.not. parser%is_at_end())
-                        token = parser%peek()
-                        if (token%kind == TK_KEYWORD .and. token%text == "end") then
-                            has_end_if = .false.
-                            block
-                                type(token_t) :: next_token
-                                integer :: next_index
-
-                                next_index = parser%current_token + 1
-                                if (next_index <= size(parser%tokens)) then
-                                    next_token = parser%tokens(next_index)
-                                    has_end_if = next_token%kind == TK_KEYWORD
-                                    if (has_end_if) then
-                                        has_end_if = next_token%text == "if"
-                                    end if
-                                end if
-                            end block
-                            if (has_end_if) then
-                                token = parser%consume()
-                                token = parser%consume()
-                                exit
-                            end if
-                        end if
-                        token = parser%consume()
-                    end do
-                    exit
-                case ("else")
-                    ! Distinguish between ELSE and ELSE IF
-                    token = parser%consume()  ! consume 'else'
-                    if (parser%current_token <= size(parser%tokens)) then
-                        block
-                            type(token_t) :: current_token_obj
-
-                            current_token_obj = parser%tokens(parser%current_token)
-                            if (current_token_obj%kind == TK_KEYWORD .and. &
-                                current_token_obj%text == "if") then
-                                ! Treat ELSE IF like the old implementation (skip block)
-                                do while (.not. parser%is_at_end())
-                                    token = parser%peek()
-                                    if (token%kind == TK_KEYWORD .and. &
-                                        token%text == "end") then
-                                        has_end_if = .false.
-                                        block
-                                            type(token_t) :: next_token
-                                            integer :: next_index
-
-                                            next_index = parser%current_token + 1
-                                            if (next_index <= size(parser%tokens)) then
-                                                next_token = parser%tokens(next_index)
-                                                has_end_if = next_token%kind == TK_KEYWORD
-                                                if (has_end_if) then
-                                                    has_end_if = next_token%text == "if"
-                                                end if
-                                            end if
-                                        end block
-                                        if (has_end_if) then
-                                            token = parser%consume()
-                                            token = parser%consume()
-                                            exit
-                                        end if
-                                    end if
-                                    token = parser%consume()
-                                end do
-                                exit
-                            end if
-                        end block
-                    end if
-                    in_else = .true.
-                    cycle
-                end select
-            end if
-
-            if (in_else) then
-                call parse_if_body_statement(parser, arena, else_body_indices)
-            else
-                call parse_if_body_statement(parser, arena, then_body_indices)
-            end if
-        end do
-
-        if (.not. allocated(else_body_indices)) allocate (else_body_indices(0))
-        if_index = push_if(arena, condition_index, then_body_indices, &
-                           else_body_indices=else_body_indices, &
-                           line=line, column=column)
-    end function parse_simple_if
-
-    ! Parse a statement in an if body
-    subroutine parse_if_body_statement(parser, arena, body_indices)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer, allocatable, intent(inout) :: body_indices(:)
-        type(token_t) :: token
-        integer :: stmt_index
-
-        token = parser%peek()
-        stmt_index = 0
-
-        select case (token%kind)
-        case (TK_KEYWORD)
-            select case (token%text)
-            case ("print")
-                stmt_index = parse_print_statement(parser, arena)
-            case ("real", "integer", "logical", "character", "complex", "double", "class")
-                stmt_index = parse_declaration(parser, arena)
-            case default
-                token = parser%consume()
-            end select
-        case (TK_IDENTIFIER)
-            call parse_assignment_statement(parser, arena, stmt_index, &
-                                            additional_execution_indices)
-        case (TK_NEWLINE)
-            token = parser%consume()
-        case default
-            token = parser%consume()
-        end select
-
-        if (stmt_index > 0) then
-            body_indices = [body_indices, stmt_index]
-        end if
-
-        if (allocated(additional_execution_indices)) then
-            if (size(additional_execution_indices) > 0) then
-                body_indices = [body_indices, additional_execution_indices]
-            end if
-            deallocate (additional_execution_indices)
-        end if
-    end subroutine parse_if_body_statement
 
     ! Parse a simple assignment statement or multi-variable assignment
     ! Parse a simple variable declaration

--- a/src/parser/parser_expression_helpers.f90
+++ b/src/parser/parser_expression_helpers.f90
@@ -5,7 +5,7 @@ module parser_expression_helpers_module
     use ast_types, only: LITERAL_REAL, LITERAL_INTEGER, LITERAL_STRING, LITERAL_LOGICAL
     use ast_nodes_core, only: component_access_node, identifier_node
     use ast_factory, only: push_literal, push_identifier, push_component_access, &
-                           push_call_or_subscript, push_call_or_subscript_with_slice_detection
+                       push_call_or_subscript, push_call_or_subscript_with_slice_detection
     use parser_state_module, only: parser_state_t
     implicit none
     private
@@ -28,7 +28,7 @@ contains
         else
             ! No decimal point - classify as integer
             expr_index = push_literal(arena, current_token%text, &
-                                      LITERAL_INTEGER, current_token%line, current_token%column)
+                                LITERAL_INTEGER, current_token%line, current_token%column)
         end if
     end function parse_number_literal
 
@@ -68,10 +68,8 @@ contains
                                                component_token%text, &
                                                op_token%line, op_token%column)
         else
-            ! Error: expected identifier after %
-            expr_index = push_literal(arena, &
-                                      "!ERROR: Expected identifier after %, got '" // trim(component_token%text) // "'", &
-                                      LITERAL_STRING, op_token%line, op_token%column)
+            call parser%error("Expected identifier after % operator")
+            expr_index = base_expr
         end if
     end function parse_component_access_postfix
 

--- a/src/parser/parser_expressions.f90
+++ b/src/parser/parser_expressions.f90
@@ -14,7 +14,7 @@ module parser_expressions_module
                            push_component_access, push_range_subscript, push_do_loop
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_expression_helpers_module, only: parse_number_literal, &
-                                                parse_string_literal, parse_boolean_literal, &
+                                            parse_string_literal, parse_boolean_literal, &
                                                 parse_component_access_postfix
     implicit none
     private
@@ -444,7 +444,7 @@ contains
         end if
 
         lowered = to_lower(token%text)
-        is_prefix_operator_token = (lowered == "+" .or. lowered == "-" .or. lowered == ".not.")
+   is_prefix_operator_token = (lowered == "+" .or. lowered == "-" .or. lowered == ".not.")
     end function is_prefix_operator_token
 
     function get_infix_operator_entry(token) result(entry)
@@ -569,7 +569,7 @@ contains
         end if
 
         call operand_stack_push(operands, push_binary_op(arena, left_index, right_index, &
-                                                         op_entry%symbol, op_entry%token%line, op_entry%token%column))
+                             op_entry%symbol, op_entry%token%line, op_entry%token%column))
     end subroutine reduce_single_operator
 
     subroutine reduce_operators_for_incoming(operators, operands, arena, incoming)
@@ -712,14 +712,13 @@ contains
             end if
 
         case default
-            expr_index = push_literal(arena, &
-                                      "!ERROR: Unexpected token '" // trim(token%text) // "'", &
-                                      LITERAL_STRING, token%line, token%column)
+            call parser%error("Unexpected token '"//trim(token%text)//"' in expression")
+            expr_index = 0
             token = view_consume_token(view, parser)
         end select
     end function parse_operand_base
 
-    recursive function parse_expression_with_precedence(parser, arena, minimum_precedence, &
+  recursive function parse_expression_with_precedence(parser, arena, minimum_precedence, &
                                                         terminators) result(expr_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
@@ -756,14 +755,14 @@ contains
                         call reduce_until_group(operators, operands, arena)
                         op_entry = operator_stack_pop(operators)
                         if (prefix_stack%size > 0) then
-                            if (prefix_stack%values(prefix_stack%size)%kind == PREFIX_MARKER_KIND) then
+               if (prefix_stack%values(prefix_stack%size)%kind == PREFIX_MARKER_KIND) then
                                 block
                                     type(token_t) :: discarded_marker
                                     discarded_marker = token_stack_pop(prefix_stack)
                                 end block
                                 if (.not. operand_stack_is_empty(operands)) then
                                     current_index = operand_stack_pop(operands)
-                                    current_index = apply_prefix_stack(arena, prefix_stack, current_index)
+                    current_index = apply_prefix_stack(arena, prefix_stack, current_index)
                                     call operand_stack_push(operands, current_index)
                                 end if
                             end if
@@ -951,7 +950,7 @@ contains
 
         if (present(terminators)) then
             if (size(terminators) > 0) then
-                allocate (character(len=MAX_OPERATOR_LEN) :: local_terms(size(terminators)))
+              allocate (character(len=MAX_OPERATOR_LEN) :: local_terms(size(terminators)))
                 local_terms = terminators
                 expr_index = parse_expression_with_precedence(parser, arena, &
                                                               PREC_RANGE + 1, local_terms)
@@ -1002,7 +1001,7 @@ contains
                     type(token_t) :: next_tok
                     next_tok = parser%peek()
                     if (.not. (next_tok%kind == TK_OPERATOR .and. &
-                               (next_tok%text == ")" .or. next_tok%text == "]" .or. next_tok%text == ","))) then
+         (next_tok%text == ")" .or. next_tok%text == "]" .or. next_tok%text == ","))) then
                         right_index = parse_logical_eqv(parser, arena)
                     else
                         right_index = 0
@@ -1017,7 +1016,7 @@ contains
                 stride_index = parse_stride_component(parser, arena)
 
                 expr_index = push_range_expression(arena, expr_index, right_index, &
-                                                   stride_index=stride_index, line=op_token%line, column=op_token%column)
+                    stride_index=stride_index, line=op_token%line, column=op_token%column)
             end block
             return
         end if
@@ -1034,7 +1033,7 @@ contains
                         type(token_t) :: next_tok
                         next_tok = parser%peek()
                         if (.not. (next_tok%kind == TK_OPERATOR .and. &
-                                   (next_tok%text == ")" .or. next_tok%text == "]" .or. next_tok%text == ","))) then
+         (next_tok%text == ")" .or. next_tok%text == "]" .or. next_tok%text == ","))) then
                             right_index = parse_logical_eqv(parser, arena)
                         else
                             right_index = 0
@@ -1049,7 +1048,7 @@ contains
                     stride_index = parse_stride_component(parser, arena)
 
                     expr_index = push_range_expression(arena, expr_index, right_index, &
-                                                       stride_index=stride_index, line=op_token%line, column=op_token%column)
+                    stride_index=stride_index, line=op_token%line, column=op_token%column)
                 end block
             end if
         end if
@@ -1170,7 +1169,7 @@ contains
                     current = parser%consume()
                     allocate (element_indices(0))
                     expr_index = push_array_literal(arena, element_indices, &
-                                                    paren_token%line, paren_token%column, &
+                                                   paren_token%line, paren_token%column, &
                                                     syntax_style="legacy")
                 else
                     expr_index = 0
@@ -1179,7 +1178,7 @@ contains
             end if
 
             ! Parse elements with legacy syntax (closing /))
-            expr_index = parse_simple_array_elements(parser, arena, "/", "legacy", paren_token)
+       expr_index = parse_simple_array_elements(parser, arena, "/", "legacy", paren_token)
 
             ! Consume final closing paren for legacy syntax
             if (expr_index > 0) then
@@ -1230,7 +1229,7 @@ contains
                 expr_index = parse_implied_do_constructor(parser, arena, start_token)
             else
                 ! Parse regular array elements
-                expr_index = parse_simple_array_elements(parser, arena, "]", "modern", start_token)
+       expr_index = parse_simple_array_elements(parser, arena, "]", "modern", start_token)
             end if
         end block
     end function parse_modern_array_literal
@@ -1372,7 +1371,7 @@ contains
                     allocate (element_indices(element_count))
                     element_indices = temp_indices(1:element_count)
                     expr_index = push_array_literal(arena, element_indices, &
-                                                    bracket_token%line, bracket_token%column, &
+                                               bracket_token%line, bracket_token%column, &
                                                     syntax_style="modern")
                 end block
                 return
@@ -1463,8 +1462,8 @@ contains
                 if (allocated(name_for_call)) then
                     expr_index = &
                         push_call_or_subscript_with_slice_detection(arena, &
-                                                                    name_for_call, arg_indices, &
-                                                                    paren%line, paren%column)
+                                                             name_for_call, arg_indices, &
+                                                                 paren%line, paren%column)
                 end if
             end if
         end block
@@ -1542,8 +1541,8 @@ contains
                 if (allocated(name_for_call)) then
                     expr_index = &
                         push_call_or_subscript_with_slice_detection(arena, &
-                                                                    name_for_call, arg_indices, &
-                                                                    bracket%line, bracket%column)
+                                                             name_for_call, arg_indices, &
+                                                             bracket%line, bracket%column)
                 end if
             end if
         end block
@@ -1569,7 +1568,7 @@ contains
 
             if (op_token%kind == TK_OPERATOR .and. op_token%text == "%") then
                 op_token = view_consume_token(view, parser)
-                expr_index = parse_component_access_postfix(parser, arena, expr_index, op_token)
+          expr_index = parse_component_access_postfix(parser, arena, expr_index, op_token)
                 if (expr_index <= 0) exit
             else if (op_token%kind == TK_OPERATOR .and. op_token%text == "(") then
                 expr_index = parse_array_indexing_postfix(parser, arena, expr_index)

--- a/src/parser/parser_statement_callbacks.f90
+++ b/src/parser/parser_statement_callbacks.f90
@@ -1,0 +1,49 @@
+module parser_statement_callbacks_module
+    use parser_state_module, only: parser_state_t
+    use ast_arena_modern, only: ast_arena_t
+    implicit none
+    private
+
+    abstract interface
+        function parse_with_parent_interface(parser, arena, parent_index) &
+            result(node_index)
+            import :: parser_state_t, ast_arena_t
+            type(parser_state_t), intent(inout) :: parser
+            type(ast_arena_t), intent(inout) :: arena
+            integer, intent(in), optional :: parent_index
+            integer :: node_index
+        end function parse_with_parent_interface
+
+        function parse_without_parent_interface(parser, arena) result(node_index)
+            import :: parser_state_t, ast_arena_t
+            type(parser_state_t), intent(inout) :: parser
+            type(ast_arena_t), intent(inout) :: arena
+            integer :: node_index
+        end function parse_without_parent_interface
+    end interface
+
+    type, public :: statement_callbacks_t
+        procedure(parse_with_parent_interface), pointer, nopass :: parse_if => null()
+        procedure(parse_without_parent_interface), pointer, nopass :: &
+            parse_do_loop => null()
+        procedure(parse_without_parent_interface), pointer, nopass :: &
+            parse_select_case => null()
+        procedure(parse_without_parent_interface), pointer, nopass :: &
+            parse_where => null()
+        procedure(parse_without_parent_interface), pointer, nopass :: &
+            parse_forall => null()
+        procedure(parse_without_parent_interface), pointer, nopass :: &
+            parse_associate => null()
+    end type statement_callbacks_t
+
+    public :: null_statement_callbacks
+    public :: parse_with_parent_interface
+    public :: parse_without_parent_interface
+
+contains
+
+    pure function null_statement_callbacks() result(callbacks)
+        type(statement_callbacks_t) :: callbacks
+    end function null_statement_callbacks
+
+end module parser_statement_callbacks_module

--- a/src/parser/parser_statement_core.f90
+++ b/src/parser/parser_statement_core.f90
@@ -1,7 +1,6 @@
 module parser_statement_core_module
     use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_OPERATOR, TK_KEYWORD, &
                           TK_NEWLINE, TK_COMMENT, TK_WHITESPACE, to_lower
-    use ast_types, only: LITERAL_STRING
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_expressions_module, only: parse_expression
     use parser_io_statements_module, only: parse_print_statement, &
@@ -13,50 +12,16 @@ module parser_statement_core_module
     use parser_call_module, only: parse_call_statement
     use parser_utils, only: analyze_declaration_structure
     use ast_arena_modern, only: ast_arena_t
-    use ast_factory, only: push_assignment, push_identifier, push_literal
+    use ast_factory, only: push_assignment, push_identifier
+    use parser_statement_callbacks_module, only: statement_callbacks_t, &
+                                                 null_statement_callbacks
     implicit none
     private
 
-    public :: statement_callbacks_t, parse_basic_statement_core, &
-              null_statement_callbacks, find_statement_end, extend_if_statement_end
-
-    abstract interface
-        function parse_with_parent_interface(parser, arena, parent_index) &
-            result(node_index)
-            import :: parser_state_t, ast_arena_t
-            type(parser_state_t), intent(inout) :: parser
-            type(ast_arena_t), intent(inout) :: arena
-            integer, intent(in), optional :: parent_index
-            integer :: node_index
-        end function parse_with_parent_interface
-
-        function parse_without_parent_interface(parser, arena) result(node_index)
-            import :: parser_state_t, ast_arena_t
-            type(parser_state_t), intent(inout) :: parser
-            type(ast_arena_t), intent(inout) :: arena
-            integer :: node_index
-        end function parse_without_parent_interface
-    end interface
-
-    type :: statement_callbacks_t
-        procedure(parse_with_parent_interface), pointer, nopass :: parse_if => null()
-        procedure(parse_without_parent_interface), pointer, nopass :: &
-            parse_do_loop => null()
-        procedure(parse_without_parent_interface), pointer, nopass :: &
-            parse_select_case => null()
-        procedure(parse_without_parent_interface), pointer, nopass :: &
-            parse_where => null()
-        procedure(parse_without_parent_interface), pointer, nopass :: &
-            parse_forall => null()
-        procedure(parse_without_parent_interface), pointer, nopass :: &
-            parse_associate => null()
-    end type statement_callbacks_t
+    public :: statement_callbacks_t, null_statement_callbacks
+    public :: parse_basic_statement_core, find_statement_end, extend_if_statement_end
 
 contains
-
-    pure function null_statement_callbacks() result(callbacks)
-        type(statement_callbacks_t) :: callbacks
-    end function null_statement_callbacks
 
     logical function is_block_if(tokens, start_index) result(is_block)
         type(token_t), intent(in) :: tokens(:)
@@ -86,7 +51,7 @@ contains
     end function is_block_if
 
     pure logical function at_top_level(if_depth, select_depth, do_depth, &
-                                       where_depth, assoc_depth, forall_depth) result(is_top_level)
+                              where_depth, assoc_depth, forall_depth) result(is_top_level)
         integer, intent(in) :: if_depth, select_depth, do_depth
         integer, intent(in) :: where_depth, assoc_depth, forall_depth
 
@@ -535,7 +500,18 @@ contains
         end select
 
         if (stmt_index == 0) then
-            stmt_index = build_placeholder_or_zero(tokens, first_token, arena)
+            if (is_terminator_statement(first_token, tokens)) then
+                allocate (stmt_indices(1))
+                stmt_indices(1) = 0
+            else
+                call report_unparsed_statement(parser, tokens)
+                allocate (stmt_indices(1))
+                stmt_indices(1) = 0
+            end if
+            if (present(consumed_count)) then
+                consumed_count = parser%current_token - 1
+            end if
+            return
         end if
 
         if (.not. allocated(stmt_indices)) then
@@ -782,54 +758,58 @@ contains
                                      id_token%column, parent_index)
     end function parse_complex_assignment
 
-    integer function build_placeholder_or_zero(tokens, first_token, arena) &
-        result(stmt_index)
-        type(token_t), intent(in) :: tokens(:)
+    logical function is_terminator_statement(first_token, tokens) result(is_terminator)
         type(token_t), intent(in) :: first_token
-        type(ast_arena_t), intent(inout) :: arena
-        logical :: is_terminator
+        type(token_t), intent(in) :: tokens(:)
         character(len=:), allocatable :: lowered
-        character(len=256) :: debug_msg
-        character(len=64) :: token_text
-        integer :: debug_len, i
 
-        stmt_index = 0
         is_terminator = .false.
-        if (first_token%kind == TK_KEYWORD) then
-            lowered = to_lower(first_token%text)
-            select case (lowered)
-            case ("end")
-                if (size(tokens) >= 2) then
-                    select case (to_lower(tokens(2)%text))
-                    case ("if", "do", "select", "where", "forall", "associate", "case")
-                        is_terminator = .true.
-                    end select
-                else
+        if (first_token%kind /= TK_KEYWORD) return
+
+        lowered = to_lower(first_token%text)
+        select case (lowered)
+        case ("end")
+            if (size(tokens) >= 2) then
+                select case (to_lower(tokens(2)%text))
+                case ("if", "do", "select", "where", "forall", "associate", "case")
                     is_terminator = .true.
-                end if
-            case ("else", "elseif", "contains", "case", "endselect", "enddo", &
-                  "endif", "endwhere", "endforall", "elsewhere")
+                end select
+            else
                 is_terminator = .true.
-            end select
-        end if
+            end if
+        case ("else", "elseif", "contains", "case", "endselect", "enddo", &
+              "endif", "endwhere", "endforall", "elsewhere")
+            is_terminator = .true.
+        end select
+    end function is_terminator_statement
 
-        if (is_terminator) return
+    subroutine report_unparsed_statement(parser, tokens)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t), intent(in) :: tokens(:)
+        character(len=256) :: message
+        character(len=64) :: token_text
+        integer :: i, msg_len
 
-        debug_msg = "! Unparsed: "
-        debug_len = len_trim(debug_msg)
+        message = "Unrecognized statement:"
+        msg_len = len_trim(message)
+
         do i = 1, min(3, size(tokens))
             if (tokens(i)%kind == TK_EOF) exit
-            if (len_trim(tokens(i)%text) > 0) then
-                token_text = trim(tokens(i)%text)
-                if (debug_len + len_trim(token_text) + 1 < 250) then
-                    debug_msg = debug_msg(1:debug_len) // " " // trim(token_text)
-                    debug_len = len_trim(debug_msg)
-                end if
+            if (len_trim(tokens(i)%text) == 0) cycle
+
+            token_text = trim(tokens(i)%text)
+            if (msg_len + len_trim(token_text) + 1 < len(message)) then
+                message = message(1:msg_len) // " " // token_text
+                msg_len = len_trim(message)
             end if
         end do
 
-        stmt_index = push_literal(arena, trim(debug_msg), LITERAL_STRING, &
-                                  first_token%line, first_token%column)
-    end function build_placeholder_or_zero
+        if (msg_len == len_trim("Unrecognized statement:")) then
+            message = "Unrecognized statement"
+        end if
+
+        parser%current_token = max(1, parser%current_token)
+        call parser%error(trim(message))
+    end subroutine report_unparsed_statement
 
 end module parser_statement_core_module

--- a/src/parser/parser_type_hooks.f90
+++ b/src/parser/parser_type_hooks.f90
@@ -1,0 +1,122 @@
+module parser_type_hooks_module
+    implicit none
+    private
+
+    type, public :: type_annotation_t
+        integer :: decl_index = 0
+        character(len=:), allocatable :: type_name
+        character(len=:), allocatable :: var_names(:)
+        logical :: has_kind = .false.
+        integer :: kind_value = 0
+        logical :: is_parameter = .false.
+        logical :: is_allocatable = .false.
+        logical :: is_pointer = .false.
+        logical :: has_dimensions = .false.
+        integer, allocatable :: dimension_indices(:)
+    end type type_annotation_t
+
+    type(type_annotation_t), allocatable :: registry(:)
+
+    public :: register_type_annotation
+    public :: consume_type_annotations
+    public :: has_type_annotations
+
+contains
+
+    subroutine register_type_annotation(decl_index, type_name, var_names, has_kind, kind_value, &
+                              is_parameter, is_allocatable, is_pointer, dimension_indices)
+        integer, intent(in) :: decl_index
+        character(len=*), intent(in) :: type_name
+        character(len=*), intent(in) :: var_names(:)
+        logical, intent(in), optional :: has_kind
+        integer, intent(in), optional :: kind_value
+        logical, intent(in), optional :: is_parameter, is_allocatable, is_pointer
+        integer, intent(in), optional :: dimension_indices(:)
+        type(type_annotation_t), allocatable :: temp(:)
+        integer :: entry_index, n, max_len, i
+
+        if (.not. allocated(registry)) then
+            allocate (registry(1))
+        else
+            n = size(registry)
+            allocate (temp(n + 1))
+            temp(1:n) = registry
+            call move_alloc(temp, registry)
+        end if
+        entry_index = size(registry)
+
+        registry(entry_index)%decl_index = decl_index
+        registry(entry_index)%type_name = trim(type_name)
+
+        max_len = 1
+        do i = 1, size(var_names)
+            max_len = max(max_len, len_trim(var_names(i)))
+        end do
+     allocate (character(len=max_len) :: registry(entry_index)%var_names(size(var_names)))
+        do i = 1, size(var_names)
+            registry(entry_index)%var_names(i) = adjustl(trim(var_names(i)))
+        end do
+
+        if (present(has_kind)) then
+            registry(entry_index)%has_kind = has_kind
+        else
+            registry(entry_index)%has_kind = .false.
+        end if
+
+        if (present(kind_value)) then
+            registry(entry_index)%kind_value = kind_value
+        else
+            registry(entry_index)%kind_value = 0
+        end if
+
+        if (present(is_parameter)) then
+            registry(entry_index)%is_parameter = is_parameter
+        else
+            registry(entry_index)%is_parameter = .false.
+        end if
+
+        if (present(is_allocatable)) then
+            registry(entry_index)%is_allocatable = is_allocatable
+        else
+            registry(entry_index)%is_allocatable = .false.
+        end if
+
+        if (present(is_pointer)) then
+            registry(entry_index)%is_pointer = is_pointer
+        else
+            registry(entry_index)%is_pointer = .false.
+        end if
+
+        if (present(dimension_indices)) then
+            registry(entry_index)%has_dimensions = .true.
+            if (size(dimension_indices) > 0) then
+               allocate (registry(entry_index)%dimension_indices(size(dimension_indices)))
+                registry(entry_index)%dimension_indices = dimension_indices
+            else
+                allocate (registry(entry_index)%dimension_indices(0))
+            end if
+        else
+            registry(entry_index)%has_dimensions = .false.
+        end if
+    end subroutine register_type_annotation
+
+    logical function has_type_annotations()
+        if (.not. allocated(registry)) then
+            has_type_annotations = .false.
+        else
+            has_type_annotations = size(registry) > 0
+        end if
+    end function has_type_annotations
+
+    subroutine consume_type_annotations(entries)
+        type(type_annotation_t), allocatable, intent(out) :: entries(:)
+
+        if (.not. allocated(registry)) then
+            allocate (entries(0))
+            return
+        end if
+
+        call move_alloc(registry, entries)
+    end subroutine consume_type_annotations
+
+end module parser_type_hooks_module

--- a/src/semantic/analyzers/semantic_analyzer.f90
+++ b/src/semantic/analyzers/semantic_analyzer.f90
@@ -28,10 +28,13 @@ module semantic_analyzer
                                           infer_comparison_operation, &
                                           infer_logical_operation
     use semantic_inference_helpers, only: process_if_node_branches, process_do_while_node_body, &
-                                          process_where_node_clauses, process_where_stmt_node, &
-                                          process_forall_node_body, process_select_case_blocks, &
-                                          process_associate_node_body, process_stop_node_code, &
+                                    process_where_node_clauses, process_where_stmt_node, &
+                                   process_forall_node_body, process_select_case_blocks, &
+                                    process_associate_node_body, process_stop_node_code, &
                                           process_declaration_variables
+    use parser_type_hooks_module, only: type_annotation_t, consume_type_annotations, &
+                                        has_type_annotations
+    use lexer_core, only: to_lower
     use ast_base, only: LITERAL_INTEGER, LITERAL_REAL, LITERAL_STRING, LITERAL_LOGICAL
     use ast_nodes_core, only: literal_node, identifier_node, binary_op_node, &
                               assignment_node, call_or_subscript_node, &
@@ -67,6 +70,7 @@ module semantic_analyzer
         type(error_collection_t) :: errors  ! Collect semantic errors
         logical :: strict_mode = .false.  ! Default lazy mode; callers may enable strict
         logical :: respect_implicit_none = .true.
+        type(type_annotation_t), allocatable :: parser_type_hints(:)
     contains
         ! Implement required abstract procedures from semantic_context_base_t FIRST
         procedure :: get_context_name => semantic_get_context_name
@@ -86,6 +90,7 @@ module semantic_analyzer
         procedure :: validate_bounds => validate_array_access_bounds
         procedure :: check_conformance => check_array_shape_conformance
         procedure :: has_errors => semantic_context_has_errors
+        procedure :: get_type_hint => semantic_get_type_hint
 
         generic :: assignment(=) => assign
     end type semantic_context_t
@@ -132,12 +137,13 @@ contains
         ! Create polymorphic type scheme (no type variables to generalize)
         builtin_scheme = create_poly_type(forall_vars=[type_var_t ::], mono=real_to_real)
 
-        ! Add common math functions to global scope
-        call ctx%scopes%define("sin", builtin_scheme)
-        call ctx%scopes%define("cos", builtin_scheme)
-        call ctx%scopes%define("tan", builtin_scheme)
-        call ctx%scopes%define("sqrt", builtin_scheme)
         call ctx%scopes%define("exp", builtin_scheme)
+
+        if (has_type_annotations()) then
+            call consume_type_annotations(ctx%parser_type_hints)
+        else
+            allocate (ctx%parser_type_hints(0))
+        end if
         call ctx%scopes%define("log", builtin_scheme)
         call ctx%scopes%define("abs", builtin_scheme)
     end subroutine create_semantic_context
@@ -178,17 +184,24 @@ contains
         ! Prepass: define all declared variables in scope before inference
         if (allocated(prog%body_indices)) then
             do i = 1, size(prog%body_indices)
-                if (prog%body_indices(i) > 0 .and. prog%body_indices(i) <= arena%size) then
+               if (prog%body_indices(i) > 0 .and. prog%body_indices(i) <= arena%size) then
                     if (allocated(arena%entries(prog%body_indices(i))%node)) then
                         select type (node => arena%entries(prog%body_indices(i))%node)
                         type is (declaration_node)
                             block
                                 type(mono_type_t) :: decl_type
                                 type(poly_type_t) :: scheme
+                                type(type_annotation_t) :: hint
                                 integer :: j
-                                call process_declaration_variables(node, decl_type)
+
+                                if (ctx%get_type_hint(prog%body_indices(i), hint)) then
+                                    call type_from_annotation(hint, decl_type)
+                                else
+                                    call process_declaration_variables(node, decl_type)
+                                end if
+
                                 scheme = ctx%generalize(decl_type)
-                                if (node%is_multi_declaration .and. allocated(node%var_names)) then
+                       if (node%is_multi_declaration .and. allocated(node%var_names)) then
                                     do j = 1, size(node%var_names)
                                         call ctx%scopes%define(node%var_names(j), scheme)
                                     end do
@@ -207,7 +220,7 @@ contains
         ! Main inference over statements
         if (allocated(prog%body_indices)) then
             do i = 1, size(prog%body_indices)
-                if (prog%body_indices(i) > 0 .and. prog%body_indices(i) <= arena%size) then
+               if (prog%body_indices(i) > 0 .and. prog%body_indices(i) <= arena%size) then
                     call infer_and_store_type(ctx, arena, prog%body_indices(i))
                 end if
             end do
@@ -383,9 +396,9 @@ contains
                     end do
                 end if
             type is (function_def_node)
-                call analyze_function_parameters(arena, expr, param_types, this%scopes, this%next_var_id)
-                return_type = determine_function_return_type(arena, expr, this%next_var_id)
-                call create_function_scope(arena, expr, node_index, return_type, this%scopes)
+ call analyze_function_parameters(arena, expr, param_types, this%scopes, this%next_var_id)
+               return_type = determine_function_return_type(arena, expr, this%next_var_id)
+             call create_function_scope(arena, expr, node_index, return_type, this%scopes)
                 post_frame = current
                 post_frame%state = STATE_POST
                 post_frame%leave_scope = .true.
@@ -523,7 +536,7 @@ contains
                     do i = size(expr%associations), 1, -1
                         if (expr%associations(i)%expr_index > 0) then
                             post_frame = current
-                            if (allocated(post_frame%param_types)) deallocate (post_frame%param_types)
+                if (allocated(post_frame%param_types)) deallocate (post_frame%param_types)
                             post_frame%node_index = current%node_index
                             post_frame%state = STATE_ASSOC_DEFINE
                             post_frame%aux_index = i
@@ -641,12 +654,12 @@ contains
             select type (assoc_node => arena%entries(parent_index)%node)
             type is (associate_node)
                 if (.not. allocated(assoc_node%associations)) return
-                if (assoc_index < 1 .or. assoc_index > size(assoc_node%associations)) return
+              if (assoc_index < 1 .or. assoc_index > size(assoc_node%associations)) return
                 if (assoc_node%associations(assoc_index)%expr_index <= 0) return
-                assoc_type = get_node_type(assoc_node%associations(assoc_index)%expr_index)
-                assoc_scheme = create_poly_type(forall_vars=[type_var_t ::], mono=assoc_type)
+               assoc_type = get_node_type(assoc_node%associations(assoc_index)%expr_index)
+             assoc_scheme = create_poly_type(forall_vars=[type_var_t ::], mono=assoc_type)
                 if (allocated(assoc_node%associations(assoc_index)%name)) then
-                    call this%scopes%define(assoc_node%associations(assoc_index)%name, assoc_scheme)
+          call this%scopes%define(assoc_node%associations(assoc_index)%name, assoc_scheme)
                 end if
             end select
         end subroutine handle_association
@@ -907,6 +920,67 @@ contains
         has_errors = this%errors%has_errors()
     end function semantic_context_has_errors
 
+    logical function semantic_get_type_hint(this, decl_index, annotation)
+        class(semantic_context_t), intent(in) :: this
+        integer, intent(in) :: decl_index
+        type(type_annotation_t), intent(out) :: annotation
+        integer :: i
+
+        semantic_get_type_hint = .false.
+        if (.not. allocated(this%parser_type_hints)) return
+        if (size(this%parser_type_hints) == 0) return
+
+        do i = 1, size(this%parser_type_hints)
+            if (this%parser_type_hints(i)%decl_index == decl_index) then
+                annotation = this%parser_type_hints(i)
+                semantic_get_type_hint = .true.
+                return
+            end if
+        end do
+    end function semantic_get_type_hint
+
+    subroutine type_from_annotation(annotation, var_type)
+        type(type_annotation_t), intent(in) :: annotation
+        type(mono_type_t), intent(out) :: var_type
+        integer :: kind_id
+        character(len=:), allocatable :: lowered
+
+        lowered = adjustl(to_lower(trim(annotation%type_name)))
+        select case (lowered)
+        case ("integer")
+            kind_id = TINT
+        case ("real")
+            kind_id = TREAL
+        case ("character")
+            kind_id = TCHAR
+        case ("logical")
+            kind_id = TLOGICAL
+        case ("complex")
+            kind_id = TCOMPLEX
+        case ("double precision")
+            kind_id = TDOUBLE
+        case default
+            if (index(lowered, "type(") == 1) then
+                kind_id = TDERIVED
+            else
+                kind_id = TREAL
+            end if
+        end select
+
+        var_type = create_mono_type(kind_id)
+
+        if (annotation%has_kind) then
+            if (kind_id == TCHAR) then
+                if (annotation%kind_value > 0) then
+                    var_type%size = annotation%kind_value
+                else if (annotation%kind_value == -1) then
+                    var_type%size = -1
+                end if
+            end if
+            var_type%kind = kind_id
+        end if
+    end subroutine type_from_annotation
+
     ! Infer type of literal
     function infer_literal(ctx, lit) result(typ)
         type(semantic_context_t), intent(inout) :: ctx
@@ -958,11 +1032,11 @@ contains
             if (ctx%strict_mode) then
                 ! Standard Fortran mode: undefined variable is an error
                 error_result = create_error_result( &
-                               "Undefined variable '" // ident%name // "' in strict mode", &
+                               "Undefined variable '"//ident%name//"' in strict mode", &
                                ERROR_SEMANTIC, &
                                component="semantic_analyzer", &
                                context="infer_identifier", &
-                               suggestion="Declare the variable with 'integer :: " // ident%name // &
+                       suggestion="Declare the variable with 'integer :: "//ident%name// &
                                "' or remove 'implicit none' for lazy Fortran mode" &
                                )
                 call ctx%errors%add_result(error_result)
@@ -1066,7 +1140,7 @@ contains
         ! Process arguments to detect undefined variables
         if (allocated(call_node%arg_indices)) then
             do i = 1, size(call_node%arg_indices)
-                arg_type = get_inferred_type_from_arena(ctx, arena, call_node%arg_indices(i))
+             arg_type = get_inferred_type_from_arena(ctx, arena, call_node%arg_indices(i))
             end do
         end if
 
@@ -1076,7 +1150,7 @@ contains
         if (allocated(scheme)) then
             typ = ctx%instantiate(scheme)
             ! Extract return type from function type
-            if (typ%kind == TFUN .and. type_args_allocated(typ) .and. type_args_size(typ) >= 2) then
+  if (typ%kind == TFUN .and. type_args_allocated(typ) .and. type_args_size(typ) >= 2) then
                 typ = type_args_element(typ, 2)  ! Second arg is return type
             end if
         else
@@ -1147,7 +1221,8 @@ contains
         ! Use extracted assignment processing
         call process_assignment_inference(arena, assignment, assignment_index, &
                                           lhs_index, expr_typ, updated_expr_typ, &
-                                          ctx%scopes, ctx%errors, ctx%strict_mode, ctx%next_var_id)
+                               ctx%scopes, ctx%errors, ctx%strict_mode, ctx%next_var_id, &
+                                          ctx%parser_type_hints)
 
         typ = updated_expr_typ
 
@@ -1212,7 +1287,7 @@ contains
         end if
 
         ! Start with first element type
-        first_type = get_inferred_type_from_arena(ctx, arena, array_lit%element_indices(1))
+       first_type = get_inferred_type_from_arena(ctx, arena, array_lit%element_indices(1))
         promoted_type = first_type
         has_real = (first_type%kind == TREAL)
         all_arrays = (first_type%kind == TARRAY)
@@ -1225,7 +1300,7 @@ contains
 
         ! Check all elements for type promotion and consistency
         do i = 2, size(array_lit%element_indices)
-            element_type = get_inferred_type_from_arena(ctx, arena, array_lit%element_indices(i))
+     element_type = get_inferred_type_from_arena(ctx, arena, array_lit%element_indices(i))
 
             ! Check if all elements are arrays (for nested arrays)
             if (all_arrays .and. element_type%kind /= TARRAY) then

--- a/src/semantic/analyzers/semantic_assignment_inference.f90
+++ b/src/semantic/analyzers/semantic_assignment_inference.f90
@@ -3,7 +3,8 @@ module semantic_assignment_inference
     ! for architectural compliance (Issue #1117)
     use type_system_unified, only: mono_type_t, poly_type_t, type_var_t, &
                                    create_mono_type, create_poly_type, &
-                                   TCHAR, TARRAY, TINT, TREAL, TLOGICAL
+                                   TCHAR, TARRAY, TINT, TREAL, TLOGICAL, &
+                                   TCOMPLEX, TDOUBLE, TDERIVED
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: identifier_node, binary_op_node, assignment_node, &
                               call_or_subscript_node, literal_node
@@ -14,6 +15,8 @@ module semantic_assignment_inference
     use standardizer_types, only: calculate_loop_size
     ! No direct dependency on function analysis here
     use error_handling, only: error_collection_t
+    use parser_type_hooks_module, only: type_annotation_t
+    use lexer_core, only: to_lower
     implicit none
     private
 
@@ -24,7 +27,7 @@ contains
     ! Process assignment inference with scope and error handling
     subroutine process_assignment_inference(arena, assignment, assignment_index, &
                                             lhs_index, expr_typ, updated_expr_typ, &
-                                            scopes, errors, strict_mode, next_var_id)
+                                     scopes, errors, strict_mode, next_var_id, type_hints)
         type(ast_arena_t), intent(inout) :: arena
         type(assignment_node), intent(in) :: assignment
         integer, intent(in) :: assignment_index, lhs_index
@@ -34,6 +37,7 @@ contains
         type(error_collection_t), intent(inout) :: errors
         logical, intent(in) :: strict_mode
         integer, intent(inout) :: next_var_id
+        type(type_annotation_t), intent(in), optional :: type_hints(:)
         type(poly_type_t) :: scheme
         type(poly_type_t), allocatable :: existing_scheme
         type(result_t) :: error_result
@@ -51,7 +55,11 @@ contains
                         ! Fallback: if this identifier is declared somewhere in the arena,
                         ! define it in scope before deciding it's undefined. This protects
                         ! multi-variable declarations with initializers and re-ordered nodes.
-                        call ensure_declared_from_arena_local(scopes, arena, lhs_node%name)
+                        if (present(type_hints)) then
+           call ensure_declared_from_arena_local(scopes, arena, lhs_node%name, type_hints)
+                        else
+                       call ensure_declared_from_arena_local(scopes, arena, lhs_node%name)
+                        end if
                         call scopes%lookup(lhs_node%name, existing_scheme)
                     end if
 
@@ -64,15 +72,15 @@ contains
 
                     ! Handle allocatable character detection
                     if (updated_expr_typ%kind == TCHAR) then
-                        call handle_character_allocation(arena, assignment, updated_expr_typ, &
+                   call handle_character_allocation(arena, assignment, updated_expr_typ, &
                                                          lhs_node%name)
                     end if
 
                     ! Update all identifier nodes in the arena with the inferred type
-                    call update_identifier_type_in_arena(arena, lhs_node%name, updated_expr_typ)
+              call update_identifier_type_in_arena(arena, lhs_node%name, updated_expr_typ)
 
                     ! Generalize the expression type and define/update in scope
-                    scheme = create_poly_type(forall_vars=[type_var_t ::], mono=updated_expr_typ)
+             scheme = create_poly_type(forall_vars=[type_var_t ::], mono=updated_expr_typ)
                     call scopes%define(lhs_node%name, scheme)
                 type is (call_or_subscript_node)
                     call handle_array_assignment(arena, assignment_index, lhs_node, &
@@ -83,15 +91,29 @@ contains
     end subroutine process_assignment_inference
 
     ! Local helper: best-effort define symbol from any declaration present in the arena
-    subroutine ensure_declared_from_arena_local(scopes, arena, name)
+    subroutine ensure_declared_from_arena_local(scopes, arena, name, type_hints)
         use ast_nodes_data, only: declaration_node
         use semantic_inference_helpers, only: process_declaration_variables
         type(scope_stack_t), intent(inout) :: scopes
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: name
+        type(type_annotation_t), intent(in), optional :: type_hints(:)
         integer :: i, j
         type(mono_type_t) :: decl_type
         type(poly_type_t) :: scheme
+
+        if (present(type_hints)) then
+            do i = 1, size(type_hints)
+                do j = 1, size(type_hints(i)%var_names)
+                    if (trim(type_hints(i)%var_names(j)) == trim(name)) then
+                        call type_from_annotation(type_hints(i), decl_type)
+                    scheme = create_poly_type(forall_vars=[type_var_t ::], mono=decl_type)
+                        call scopes%define(name, scheme)
+                        return
+                    end if
+                end do
+            end do
+        end if
 
         do i = 1, arena%size
             if (.not. allocated(arena%entries(i)%node)) cycle
@@ -100,7 +122,7 @@ contains
                 if (allocated(node%var_name)) then
                     if (trim(node%var_name) == trim(name)) then
                         call process_declaration_variables(node, decl_type)
-                        scheme = create_poly_type(forall_vars=[type_var_t ::], mono=decl_type)
+                    scheme = create_poly_type(forall_vars=[type_var_t ::], mono=decl_type)
                         call scopes%define(name, scheme)
                         return
                     end if
@@ -109,7 +131,7 @@ contains
                     do j = 1, size(node%var_names)
                         if (trim(node%var_names(j)) == trim(name)) then
                             call process_declaration_variables(node, decl_type)
-                            scheme = create_poly_type(forall_vars=[type_var_t ::], mono=decl_type)
+                    scheme = create_poly_type(forall_vars=[type_var_t ::], mono=decl_type)
                             call scopes%define(name, scheme)
                             return
                         end if
@@ -118,6 +140,48 @@ contains
             end select
         end do
     end subroutine ensure_declared_from_arena_local
+
+    subroutine type_from_annotation(annotation, var_type)
+        type(type_annotation_t), intent(in) :: annotation
+        type(mono_type_t), intent(out) :: var_type
+        integer :: kind_id
+        character(len=:), allocatable :: lowered
+
+        lowered = adjustl(to_lower(trim(annotation%type_name)))
+        select case (lowered)
+        case ("integer")
+            kind_id = TINT
+        case ("real")
+            kind_id = TREAL
+        case ("character")
+            kind_id = TCHAR
+        case ("logical")
+            kind_id = TLOGICAL
+        case ("complex")
+            kind_id = TCOMPLEX
+        case ("double precision")
+            kind_id = TDOUBLE
+        case default
+            if (index(lowered, "type(") == 1) then
+                kind_id = TDERIVED
+            else
+                kind_id = TREAL
+            end if
+        end select
+
+        var_type = create_mono_type(kind_id)
+
+        if (annotation%has_kind) then
+            if (kind_id == TCHAR) then
+                if (annotation%kind_value > 0) then
+                    var_type%size = annotation%kind_value
+                else if (annotation%kind_value == -1) then
+                    var_type%size = -1
+                end if
+            end if
+            var_type%kind = kind_id
+        end if
+    end subroutine type_from_annotation
 
     ! Handle character allocation detection for string concatenation
     subroutine handle_character_allocation(arena, assignment, expr_typ, var_name)
@@ -222,7 +286,7 @@ contains
 
         select type (arg_node => arena%entries(expr_index)%node)
         type is (identifier_node)
-            dim_size = find_loop_extent_for_variable(arena, assignment_index, arg_node%name)
+          dim_size = find_loop_extent_for_variable(arena, assignment_index, arg_node%name)
         type is (literal_node)
             dim_size = 0
         class default
@@ -251,8 +315,8 @@ contains
                 type is (do_loop_node)
                     if (allocated(loop_node%var_name)) then
                         if (trim(loop_node%var_name) == trim(var_name)) then
-                            extent = calculate_loop_size(arena, loop_node%start_expr_index, &
-                                                         loop_node%end_expr_index, loop_node%step_expr_index)
+                         extent = calculate_loop_size(arena, loop_node%start_expr_index, &
+                                      loop_node%end_expr_index, loop_node%step_expr_index)
                             if (extent < 0) extent = 0
                             return
                         end if
@@ -287,12 +351,12 @@ contains
                             if (candidate_idx <= 0 .or. candidate_idx > arena%size) cycle
                             if (.not. allocated(arena%entries(candidate_idx)%node)) cycle
 
-                            select type (sibling_loop => arena%entries(candidate_idx)%node)
+                           select type (sibling_loop => arena%entries(candidate_idx)%node)
                             type is (do_loop_node)
                                 if (allocated(sibling_loop%var_name)) then
-                                    if (trim(sibling_loop%var_name) == trim(var_name)) then
-                                        extent = calculate_loop_size(arena, sibling_loop%start_expr_index, &
-                                                                     sibling_loop%end_expr_index, sibling_loop%step_expr_index)
+                                   if (trim(sibling_loop%var_name) == trim(var_name)) then
+                      extent = calculate_loop_size(arena, sibling_loop%start_expr_index, &
+                                sibling_loop%end_expr_index, sibling_loop%step_expr_index)
                                         if (extent < 0) extent = 0
                                         if (extent > 0) return
                                     end if
@@ -326,7 +390,7 @@ contains
             allocate (args(1))
             args(1) = current_type
             if (dim_sizes(idx) > 0) then
-                current_type = create_mono_type(TARRAY, args=args, array_size=dim_sizes(idx))
+             current_type = create_mono_type(TARRAY, args=args, array_size=dim_sizes(idx))
             else
                 current_type = create_mono_type(TARRAY, args=args)
                 current_type%alloc_info%is_allocatable = .true.

--- a/test/parser/test_control_flow_router_nested.f90
+++ b/test/parser/test_control_flow_router_nested.f90
@@ -1,0 +1,94 @@
+program test_control_flow_router_nested
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use lexer_core, only: token_t, tokenize_core
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_execution_statements_module, only: parse_program_statement
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_loops, only: do_loop_node
+    use ast_nodes_control, only: if_node, select_case_node
+    use ast_nodes_core, only: literal_node, program_node
+    implicit none
+
+    character(len=:), allocatable :: source
+    type(token_t), allocatable :: tokens(:)
+    type(parser_state_t) :: parser
+    type(ast_arena_t) :: arena
+    integer :: prog_index, i
+    logical :: has_do_loop, has_if_block, has_select_case, has_placeholder
+
+    print *, '=== Test: control-flow router handles nested constructs ==='
+
+    source = 'program nested_cf' // new_line('a') // &
+             '  do i = 1, 3' // new_line('a') // &
+             '    if (flag) then' // new_line('a') // &
+             '      select case(value)' // new_line('a') // &
+             '      case (1)' // new_line('a') // &
+             '        print *, "one"' // new_line('a') // &
+             '      case default' // new_line('a') // &
+             '        print *, "other"' // new_line('a') // &
+             '      end select' // new_line('a') // &
+             '    end if' // new_line('a') // &
+             '  end do' // new_line('a') // &
+             'end program nested_cf'
+
+    call tokenize_core(source, tokens)
+    parser = create_parser_state(tokens)
+    arena = create_ast_arena(256)
+
+    prog_index = parse_program_statement(parser, arena)
+    if (prog_index <= 0) then
+        write (error_unit, '(a)') 'ERROR: parse_program_statement returned invalid index'
+        stop 1
+    end if
+
+    if (parser%has_errors()) then
+        write (error_unit, '(a)') 'ERROR: parser reported structured errors'
+        stop 1
+    end if
+
+    has_do_loop = .false.
+    has_if_block = .false.
+    has_select_case = .false.
+    has_placeholder = .false.
+
+    do i = 1, arena%size
+        if (.not. arena%has_node_at(i)) cycle
+        select type (node => arena%entries(i)%node)
+        type is (program_node)
+            cycle
+        type is (do_loop_node)
+            has_do_loop = .true.
+        type is (if_node)
+            has_if_block = .true.
+        type is (select_case_node)
+            has_select_case = .true.
+        type is (literal_node)
+            if (allocated(node%value)) then
+                if (index(node%value, '! Unparsed') > 0) has_placeholder = .true.
+            end if
+        end select
+    end do
+
+    if (.not. has_do_loop) then
+        write (error_unit, '(a)') 'ERROR: expected DO loop node not found'
+        stop 1
+    end if
+
+    if (.not. has_if_block) then
+        write (error_unit, '(a)') 'ERROR: expected IF node not found'
+        stop 1
+    end if
+
+    if (.not. has_select_case) then
+        write (error_unit, '(a)') 'ERROR: expected SELECT CASE node not found'
+        stop 1
+    end if
+
+    if (has_placeholder) then
+        write (error_unit, '(a)') 'ERROR: unexpected placeholder literal emitted'
+        stop 1
+    end if
+
+    print *, 'PASS: nested control flow parsed without placeholders'
+
+end program test_control_flow_router_nested

--- a/test/semantic/test_parser_type_hints.f90
+++ b/test/semantic/test_parser_type_hints.f90
@@ -1,0 +1,86 @@
+program test_parser_type_hints
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use lexer_core, only: token_t, tokenize_core
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_declarations, only: parse_declaration
+    use semantic_analyzer, only: semantic_context_t, create_semantic_context
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use parser_type_hooks_module, only: type_annotation_t
+    implicit none
+
+    character(len=:), allocatable :: source
+    type(token_t), allocatable :: tokens(:)
+    type(parser_state_t) :: parser
+    type(ast_arena_t) :: arena
+    integer :: decl_index
+    type(semantic_context_t) :: ctx
+    type(type_annotation_t) :: hint
+    logical :: found
+
+    print *, '=== Test: parser type hooks capture declaration metadata ==='
+
+    source = 'real(kind=8), allocatable :: mat(:,:)' // new_line('a')
+
+    call tokenize_core(source, tokens)
+    parser = create_parser_state(tokens)
+    arena = create_ast_arena(64)
+
+    decl_index = parse_declaration(parser, arena)
+    if (decl_index <= 0) then
+        write (error_unit, '(a)') 'ERROR: parse_declaration did not return a valid node'
+        stop 1
+    end if
+
+    call create_semantic_context(ctx)
+
+    if (.not. allocated(ctx%parser_type_hints)) then
+        write (error_unit, '(a)') 'ERROR: semantic context did not receive parser hints'
+        stop 1
+    end if
+
+    if (size(ctx%parser_type_hints) /= 1) then
+        write (error_unit, '(a,i0)') 'ERROR: expected a single type annotation, found ', &
+            size(ctx%parser_type_hints)
+        stop 1
+    end if
+
+    if (trim(ctx%parser_type_hints(1)%type_name) /= 'real') then
+        write (error_unit, '(a)') 'ERROR: recorded type name is incorrect'
+        stop 1
+    end if
+
+    if (.not. ctx%parser_type_hints(1)%is_allocatable) then
+        write (error_unit, '(a)') 'ERROR: allocatable attribute missing from annotation'
+        stop 1
+    end if
+
+    if (.not. ctx%parser_type_hints(1)%has_dimensions) then
+        write (error_unit, '(a)') 'ERROR: dimension metadata missing from annotation'
+        stop 1
+    end if
+
+    if (size(ctx%parser_type_hints(1)%var_names) /= 1) then
+        write (error_unit, '(a,i0)') 'ERROR: expected one variable name, found ', &
+            size(ctx%parser_type_hints(1)%var_names)
+        stop 1
+    end if
+
+    found = ctx%get_type_hint(decl_index, hint)
+    if (.not. found) then
+        write (error_unit, '(a)') 'ERROR: context lookup for type hint failed'
+        stop 1
+    end if
+
+    if (.not. hint%has_dimensions) then
+        write (error_unit, '(a)') 'ERROR: lookup annotation missing dimensions'
+        stop 1
+    end if
+
+    if (hint%dimension_indices(1) /= ctx%parser_type_hints(1)%dimension_indices(1)) then
+        write (error_unit, '(a)') 'ERROR: dimension metadata mismatch'
+        stop 1
+    end if
+
+    print *, 'PASS: parser type annotations propagated to semantic context'
+
+end program test_parser_type_hints


### PR DESCRIPTION
## Summary
- add dedicated parser_control_flow_router with callbacks module to centralize control-flow dispatch
- introduce parser_type_hooks for registering declaration metadata and surface hints to semantics
- remove placeholder literal fallbacks, streamline parser error reporting, and add regression coverage for nested control flow and type hints

## Testing
- make test

Fixes #1380