### PR TITLE
fix: guard missing operand in string concat

### DIFF
--- a/src/codegen/codegen_expressions.f90
+++ b/src/codegen/codegen_expressions.f90
@@ -113,11 +113,13 @@ contains
             fortran_operator = node%operator
 
             ! Recover from missing operands in concatenation nodes (issue #1386)
-            if (trim(fortran_operator) == '//' .and. len_trim(left_code) == 0) then
+            if (is_missing_concat_operand(trim(fortran_operator), .false., left_code, &
+                                          right_code)) then
                 code = right_code
                 return
             end if
-            if (trim(fortran_operator) == '//' .and. len_trim(right_code) == 0) then
+            if (is_missing_concat_operand(trim(fortran_operator), .true., left_code, &
+                                          right_code)) then
                 code = left_code
                 return
             end if
@@ -817,7 +819,7 @@ contains
     end function int_to_string
 
     ! Check if we have string concatenation (both operands are string literals)
-    function is_string_concatenation(left_code, right_code) result(is_string)
+    pure function is_string_concatenation(left_code, right_code) result(is_string)
         character(len=*), intent(in) :: left_code, right_code
         logical :: is_string
 
@@ -826,7 +828,7 @@ contains
     end function is_string_concatenation
 
     ! Check if a code fragment is a string literal
-    function is_string_literal(code) result(is_string)
+    pure function is_string_literal(code) result(is_string)
         character(len=*), intent(in) :: code
         logical :: is_string
         character(len=:), allocatable :: trimmed_code
@@ -848,6 +850,30 @@ contains
             end if
         end if
     end function is_string_literal
+
+    pure logical function is_missing_concat_operand(operator, checking_left, left_code, &
+                                                    right_code) result(is_missing)
+        character(len=*), intent(in) :: operator
+        logical, intent(in) :: checking_left
+        character(len=*), intent(in) :: left_code
+        character(len=*), intent(in) :: right_code
+        logical :: is_concat_op
+
+        is_concat_op = (operator == '//') .or. &
+                       (operator == '+' .and. (is_string_literal(left_code) .or. &
+                                               is_string_literal(right_code)))
+
+        if (.not. is_concat_op) then
+            is_missing = .false.
+            return
+        end if
+
+        if (checking_left) then
+            is_missing = len_trim(right_code) == 0
+        else
+            is_missing = len_trim(left_code) == 0
+        end if
+    end function is_missing_concat_operand
 
     ! generate_code_from_arena is provided as an interface at the module level
 

--- a/test/codegen/test_issue_1386_string_concatenation.f90
+++ b/test/codegen/test_issue_1386_string_concatenation.f90
@@ -8,10 +8,13 @@ program test_issue_1386_string_concatenation
 
     type(ast_arena_t) :: arena
     integer :: lazy_id
+    integer :: lazy_plus_id, lazy_plus_right_id
     integer :: seg1_id, seg2_id, seg3_id
     integer :: concat_pair_idx, concat_chain_idx
     integer :: dangling_concat_idx
-    integer :: assign_idx, prog_idx
+    integer :: dangling_plus_idx, dangling_plus_right_idx
+    integer :: assign_idx, assign_plus_idx, assign_plus_right_idx
+    integer :: prog_idx
     character(len=:), allocatable :: generated
 
     print *, '=== Issue #1386: guard concatenation without left operand ==='
@@ -22,15 +25,23 @@ program test_issue_1386_string_concatenation
     seg1_id = push_literal(arena, '"segment1"', LITERAL_STRING)
     seg2_id = push_literal(arena, '"segment2"', LITERAL_STRING)
     seg3_id = push_literal(arena, '"segment3"', LITERAL_STRING)
+    lazy_plus_id = push_identifier(arena, 'lazy_plus')
+    lazy_plus_right_id = push_identifier(arena, 'lazy_plus_right')
 
     concat_pair_idx = push_binary_op(arena, seg1_id, seg2_id, '//')
     concat_chain_idx = push_binary_op(arena, concat_pair_idx, seg3_id, '//')
 
     ! Reproduce issue #1386 by creating a dangling operator with an absent left operand.
     dangling_concat_idx = push_binary_op(arena, 0, concat_chain_idx, '//')
+    dangling_plus_idx = push_binary_op(arena, 0, seg3_id, '+')
+    dangling_plus_right_idx = push_binary_op(arena, seg2_id, 0, '+')
 
     assign_idx = push_assignment(arena, lazy_id, dangling_concat_idx)
-    prog_idx = push_program(arena, 'demo', [assign_idx])
+    assign_plus_idx = push_assignment(arena, lazy_plus_id, dangling_plus_idx)
+    assign_plus_right_idx = push_assignment(arena, lazy_plus_right_id, &
+                                            dangling_plus_right_idx)
+    prog_idx = push_program(arena, 'demo', [assign_idx, assign_plus_idx, &
+                                            assign_plus_right_idx])
 
     call emit_fortran(arena, prog_idx, generated)
 
@@ -47,6 +58,24 @@ program test_issue_1386_string_concatenation
 
     if (index(generated, 'segment1') == 0) then
         print *, 'FAIL: Leading literal was lost during code generation'
+        print *, trim(generated)
+        stop 1
+    end if
+
+    if (index(generated, 'lazy_plus = +') > 0) then
+        print *, 'FAIL: Plus-based concatenation retained leading operator'
+        print *, trim(generated)
+        stop 1
+    end if
+
+    if (index(generated, 'lazy_plus_right = ') > 0) then
+        if (index(generated, 'lazy_plus_right = "segment2"') == 0) then
+            print *, 'FAIL: Missing right operand was not reduced to left literal'
+            print *, trim(generated)
+            stop 1
+        end if
+    else
+        print *, 'FAIL: Expected lazy_plus_right assignment missing'
         print *, trim(generated)
         stop 1
     end if


### PR DESCRIPTION
### **User description**
## Summary
- ensure the code generator skips dangling // nodes so assignments stay valid (#1386)
- add regression coverage for missing left operand concatenations

## Testing
- make test


___

### **PR Type**
Bug fix


___

### **Description**
- Guard against dangling string concatenation operators with missing operands

- Handle edge cases where left or right operand is empty in concatenation

- Return empty string when both operands are missing to prevent invalid code

- Add regression test for issue #1386 with missing left operand

- Improve code formatting with consistent line wrapping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Binary Op Node<br/>with missing operand"] -->|Check operands| B["Both empty?"]
  B -->|Yes| C["Return empty string"]
  B -->|No| D["Concatenation operator?"]
  D -->|Yes & left empty| E["Return right operand"]
  D -->|Yes & right empty| F["Return left operand"]
  D -->|No| G["Generate normal code"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen_expressions.f90</strong><dd><code>Guard missing operands in string concatenation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_expressions.f90

<ul><li>Add guard checks for missing operands in binary concatenation <br>operations<br> <li> Return empty string when both left and right operands are empty<br> <li> Handle dangling <code>//</code> operators by returning the non-empty operand<br> <li> Reformat long lines for improved code readability and consistency<br> <li> Fix indentation issues throughout the file</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1403/files#diff-3b1738eec18cf24328ed23cb81f11a3f57f703a21111d4353d7e1773900cde23">+49/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1386_string_concatenation.f90</strong><dd><code>Add regression test for missing operand concatenation</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/codegen/test_issue_1386_string_concatenation.f90

<ul><li>Create new regression test for issue #1386<br> <li> Test scenario with dangling concatenation operator missing left <br>operand<br> <li> Verify generated code does not contain invalid <code>//</code> operator at start<br> <li> Verify all string segments are preserved in output<br> <li> Validate proper handling of complex concatenation chains</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1403/files#diff-48279551fe4e780e284d7c268d45145a71596fba0494d3ab73be7d268406c153">+55/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

