### PR TITLE
fix: honor intrinsic use clauses

### DIFF
--- a/src/ast/ast_core.f90
+++ b/src/ast/ast_core.f90
@@ -261,12 +261,14 @@ contains
     end function create_subroutine_call
 
     function create_use_statement(module_name, only_list, rename_list, &
-                                  has_only, line, column, url_spec) result(node)
+                                  has_only, line, column, url_spec, &
+                                  has_double_colon, is_intrinsic, is_non_intrinsic) result(node)
         character(len=*), intent(in) :: module_name
         character(len=*), intent(in), optional :: only_list(:), rename_list(:)
         character(len=*), intent(in), optional :: url_spec
         logical, intent(in), optional :: has_only
         integer, intent(in), optional :: line, column
+        logical, intent(in), optional :: has_double_colon, is_intrinsic, is_non_intrinsic
         type(use_statement_node) :: node
         integer :: i
 
@@ -274,6 +276,9 @@ contains
         node%uid = generate_uid()
         if (present(url_spec)) node%url_spec = url_spec
         if (present(has_only)) node%has_only = has_only
+        if (present(has_double_colon)) node%has_double_colon = has_double_colon
+        if (present(is_intrinsic)) node%is_intrinsic = is_intrinsic
+        if (present(is_non_intrinsic)) node%is_non_intrinsic = is_non_intrinsic
 
         if (present(only_list)) then
             if (size(only_list) > 0) then

--- a/src/ast/factory/ast_factory_statements.f90
+++ b/src/ast/factory/ast_factory_statements.f90
@@ -25,12 +25,14 @@ contains
     ! Create use statement node and add to stack
     function push_use_statement(arena, module_name, only_list, rename_list, &
                                 has_only, line, column, parent_index, &
-                                url_spec) result(use_index)
+                                url_spec, has_double_colon, is_intrinsic, &
+                                is_non_intrinsic) result(use_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: module_name
         character(len=*), intent(in), optional :: only_list(:), rename_list(:)
         character(len=*), intent(in), optional :: url_spec
         logical, intent(in), optional :: has_only
+        logical, intent(in), optional :: has_double_colon, is_intrinsic, is_non_intrinsic
         integer, intent(in), optional :: line, column, parent_index
         integer :: use_index
         type(use_statement_node) :: use_stmt
@@ -40,6 +42,9 @@ contains
         use_stmt%module_name = module_name
         if (present(url_spec)) use_stmt%url_spec = url_spec
         if (present(has_only)) use_stmt%has_only = has_only
+        if (present(has_double_colon)) use_stmt%has_double_colon = has_double_colon
+        if (present(is_intrinsic)) use_stmt%is_intrinsic = is_intrinsic
+        if (present(is_non_intrinsic)) use_stmt%is_non_intrinsic = is_non_intrinsic
         if (present(only_list)) then
             if (size(only_list) > 0) then
                 allocate (use_stmt%only_list(size(only_list)))

--- a/src/ast/nodes/ast_nodes_misc.f90
+++ b/src/ast/nodes/ast_nodes_misc.f90
@@ -76,6 +76,9 @@ module ast_nodes_misc
         ! mappings (new_name => old_name)
         logical :: has_only = .false.  ! Whether the only
         ! clause is present
+        logical :: has_double_colon = .false.
+        logical :: is_intrinsic = .false.
+        logical :: is_non_intrinsic = .false.
     contains
         procedure :: accept => use_statement_accept
         procedure :: to_json => use_statement_to_json
@@ -218,13 +221,15 @@ contains
     end function create_end_statement
 
     function create_use_statement(module_name, only_list, rename_list, &
-                                  has_only, line, column, url_spec) result(node)
+                                  has_only, line, column, url_spec, &
+                                  has_double_colon, is_intrinsic, is_non_intrinsic) result(node)
         use uid_generator, only: generate_uid
         character(len=*), intent(in) :: module_name
         character(len=*), intent(in), optional :: only_list(:), rename_list(:)
         character(len=*), intent(in), optional :: url_spec
         logical, intent(in), optional :: has_only
         integer, intent(in), optional :: line, column
+        logical, intent(in), optional :: has_double_colon, is_intrinsic, is_non_intrinsic
         type(use_statement_node) :: node
         integer :: i
 
@@ -232,6 +237,9 @@ contains
         node%uid = generate_uid()
         if (present(url_spec)) node%url_spec = url_spec
         if (present(has_only)) node%has_only = has_only
+        if (present(has_double_colon)) node%has_double_colon = has_double_colon
+        if (present(is_intrinsic)) node%is_intrinsic = is_intrinsic
+        if (present(is_non_intrinsic)) node%is_non_intrinsic = is_non_intrinsic
 
         if (present(only_list)) then
             if (size(only_list) > 0) then
@@ -517,6 +525,9 @@ contains
         if (allocated(this%url_spec)) call json%add(obj, 'url_spec', &
                                                     this%url_spec)
         call json%add(obj, 'has_only', this%has_only)
+        call json%add(obj, 'has_double_colon', this%has_double_colon)
+        call json%add(obj, 'is_intrinsic', this%is_intrinsic)
+        call json%add(obj, 'is_non_intrinsic', this%is_non_intrinsic)
         call json%add(parent, obj)
     end subroutine use_statement_to_json
 
@@ -547,6 +558,9 @@ contains
             lhs%rename_list = rhs%rename_list
         end if
         lhs%has_only = rhs%has_only
+        lhs%has_double_colon = rhs%has_double_colon
+        lhs%is_intrinsic = rhs%is_intrinsic
+        lhs%is_non_intrinsic = rhs%is_non_intrinsic
     end subroutine use_statement_assign
 
     ! Include statement implementations

--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -262,6 +262,7 @@ contains
         character(len=:), allocatable :: only_clause
         character(len=:), allocatable :: rename_entry
         integer :: i
+        logical :: needs_double_colon
 
         ! Build proper use statement with all components
         if (.not. allocated(node%module_name)) then
@@ -271,9 +272,20 @@ contains
 
         code = "use"
 
+        needs_double_colon = node%has_double_colon .or. node%is_intrinsic .or. &
+                             node%is_non_intrinsic
+
         ! Add URL spec for Go-style imports if present
         if (allocated(node%url_spec)) then
-            code = code // " " // node%url_spec // " "
+            code = code // " " // node%url_spec
+            if (needs_double_colon) code = code // " ::"
+        else
+            if (node%is_intrinsic) then
+                code = code // ", intrinsic"
+            else if (node%is_non_intrinsic) then
+                code = code // ", non_intrinsic"
+            end if
+            if (needs_double_colon) code = code // " ::"
         end if
 
         ! Add module name

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -57,6 +57,25 @@ contains
             end if
         end do
 
+        ! Capture optional kind suffix (e.g., _int32, _real64)
+        if (pos <= len(source)) then
+            c = source(pos:pos)
+            if (c == '_') then
+                pos = pos + 1
+                col_num = col_num + 1
+                do while (pos <= len(source))
+                    c = source(pos:pos)
+                    if ((c >= '0' .and. c <= '9') .or. (c >= 'A' .and. c <= 'Z') .or. &
+                        (c >= 'a' .and. c <= 'z') .or. c == '_') then
+                        pos = pos + 1
+                        col_num = col_num + 1
+                    else
+                        exit
+                    end if
+                end do
+            end if
+        end if
+
         ! Create number token
         if (token_count < size(tokens)) then
             token_count = token_count + 1

--- a/src/parser/parser_declarations.f90
+++ b/src/parser/parser_declarations.f90
@@ -716,7 +716,7 @@ contains
         case ("character")
             call parse_parenthesized_character(parser, type_spec)
         case default
-            call skip_parenthesized_content(parser)
+            call capture_parenthesized_content(parser, type_spec)
         end select
     end subroutine parse_parenthesized_spec
 
@@ -876,9 +876,12 @@ contains
         end if
     end subroutine consume_comma_if_present
 
-    subroutine skip_parenthesized_content(parser)
+    subroutine capture_parenthesized_content(parser, type_spec)
         type(parser_state_t), intent(inout) :: parser
+        type(type_specifier_t), intent(inout) :: type_spec
         type(token_t) :: token
+        type(token_t), allocatable :: collected_tokens(:)
+        character(len=:), allocatable :: collected_text
 
         do while (.not. parser%is_at_end())
             token = parser%peek()
@@ -886,10 +889,20 @@ contains
                 token = parser%consume()
                 exit
             end if
+            call append_token(collected_tokens, token)
             token = parser%consume()
             call consume_comma_if_present(parser)
         end do
-    end subroutine skip_parenthesized_content
+
+        if (allocated(collected_tokens)) then
+            collected_text = tokens_to_text(collected_tokens)
+            type_spec%type_name = trim(type_spec%base_keyword) // "(" // &
+                                  trim(adjustl(collected_text)) // ")"
+            deallocate (collected_tokens)
+        else
+            type_spec%type_name = trim(type_spec%base_keyword) // "()"
+        end if
+    end subroutine capture_parenthesized_content
 
     ! Parse type specifier (e.g., "integer(kind=8)", "character(len=*)")
     function parse_type_specifier(parser, arena) result(type_spec)

--- a/src/parser/parser_import_resolution.f90
+++ b/src/parser/parser_import_resolution.f90
@@ -208,6 +208,7 @@ contains
         character(len=:), allocatable :: only_list(:)
         character(len=:), allocatable :: rename_list(:)
         logical :: has_only, is_valid_url
+        logical :: has_double_colon, intrinsic_nature, non_intrinsic_nature
         integer :: line, column
 
         ! Consume 'use' keyword
@@ -215,12 +216,46 @@ contains
         line = token%line
         column = token%column
 
+        has_double_colon = .false.
+        intrinsic_nature = .false.
+        non_intrinsic_nature = .false.
+
         ! Get module name (can be identifier or string for Go-style imports)
         token = parser%peek()
+
+        ! Handle optional comma with module nature or double colon
+        if (token%kind == TK_OPERATOR .and. token%text == ",") then
+            token = parser%consume()  ! consume ','
+            token = parser%peek()
+            if ((token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER)) then
+                block
+                    character(len=:), allocatable :: attr_text
+                    attr_text = to_lower_ascii_token(token%text)
+                    if (attr_text == "intrinsic") then
+                        intrinsic_nature = .true.
+                        token = parser%consume()
+                    else if (attr_text == "non_intrinsic") then
+                        non_intrinsic_nature = .true.
+                        token = parser%consume()
+                    end if
+                end block
+                token = parser%peek()
+            end if
+            if (token%kind == TK_OPERATOR .and. token%text == "::") then
+                token = parser%consume()
+                has_double_colon = .true.
+            end if
+            token = parser%peek()
+        else if (token%kind == TK_OPERATOR .and. token%text == "::") then
+            token = parser%consume()
+            has_double_colon = .true.
+            token = parser%peek()
+        end if
+
         if (token%kind == TK_IDENTIFIER) then
             token = parser%consume()
             module_name = token%text
-            url_spec = ""  ! No URL for regular imports
+            if (allocated(url_spec)) deallocate (url_spec)
         else if (token%kind == TK_STRING) then
             ! Go-style import with URL
             token = parser%consume()
@@ -286,9 +321,19 @@ contains
             allocate (character(len=0) :: rename_list(0))
         end if
 
-        ! Create use statement node
-        stmt_index = push_use_statement(arena, module_name, only_list, rename_list, &
-                                        has_only, line, column, url_spec=url_spec)
+        ! Create use statement node (conditionally include URL spec)
+        if (allocated(url_spec)) then
+            stmt_index = push_use_statement(arena, module_name, only_list, rename_list, &
+                                            has_only, line, column, url_spec=url_spec, &
+                                            has_double_colon=has_double_colon, &
+                                            is_intrinsic=intrinsic_nature, &
+                                            is_non_intrinsic=non_intrinsic_nature)
+        else
+            stmt_index = push_use_statement(arena, module_name, only_list, rename_list, &
+                                            has_only, line, column, has_double_colon=has_double_colon, &
+                                            is_intrinsic=intrinsic_nature, &
+                                            is_non_intrinsic=non_intrinsic_nature)
+        end if
     end function parse_use_statement
 
     function parse_include_statement(parser, arena) result(stmt_index)

--- a/test/codegen/test_issue_1412_use_intrinsic.f90
+++ b/test/codegen/test_issue_1412_use_intrinsic.f90
@@ -1,0 +1,50 @@
+program test_issue_1412_use_intrinsic
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+    logical :: success
+
+    print *, "=== Codegen: preserve USE intrinsic ONLY clause ==="
+
+    source = '! ensure intrinsic use clauses survive transformation' // new_line('a') // &
+             'use, intrinsic :: iso_fortran_env, only: int32' // new_line('a') // &
+             'integer(int32) :: value' // new_line('a') // &
+             'value = 123_int32' // new_line('a') // &
+             'print *, value' // new_line('a')
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    success = .true.
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) success = .false.
+    end if
+
+    if (.not. allocated(output)) success = .false.
+
+    if (success) then
+        if (index(output, 'use, intrinsic :: iso_fortran_env, only: int32') == 0) success = .false.
+        if (index(output, 'integer(int32) :: value') == 0) success = .false.
+        if (index(output, 'value = 123_int32') == 0) success = .false.
+    end if
+
+    if (success) then
+        print *, 'PASSED'
+    else
+        print *, 'FAILED: intrinsic USE clause or kind expressions stripped'
+        if (allocated(output)) then
+            print *, 'OUTPUT:'
+            print *, trim(output)
+        end if
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'ERRORS:'
+                print *, trim(error_msg)
+            end if
+        end if
+        stop 1
+    end if
+
+end program test_issue_1412_use_intrinsic

--- a/test/semantic/test_parser_type_hints.f90
+++ b/test/semantic/test_parser_type_hints.f90
@@ -44,10 +44,18 @@ program test_parser_type_hints
         stop 1
     end if
 
-    if (trim(ctx%parser_type_hints(1)%type_name) /= 'real') then
-        write (error_unit, '(a)') 'ERROR: recorded type name is incorrect'
-        stop 1
-    end if
+    block
+        character(len=:), allocatable :: recorded
+        recorded = trim(ctx%parser_type_hints(1)%type_name)
+        if (index(recorded, 'real') /= 1) then
+            write (error_unit, '(a)') 'ERROR: recorded type name missing real prefix'
+            stop 1
+        end if
+        if (index(recorded, 'kind=8') == 0) then
+            write (error_unit, '(a)') 'ERROR: recorded type name missing kind qualifier'
+            stop 1
+        end if
+    end block
 
     if (.not. ctx%parser_type_hints(1)%is_allocatable) then
         write (error_unit, '(a)') 'ERROR: allocatable attribute missing from annotation'


### PR DESCRIPTION
### **User description**
## Summary
- teach the USE parser to keep intrinsic/non_intrinsic qualifiers and feed them through the AST/codegen
- retain parenthesized type specifiers and numeric kind suffixes so integer(int32) and 123_int32 survive transpilation
- add regression covering issue #1412 to guard against future regressions

## Testing
- make test

Fixes #1412


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Preserve `intrinsic` and `non_intrinsic` qualifiers in USE statements

- Capture parenthesized type specifiers and numeric kind suffixes

- Add three new boolean fields to `use_statement_node` for tracking modifiers

- Update codegen to emit proper USE statement syntax with qualifiers

- Enhance lexer to capture kind suffixes (e.g., `_int32`, `_real64`)

- Add regression test for issue #1412


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Parser["Parser<br/>parse_use_statement"] -->|extracts intrinsic/non_intrinsic| AST["AST Node<br/>use_statement_node"]
  AST -->|has_double_colon,<br/>is_intrinsic,<br/>is_non_intrinsic| Codegen["Codegen<br/>generate_code_use_statement"]
  Codegen -->|emits proper syntax| Output["Output<br/>use, intrinsic :: module"]
  Lexer["Lexer<br/>scan_number"] -->|captures _int32 suffix| Parser
  Parser -->|parenthesized specs| AST
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ast_nodes_misc.f90</strong><dd><code>Add intrinsic qualifier fields to USE statement node</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/nodes/ast_nodes_misc.f90

<ul><li>Added three new boolean fields to <code>use_statement_node</code>: <br><code>has_double_colon</code>, <code>is_intrinsic</code>, <code>is_non_intrinsic</code><br> <li> Updated <code>create_use_statement</code> function signature to accept these new <br>parameters<br> <li> Modified <code>use_statement_to_json</code> to serialize the new fields<br> <li> Updated <code>use_statement_assign</code> to copy the new fields during assignment</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1419/files#diff-ff6df096f0d9682e85c70584187636e5523628c3272ceb7f112f2ab35814fe49">+15/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_core.f90</strong><dd><code>Extend USE statement creation with qualifier parameters</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/ast/ast_core.f90

<ul><li>Extended <code>create_use_statement</code> function signature with three new <br>optional parameters<br> <li> Added initialization logic for <code>has_double_colon</code>, <code>is_intrinsic</code>, <br><code>is_non_intrinsic</code> fields</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1419/files#diff-cc1dea1e746de8af0c8624e56c1d9d94912a160a0c1792f522ffe33541e4ae0d">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_factory_statements.f90</strong><dd><code>Pass intrinsic qualifiers through factory function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/factory/ast_factory_statements.f90

<ul><li>Updated <code>push_use_statement</code> function signature to accept three new <br>optional parameters<br> <li> Added parameter passing to initialize the new qualifier fields in the <br>node</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1419/files#diff-50b5550be41590e7725cb57419c3416769079f385febc4c70eb7b814628cccaa">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>lexer_scanners.f90</strong><dd><code>Capture numeric kind suffixes in lexer</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/lexer/lexer_scanners.f90

<ul><li>Enhanced <code>scan_number</code> to capture optional kind suffix (e.g., <code>_int32</code>, <br><code>_real64</code>)<br> <li> Added loop to consume alphanumeric characters and underscores after <br>underscore prefix</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1419/files#diff-23a7515b6f8ead20c3a2eee7154a896324bd47e25cdc7309152c90487b4f0b40">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_declarations.f90</strong><dd><code>Preserve parenthesized type specifiers in parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_declarations.f90

<ul><li>Renamed <code>skip_parenthesized_content</code> to <code>capture_parenthesized_content</code><br> <li> Modified function to collect and reconstruct parenthesized content as <br>part of type name<br> <li> Added helper functions <code>append_token</code> and <code>tokens_to_text</code> to build <br>parenthesized type specifiers</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1419/files#diff-ebbd95623c5af37d8eae5f4f3ecd04bf32a8e1999d49a458a79fc7552409869b">+16/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen_statements.f90</strong><dd><code>Generate proper USE statement syntax with qualifiers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_statements.f90

<ul><li>Modified <code>generate_code_use_statement</code> to emit <code>intrinsic</code> or <br><code>non_intrinsic</code> keywords<br> <li> Added logic to insert <code>::</code> operator when qualifiers are present<br> <li> Fixed URL spec handling to properly format with double colon</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1419/files#diff-29bb67b9e89dcf55c06da03eff7b099893787438130a736fe36a297f8008a881">+13/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_import_resolution.f90</strong><dd><code>Parse intrinsic qualifiers in USE statements</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_import_resolution.f90

<ul><li>Extended <code>parse_use_statement</code> to detect and parse <code>intrinsic</code> and <br><code>non_intrinsic</code> keywords<br> <li> Added logic to handle optional comma and double colon operators<br> <li> Updated node creation calls to pass the new qualifier flags<br> <li> Fixed URL spec allocation/deallocation handling</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1419/files#diff-e25a1bb8b90fa324f467e55214db2514088dcc24ad268893c115b5a4661660fc">+49/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1412_use_intrinsic.f90</strong><dd><code>Add regression test for USE intrinsic preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/codegen/test_issue_1412_use_intrinsic.f90

<ul><li>New regression test for issue #1412<br> <li> Tests preservation of <code>use, intrinsic :: iso_fortran_env, only: int32</code> <br>syntax<br> <li> Verifies that parenthesized type specifiers like <code>integer(int32)</code> <br>survive transpilation<br> <li> Verifies that numeric kind suffixes like <code>123_int32</code> are preserved</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1419/files#diff-d445b8b0521fa60bcc555a211b489577c09de2e939ab0e31bb70d15fb803c599">+50/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

