### PR TITLE
fix: stop module procedure interface false positive

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -9,8 +9,6 @@
 # Lazy Fortran type inference
 # Known semantic/codegen gaps awaiting fixes
 # F90/F95 parser issues
-issue_1347_interface.f90        # Issue #1347: INTERFACE blocks cause parser error
-
 # Lazy Fortran control flow
 
 # Silent bugs (compile successfully but produce wrong code - cannot be detected by test)

--- a/src/utilities/input_validation.f90
+++ b/src/utilities/input_validation.f90
@@ -5,7 +5,8 @@ module input_validation
     ! Cleanly separated from frontend concerns with no circular dependencies
 
     use lexer_core, only: token_t, TK_EOF, TK_KEYWORD, TK_COMMENT, TK_NEWLINE, &
-                          TK_OPERATOR, TK_IDENTIFIER, TK_NUMBER, TK_UNKNOWN, TK_STRING
+                          TK_OPERATOR, TK_IDENTIFIER, TK_NUMBER, TK_UNKNOWN, TK_STRING, &
+                          to_lower
 
     implicit none
     private
@@ -434,6 +435,7 @@ contains
                         subroutine_count = subroutine_count + 1
                     end if
                 case ("module")
+                    if (is_module_procedure_statement(tokens, i)) cycle
                     ! Check if this is not "end module"
                     if (i == 1) then
                         module_count = module_count + 1
@@ -481,6 +483,34 @@ contains
                                               "MISSING_END")
         end if
     end subroutine check_missing_end_constructs
+
+    logical function is_module_procedure_statement(tokens, pos) result(is_module_proc)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: pos
+        integer :: j
+        character(len=:), allocatable :: next_kw
+
+        is_module_proc = .false.
+        if (pos < 1 .or. pos > size(tokens)) return
+
+        j = pos + 1
+        do while (j <= size(tokens))
+            if (tokens(j)%kind == TK_EOF) return
+            select case (tokens(j)%kind)
+            case (TK_NEWLINE, TK_COMMENT)
+                j = j + 1
+                cycle
+            case (TK_KEYWORD)
+                next_kw = trim(to_lower(tokens(j)%text))
+                if (next_kw == "procedure") then
+                    is_module_proc = .true.
+                end if
+                return
+            case default
+                return
+            end select
+        end do
+    end function is_module_procedure_statement
 
     ! Check for specifically invalid patterns that should be rejected
     logical function contains_invalid_patterns(tokens) result(is_invalid)


### PR DESCRIPTION
### **User description**
## Summary
- prevent the missing-end checker from counting `module procedure` statements as new modules
- drop the expected failure for `issue_1347_interface.f90` so the example now runs in CI
- keep interface-block handling covered via the existing example-driven regression test

## Testing
- cat examples/issue_1347_interface.f90 | fpm run --target fortfront > /tmp/issue_1347_interface.f90
- gfortran -fsyntax-only -I build/gfortran_A15D61B5EE9F417F -I build/gfortran_579709C83F7E4096 /tmp/issue_1347_interface.f90
- make test

Fixes #1393


___

### **PR Type**
Bug fix


___

### **Description**
- Prevent false positive in missing-end checker for module procedure statements

- Add `is_module_procedure_statement()` helper to distinguish module procedures from modules

- Remove expected failure for `issue_1347_interface.f90` example

- Import `to_lower` function for case-insensitive keyword comparison


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["check_missing_end_constructs"] -->|detects module keyword| B["is_module_procedure_statement"]
  B -->|checks next keyword| C{Is procedure?}
  C -->|yes| D["Skip counting as module"]
  C -->|no| E["Count as module"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>input_validation.f90</strong><dd><code>Add module procedure detection logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utilities/input_validation.f90

<ul><li>Import <code>to_lower</code> function from <code>lexer_core</code> module<br> <li> Add new <code>is_module_procedure_statement()</code> function to detect module <br>procedure keywords<br> <li> Insert check in <code>check_missing_end_constructs()</code> to skip module <br>procedure statements when counting modules<br> <li> Function scans tokens after "module" keyword, skipping <br>comments/newlines, to find "procedure" keyword</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1402/files#diff-76c6c3d6e72c3be2f7e8453c014734521f118f211cc74444ae7178f99f4699ef">+31/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>expected_failures.txt</strong><dd><code>Remove interface block expected failure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/expected_failures.txt

<ul><li>Remove two lines referencing <code>issue_1347_interface.f90</code> and Issue #1347<br> <li> Example now passes validation and no longer needs to be marked as <br>expected failure</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1402/files#diff-f5e7f1a27130e10c3fa158ab22b6d673c4cb6e666a708bb1b9f0b312b4abc497">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

