### PR TITLE
fix: preserve array function results

### DIFF
--- a/src/codegen/codegen_utilities.f90
+++ b/src/codegen/codegen_utilities.f90
@@ -387,6 +387,8 @@ contains
         logical :: append_kind_param
         character(len=:), allocatable :: result_var_name
         logical :: has_return_type_in_signature
+        logical :: keep_result_decl
+        logical :: has_dimensions
 
         ! Build indent string
         indent_str = repeat("    ", indent)
@@ -651,21 +653,32 @@ contains
                             end if
                         end if
 
-                        ! Skip result variable declaration if return type is in signature
+                        ! Skip result variable declaration if return type is in signature,
+                        ! unless the declaration carries attributes that cannot be expressed
+                        ! in the function statement (e.g., array shape or allocatable flag).
                         if (.not. should_skip .and. has_return_type_in_signature) then
                             if (len_trim(result_var_name) > 0) then
-                                if (node%is_multi_declaration .and. allocated(node%var_names)) then
-                                    ! Check if any variable in multi-declaration is the result variable
-                                    do var_idx = 1, size(node%var_names)
-                                        if (trim(node%var_names(var_idx)) == result_var_name) then
+                                has_dimensions = allocated(node%dimension_indices) .and. &
+                                                 size(node%dimension_indices) > 0
+                                keep_result_decl = node%is_multi_declaration .or. node%is_array .or. &
+                                                   has_dimensions .or. node%is_allocatable .or. &
+                                                   node%is_pointer .or. node%is_target .or. &
+                                                   node%is_parameter .or. node%has_initializer
+
+                                if (.not. keep_result_decl) then
+                                    if (node%is_multi_declaration .and. allocated(node%var_names)) then
+                                        ! Check if any variable in multi-declaration is the result variable
+                                        do var_idx = 1, size(node%var_names)
+                                            if (trim(node%var_names(var_idx)) == result_var_name) then
+                                                should_skip = .true.
+                                                exit
+                                            end if
+                                        end do
+                                    else
+                                        ! Single variable declaration
+                                        if (trim(node%var_name) == result_var_name) then
                                             should_skip = .true.
-                                            exit
                                         end if
-                                    end do
-                                else
-                                    ! Single variable declaration
-                                    if (trim(node%var_name) == result_var_name) then
-                                        should_skip = .true.
                                     end if
                                 end if
                             end if

--- a/src/parser/parser_expressions.f90
+++ b/src/parser/parser_expressions.f90
@@ -1446,26 +1446,39 @@ contains
                 paren = parser%consume()
             end if
 
-            ! Create call_or_subscript node with slice detection
-            if (allocated(arg_indices)) then
-
+            ! Determine the call target name (identifier or component)
+            block
+                logical :: name_available
+                name_available = .false.
                 select type (node => arena%entries(expr_index)%node)
                 type is (component_access_node)
-                    name_for_call = node%component_name
+                    if (allocated(node%component_name)) then
+                        name_for_call = node%component_name
+                        name_available = .true.
+                    end if
                 type is (identifier_node)
-                    name_for_call = node%name
+                    if (allocated(node%name)) then
+                        name_for_call = node%name
+                        name_available = .true.
+                    end if
                 class default
                     if (allocated(arg_indices)) deallocate (arg_indices)
                     return
                 end select
 
-                if (allocated(name_for_call)) then
-                    expr_index = &
-                        push_call_or_subscript_with_slice_detection(arena, &
-                                                             name_for_call, arg_indices, &
-                                                                 paren%line, paren%column)
+                if (.not. name_available) then
+                    if (allocated(arg_indices)) deallocate (arg_indices)
+                    return
                 end if
+            end block
+
+            ! Create call_or_subscript node with slice detection even when no args are present
+            if (.not. allocated(arg_indices)) then
+                allocate (arg_indices(0))
             end if
+
+            expr_index = push_call_or_subscript_with_slice_detection(arena, &
+                                        name_for_call, arg_indices, paren%line, paren%column)
         end block
     end function parse_array_indexing_postfix
 

--- a/test/codegen/test_issue_1413_array_function_result.f90
+++ b/test/codegen/test_issue_1413_array_function_result.f90
@@ -1,0 +1,51 @@
+program test_issue_1413_array_function_result
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+    logical :: success
+
+    print *, "=== Codegen: preserve array function result ==="
+
+    source = '! array-valued function should retain rank' // new_line('a') // &
+             'function create_vector()' // new_line('a') // &
+             '    implicit none' // new_line('a') // &
+             '    real, dimension(3) :: create_vector' // new_line('a') // &
+             '    create_vector = (/1.0, 2.0, 3.0/)' // new_line('a') // &
+             'end function create_vector' // new_line('a') // &
+             new_line('a') // &
+             'print *, create_vector()' // new_line('a')
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    success = .true.
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) success = .false.
+    end if
+
+    if (.not. allocated(output)) success = .false.
+    if (success) then
+        if (index(output, 'real :: create_vector(3)') == 0) success = .false.
+        if (index(output, 'print *, create_vector()') == 0) success = .false.
+    end if
+
+    if (success) then
+        print *, 'PASSED'
+    else
+        print *, 'FAILED: array function result not preserved'
+        if (allocated(output)) then
+            print *, 'OUTPUT:'
+            print *, trim(output)
+        end if
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'ERRORS:'
+                print *, trim(error_msg)
+            end if
+        end if
+        stop 1
+    end if
+
+end program test_issue_1413_array_function_result


### PR DESCRIPTION
### **User description**
## Summary
- ensure zero-argument postfix parentheses still emit a call node so array-valued functions remain invocations
- keep array result declarations when they carry shape/attribute metadata even if the signature is typed
- add regression coverage reproducing issue #1413 to guard against future regressions

## Testing
- make test

Fixes #1413


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve array function result declarations with shape metadata

- Emit call nodes for zero-argument postfix parentheses on arrays

- Improve result variable skipping logic to retain necessary attributes

- Add regression test for issue #1413


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parser: Zero-arg postfix"] -->|"Always emit call node"| B["Call node created"]
  C["Codegen: Result declaration"] -->|"Check attributes"| D["Keep if array/shape/allocatable"]
  D -->|"Preserve metadata"| E["Array rank maintained"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser_expressions.f90</strong><dd><code>Always emit call nodes for postfix parentheses</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_expressions.f90

<ul><li>Refactored <code>parse_array_indexing_postfix</code> to always create call nodes <br>for zero-argument postfix parentheses<br> <li> Added safety checks for name availability before accessing <br>component/identifier names<br> <li> Allocate empty <code>arg_indices</code> array when no arguments present to ensure <br>call node emission<br> <li> Wrapped name extraction logic in a block for better control flow</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1418/files#diff-3840ac8e1ba949344a6d9bb928875718aaa4ed437ffbe93f1a8458377286b1aa">+23/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codegen_utilities.f90</strong><dd><code>Preserve result declarations with metadata attributes</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_utilities.f90

<ul><li>Added <code>keep_result_decl</code> logical flag to determine when result <br>declarations must be retained<br> <li> Enhanced logic to preserve declarations carrying array shape, <br>allocatable, pointer, target, parameter, or initializer attributes<br> <li> Refactored conditional structure to check attribute presence before <br>skipping result variable declarations<br> <li> Improved comments explaining why certain result declarations cannot be <br>omitted</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1418/files#diff-b0a2107e70b99a22eb33987c481147208821fd4fd9b203e7186c751f92d44c46">+25/-11</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1413_array_function_result.f90</strong><dd><code>Regression test for array function result preservation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/codegen/test_issue_1413_array_function_result.f90

<ul><li>New regression test program for issue #1413<br> <li> Tests array-valued function with dimension declaration and <br>zero-argument call<br> <li> Validates that output contains both array rank declaration and <br>function call syntax<br> <li> Verifies error handling and provides detailed failure diagnostics</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1418/files#diff-c107f0575e490e90f1b9b2529652a13d1b818bc9815f7c637eab99f5765d56df">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

