### PR TITLE
fix: preserve USE renaming

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -17,7 +17,6 @@ issue_1405_data_statement.lf      # Issue #1405: DATA statement dropped
 # issue_1406_namelist.lf         # Issue #1406: NAMELIST declaration lost (XPASS: manual verification still fails)
 issue_1407_character_function.lf   # Issue #1407: Character function result mishandled
 # issue_1408_module_visibility.lf # Issue #1408: Module visibility clauses dropped (XPASS: manual inspection confirms loss)
-issue_1409_use_rename.f90        # Issue #1409: USE renaming rewritten incorrectly
 # issue_1411_generic_module.lf  # Issue #1411: Top-level statements dropped with generic interface (XPASS: reproducer stored)
 # issue_1412_iso_only.lf        # Issue #1412: USE, intrinsic ONLY list dropped (XPASS: transformer still wrong)
 issue_1413_array_function.lf # Issue #1413: Array function result collapsed to scalar

--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -79,7 +79,8 @@ contains
             do i = 1, size(node%arg_indices)
                 if (i > 1) args_code = args_code // ", "
                 if (node%arg_indices(i) > 0 .and. node%arg_indices(i) <= arena%size) then
-                    args_code = args_code // generate_code_from_arena(arena, node%arg_indices(i))
+                    args_code = args_code // generate_code_from_arena(arena, &
+                                                                      node%arg_indices(i))
                 end if
             end do
             code = code // "(" // args_code // ")"
@@ -109,8 +110,10 @@ contains
         if (allocated(node%expression_indices)) then
             do i = 1, size(node%expression_indices)
                 if (i > 1) args_code = args_code // ", "
-                if (node%expression_indices(i) > 0 .and. node%expression_indices(i) <= arena%size) then
-                    args_code = args_code // generate_code_from_arena(arena, node%expression_indices(i))
+                if (node%expression_indices(i) > 0 .and. node%expression_indices(i) <= &
+                    arena%size) then
+                    args_code = args_code // generate_code_from_arena(arena, &
+                                                               node%expression_indices(i))
                 end if
             end do
         end if
@@ -151,7 +154,8 @@ contains
                 if (i > 1) args_code = args_code // ", "
                 if (node%arg_indices(i) > 0 .and. node%arg_indices(i) <= arena%size) then
                     ! Use recursive code generation for proper expression handling
-                    args_code = args_code // generate_code_from_arena(arena, node%arg_indices(i))
+                    args_code = args_code // generate_code_from_arena(arena, &
+                                                                      node%arg_indices(i))
                 end if
             end do
         end if
@@ -255,7 +259,8 @@ contains
     function generate_code_use_statement(node) result(code)
         type(use_statement_node), intent(in) :: node
         character(len=:), allocatable :: code
-        character(len=:), allocatable :: only_clause, rename_clause
+        character(len=:), allocatable :: only_clause
+        character(len=:), allocatable :: rename_entry
         integer :: i
 
         ! Build proper use statement with all components
@@ -275,41 +280,44 @@ contains
         code = code // " " // node%module_name
 
         ! Add only clause if present
-        if (node%has_only .and. allocated(node%only_list)) then
-            only_clause = ""
-            do i = 1, size(node%only_list)
-                if (allocated(node%only_list(i)%s)) then
-                    if (i == 1) then
-                        only_clause = only_clause // node%only_list(i)%s
-                    else
-                        only_clause = only_clause // ", " // node%only_list(i)%s
-                    end if
-                end if
+        only_clause = ""
+        if (node%has_only) then
+            if (allocated(node%only_list)) then
+                do i = 1, size(node%only_list)
+                    if (.not. allocated(node%only_list(i)%s)) cycle
+                    if (len_trim(only_clause) > 0) only_clause = only_clause // ", "
+                    only_clause = only_clause // node%only_list(i)%s
+                end do
+            end if
+            if (allocated(node%rename_list)) then
+                do i = 1, size(node%rename_list), 2
+                    if (i + 1 > size(node%rename_list)) exit
+                    if (.not. allocated(node%rename_list(i)%s)) cycle
+                    if (.not. allocated(node%rename_list(i + 1)%s)) cycle
+                    rename_entry = node%rename_list(i)%s // " => " // &
+                                   node%rename_list(i + 1)%s
+                    if (len_trim(only_clause) > 0) only_clause = only_clause // ", "
+                    only_clause = only_clause // rename_entry
+                end do
+            end if
+            if (len_trim(only_clause) > 0) then
+                code = code // ", only: " // trim(only_clause)
+            else
+                code = code // ", only:"
+            end if
+        else if (allocated(node%rename_list)) then
+            ! Fallback: emit rename list under only clause even if flag missing
+            do i = 1, size(node%rename_list), 2
+                if (i + 1 > size(node%rename_list)) exit
+                if (.not. allocated(node%rename_list(i)%s)) cycle
+                if (.not. allocated(node%rename_list(i + 1)%s)) cycle
+                rename_entry = node%rename_list(i)%s // " => " // &
+                               node%rename_list(i + 1)%s
+                if (len_trim(only_clause) > 0) only_clause = only_clause // ", "
+                only_clause = only_clause // rename_entry
             end do
             if (len_trim(only_clause) > 0) then
                 code = code // ", only: " // trim(only_clause)
-            end if
-        end if
-
-        ! Add rename clause if present (format: new_name => old_name)
-        if (allocated(node%rename_list) .and. size(node%rename_list) > 0) then
-            rename_clause = ""
-            do i = 1, size(node%rename_list), 2  ! Process pairs
-                if (i + 1 <= size(node%rename_list)) then
-                    if (allocated(node%rename_list(i)%s) .and. allocated(node%rename_list(i + 1)%s)) then
-                        if (len_trim(rename_clause) > 0) then
-                            rename_clause = rename_clause // ", "
-                        end if
-                        rename_clause = rename_clause // node%rename_list(i)%s // " => " // node%rename_list(i+1)%s
-                    end if
-                end if
-            end do
-            if (len_trim(rename_clause) > 0) then
-                if (index(code, "only:") > 0) then
-                    code = code // ", " // trim(rename_clause)
-                else
-                    code = code // ", " // trim(rename_clause)
-                end if
             end if
         end if
     end function generate_code_use_statement
@@ -376,8 +384,11 @@ contains
                             shape_code = ""
                             do j = 1, size(node%shape_indices)
                                 if (j > 1) shape_code = shape_code // ", "
-                                if (node%shape_indices(j) > 0 .and. node%shape_indices(j) <= arena%size) then
-                                    shape_code = shape_code // generate_code_from_arena(arena, node%shape_indices(j))
+                                if (node%shape_indices(j) > 0 .and. &
+                                    node%shape_indices(j) <= arena%size) then
+                                    shape_code = shape_code // &
+                                                 generate_code_from_arena(arena, &
+                                                                    node%shape_indices(j))
                                 end if
                             end do
                             if (len(shape_code) > 0) then
@@ -392,16 +403,20 @@ contains
 
         ! Optional keyword arguments
         if (node%stat_var_index > 0 .and. node%stat_var_index <= arena%size) then
-            args = args // ", stat=" // generate_code_from_arena(arena, node%stat_var_index)
+            args = args // ", stat=" // generate_code_from_arena(arena, &
+                                                                 node%stat_var_index)
         end if
         if (node%errmsg_var_index > 0 .and. node%errmsg_var_index <= arena%size) then
-            args = args // ", errmsg=" // generate_code_from_arena(arena, node%errmsg_var_index)
+            args = args // ", errmsg=" // generate_code_from_arena(arena, &
+                                                                   node%errmsg_var_index)
         end if
         if (node%source_expr_index > 0 .and. node%source_expr_index <= arena%size) then
-            args = args // ", source=" // generate_code_from_arena(arena, node%source_expr_index)
+            args = args // ", source=" // generate_code_from_arena(arena, &
+                                                                   node%source_expr_index)
         end if
         if (node%mold_expr_index > 0 .and. node%mold_expr_index <= arena%size) then
-            args = args // ", mold=" // generate_code_from_arena(arena, node%mold_expr_index)
+            args = args // ", mold=" // generate_code_from_arena(arena, &
+                                                                 node%mold_expr_index)
         end if
 
         code = "allocate(" // args // ")"
@@ -428,10 +443,12 @@ contains
         end if
 
         if (node%stat_var_index > 0 .and. node%stat_var_index <= arena%size) then
-            args = args // ", stat=" // generate_code_from_arena(arena, node%stat_var_index)
+            args = args // ", stat=" // generate_code_from_arena(arena, &
+                                                                 node%stat_var_index)
         end if
         if (node%errmsg_var_index > 0 .and. node%errmsg_var_index <= arena%size) then
-            args = args // ", errmsg=" // generate_code_from_arena(arena, node%errmsg_var_index)
+            args = args // ", errmsg=" // generate_code_from_arena(arena, &
+                                                                   node%errmsg_var_index)
         end if
 
         code = "deallocate(" // args // ")"

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -26,6 +26,7 @@ module parser_execution_statements_module
     use parser_control_flow_router_module, only: route_control_flow, &
                                                  is_control_flow_keyword
     use parser_call_module, only: parse_call_statement
+    use parser_import_statements_module, only: parse_use_statement
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_program, &
                            push_declaration, push_implicit_statement
@@ -110,7 +111,8 @@ contains
             ! Check for 'end program'
             if (token%kind == TK_KEYWORD .and. token%text == "end") then
                 if (parser%current_token + 1 <= size(parser%tokens)) then
-                    if (parser%tokens(parser%current_token + 1)%kind == TK_KEYWORD .and. &
+                    if (parser%tokens(parser%current_token + 1)%kind == &
+                        TK_KEYWORD .and. &
                         parser%tokens(parser%current_token + 1)%text == "program") then
                         ! Found 'end program', consume both tokens
                         token = parser%consume()  ! end
@@ -158,7 +160,8 @@ contains
                         else
                             call prefix_buffer%clear()
                         end if
-                      stmt_index = parse_function_definition(parser, arena, prefix_buffer)
+                        stmt_index = parse_function_definition(parser, arena, &
+                                                               prefix_buffer)
                         call prefix_buffer%clear()
                     case ("subroutine")
                         if (allocated(pending_prefixes)) then
@@ -167,7 +170,8 @@ contains
                         else
                             call prefix_buffer%clear()
                         end if
-                    stmt_index = parse_subroutine_definition(parser, arena, prefix_buffer)
+                        stmt_index = parse_subroutine_definition(parser, arena, &
+                                                                 prefix_buffer)
                         call prefix_buffer%clear()
                     case ("implicit")
                         if (allocated(pending_prefixes)) then
@@ -194,6 +198,12 @@ contains
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_print_statement(parser, arena)
+                    case ("use")
+                        if (allocated(pending_prefixes)) then
+                            deallocate (pending_prefixes)
+                            call prefix_buffer%clear()
+                        end if
+                        stmt_index = parse_use_statement(parser, arena)
                     case ("write")
                         if (allocated(pending_prefixes)) then
                             deallocate (pending_prefixes)

--- a/src/parser/parser_import_resolution.f90
+++ b/src/parser/parser_import_resolution.f90
@@ -7,6 +7,7 @@ module parser_import_resolution_module
     use ast_factory, only: push_use_statement, push_include_statement, push_literal
     use ast_factory, only: push_use_statement, push_include_statement, push_literal
     use ast_types, only: LITERAL_STRING
+    use string_types, only: string_t
     use url_utilities, only: extract_module_from_url
     implicit none
     private
@@ -16,23 +17,45 @@ module parser_import_resolution_module
 contains
 
     ! Parse comma-separated list of identifiers (for only clause)
-    subroutine parse_identifier_list(parser, identifier_list)
+    subroutine parse_identifier_list(parser, identifier_list, rename_list)
         type(parser_state_t), intent(inout) :: parser
         character(len=:), allocatable, intent(out) :: identifier_list(:)
-        character(len=:), allocatable :: temp_list(:)
+        character(len=:), allocatable, intent(out) :: rename_list(:)
         type(token_t) :: token
+        character(len=:), allocatable :: local_name, remote_name
+        type(string_t), allocatable :: only_temp(:)
+        type(string_t), allocatable :: rename_temp(:)
         integer :: count, capacity
+        integer :: rename_count, rename_capacity
+        integer :: alloc_len
+        integer :: i, max_len
 
         count = 0
-        capacity = 4  ! Initial capacity
-        allocate (character(len=64) :: temp_list(capacity))
+        capacity = 0
+        rename_count = 0
+        rename_capacity = 0
 
         ! Parse first identifier
         token = parser%peek()
         if (token%kind == TK_IDENTIFIER) then
             token = parser%consume()
-            count = count + 1
-            temp_list(count) = token%text
+            local_name = trimmed_or_empty(token%text)
+
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == "=>") then
+                token = parser%consume()  ! consume '=>'
+                token = parser%peek()
+                if (token%kind == TK_IDENTIFIER) then
+                    token = parser%consume()
+                    remote_name = trimmed_or_empty(token%text)
+                    call append_rename_pair(local_name, remote_name)
+                else
+                    ! Malformed rename - treat as simple identifier
+                    call append_only(local_name)
+                end if
+            else
+                call append_only(local_name)
+            end if
 
             ! Parse additional identifiers (comma-separated)
             do while (.not. parser%is_at_end())
@@ -42,24 +65,24 @@ contains
                     token = parser%peek()
                     if (token%kind == TK_IDENTIFIER) then
                         token = parser%consume()
+                        local_name = trimmed_or_empty(token%text)
 
-                        ! Expand array if needed
-                        if (count >= capacity) then
-                            capacity = capacity * 2
-                            block
-                                character(len=64), allocatable :: new_temp_list(:)
-                                integer :: i
-                                allocate (new_temp_list(capacity))
-                                do i = 1, count
-                                    new_temp_list(i) = temp_list(i)
-                                end do
-                                deallocate (temp_list)
-                                call move_alloc(new_temp_list, temp_list)
-                            end block
+                        token = parser%peek()
+                        if (token%kind == TK_OPERATOR .and. token%text == "=>") then
+                            token = parser%consume()
+                            token = parser%peek()
+                            if (token%kind == TK_IDENTIFIER) then
+                                token = parser%consume()
+                                remote_name = trimmed_or_empty(token%text)
+                                call append_rename_pair(local_name, remote_name)
+                            else
+                                ! Malformed rename - treat as simple identifier
+                                call append_only(local_name)
+                            end if
+                        else
+                            ! Simple identifier entry
+                            call append_only(local_name)
                         end if
-
-                        count = count + 1
-                        temp_list(count) = token%text
                     else
                         exit  ! Not an identifier after comma
                     end if
@@ -71,13 +94,108 @@ contains
 
         ! Copy to final array with exact size
         if (count > 0) then
-            allocate (character(len=64) :: identifier_list(count))
-            identifier_list(1:count) = temp_list(1:count)
+            max_len = 0
+            do i = 1, count
+                max_len = max(max_len, len_trim(only_temp(i)%s))
+            end do
+            max_len = max(1, max_len)
+            allocate (character(len=max_len) :: identifier_list(count))
+            do i = 1, count
+                identifier_list(i) = trim(only_temp(i)%s)
+            end do
         else
             allocate (character(len=0) :: identifier_list(0))
         end if
 
-        deallocate (temp_list)
+        if (rename_count > 0) then
+            max_len = 0
+            do i = 1, rename_count
+                max_len = max(max_len, len_trim(rename_temp(i)%s))
+            end do
+            max_len = max(1, max_len)
+            allocate (character(len=max_len) :: rename_list(rename_count))
+            do i = 1, rename_count
+                rename_list(i) = trim(rename_temp(i)%s)
+            end do
+        else
+            allocate (character(len=0) :: rename_list(0))
+        end if
+
+        if (allocated(only_temp)) deallocate (only_temp)
+        if (allocated(rename_temp)) deallocate (rename_temp)
+
+    contains
+
+        subroutine ensure_only_capacity(required)
+            integer, intent(in) :: required
+            type(string_t), allocatable :: new_array(:)
+            integer :: new_capacity
+
+            if (capacity >= required) return
+            new_capacity = max(4, capacity)
+            do while (new_capacity < required)
+                new_capacity = max(4, new_capacity * 2)
+            end do
+            allocate (new_array(new_capacity))
+            if (capacity > 0 .and. allocated(only_temp)) then
+                new_array(1:count) = only_temp(1:count)
+                deallocate (only_temp)
+            end if
+            call move_alloc(new_array, only_temp)
+            capacity = new_capacity
+        end subroutine ensure_only_capacity
+
+        subroutine ensure_rename_capacity(required)
+            integer, intent(in) :: required
+            type(string_t), allocatable :: new_array(:)
+            integer :: new_capacity
+
+            if (rename_capacity >= required) return
+            new_capacity = max(4, rename_capacity)
+            do while (new_capacity < required)
+                new_capacity = max(4, new_capacity * 2)
+            end do
+            allocate (new_array(new_capacity))
+            if (rename_capacity > 0 .and. allocated(rename_temp)) then
+                new_array(1:rename_count) = rename_temp(1:rename_count)
+                deallocate (rename_temp)
+            end if
+            call move_alloc(new_array, rename_temp)
+            rename_capacity = new_capacity
+        end subroutine ensure_rename_capacity
+
+        subroutine append_only(value)
+            character(len=*), intent(in) :: value
+            call ensure_only_capacity(count + 1)
+            count = count + 1
+            only_temp(count) = string_t(value)
+        end subroutine append_only
+
+        subroutine append_rename_pair(local, remote)
+            character(len=*), intent(in) :: local
+            character(len=*), intent(in) :: remote
+            call ensure_rename_capacity(rename_count + 2)
+            rename_count = rename_count + 1
+            rename_temp(rename_count) = string_t(local)
+            rename_count = rename_count + 1
+            rename_temp(rename_count) = string_t(remote)
+        end subroutine append_rename_pair
+
+        function trimmed_or_empty(text) result(clean)
+            character(len=*), intent(in) :: text
+            character(len=:), allocatable :: clean
+            integer :: len_clean
+
+            len_clean = len_trim(text)
+            if (len_clean <= 0) len_clean = 1
+            allocate (character(len=len_clean) :: clean)
+            if (len_trim(text) > 0) then
+                clean = trim(text)
+            else
+                clean = ""
+            end if
+        end function trimmed_or_empty
+
     end subroutine parse_identifier_list
 
     function parse_use_statement(parser, arena) result(stmt_index)
@@ -144,7 +262,8 @@ contains
 
             ! Check for 'only' keyword
             token = parser%peek()
-            if (token%kind == TK_KEYWORD .and. token%text == "only") then
+            if ((token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER) .and. &
+                trim(to_lower_ascii_token(token%text)) == "only") then
                 token = parser%consume()  ! consume 'only'
                 has_only = .true.
 
@@ -153,9 +272,7 @@ contains
                 if (token%kind == TK_OPERATOR .and. token%text == ":") then
                     token = parser%consume()  ! consume ':'
                     ! Parse only list - collect identifiers
-                    call parse_identifier_list(parser, only_list)
-                    ! For now, no rename support (simplified)
-                    allocate (character(len=0) :: rename_list(0))
+                    call parse_identifier_list(parser, only_list, rename_list)
                 else
                     ! Malformed only clause
                     allocate (character(len=0) :: only_list(0))
@@ -199,5 +316,20 @@ contains
         ! Create include statement node
         stmt_index = push_include_statement(arena, filename, line, column)
     end function parse_include_statement
+
+    pure function to_lower_ascii_token(text) result(lower_text)
+        character(len=*), intent(in) :: text
+        character(len=len(text)) :: lower_text
+        integer :: i
+        integer :: char_code
+
+        lower_text = text
+        do i = 1, len(text)
+            char_code = iachar(lower_text(i:i))
+            if (char_code >= iachar('A') .and. char_code <= iachar('Z')) then
+                lower_text(i:i) = achar(char_code + 32)
+            end if
+        end do
+    end function to_lower_ascii_token
 
 end module parser_import_resolution_module

--- a/test/frontend/test_issue_1409_use_rename.f90
+++ b/test/frontend/test_issue_1409_use_rename.f90
@@ -1,0 +1,48 @@
+program test_issue_1409_use_rename
+    use frontend, only: transform_lazy_fortran_string
+    implicit none
+
+    call test_use_statement_with_rename()
+    print *, ""
+    print *, "All tests passed for issue 1409."
+
+contains
+
+    subroutine test_use_statement_with_rename()
+        character(len=:), allocatable :: input_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        integer :: idx_use
+
+        input_code = "module constants" // new_line('A') // &
+                     "    implicit none" // new_line('A') // &
+                     "    integer, parameter :: ten = 10" // new_line('A') // &
+                     "end module constants" // new_line('A') // new_line('A') // &
+                     "program rename_test" // new_line('A') // &
+                     "    use constants, only: dozen => ten" // new_line('A') // &
+                     "    implicit none" // new_line('A') // &
+                     "    print *, dozen" // new_line('A') // &
+                     "end program rename_test"
+
+        call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: unexpected transformation error:", trim(error_msg)
+            error stop 1
+        end if
+
+        idx_use = index(output_code, "use constants, only: dozen => ten")
+        if (idx_use <= 0) then
+            print *, "FAIL: use statement rename syntax not preserved"
+            error stop 1
+        end if
+
+        if (index(output_code, "real :: dozen") > 0) then
+            print *, "FAIL: superfluous declaration for renamed symbol emitted"
+            error stop 1
+        end if
+
+        print *, "PASS: USE rename preserved"
+    end subroutine test_use_statement_with_rename
+
+end program test_issue_1409_use_rename


### PR DESCRIPTION
### **User description**
## Summary
- parse USE only lists with renames and ensure program bodies keep use statements
- emit rename pairs directly inside the generated only clause
- add regression coverage for issue #1409 and drop the example from expected failures

## Testing
- make test

Closes #1409


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve USE statement rename syntax in only clause

- Parse rename pairs from identifier list during USE statement parsing

- Emit rename entries directly within only clause instead of separately

- Add regression test for issue #1409 and remove from expected failures

- Apply code formatting improvements for line length consistency


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["USE statement with rename"] --> B["parse_identifier_list"]
  B --> C["Detect rename operator =>"]
  C --> D["Collect rename pairs"]
  D --> E["generate_code_use_statement"]
  E --> F["Emit only: with renames"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen_statements.f90</strong><dd><code>Consolidate rename handling into only clause generation</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_statements.f90

<ul><li>Refactored <code>generate_code_use_statement</code> to merge rename list into only <br>clause<br> <li> Removed separate <code>rename_clause</code> variable and consolidated logic<br> <li> Added fallback handling for rename list when <code>has_only</code> flag is missing<br> <li> Applied code formatting for long lines (line continuations)</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1416/files#diff-29bb67b9e89dcf55c06da03eff7b099893787438130a736fe36a297f8008a881">+61/-44</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser_execution_statements.f90</strong><dd><code>Enable USE statement parsing in program body</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_execution_statements.f90

<ul><li>Added import of <code>parse_use_statement</code> from <br><code>parser_import_statements_module</code><br> <li> Added case handler for "use" keyword in program body parsing<br> <li> Applied code formatting for line continuations</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1416/files#diff-9ccd5393b9a82f76b4345c7b1141a995279e28b89526ec3c6a4d9b39e1ecaf62">+13/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_import_resolution.f90</strong><dd><code>Parse and collect USE statement rename pairs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_import_resolution.f90

<ul><li>Extended <code>parse_identifier_list</code> to accept and populate <code>rename_list</code> <br>output parameter<br> <li> Added detection of rename operator <code>=></code> during identifier parsing<br> <li> Implemented dynamic array expansion for rename pairs storage<br> <li> Added <code>to_lower_ascii_token</code> pure function for case-insensitive keyword <br>matching<br> <li> Updated <code>parse_use_statement</code> to handle "only" keyword <br>case-insensitively<br> <li> Removed placeholder comment about missing rename support</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1416/files#diff-e25a1bb8b90fa324f467e55214db2514088dcc24ad268893c115b5a4661660fc">+145/-23</a></td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1409_use_rename.f90</strong><dd><code>Add regression test for USE rename preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/frontend/test_issue_1409_use_rename.f90

<ul><li>New regression test for issue #1409 covering USE statement with rename <br>syntax<br> <li> Tests that rename syntax <code>dozen => ten</code> is preserved in output<br> <li> Verifies no spurious declarations are generated for renamed symbols<br> <li> Validates transformation completes without errors</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1416/files#diff-d66b967ed17e45973a8b011730c54350ddcb9af8492646063ac976207444258c">+48/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected_failures.txt</strong><dd><code>Remove resolved issue from expected failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/expected_failures.txt

<ul><li>Removed <code>issue_1409_use_rename.f90</code> from expected failures list<br> <li> Issue now resolved and test passing</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1416/files#diff-f5e7f1a27130e10c3fa158ab22b6d673c4cb6e666a708bb1b9f0b312b4abc497">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

