### PR TITLE
test: guard issue_1356 integer inference

### DIFF
--- a/test/integration/issue_tests/test_issue_1356_function_name.f90
+++ b/test/integration/issue_tests/test_issue_1356_function_name.f90
@@ -1,9 +1,12 @@
 program test_issue_1356_function_name
     use frontend, only: transform_lazy_fortran_string
+    use lexer_core, only: to_lower
+    use cli_io, only: read_all_stdin_or_file
     implicit none
 
     character(len=:), allocatable :: input_text
     character(len=:), allocatable :: output_text
+    character(len=:), allocatable :: lower_output_text
     character(len=:), allocatable :: error_msg
 
     call read_example('examples/issue_1356_function_name.lf', input_text)
@@ -23,27 +26,29 @@ program test_issue_1356_function_name
         error stop 1
     end if
 
-    if (index(output_text, 'integer function double') == 0) then
+    lower_output_text = to_lower(output_text)
+
+    if (index(lower_output_text, 'integer function double') == 0) then
         print *, 'FAIL: function double is not emitted with integer return type'
         print *, trim(output_text)
         error stop 1
     end if
 
-    if (index(output_text, 'integer :: x') == 0) then
+    if (index(lower_output_text, 'integer :: x') == 0) then
         print *, 'FAIL: parameter x is not inferred as integer'
         print *, trim(output_text)
         error stop 1
     end if
 
-    if (index(output_text, 'integer :: a') == 0 .or. &
-        index(output_text, 'integer :: b') == 0) then
+    if (index(lower_output_text, 'integer :: a') == 0 .or. &
+        index(lower_output_text, 'integer :: b') == 0) then
         print *, 'FAIL: caller variables a/b lack inferred integer declarations'
         print *, trim(output_text)
         error stop 1
     end if
 
-    if (index(output_text, 'real function double') > 0 .or. &
-        index(output_text, 'real :: double') > 0) then
+    if (index(lower_output_text, 'real function double') > 0 .or. &
+        index(lower_output_text, 'real :: double') > 0) then
         print *, 'FAIL: real declarations for double remain in output'
         print *, trim(output_text)
         error stop 1
@@ -56,32 +61,13 @@ contains
     subroutine read_example(path, content)
         character(len=*), intent(in) :: path
         character(len=:), allocatable, intent(out) :: content
-        integer :: unit_id, ios
-        character(len=512) :: buffer
-        logical :: first_line
+        integer :: status
 
-        content = ''
-        first_line = .true.
-
-        open (newunit=unit_id, file=path, status='old', action='read', iostat=ios)
-        if (ios /= 0) then
-            print *, 'FAIL: could not open ', trim(path)
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            print *, 'FAIL: failed to read ', trim(path)
             error stop 1
         end if
-
-        do
-            read (unit_id, '(A)', iostat=ios) buffer
-            if (ios /= 0) exit
-            if (first_line) then
-                content = trim(buffer)
-                first_line = .false.
-            else
-                content = content // new_line('a') // trim(buffer)
-            end if
-        end do
-        close (unit_id)
-
-        content = content // new_line('a')
     end subroutine read_example
 
 end program test_issue_1356_function_name


### PR DESCRIPTION
### **User description**
## Summary
- add an integration regression that runs the issue_1356 example through the CLI pipeline
- assert the generated code keeps integer typing for the function, parameter, and callers
- document the absence of any remaining real declarations for double so regressions are caught immediately

## Testing
- make test


___

### **PR Type**
Tests


___

### **Description**
- Add integration test for issue_1356 integer type inference

- Verify function, parameter, and caller variables retain integer types

- Assert no real declarations remain in transformed output

- Test CLI pipeline end-to-end with Lazy Fortran example


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Lazy Fortran Example"] -- "transform_lazy_fortran_string" --> B["Fortran Output"]
  B -- "Verify integer function" --> C["Type Assertions"]
  B -- "Verify integer parameters" --> C
  B -- "Verify no real declarations" --> C
  C -- "Pass/Fail" --> D["Test Result"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1356_function_name.f90</strong><dd><code>Integration test for integer type inference regression</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/integration/issue_tests/test_issue_1356_function_name.f90

<ul><li>New integration test program that reads issue_1356 Lazy Fortran <br>example<br> <li> Transforms input through CLI pipeline using <br><code>transform_lazy_fortran_string</code><br> <li> Validates function <code>double</code> is emitted with integer return type<br> <li> Asserts parameters and caller variables are inferred as integer<br> <li> Confirms no real declarations remain in output to catch regressions<br> <li> Includes helper subroutine to read example file content</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1404/files#diff-8d0ac720094a87dad49c9f05134fb9e36def6a1d930825aa1dda89b7b17a885a">+87/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

