### PR TITLE
fix: preserve IO implied-do loops

### DIFF
--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -53,7 +53,7 @@ module ast_factory
     use ast_factory_statements, only: &
         push_use_statement, push_implicit_statement, push_include_statement, &
         push_end_statement, push_stop, push_return, push_goto, push_error_stop, &
-        push_cycle, push_exit, push_allocate, push_deallocate
+        push_cycle, push_exit, push_allocate, push_deallocate, push_io_implied_do
 
     implicit none
     private
@@ -99,7 +99,7 @@ module ast_factory
     ! Statement nodes
     public :: push_use_statement, push_implicit_statement, push_include_statement
     public :: push_end_statement, push_stop, push_return, push_goto, push_error_stop
-    public :: push_cycle, push_exit, push_allocate, push_deallocate
+    public :: push_cycle, push_exit, push_allocate, push_deallocate, push_io_implied_do
 
     ! Note: No module body needed - all functionality is provided by re-exported modules
     ! This maintains full API compatibility while achieving architectural compliance

--- a/src/ast/factory/ast_factory_statements.f90
+++ b/src/ast/factory/ast_factory_statements.f90
@@ -2,9 +2,13 @@ module ast_factory_statements
     use ast_arena_modern, only: ast_arena_t
     use ast_base, only: string_t
     use uid_generator, only: generate_uid
-    use ast_nodes_misc, only: use_statement_node, implicit_statement_node, include_statement_node, &
-                              end_statement_node, allocate_statement_node, deallocate_statement_node
-    use ast_nodes_control, only: stop_node, return_node, goto_node, error_stop_node, cycle_node, exit_node
+    use ast_nodes_misc, only: use_statement_node, implicit_statement_node, &
+                              include_statement_node, &
+                              end_statement_node, allocate_statement_node, &
+                              deallocate_statement_node
+    use ast_nodes_control, only: stop_node, return_node, goto_node, error_stop_node, &
+                                 cycle_node, exit_node
+    use ast_nodes_io, only: io_implied_do_node
     implicit none
     private
 
@@ -14,6 +18,7 @@ module ast_factory_statements
     public :: push_stop, push_return, push_goto, push_error_stop
     public :: push_cycle, push_exit
     public :: push_allocate, push_deallocate
+    public :: push_io_implied_do
 
 contains
 
@@ -57,6 +62,33 @@ contains
         use_index = arena%size
     end function push_use_statement
 
+    ! Create IO implied-do node and add to arena
+    function push_io_implied_do(arena, expr_index, var_name, start_expr_index, &
+                                end_expr_index, step_expr_index, line, column, &
+                                parent_index) result(node_index)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: expr_index
+        character(len=*), intent(in) :: var_name
+        integer, intent(in) :: start_expr_index
+        integer, intent(in) :: end_expr_index
+        integer, intent(in), optional :: step_expr_index
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: node_index
+        type(io_implied_do_node) :: node
+
+        node%uid = generate_uid()
+        node%expr_index = expr_index
+        node%var_name = var_name
+        node%start_expr_index = start_expr_index
+        node%end_expr_index = end_expr_index
+        if (present(step_expr_index)) node%step_expr_index = step_expr_index
+        if (present(line)) node%line = line
+        if (present(column)) node%column = column
+
+        call arena%push(node, "io_implied_do", parent_index)
+        node_index = arena%size
+    end function push_io_implied_do
+
     ! Create implicit statement node and add to stack
     function push_implicit_statement(arena, is_none, type_name, kind_value, has_kind, &
                                      length_value, has_length, letter_ranges, &
@@ -87,11 +119,15 @@ contains
                 do i = 1, size(letter_ranges)
                     dash_pos = index(letter_ranges(i), '-')
                     if (dash_pos > 0) then
-                        implicit_stmt%letter_specs(i)%start_letter = letter_ranges(i) (1:1)
-                        implicit_stmt%letter_specs(i)%end_letter = letter_ranges(i) (dash_pos + 1:dash_pos + 1)
+                        implicit_stmt%letter_specs(i)%start_letter = &
+                            letter_ranges(i) (1:1)
+                        implicit_stmt%letter_specs(i)%end_letter = &
+                            letter_ranges(i) (dash_pos + 1:dash_pos + 1)
                     else
-                        implicit_stmt%letter_specs(i)%start_letter = letter_ranges(i) (1:1)
-                        implicit_stmt%letter_specs(i)%end_letter = letter_ranges(i) (1:1)
+                        implicit_stmt%letter_specs(i)%start_letter = &
+                            letter_ranges(i) (1:1)
+                        implicit_stmt%letter_specs(i)%end_letter = &
+                            letter_ranges(i) (1:1)
                     end if
                 end do
             end if
@@ -182,7 +218,8 @@ contains
     end function push_goto
 
     ! Create ERROR STOP statement node and add to stack
-    function push_error_stop(arena, error_code_index, error_message, line, column, parent_index) result(error_stop_index)
+    function push_error_stop(arena, error_code_index, error_message, line, column, &
+                             parent_index) result(error_stop_index)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in), optional :: error_code_index
         character(len=*), intent(in), optional :: error_message
@@ -190,7 +227,8 @@ contains
         integer :: error_stop_index
         type(error_stop_node) :: error_stop_stmt
         error_stop_stmt%uid = generate_uid()
-        if (present(error_code_index)) error_stop_stmt%error_code_index = error_code_index
+        if (present(error_code_index)) error_stop_stmt%error_code_index = &
+            error_code_index
         if (present(error_message)) error_stop_stmt%error_message = error_message
         if (present(line)) error_stop_stmt%line = line
         if (present(column)) error_stop_stmt%column = column
@@ -200,7 +238,8 @@ contains
     end function push_error_stop
 
     ! Create CYCLE statement node and add to stack
-    function push_cycle(arena, loop_label, line, column, parent_index) result(cycle_index)
+    function push_cycle(arena, loop_label, line, column, parent_index) &
+        result(cycle_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in), optional :: loop_label
         integer, intent(in), optional :: line, column, parent_index

--- a/src/ast/nodes/ast_nodes_io.f90
+++ b/src/ast/nodes/ast_nodes_io.f90
@@ -8,6 +8,7 @@ module ast_nodes_io
 
     ! Public factory functions
     public :: create_print_statement
+    public :: create_io_implied_do
 
     ! I/O statement AST nodes
 
@@ -21,6 +22,20 @@ module ast_nodes_io
         procedure :: assign => print_statement_assign
         generic :: assignment(=) => assign
     end type print_statement_node
+
+    ! I/O implied-do node used within I/O lists
+    type, extends(ast_node), public :: io_implied_do_node
+        integer :: expr_index = 0
+        character(len=:), allocatable :: var_name
+        integer :: start_expr_index = 0
+        integer :: end_expr_index = 0
+        integer :: step_expr_index = 0
+    contains
+        procedure :: accept => io_implied_do_accept
+        procedure :: to_json => io_implied_do_to_json
+        procedure :: assign => io_implied_do_assign
+        generic :: assignment(=) => assign
+    end type io_implied_do_node
 
     ! Write statement node
     type, extends(ast_node), public :: write_statement_node
@@ -113,6 +128,40 @@ contains
         end if
         if (allocated(rhs%format_spec)) lhs%format_spec = rhs%format_spec
     end subroutine print_statement_assign
+
+    ! Stub implementations for io_implied_do_node
+    subroutine io_implied_do_accept(this, visitor)
+        class(io_implied_do_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+        ! Stub implementation
+    end subroutine io_implied_do_accept
+
+    subroutine io_implied_do_to_json(this, json, parent)
+        class(io_implied_do_node), intent(in) :: this
+        type(json_core), intent(inout) :: json
+        type(json_value), pointer, intent(in) :: parent
+        ! Stub implementation
+    end subroutine io_implied_do_to_json
+
+    subroutine io_implied_do_assign(lhs, rhs)
+        class(io_implied_do_node), intent(inout) :: lhs
+        class(io_implied_do_node), intent(in) :: rhs
+
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+        lhs%expr_index = rhs%expr_index
+        if (allocated(rhs%var_name)) lhs%var_name = rhs%var_name
+        lhs%start_expr_index = rhs%start_expr_index
+        lhs%end_expr_index = rhs%end_expr_index
+        lhs%step_expr_index = rhs%step_expr_index
+    end subroutine io_implied_do_assign
 
     ! Stub implementations for write_statement_node
     subroutine write_statement_accept(this, visitor)
@@ -232,7 +281,8 @@ contains
         call json%add(obj, 'line', this%line)
         call json%add(obj, 'column', this%column)
         if (allocated(this%descriptor_type)) call json%add(obj, &
-                                                           'descriptor_type', this%descriptor_type)
+                                                           'descriptor_type', &
+                                                           this%descriptor_type)
         call json%add(obj, 'width', this%width)
         call json%add(obj, 'decimal_places', this%decimal_places)
         call json%add(obj, 'exponent_width', this%exponent_width)
@@ -288,5 +338,25 @@ contains
         if (present(line)) node%line = line
         if (present(column)) node%column = column
     end function create_print_statement
+
+    function create_io_implied_do(expr_index, var_name, start_expr_index, &
+                                  end_expr_index, step_expr_index, line, column) &
+        result(node)
+        integer, intent(in) :: expr_index
+        character(len=*), intent(in) :: var_name
+        integer, intent(in) :: start_expr_index, end_expr_index
+        integer, intent(in), optional :: step_expr_index
+        integer, intent(in), optional :: line, column
+        type(io_implied_do_node) :: node
+
+        node%uid = generate_uid()
+        node%expr_index = expr_index
+        node%var_name = var_name
+        node%start_expr_index = start_expr_index
+        node%end_expr_index = end_expr_index
+        if (present(step_expr_index)) node%step_expr_index = step_expr_index
+        if (present(line)) node%line = line
+        if (present(column)) node%column = column
+    end function create_io_implied_do
 
 end module ast_nodes_io

--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -10,10 +10,12 @@ module codegen_core
     use codegen_arena_interface, only: set_arena_generator
     use ast_nodes_data, only: mixed_construct_container_node, declaration_node, &
                               parameter_declaration_node, module_node, derived_type_node
-    use ast_nodes_bounds, only: range_expression_node, array_bounds_node, array_slice_node, &
+    use ast_nodes_bounds, only: range_expression_node, array_bounds_node, &
+                                array_slice_node, &
                                 array_operation_node
     use ast_nodes_core, only: range_subscript_node, literal_node, identifier_node, &
-                              binary_op_node, call_or_subscript_node, array_literal_node, &
+                              binary_op_node, call_or_subscript_node, &
+                              array_literal_node, &
                               assignment_node, program_node, component_access_node
     use ast_nodes_procedure
     use ast_nodes_associate, only: associate_node
@@ -62,6 +64,8 @@ contains
             code = generate_code_component_access(arena, node, node_index)
         type is (array_literal_node)
             code = generate_code_array_literal(arena, node, node_index)
+        type is (io_implied_do_node)
+            code = generate_code_io_implied_do(arena, node, node_index)
         type is (complex_literal_node)
             code = generate_code_complex_literal(arena, node, node_index)
         type is (range_expression_node)
@@ -320,7 +324,8 @@ contains
     end subroutine initialize_codegen
 
     ! Generate code for mixed construct containers
-    function generate_code_mixed_construct_container(arena, node, node_index) result(code)
+    function generate_code_mixed_construct_container(arena, node, node_index) &
+        result(code)
         type(ast_arena_t), intent(in) :: arena
         type(mixed_construct_container_node), intent(in) :: node
         integer, intent(in) :: node_index
@@ -339,7 +344,9 @@ contains
                         code = code // new_line('A') // new_line('A')
                     end if
 
-                    code = code // codegen_core_generate_arena(arena, node%explicit_program_indices(i))
+                    code = code // &
+                        codegen_core_generate_arena(arena, &
+                        node%explicit_program_indices(i))
                 end if
             end do
         end if
@@ -354,7 +361,9 @@ contains
                         code = code // new_line('A') // new_line('A')
                     end if
 
-                    code = code // codegen_core_generate_arena(arena, node%implicit_declaration_indices(i))
+                    code = code // &
+                        codegen_core_generate_arena(arena, &
+                        node%implicit_declaration_indices(i))
                 end if
             end do
         end if

--- a/src/codegen/codegen_expressions.f90
+++ b/src/codegen/codegen_expressions.f90
@@ -8,6 +8,7 @@ module codegen_expressions
                                 range_expression_node
     use ast_nodes_misc, only: complex_literal_node
     use ast_nodes_loops, only: do_loop_node
+    use ast_nodes_io, only: io_implied_do_node
     use type_system_unified
     use string_types, only: string_t
     use codegen_indent
@@ -28,6 +29,7 @@ module codegen_expressions
     public :: generate_code_array_bounds
     public :: generate_code_array_slice
     public :: generate_code_array_operation
+    public :: generate_code_io_implied_do
     public :: generate_code_implied_do
     public :: get_operator_precedence
     public :: needs_parentheses
@@ -711,6 +713,46 @@ contains
             code = "[integer ::]"
         end select
     end function generate_implied_do_array
+
+    function generate_code_io_implied_do(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(io_implied_do_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+        character(len=:), allocatable :: expr_code
+        character(len=:), allocatable :: start_code, end_code, step_code
+
+        expr_code = ""
+        if (node%expr_index > 0) then
+            expr_code = generate_code_from_arena(arena, node%expr_index)
+            expr_code = trim(expr_code)
+        end if
+
+        if (node%start_expr_index > 0) then
+            start_code = generate_code_from_arena(arena, node%start_expr_index)
+            start_code = trim(start_code)
+        else
+            start_code = "1"
+        end if
+
+        if (node%end_expr_index > 0) then
+            end_code = generate_code_from_arena(arena, node%end_expr_index)
+            end_code = trim(end_code)
+        else
+            end_code = "1"
+        end if
+
+        if (node%step_expr_index > 0) then
+            step_code = generate_code_from_arena(arena, node%step_expr_index)
+            step_code = trim(step_code)
+            code = "(" // trim(expr_code) // ", " // trim(node%var_name) // " = " // &
+                   trim(start_code) // ", " // trim(end_code) // ", " // &
+                   trim(step_code) // ")"
+        else
+            code = "(" // trim(expr_code) // ", " // trim(node%var_name) // " = " // &
+                   trim(start_code) // ", " // trim(end_code) // ")"
+        end if
+    end function generate_code_io_implied_do
 
     ! Get operator precedence (higher number = higher precedence)
     function get_operator_precedence(op) result(precedence)

--- a/src/parser/parser_io_statements.f90
+++ b/src/parser/parser_io_statements.f90
@@ -6,7 +6,8 @@ module parser_io_statements_module
     use parser_state_module
     use parser_expressions_module, only: parse_comparison
     use ast_arena_modern, only: ast_arena_t
-    use ast_factory, only: push_print_statement, push_write_statement, push_read_statement
+    use ast_factory, only: push_print_statement, push_write_statement, &
+                           push_read_statement
     use ast_factory
     implicit none
     private
@@ -69,7 +70,9 @@ contains
 
         if (.not. parser%is_at_end()) then
             ! Parse first argument
-            current_arg_index = parse_comparison(parser, arena)
+            current_arg_index = parse_io_implied_do(parser, arena)
+            if (current_arg_index == 0) current_arg_index = &
+                parse_comparison(parser, arena)
             if (current_arg_index > 0) then
                 arg_indices = [current_arg_index]
 
@@ -79,7 +82,9 @@ contains
                     if (token%kind /= TK_OPERATOR .or. token%text /= ",") exit
 
                     token = parser%consume()  ! consume comma
-                    current_arg_index = parse_comparison(parser, arena)
+                    current_arg_index = parse_io_implied_do(parser, arena)
+                    if (current_arg_index == 0) current_arg_index = &
+                        parse_comparison(parser, arena)
                     if (current_arg_index > 0) then
                         arg_indices = [arg_indices, current_arg_index]
                     else
@@ -89,6 +94,116 @@ contains
             end if
         end if
     end subroutine parse_argument_list
+
+    ! Parse implied-do expression specific to I/O lists: (expr, var = start, end [, step])
+    function parse_io_implied_do(parser, arena) result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer :: expr_index
+
+        type(token_t) :: token
+        integer :: saved_pos
+        integer :: value_expr_index
+        integer :: start_index, end_index, step_index
+        character(len=:), allocatable :: var_name
+        integer :: line, column
+
+        expr_index = 0
+        saved_pos = parser%current_token
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= "(") return
+        line = token%line
+        column = token%column
+        token = parser%consume()  ! consume '('
+
+        value_expr_index = parse_comparison(parser, arena)
+        if (value_expr_index <= 0) then
+            expr_index = fail_and_restore()
+            return
+        end if
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= ",") then
+            expr_index = fail_and_restore()
+            return
+        end if
+        token = parser%consume()
+
+        token = parser%peek()
+        if (token%kind /= TK_IDENTIFIER) then
+            expr_index = fail_and_restore()
+            return
+        end if
+        var_name = token%text
+        token = parser%consume()
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= "=") then
+            expr_index = fail_and_restore()
+            return
+        end if
+        token = parser%consume()
+
+        start_index = parse_comparison(parser, arena)
+        if (start_index <= 0) then
+            expr_index = fail_and_restore()
+            return
+        end if
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= ",") then
+            expr_index = fail_and_restore()
+            return
+        end if
+        token = parser%consume()
+
+        end_index = parse_comparison(parser, arena)
+        if (end_index <= 0) then
+            expr_index = fail_and_restore()
+            return
+        end if
+
+        step_index = 0
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. token%text == ",") then
+            token = parser%consume()
+            step_index = parse_comparison(parser, arena)
+            if (step_index <= 0) then
+                expr_index = fail_and_restore()
+                return
+            end if
+        end if
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= ")") then
+            expr_index = fail_and_restore()
+            return
+        end if
+        token = parser%consume()
+
+        if (step_index > 0) then
+            expr_index = push_io_implied_do(arena, value_expr_index, var_name, &
+                                            start_expr_index=start_index, &
+                                            end_expr_index=end_index, &
+                                            step_expr_index=step_index, line=line, &
+                                            column=column)
+        else
+            expr_index = push_io_implied_do(arena, value_expr_index, var_name, &
+                                            start_expr_index=start_index, &
+                                            end_expr_index=end_index, line=line, &
+                                            column=column)
+        end if
+        if (allocated(var_name)) deallocate (var_name)
+        return
+
+    contains
+        integer function fail_and_restore()
+            if (allocated(var_name)) deallocate (var_name)
+            parser%current_token = saved_pos
+            fail_and_restore = 0
+        end function fail_and_restore
+    end function parse_io_implied_do
 
     function parse_print_statement(parser, arena) result(print_index)
         type(parser_state_t), intent(inout) :: parser

--- a/test/frontend/test_issue_1414_implied_do.f90
+++ b/test/frontend/test_issue_1414_implied_do.f90
@@ -1,0 +1,44 @@
+program test_issue_1414_implied_do
+    use frontend, only: transform_lazy_fortran_string
+    implicit none
+
+    call test_print_implied_do()
+    print *, ""
+    print *, "All tests passed for issue 1414."
+
+contains
+
+    subroutine test_print_implied_do()
+        character(len=:), allocatable :: input_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        integer :: idx
+
+        input_code = "program implied" // new_line('A') // &
+                     "    implicit none" // new_line('A') // &
+                     "    integer :: i" // new_line('A') // &
+                     "    print *, (i, i = 1, 3)" // new_line('A') // &
+                     "end program implied"
+
+        call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: unexpected error:", trim(error_msg)
+            error stop 1
+        end if
+
+        idx = index(output_code, "print *, (i, i = 1, 3)")
+        if (idx <= 0) then
+            print *, "FAIL: implied-do syntax not preserved"
+            error stop 1
+        end if
+
+        if (index(output_code, "print *, i") > 0 .and. idx <= 0) then
+            print *, "FAIL: implied-do expanded to flat list"
+            error stop 1
+        end if
+
+        print *, "PASS: implied-do in print preserved"
+    end subroutine test_print_implied_do
+
+end program test_issue_1414_implied_do


### PR DESCRIPTION
### **User description**
## Summary
- parse print/write argument lists for IO implied-do loops and build dedicated AST nodes
- generate IO implied-do expressions with canonical  syntax
- add regression coverage for issue #1414 verifying print retains implied-do form

## Testing
- make test

Closes #1414


___

### **PR Type**
Bug fix


___

### **Description**
- Add IO implied-do AST node type for preserving loop syntax

- Implement parser to recognize and build IO implied-do expressions

- Generate canonical IO implied-do syntax in code output

- Add regression test for issue #1414 verifying print statement preservation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Parser["Parser<br/>parse_io_implied_do"] -->|creates| Node["IO Implied-Do<br/>AST Node"]
  Node -->|stored in| Arena["AST Arena"]
  Arena -->|code generation| Codegen["Code Generator<br/>generate_code_io_implied_do"]
  Codegen -->|outputs| Syntax["Canonical Syntax<br/>expr, var = start, end"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ast_nodes_io.f90</strong><dd><code>Add IO implied-do AST node definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/nodes/ast_nodes_io.f90

<ul><li>Define new <code>io_implied_do_node</code> type extending <code>ast_node</code> with fields for <br>expression index, loop variable name, and loop bounds<br> <li> Implement stub procedures for <code>accept</code>, <code>to_json</code>, and assignment operator<br> <li> Add <code>create_io_implied_do</code> factory function to construct IO implied-do <br>nodes</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1417/files#diff-fb14e7e9930983a528184fcc7eaa81331c3e01f94dc9188d2a6023698b0cb370">+71/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_factory_statements.f90</strong><dd><code>Add IO implied-do node factory function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/factory/ast_factory_statements.f90

<ul><li>Import <code>io_implied_do_node</code> from <code>ast_nodes_io</code> module<br> <li> Implement <code>push_io_implied_do</code> function to create and push IO implied-do <br>nodes to arena<br> <li> Export <code>push_io_implied_do</code> in public interface</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1417/files#diff-50b5550be41590e7725cb57419c3416769079f385febc4c70eb7b814628cccaa">+49/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_factory.f90</strong><dd><code>Export IO implied-do factory function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/factory/ast_factory.f90

<ul><li>Import <code>push_io_implied_do</code> from <code>ast_factory_statements</code> module<br> <li> Export <code>push_io_implied_do</code> in public API</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1417/files#diff-7bdd7265a20a3d2c3901dbdd0dc702706fb4f476c9ea0cd4cb11f85ca171a4ba">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_io_statements.f90</strong><dd><code>Add IO implied-do parser implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_io_statements.f90

<ul><li>Implement <code>parse_io_implied_do</code> function to recognize and parse IO <br>implied-do syntax <code>(expr, var = start, end [, step])</code><br> <li> Integrate parser into <code>parse_argument_list</code> to attempt IO implied-do <br>parsing before falling back to comparison expressions<br> <li> Handle optional step parameter and state restoration on parse failure</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1417/files#diff-29bdc9e3a85346200add60518cef4dafea64ad5761991589b825473bceeb7399">+118/-3</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codegen_expressions.f90</strong><dd><code>Add IO implied-do code generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_expressions.f90

<ul><li>Import <code>io_implied_do_node</code> type from <code>ast_nodes_io</code><br> <li> Implement <code>generate_code_io_implied_do</code> function to generate canonical <br>IO implied-do syntax with proper formatting<br> <li> Export <code>generate_code_io_implied_do</code> in public interface</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1417/files#diff-3b1738eec18cf24328ed23cb81f11a3f57f703a21111d4353d7e1773900cde23">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codegen_core.f90</strong><dd><code>Integrate IO implied-do into code generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_core.f90

<ul><li>Add type guard for <code>io_implied_do_node</code> in main code generation <br>dispatcher<br> <li> Route IO implied-do nodes to <code>generate_code_io_implied_do</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1417/files#diff-c81dee672bc2729fc6591078149f41c001c1860248a5c6fc86294fb9dac68b15">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1414_implied_do.f90</strong><dd><code>Add regression test for implied-do preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/frontend/test_issue_1414_implied_do.f90

<ul><li>Create regression test program for issue #1414<br> <li> Test that print statement with implied-do loop <code>(i, i = 1, 3)</code> preserves <br>syntax after transformation<br> <li> Verify output contains canonical implied-do form and not expanded flat <br>list</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1417/files#diff-125ad7f652816c20fbdf15de45d99dbb6a568389e5900724321f5fd8c1117fe5">+44/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

