### PR TITLE
fix: hoist optional subroutines into contains (fixes #1394)

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -10,7 +10,6 @@
 # Known semantic/codegen gaps awaiting fixes
 # F90/F95 parser issues
 issue_1347_interface.f90        # Issue #1347: INTERFACE blocks cause parser error
-issue_1352_optional.f90         # Issue #1352: OPTIONAL parameters broken
 
 # Lazy Fortran control flow
 

--- a/src/frontend_transformation.f90
+++ b/src/frontend_transformation.f90
@@ -20,12 +20,13 @@ module frontend_transformation
                               set_line_length_config, get_line_length_config
     use input_validation, only: validate_basic_syntax, has_only_meaningless_tokens
     use ast_nodes_core, only: program_node
-    use ast_nodes_procedure, only: function_def_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
     use ast_nodes_misc, only: contains_node
     use ast_nodes_data, only: declaration_node
     use frontend_parsing, only: parse_tokens
     use frontend_core, only: lex_source, emit_fortran
     use debug_trace, only: trace_init, trace_enter, trace_leave
+    use procedure_classification, only: should_hoist_procedure
 
     implicit none
     private
@@ -184,7 +185,8 @@ contains
         logical :: saved_standardize_types, saved_standardizer_types
 
         call save_current_configuration(saved_size, saved_char, saved_line_length, &
-                                        saved_standardize_types, saved_standardizer_types)
+                                        saved_standardize_types, &
+                                        saved_standardizer_types)
 
         ! Set new configuration
         call apply_format_options(format_opts)
@@ -433,7 +435,8 @@ contains
         output = "program main" // new_line('A') // &
                  "    implicit none" // new_line('A') // &
                  "    ! COMPILATION FAILED" // new_line('A') // &
-          "    ! Original code could not be structured as a program" // new_line('A') // &
+                 "    ! Original code could not be structured as a program" // &
+                 new_line('A') // &
                  "end program main" // new_line('A')
         ! error_msg already contains the error details for stderr
         ! Reuse shared arena: do not destroy here
@@ -574,7 +577,8 @@ contains
         integer, intent(inout) :: root_index
 
         integer :: i, j, target_prog_idx, contains_pos
-        integer, allocatable :: functions(:)
+        integer, allocatable :: procedures(:)
+        integer, allocatable :: all_procedures(:)
         integer, allocatable :: new_body(:)
         class(program_node), pointer :: root_prog => null()
 
@@ -590,7 +594,8 @@ contains
         end select
         if (.not. associated(root_prog)) return
 
-        allocate (functions(0))
+        if (allocated(all_procedures)) deallocate (all_procedures)
+        allocate (all_procedures(0))
         target_prog_idx = 0
 
         if (allocated(root_prog%body_indices)) then
@@ -607,19 +612,31 @@ contains
                         end if
                     end if
                 type is (function_def_node)
-                    functions = [functions, root_prog%body_indices(i)]
+                    all_procedures = [all_procedures, root_prog%body_indices(i)]
+                type is (subroutine_def_node)
+                    all_procedures = [all_procedures, root_prog%body_indices(i)]
                 end select
             end do
         end if
 
         if (target_prog_idx == 0) return
-        if (size(functions) == 0) return
+        if (size(all_procedures) == 0) return
+
+        if (allocated(procedures)) deallocate (procedures)
+        allocate (procedures(0))
+        do i = 1, size(all_procedures)
+            if (should_hoist_procedure(arena, all_procedures(i), target_prog_idx)) then
+                procedures = [procedures, all_procedures(i)]
+            end if
+        end do
+
+        if (size(procedures) == 0) return
 
         ! Remove function indices from multi-unit body
         allocate (new_body(0))
         if (allocated(root_prog%body_indices)) then
             do i = 1, size(root_prog%body_indices)
-                if (any(root_prog%body_indices(i) == functions)) cycle
+                if (any(root_prog%body_indices(i) == procedures)) cycle
                 new_body = [new_body, root_prog%body_indices(i)]
             end do
         end if
@@ -676,13 +693,13 @@ contains
                     allocate (original(0))
                 end if
                 orig_size = size(original)
-                insert_size = size(functions)
+                insert_size = size(procedures)
                 allocate (target%body_indices(orig_size + insert_size))
                 if (contains_pos >= 1) then
                     target%body_indices(1:contains_pos) = original(1:contains_pos)
                 end if
                 target%body_indices(contains_pos + 1:contains_pos + insert_size) &
-                    & = functions
+                    & = procedures
                 if (contains_pos < orig_size) then
                     target%body_indices(contains_pos + insert_size + 1:) = &
                         original(contains_pos + 1:orig_size)
@@ -690,9 +707,9 @@ contains
             end block
 
             ! Update parent indices and remove external declarations
-            do i = 1, size(functions)
-                if (functions(i) > 0 .and. functions(i) <= arena%size) then
-                    arena%entries(functions(i))%parent_index = target_prog_idx
+            do i = 1, size(procedures)
+                if (procedures(i) > 0 .and. procedures(i) <= arena%size) then
+                    arena%entries(procedures(i))%parent_index = target_prog_idx
                 end if
             end do
 
@@ -700,7 +717,8 @@ contains
                 do i = 1, size(target%body_indices)
                     if (target%body_indices(i) <= 0 .or. target%body_indices(i) > &
                         & arena%size) cycle
-                    if (.not. allocated(arena%entries(target%body_indices(i))%node)) cycle
+                    if (.not. &
+                        allocated(arena%entries(target%body_indices(i))%node)) cycle
                     select type (stmt => arena%entries(target%body_indices(i))%node)
                     type is (declaration_node)
                         block
@@ -709,15 +727,17 @@ contains
                             if (stmt%is_multi_declaration .and. &
                                 & allocated(stmt%var_names)) then
                                 do j = 1, size(stmt%var_names)
-                                    if (is_function_name(trim(stmt%var_names(j)), arena, &
-                                        & functions)) then
+                                    if &
+                                        (is_procedure_name(trim(stmt%var_names(j)), &
+                                        arena, &
+                                        & procedures)) then
                                         declares_function = .true.
                                         exit
                                     end if
                                 end do
                             else
-                                if (is_function_name(trim(stmt%var_name), arena, &
-                                    & functions)) then
+                                if (is_procedure_name(trim(stmt%var_name), arena, &
+                                    & procedures)) then
                                     declares_function = .true.
                                 end if
                             end if
@@ -740,25 +760,30 @@ contains
         end select
     end subroutine normalize_multi_unit_container
 
-    logical function is_function_name(name, arena, func_indices) result(match)
+    logical function is_procedure_name(name, arena, proc_indices) result(match)
         character(len=*), intent(in) :: name
         type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: func_indices(:)
+        integer, intent(in) :: proc_indices(:)
         integer :: k
 
         match = .false.
-        do k = 1, size(func_indices)
-            if (func_indices(k) <= 0 .or. func_indices(k) > arena%size) cycle
-            if (.not. allocated(arena%entries(func_indices(k))%node)) cycle
-            select type (fn => arena%entries(func_indices(k))%node)
+        do k = 1, size(proc_indices)
+            if (proc_indices(k) <= 0 .or. proc_indices(k) > arena%size) cycle
+            if (.not. allocated(arena%entries(proc_indices(k))%node)) cycle
+            select type (proc_node => arena%entries(proc_indices(k))%node)
             type is (function_def_node)
-                if (trim(fn%name) == trim(name)) then
+                if (trim(proc_node%name) == trim(name)) then
+                    match = .true.
+                    return
+                end if
+            type is (subroutine_def_node)
+                if (trim(proc_node%name) == trim(name)) then
                     match = .true.
                     return
                 end if
             end select
         end do
-    end function is_function_name
+    end function is_procedure_name
 
     ! Run code generation phase
     subroutine run_code_generation_phase(compiler_arena, prog_index, output)
@@ -774,7 +799,7 @@ contains
 
     subroutine maybe_dump_program_overview(arena, prog_index)
         use, intrinsic :: iso_fortran_env, only: error_unit
-        use ast_nodes_procedure, only: function_def_node
+        use ast_nodes_procedure, only: function_def_node, subroutine_def_node
         use ast_nodes_data, only: declaration_node
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: prog_index
@@ -801,6 +826,8 @@ contains
                 end if
             type is (function_def_node)
                 write (error_unit, '(A,I0,2X,A)') '  function idx', i, trim(node%name)
+            type is (subroutine_def_node)
+                write (error_unit, '(A,I0,2X,A)') '  subroutine idx', i, trim(node%name)
             type is (declaration_node)
                 write (error_unit, '(A,I0,2X,A,2X,A)') '  decl idx', i, &
                     & trim(node%type_name), &

--- a/src/utilities/procedure_classification.f90
+++ b/src/utilities/procedure_classification.f90
@@ -1,0 +1,267 @@
+module procedure_classification
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: program_node
+    use ast_nodes_data, only: declaration_node, parameter_declaration_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node, &
+        & get_procedure_params, get_procedure_name
+    implicit none
+    private
+
+    public :: should_hoist_procedure
+
+contains
+
+    pure function to_lower_ascii(text) result(lower_text)
+        character(len=*), intent(in) :: text
+        character(len=len(text)) :: lower_text
+        integer, parameter :: upper_a = iachar('A')
+        integer, parameter :: upper_z = iachar('Z')
+        integer, parameter :: delta = iachar('a') - iachar('A')
+        integer :: i, code
+
+        lower_text = text
+        do i = 1, len(text)
+            code = iachar(text(i:i))
+            if (code >= upper_a .and. code <= upper_z) then
+                lower_text(i:i) = achar(code + delta)
+            end if
+        end do
+    end function to_lower_ascii
+
+    logical function should_hoist_procedure(arena, proc_idx, target_prog_idx) &
+        & result(should_hoist)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_idx
+        integer, intent(in) :: target_prog_idx
+
+        should_hoist = .false.
+        if (proc_idx <= 0) return
+        if (proc_idx > arena%size) return
+        if (.not. allocated(arena%entries(proc_idx)%node)) return
+
+        if (procedure_has_optional_arguments(arena, proc_idx)) then
+            should_hoist = .true.
+            return
+        end if
+
+        if (procedure_has_special_prefix(arena, proc_idx)) then
+            should_hoist = .true.
+            return
+        end if
+
+        if (procedure_declared_external(arena, proc_idx, target_prog_idx)) then
+            should_hoist = .true.
+            return
+        end if
+    end function should_hoist_procedure
+
+    logical function procedure_has_optional_arguments(arena, proc_idx) &
+        & result(has_optional)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_idx
+        integer, allocatable :: param_indices(:)
+        integer :: i, param_idx
+
+        has_optional = .false.
+        if (proc_idx <= 0) return
+        if (proc_idx > arena%size) return
+        if (.not. allocated(arena%entries(proc_idx)%node)) return
+
+        param_indices = get_procedure_params(arena%entries(proc_idx)%node)
+        if (.not. allocated(param_indices)) return
+
+        do i = 1, size(param_indices)
+            param_idx = param_indices(i)
+            if (param_idx <= 0) cycle
+            if (param_idx > arena%size) cycle
+            if (.not. allocated(arena%entries(param_idx)%node)) cycle
+            select type (param_node => arena%entries(param_idx)%node)
+            type is (parameter_declaration_node)
+                if (param_node%is_optional) then
+                    has_optional = .true.
+                    return
+                end if
+            type is (declaration_node)
+                if (param_node%is_optional) then
+                    has_optional = .true.
+                    return
+                end if
+            end select
+        end do
+
+        select type (proc_node => arena%entries(proc_idx)%node)
+        type is (function_def_node)
+            if (allocated(proc_node%body_indices)) then
+                if (body_has_optional_declaration(arena, proc_node%body_indices)) then
+                    has_optional = .true.
+                end if
+            end if
+        type is (subroutine_def_node)
+            if (allocated(proc_node%body_indices)) then
+                if (body_has_optional_declaration(arena, proc_node%body_indices)) then
+                    has_optional = .true.
+                end if
+            end if
+        class default
+        end select
+    end function procedure_has_optional_arguments
+
+    logical function procedure_has_special_prefix(arena, proc_idx) &
+        & result(has_prefix)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_idx
+        integer :: i
+        character(len=:), allocatable :: keyword
+
+        has_prefix = .false.
+        if (proc_idx <= 0) return
+        if (proc_idx > arena%size) return
+        if (.not. allocated(arena%entries(proc_idx)%node)) return
+
+        select type (proc_node => arena%entries(proc_idx)%node)
+        type is (function_def_node)
+            if (.not. allocated(proc_node%prefix_keywords)) return
+            do i = 1, size(proc_node%prefix_keywords)
+                keyword = to_lower_ascii(trim(proc_node%prefix_keywords(i)))
+                select case (keyword)
+                case ('pure', 'elemental')
+                    has_prefix = .true.
+                    return
+                end select
+            end do
+        type is (subroutine_def_node)
+            ! Note: subroutine_def_node does not store prefix keywords directly
+            ! in our AST, so fall back to scanning its body declarations.
+            if (allocated(proc_node%body_indices)) then
+                if (body_has_special_prefix(arena, proc_node%body_indices)) then
+                    has_prefix = .true.
+                end if
+            end if
+        class default
+        end select
+    end function procedure_has_special_prefix
+
+    logical function body_has_special_prefix(arena, body_indices) &
+        & result(has_prefix)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        integer :: i, idx
+
+        has_prefix = .false.
+
+        do i = 1, size(body_indices)
+            idx = body_indices(i)
+            if (idx <= 0) cycle
+            if (idx > arena%size) cycle
+            if (.not. allocated(arena%entries(idx)%node)) cycle
+            select type (node => arena%entries(idx)%node)
+            type is (function_def_node)
+                if (procedure_has_special_prefix(arena, idx)) then
+                    has_prefix = .true.
+                    return
+                end if
+            type is (subroutine_def_node)
+                if (procedure_has_special_prefix(arena, idx)) then
+                    has_prefix = .true.
+                    return
+                end if
+            class default
+            end select
+        end do
+    end function body_has_special_prefix
+
+    logical function body_has_optional_declaration(arena, body_indices) &
+        & result(has_optional)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        integer :: i, idx
+
+        has_optional = .false.
+
+        do i = 1, size(body_indices)
+            idx = body_indices(i)
+            if (idx <= 0) cycle
+            if (idx > arena%size) cycle
+            if (.not. allocated(arena%entries(idx)%node)) cycle
+            select type (decl => arena%entries(idx)%node)
+            type is (declaration_node)
+                if (decl%is_optional) then
+                    has_optional = .true.
+                    return
+                end if
+            end select
+        end do
+    end function body_has_optional_declaration
+
+    logical function procedure_declared_external(arena, proc_idx, target_prog_idx) &
+        result(is_external_proc)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_idx
+        integer, intent(in) :: target_prog_idx
+        character(len=:), allocatable :: proc_name
+
+        is_external_proc = .false.
+        if (target_prog_idx <= 0) return
+        if (target_prog_idx > arena%size) return
+        if (.not. allocated(arena%entries(target_prog_idx)%node)) return
+        if (proc_idx <= 0) return
+        if (proc_idx > arena%size) return
+        if (.not. allocated(arena%entries(proc_idx)%node)) return
+
+        proc_name = get_procedure_name(arena%entries(proc_idx)%node)
+        if (.not. allocated(proc_name)) return
+        proc_name = trim(to_lower_ascii(proc_name))
+        if (len(proc_name) == 0) return
+
+        select type (target => arena%entries(target_prog_idx)%node)
+        type is (program_node)
+            if (.not. allocated(target%body_indices)) return
+            if (body_declares_external_with_name(arena, target%body_indices, &
+                                                 proc_name)) then
+                is_external_proc = .true.
+            end if
+        class default
+        end select
+    end function procedure_declared_external
+
+    logical function body_declares_external_with_name(arena, body_indices, name) &
+        & result(has_match)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: name
+        integer :: i, idx, j
+        character(len=:), allocatable :: candidate
+
+        has_match = .false.
+
+        do i = 1, size(body_indices)
+            idx = body_indices(i)
+            if (idx <= 0) cycle
+            if (idx > arena%size) cycle
+            if (.not. allocated(arena%entries(idx)%node)) cycle
+            select type (decl => arena%entries(idx)%node)
+            type is (declaration_node)
+                if (.not. decl%is_external) cycle
+                if (allocated(decl%var_name)) then
+                    candidate = trim(to_lower_ascii(decl%var_name))
+                    if (candidate == name) then
+                        has_match = .true.
+                        return
+                    end if
+                end if
+                if (decl%is_multi_declaration) then
+                    if (allocated(decl%var_names)) then
+                        do j = 1, size(decl%var_names)
+                            candidate = trim(to_lower_ascii(decl%var_names(j)))
+                            if (candidate == name) then
+                                has_match = .true.
+                                return
+                            end if
+                        end do
+                    end if
+                end if
+            end select
+        end do
+    end function body_declares_external_with_name
+
+end module procedure_classification

--- a/test/frontend/test_issue_1352_optional_if.f90
+++ b/test/frontend/test_issue_1352_optional_if.f90
@@ -3,11 +3,75 @@ program test_issue_1352_optional_if
     use frontend, only: transform_lazy_fortran_string
     implicit none
 
+    call test_optional_program_contains()
     call test_optional_parameter_if_control()
     print *, ''
     print *, 'All tests passed for issue 1352.'
 
 contains
+
+    subroutine test_optional_program_contains()
+        character(len=:), allocatable :: input_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        integer :: idx_program, idx_contains, idx_subroutine
+
+        input_code = 'subroutine greet(name, title)' // new_line('a') // &
+                     '    character(len=*), intent(in) :: name' // new_line('a') // &
+                     '    character(len=*), intent(in), optional :: title' // &
+                     new_line('a') // &
+                     '    if (present(title)) then' // new_line('a') // &
+                     "        print *, trim(title), ' ', trim(name)" // &
+                     new_line('a') // &
+                     '    else' // new_line('a') // &
+                     '        print *, trim(name)' // new_line('a') // &
+                     '    end if' // new_line('a') // &
+                     'end subroutine greet' // new_line('a') // &
+                     new_line('a') // &
+                     'program test_optional' // new_line('a') // &
+                     '    implicit none' // new_line('a') // &
+                     "    call greet('Alice')" // new_line('a') // &
+                     "    call greet('Bob', 'Dr.')" // new_line('a') // &
+                     'end program test_optional'
+
+        call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            write (error_unit, '(a)') &
+                'FAIL: unexpected error for optional interface sample:'
+            write (error_unit, '(a)') trim(error_msg)
+            error stop 1
+        end if
+
+        idx_program = index(output_code, 'program test_optional')
+        idx_contains = index(output_code, 'contains')
+        idx_subroutine = index(output_code, 'subroutine greet')
+
+        if (idx_program <= 0) then
+            write (error_unit, '(a)') 'FAIL: program test_optional missing from output'
+            error stop 1
+        end if
+
+        if (idx_contains <= idx_program) then
+            write (error_unit, '(a)') &
+                'FAIL: contains block not inserted after program header'
+            error stop 1
+        end if
+
+        if (idx_subroutine <= idx_contains) then
+            write (error_unit, '(a)') &
+                'FAIL: greet subroutine not placed inside contains block'
+            error stop 1
+        end if
+
+        if (index(output_code, 'optional :: title') <= 0) then
+            write (error_unit, '(a)') &
+                'FAIL: optional attribute lost when restructuring program'
+            error stop 1
+        end if
+
+        print *, 'PASS: Optional subroutine moved inside contains block'
+    end subroutine test_optional_program_contains
 
     subroutine test_optional_parameter_if_control()
         character(len=:), allocatable :: input_code
@@ -20,7 +84,8 @@ contains
                      'contains' // new_line('a') // &
                      '    subroutine greet(name, title)' // new_line('a') // &
                      '        character(len=*), intent(in) :: name' // new_line('a') // &
-                     '        character(len=*), intent(in), optional :: title' // new_line('a') // &
+                     '        character(len=*), intent(in), optional :: title' // &
+                     new_line('a') // &
                      '        if (present(title)) then' // new_line('a') // &
                      "            print *, title, ' ', name" // new_line('a') // &
                      '        else' // new_line('a') // &
@@ -42,8 +107,10 @@ contains
             error stop 1
         end if
 
-        if (index(output_code, 'character(len=*), intent(in), optional :: title') <= 0) then
-            write (error_unit, '(a)') 'FAIL: title parameter lost optional attribute or length'
+        if (index(output_code, &
+                  'character(len=*), intent(in), optional :: title') <= 0) then
+            write (error_unit, '(a)') &
+                'FAIL: title parameter lost optional attribute or length'
             error stop 1
         end if
 
@@ -53,8 +120,11 @@ contains
         idx_else_stmt = index(output_code, 'print *, name')
         idx_end_if = index(output_code, 'end if')
 
-        if (idx_if <= 0 .or. idx_then_stmt <= 0 .or. idx_else <= 0 .or. idx_else_stmt <= 0 .or. idx_end_if <= 0) then
-            write (error_unit, '(a)') 'FAIL: expected IF/ELSE structure not found in output'
+        if (idx_if <= 0 .or. idx_then_stmt <= 0 .or. idx_else <= 0 .or. &
+            idx_else_stmt <= &
+            0 .or. idx_end_if <= 0) then
+            write (error_unit, '(a)') &
+                'FAIL: expected IF/ELSE structure not found in output'
             error stop 1
         end if
 


### PR DESCRIPTION
### **User description**
## Summary
- hoist standard Fortran subroutines from multi-unit containers into the owning program's contains block so optional arguments have an explicit interface
- extend the issue 1352 regression test with a program-level optional sample and keep optional attributes intact
- drop issue_1352_optional.f90 from expected failures now that it compiles after transformation

## Testing
- make test

Closes #1394


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Hoist subroutines with optional arguments into program `contains` block to provide explicit interface

- Extend test coverage for optional parameter handling in program-level subroutines

- Remove `issue_1352_optional.f90` from expected failures list

- Refactor code to handle both functions and subroutines uniformly


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multi-unit container"] --> B["Detect subroutines with optional args"]
  B --> C["Hoist into program contains block"]
  C --> D["Update parent indices"]
  D --> E["Remove external declarations"]
  E --> F["Valid explicit interface"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frontend_transformation.f90</strong><dd><code>Extend hoisting logic to handle subroutines with optional arguments</code></dd></summary>
<hr>

src/frontend_transformation.f90

<ul><li>Import <code>subroutine_def_node</code> to handle subroutine definitions alongside <br>functions<br> <li> Rename <code>functions</code> array to <code>procedures</code> to reflect handling of both <br>functions and subroutines<br> <li> Add subroutine detection in <code>normalize_multi_unit_container</code> to collect <br>subroutines for hoisting<br> <li> Rename <code>is_function_name</code> to <code>is_procedure_name</code> and extend to match both <br>function and subroutine names<br> <li> Add subroutine case in <code>maybe_dump_program_overview</code> for debug output</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1400/files#diff-ff30aac8bb617bd697be32cfee1fd1c1541a4bee44785e7f4fbd740f492b62b9">+41/-27</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1352_optional_if.f90</strong><dd><code>Add test for optional subroutine hoisting into program contains</code></dd></summary>
<hr>

test/frontend/test_issue_1352_optional_if.f90

<ul><li>Add <code>test_optional_program_contains</code> subroutine to verify optional <br>parameter handling in program-level subroutines<br> <li> Test that subroutine with optional argument is moved into program's <br><code>contains</code> block<br> <li> Verify optional attribute is preserved after transformation<br> <li> Add validation checks for program structure, contains block, and <br>subroutine placement</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1400/files#diff-211ea722e2ef2928d47f2704c0fe31d0358f19b14e4596ba52a67c066b060fa1">+75/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected_failures.txt</strong><dd><code>Remove resolved optional parameter test from expected failures</code></dd></summary>
<hr>

examples/expected_failures.txt

- Remove `issue_1352_optional.f90` from expected failures list


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1400/files#diff-f5e7f1a27130e10c3fa158ab22b6d673c4cb6e666a708bb1b9f0b312b4abc497">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

