### PR TITLE
fix: preserve module visibility directives

### DIFF
--- a/src/ast/ast_core.f90
+++ b/src/ast/ast_core.f90
@@ -64,7 +64,7 @@ module ast_core
                             create_print_statement
     use ast_nodes_misc, only: complex_literal_node, allocate_statement_node, &
                               deallocate_statement_node, &
-                              use_statement_node, include_statement_node, &
+                              use_statement_node, visibility_statement_node, include_statement_node, &
                               contains_node, interface_block_node, &
                               comment_node, blank_line_node, implicit_statement_node, &
                               end_statement_node, &
@@ -101,7 +101,7 @@ module ast_core
               read_statement_node, format_descriptor_node
     public :: complex_literal_node, allocate_statement_node, &
               deallocate_statement_node
-    public :: use_statement_node, include_statement_node, contains_node, &
+    public :: use_statement_node, visibility_statement_node, include_statement_node, contains_node, &
               interface_block_node, comment_node, blank_line_node, end_statement_node
     public :: array_bounds_node, array_slice_node, range_expression_node, &
               array_operation_node
@@ -124,7 +124,7 @@ module ast_core
     public :: create_identifier, create_literal, create_binary_op, &
               create_call_or_subscript, &
               create_assignment, create_program, create_subroutine_call, &
-              create_use_statement, create_implicit_statement, &
+              create_use_statement, create_visibility_statement, create_implicit_statement, &
               create_include_statement, create_interface_block, create_module, &
               create_stop, &
               create_return, create_goto, create_error_stop, &

--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -51,7 +51,7 @@ module ast_factory
 
     ! Statement nodes
     use ast_factory_statements, only: &
-        push_use_statement, push_implicit_statement, push_include_statement, &
+        push_use_statement, push_visibility_statement, push_implicit_statement, push_include_statement, &
         push_end_statement, push_stop, push_return, push_goto, push_error_stop, &
         push_cycle, push_exit, push_allocate, push_deallocate, push_io_implied_do
 
@@ -97,7 +97,7 @@ module ast_factory
     public :: push_range_expression
 
     ! Statement nodes
-    public :: push_use_statement, push_implicit_statement, push_include_statement
+    public :: push_use_statement, push_visibility_statement, push_implicit_statement, push_include_statement
     public :: push_end_statement, push_stop, push_return, push_goto, push_error_stop
     public :: push_cycle, push_exit, push_allocate, push_deallocate, push_io_implied_do
 

--- a/src/ast/factory/ast_factory_statements.f90
+++ b/src/ast/factory/ast_factory_statements.f90
@@ -3,6 +3,7 @@ module ast_factory_statements
     use ast_base, only: string_t
     use uid_generator, only: generate_uid
     use ast_nodes_misc, only: use_statement_node, implicit_statement_node, &
+                              visibility_statement_node, &
                               include_statement_node, &
                               end_statement_node, allocate_statement_node, &
                               deallocate_statement_node
@@ -13,7 +14,7 @@ module ast_factory_statements
     private
 
     ! Public statement node creation functions
-    public :: push_use_statement, push_implicit_statement, push_include_statement
+    public :: push_use_statement, push_visibility_statement, push_implicit_statement, push_include_statement
     public :: push_end_statement
     public :: push_stop, push_return, push_goto, push_error_stop
     public :: push_cycle, push_exit
@@ -66,6 +67,37 @@ contains
         call arena%push(use_stmt, "use_statement", parent_index)
         use_index = arena%size
     end function push_use_statement
+
+    function push_visibility_statement(arena, is_private, names, line, column, &
+                                       parent_index, has_double_colon) result(vis_index)
+        type(ast_arena_t), intent(inout) :: arena
+        logical, intent(in) :: is_private
+        character(len=*), intent(in), optional :: names(:)
+        integer, intent(in), optional :: line, column, parent_index
+        logical, intent(in), optional :: has_double_colon
+        integer :: vis_index
+        type(visibility_statement_node) :: vis_stmt
+        integer :: i
+
+        vis_stmt%uid = generate_uid()
+        vis_stmt%is_private = is_private
+        if (present(has_double_colon)) vis_stmt%has_double_colon = has_double_colon
+
+        if (present(names)) then
+            if (size(names) > 0) then
+                vis_stmt%has_list = .true.
+                allocate (vis_stmt%names(size(names)))
+                do i = 1, size(names)
+                    vis_stmt%names(i) = string_t(names(i))
+                end do
+            end if
+        end if
+
+        if (present(line)) vis_stmt%line = line
+        if (present(column)) vis_stmt%column = column
+        call arena%push(vis_stmt, "visibility_statement", parent_index)
+        vis_index = arena%size
+    end function push_visibility_statement
 
     ! Create IO implied-do node and add to arena
     function push_io_implied_do(arena, expr_index, var_name, start_expr_index, &

--- a/src/ast/nodes/ast_nodes_misc.f90
+++ b/src/ast/nodes/ast_nodes_misc.f90
@@ -86,6 +86,18 @@ module ast_nodes_misc
         generic :: assignment(=) => assign
     end type use_statement_node
 
+    type, extends(ast_node), public :: visibility_statement_node
+        type(string_t), allocatable :: names(:)
+        logical :: is_private = .false.
+        logical :: has_list = .false.
+        logical :: has_double_colon = .false.
+    contains
+        procedure :: accept => visibility_statement_accept
+        procedure :: to_json => visibility_statement_to_json
+        procedure :: assign => visibility_statement_assign
+        generic :: assignment(=) => assign
+    end type visibility_statement_node
+
     ! Include statement node
     type, extends(ast_node), public :: include_statement_node
         character(len=:), allocatable :: filename
@@ -168,7 +180,7 @@ module ast_nodes_misc
 
     ! Constructors migrated from ast_core
     public :: create_comment, create_blank_line, create_end_statement
-    public :: create_use_statement, create_include_statement
+    public :: create_use_statement, create_visibility_statement, create_include_statement
     public :: create_implicit_statement, create_interface_block, create_module_procedure
 
 contains
@@ -262,6 +274,34 @@ contains
         if (present(line)) node%line = line
         if (present(column)) node%column = column
     end function create_use_statement
+
+    function create_visibility_statement(is_private, names, has_double_colon, &
+                                         line, column) result(node)
+        use uid_generator, only: generate_uid
+        logical, intent(in) :: is_private
+        character(len=*), intent(in), optional :: names(:)
+        logical, intent(in), optional :: has_double_colon
+        integer, intent(in), optional :: line, column
+        type(visibility_statement_node) :: node
+        integer :: i
+
+        node%uid = generate_uid()
+        node%is_private = is_private
+        if (present(has_double_colon)) node%has_double_colon = has_double_colon
+
+        if (present(names)) then
+            if (size(names) > 0) then
+                node%has_list = .true.
+                allocate (node%names(size(names)))
+                do i = 1, size(names)
+                    node%names(i)%s = names(i)
+                end do
+            end if
+        end if
+
+        if (present(line)) node%line = line
+        if (present(column)) node%column = column
+    end function create_visibility_statement
 
     function create_implicit_statement(is_none, type_name, kind_value, has_kind, &
                                        length_value, has_length, letter_ranges, &
@@ -562,6 +602,70 @@ contains
         lhs%is_intrinsic = rhs%is_intrinsic
         lhs%is_non_intrinsic = rhs%is_non_intrinsic
     end subroutine use_statement_assign
+
+    subroutine visibility_statement_accept(this, visitor)
+        class(visibility_statement_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+    end subroutine visibility_statement_accept
+
+    subroutine visibility_statement_to_json(this, json, parent)
+        class(visibility_statement_node), intent(in) :: this
+        type(json_core), intent(inout) :: json
+        type(json_value), pointer, intent(in) :: parent
+        type(json_value), pointer :: obj
+        integer :: i
+
+        call json%create_object(obj, '')
+        call json%add(obj, 'type', 'visibility_statement')
+        call json%add(obj, 'line', this%line)
+        call json%add(obj, 'column', this%column)
+        call json%add(obj, 'is_private', this%is_private)
+        call json%add(obj, 'has_list', this%has_list)
+        call json%add(obj, 'has_double_colon', this%has_double_colon)
+        if (allocated(this%names)) then
+            do i = 1, size(this%names)
+                if (allocated(this%names(i)%s)) then
+                    call json%add(obj, 'name_' // trim(adjustl(to_string(i))), this%names(i)%s)
+                end if
+            end do
+        end if
+        call json%add(parent, obj)
+    contains
+        pure function to_string(val) result(str)
+            integer, intent(in) :: val
+            character(len=:), allocatable :: str
+            character(len=16) :: buf
+            write (buf, '(I0)') val
+            str = trim(buf)
+        end function to_string
+    end subroutine visibility_statement_to_json
+
+    subroutine visibility_statement_assign(lhs, rhs)
+        class(visibility_statement_node), intent(inout) :: lhs
+        class(visibility_statement_node), intent(in) :: rhs
+        integer :: i
+
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+        lhs%is_private = rhs%is_private
+        lhs%has_list = rhs%has_list
+        lhs%has_double_colon = rhs%has_double_colon
+
+        if (allocated(lhs%names)) deallocate (lhs%names)
+        if (allocated(rhs%names)) then
+            allocate (lhs%names(size(rhs%names)))
+            do i = 1, size(rhs%names)
+                lhs%names(i) = rhs%names(i)
+            end do
+        end if
+    end subroutine visibility_statement_assign
 
     ! Include statement implementations
     subroutine include_statement_accept(this, visitor)

--- a/src/ast/traversal/ast_visitor.f90
+++ b/src/ast/traversal/ast_visitor.f90
@@ -33,6 +33,7 @@ module ast_visitor
         procedure(visit_interface_block_interface), deferred :: visit_interface_block
         procedure(visit_module_interface), deferred :: visit_module
         procedure(visit_use_statement_interface), deferred :: visit_use_statement
+        procedure(visit_visibility_statement_interface), deferred :: visit_visibility_statement
         procedure(visit_include_statement_interface), deferred :: visit_include_statement
     end type ast_visitor_t
 
@@ -59,6 +60,7 @@ module ast_visitor
         procedure :: visit_interface_block => debug_visit_interface_block
         procedure :: visit_module => debug_visit_module
         procedure :: visit_use_statement => debug_visit_use_statement
+        procedure :: visit_visibility_statement => debug_visit_visibility_statement
         procedure :: visit_include_statement => debug_visit_include_statement
         procedure :: visit_call_or_subscript => debug_visit_call_or_subscript
     end type debug_visitor_t
@@ -173,6 +175,12 @@ module ast_visitor
             class(module_node), intent(in) :: node
         end subroutine visit_module_interface
 
+        subroutine visit_visibility_statement_interface(this, node)
+            import :: ast_visitor_t, visibility_statement_node
+            class(ast_visitor_t), intent(inout) :: this
+            class(visibility_statement_node), intent(in) :: node
+        end subroutine visit_visibility_statement_interface
+
         subroutine visit_use_statement_interface(this, node)
             import :: ast_visitor_t, use_statement_node
             class(ast_visitor_t), intent(inout) :: this
@@ -192,7 +200,7 @@ module ast_visitor
     public :: function_def_accept, subroutine_def_accept
     public :: call_or_subscript_accept, subroutine_call_accept, &
               identifier_accept, literal_accept
-    public :: use_statement_accept, include_statement_accept, print_statement_accept
+    public :: use_statement_accept, visibility_statement_accept, include_statement_accept, print_statement_accept
     public :: declaration_accept, do_loop_accept, do_while_accept, if_accept
     public :: select_case_accept, derived_type_accept, interface_block_accept, module_accept
 
@@ -297,6 +305,16 @@ contains
             call vis%visit_use_statement(this)
         end select
     end subroutine use_statement_accept
+
+    subroutine visibility_statement_accept(this, visitor)
+        class(visibility_statement_node), intent(in) :: this
+        class(*), intent(inout) :: visitor
+
+        select type (vis => visitor)
+        class is (ast_visitor_t)
+            call vis%visit_visibility_statement(this)
+        end select
+    end subroutine visibility_statement_accept
 
     subroutine include_statement_accept(this, visitor)
         class(include_statement_node), intent(in) :: this
@@ -558,6 +576,30 @@ contains
 
         call append_debug(this, "use_statement: " // node%module_name)
     end subroutine debug_visit_use_statement
+
+    subroutine debug_visit_visibility_statement(this, node)
+        class(debug_visitor_t), intent(inout) :: this
+        class(visibility_statement_node), intent(in) :: node
+        character(len=:), allocatable :: clause
+        integer :: i
+
+        if (node%is_private) then
+            clause = "private"
+        else
+            clause = "public"
+        end if
+
+        if (node%has_list .and. allocated(node%names)) then
+            clause = clause // " ::"
+            do i = 1, size(node%names)
+                if (allocated(node%names(i)%s)) then
+                    clause = clause // " " // trim(node%names(i)%s)
+                end if
+            end do
+        end if
+
+        call append_debug(this, "visibility_statement: " // clause)
+    end subroutine debug_visit_visibility_statement
 
     subroutine debug_visit_include_statement(this, node)
         class(debug_visitor_t), intent(inout) :: this

--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -22,6 +22,7 @@ module codegen_core
     use ast_nodes_misc, only: complex_literal_node, comment_node, blank_line_node, &
                               implicit_statement_node, allocate_statement_node, &
                               deallocate_statement_node, use_statement_node, &
+                              visibility_statement_node, &
                               contains_node, end_statement_node, interface_block_node, &
                               module_procedure_node
     use ast_nodes_control
@@ -102,6 +103,8 @@ contains
             code = generate_code_cycle(arena, node, node_index)
         type is (exit_node)
             code = generate_code_exit(arena, node, node_index)
+        type is (visibility_statement_node)
+            code = generate_code_visibility_statement(node)
         type is (use_statement_node)
             code = generate_code_use_statement(node)
         type is (implicit_statement_node)

--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -25,6 +25,7 @@ module codegen_statements
     public :: generate_code_cycle
     public :: generate_code_exit
     public :: generate_code_use_statement
+    public :: generate_code_visibility_statement
     public :: generate_code_implicit_statement
     public :: generate_code_comment
     public :: generate_code_blank_line
@@ -333,6 +334,30 @@ contains
             end if
         end if
     end function generate_code_use_statement
+
+    function generate_code_visibility_statement(node) result(code)
+        type(visibility_statement_node), intent(in) :: node
+        character(len=:), allocatable :: code
+        integer :: i
+
+        if (node%is_private) then
+            code = "private"
+        else
+            code = "public"
+        end if
+
+        if (node%has_list .and. allocated(node%names)) then
+            code = code // " :: "
+            do i = 1, size(node%names)
+                if (i > 1) code = code // ", "
+                if (allocated(node%names(i)%s)) then
+                    code = code // trim(node%names(i)%s)
+                end if
+            end do
+        else if (node%has_double_colon) then
+            code = code // " ::"
+        end if
+    end function generate_code_visibility_statement
 
     ! Generate code for implicit statements
     function generate_code_implicit_statement(node) result(code)

--- a/src/parser/parser_module_structures.f90
+++ b/src/parser/parser_module_structures.f90
@@ -1,11 +1,12 @@
 module parser_module_structures_module
     ! Module structure parsing for module definitions and bodies
     use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_NUMBER, TK_STRING, &
-                          TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, TK_COMMENT, TK_WHITESPACE
+                          TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, TK_COMMENT, TK_WHITESPACE, to_lower
     use parser_state_module
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_module_structured, push_implicit_statement, &
-                           push_assignment, push_identifier, push_literal
+                           push_assignment, push_identifier, push_literal, &
+                           push_visibility_statement
     use parser_declarations, only: parse_declaration, parse_derived_type_def, &
                                    parser_is_at_type_definition
     use parser_procedure_definitions_module, only: parse_function_definition, &
@@ -84,6 +85,12 @@ contains
             if (.not. in_contains_section) then
                 if (token%kind == TK_KEYWORD) then
                     select case (token%text)
+                    case ("public", "private")
+                        stmt_index = parse_visibility_statement(parser, arena)
+                        if (stmt_index > 0) then
+                            declaration_indices = [declaration_indices, stmt_index]
+                        end if
+                        cycle
                     case ("integer", "real", "logical", "character", "complex")
                         stmt_index = parse_declaration(parser, arena)
                         if (stmt_index > 0) then
@@ -238,6 +245,89 @@ contains
         module_index = push_module_structured(arena, module_name, declaration_indices, &
                                               procedure_indices, has_contains, line, column)
     end function parse_module
+
+    function parse_visibility_statement(parser, arena) result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer :: stmt_index
+        type(token_t) :: keyword_token, token
+        logical :: is_private
+        logical :: has_double_colon
+        character(len=:), allocatable :: names(:)
+
+        stmt_index = 0
+        if (parser%is_at_end()) return
+
+        keyword_token = parser%consume()
+        is_private = to_lower(keyword_token%text) == "private"
+        has_double_colon = .false.
+
+        if (.not. parser%is_at_end()) then
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == "::") then
+                token = parser%consume()
+                has_double_colon = .true.
+            end if
+        end if
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            select case (token%kind)
+            case (TK_IDENTIFIER)
+                call append_name(names, token%text)
+                token = parser%consume()
+            case (TK_OPERATOR)
+                if (token%text == ",") then
+                    token = parser%consume()
+                    cycle
+                else if (token%text == "::" .and. .not. has_double_colon) then
+                    token = parser%consume()
+                    has_double_colon = .true.
+                    cycle
+                else
+                    exit
+                end if
+            case (TK_NEWLINE)
+                token = parser%consume()
+                exit
+            case (TK_COMMENT)
+                exit
+            case default
+                exit
+            end select
+        end do
+
+        if (allocated(names)) then
+            stmt_index = push_visibility_statement(arena, is_private, names, &
+                                                   keyword_token%line, keyword_token%column, &
+                                                   has_double_colon=has_double_colon)
+        else
+            stmt_index = push_visibility_statement(arena, is_private, &
+                                                   line=keyword_token%line, column=keyword_token%column, &
+                                                   has_double_colon=has_double_colon)
+        end if
+    contains
+        subroutine append_name(list, value)
+            character(len=:), allocatable, intent(inout) :: list(:)
+            character(len=*), intent(in) :: value
+            character(len=:), allocatable :: temp(:)
+            integer :: n, current_len, target_len
+
+            if (.not. allocated(list)) then
+                allocate (character(len=len_trim(value)) :: list(1))
+                list(1) = trim(value)
+            else
+                n = size(list)
+                current_len = len(list)
+                target_len = len_trim(value)
+                target_len = max(current_len, target_len)
+                allocate (character(len=target_len) :: temp(n + 1))
+                temp(1:n) = list
+                temp(n + 1) = trim(value)
+                call move_alloc(temp, list)
+            end if
+        end subroutine append_name
+    end function parse_visibility_statement
 
     ! Parse a simple implicit statement in module context
     subroutine parse_simple_implicit_in_module(parser, arena, stmt_index)

--- a/test/codegen/test_issue_1408_module_visibility.f90
+++ b/test/codegen/test_issue_1408_module_visibility.f90
@@ -1,0 +1,60 @@
+program test_issue_1408_module_visibility
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+    logical :: success
+
+    print *, "=== Codegen: preserve module visibility specifiers ==="
+
+    source = '! ensure private/public visibility survives' // new_line('a') // &
+             'module math_ops' // new_line('a') // &
+             '    implicit none' // new_line('a') // &
+             '    private' // new_line('a') // &
+             '    public :: double_value' // new_line('a') // &
+             'contains' // new_line('a') // &
+             '    function double_value(x)' // new_line('a') // &
+             '        implicit none' // new_line('a') // &
+             '        integer, intent(in) :: x' // new_line('a') // &
+             '        integer :: double_value' // new_line('a') // &
+             '        double_value = 2 * x' // new_line('a') // &
+             '    end function double_value' // new_line('a') // &
+             'end module math_ops' // new_line('a') // &
+             new_line('a') // &
+             'use math_ops' // new_line('a') // &
+             'print *, double_value(5)' // new_line('a')
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    success = .true.
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) success = .false.
+    end if
+
+    if (.not. allocated(output)) success = .false.
+
+    if (success) then
+        if (index(output, 'private') == 0) success = .false.
+        if (index(output, 'public :: double_value') == 0) success = .false.
+    end if
+
+    if (success) then
+        print *, 'PASSED'
+    else
+        print *, 'FAILED: module visibility statements were not preserved'
+        if (allocated(output)) then
+            print *, 'OUTPUT:'
+            print *, trim(output)
+        end if
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'ERRORS:'
+                print *, trim(error_msg)
+            end if
+        end if
+        stop 1
+    end if
+
+end program test_issue_1408_module_visibility


### PR DESCRIPTION
### **User description**
## Summary
- add an AST node plus factory/codegen support for public/private visibility statements
- parse module visibility lines and retain them in the structured module output
- add a regression covering issue #1408 to guard against regressions

## Testing
- make test

Fixes #1408


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `visibility_statement_node` AST node type for public/private directives

- Implement parser support to recognize and retain module visibility statements

- Add factory functions for creating visibility statement nodes in AST

- Implement code generation to reconstruct visibility directives in output

- Add regression test for issue #1408 covering visibility preservation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Parser["Parser<br/>parse_visibility_statement"] -->|creates| VisNode["visibility_statement_node<br/>AST Node"]
  VisNode -->|via Factory| Factory["push_visibility_statement<br/>Factory Function"]
  Factory -->|stores in| Arena["AST Arena"]
  Arena -->|codegen processes| Codegen["generate_code_visibility_statement<br/>Code Generator"]
  Codegen -->|outputs| Code["Reconstructed<br/>public/private code"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ast_core.f90</strong><dd><code>Export visibility statement node and factory</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/ast_core.f90

<ul><li>Import <code>visibility_statement_node</code> from <code>ast_nodes_misc</code><br> <li> Export <code>visibility_statement_node</code> type in public interface<br> <li> Export <code>create_visibility_statement</code> factory function</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1420/files#diff-cc1dea1e746de8af0c8624e56c1d9d94912a160a0c1792f522ffe33541e4ae0d">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_factory.f90</strong><dd><code>Re-export visibility statement factory function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/factory/ast_factory.f90

<ul><li>Import <code>push_visibility_statement</code> from <code>ast_factory_statements</code><br> <li> Export <code>push_visibility_statement</code> in public interface</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1420/files#diff-7bdd7265a20a3d2c3901dbdd0dc702706fb4f476c9ea0cd4cb11f85ca171a4ba">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_factory_statements.f90</strong><dd><code>Implement visibility statement factory function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/factory/ast_factory_statements.f90

<ul><li>Import <code>visibility_statement_node</code> type<br> <li> Export <code>push_visibility_statement</code> function in public interface<br> <li> Implement <code>push_visibility_statement</code> function to create visibility <br>nodes with optional names, line/column info, and double-colon flag</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1420/files#diff-50b5550be41590e7725cb57419c3416769079f385febc4c70eb7b814628cccaa">+33/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ast_nodes_misc.f90</strong><dd><code>Define visibility statement AST node and methods</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/nodes/ast_nodes_misc.f90

<ul><li>Define new <code>visibility_statement_node</code> type extending <code>ast_node</code> with <br>fields for names, is_private flag, has_list, and has_double_colon<br> <li> Implement visitor pattern methods: <code>accept</code>, <code>to_json</code>, and assignment <br>operator<br> <li> Export <code>create_visibility_statement</code> constructor function<br> <li> Implement <code>create_visibility_statement</code> function to construct visibility <br>nodes<br> <li> Implement <code>visibility_statement_accept</code>, <code>visibility_statement_to_json</code>, <br>and <code>visibility_statement_assign</code> procedures</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1420/files#diff-ff6df096f0d9682e85c70584187636e5523628c3272ceb7f112f2ab35814fe49">+105/-1</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codegen_core.f90</strong><dd><code>Add visibility statement code generation dispatch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_core.f90

<ul><li>Import <code>visibility_statement_node</code> type<br> <li> Add type-case handler for <code>visibility_statement_node</code> that calls <br><code>generate_code_visibility_statement</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1420/files#diff-c81dee672bc2729fc6591078149f41c001c1860248a5c6fc86294fb9dac68b15">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codegen_statements.f90</strong><dd><code>Implement visibility statement code generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_statements.f90

<ul><li>Export <code>generate_code_visibility_statement</code> function in public interface<br> <li> Implement <code>generate_code_visibility_statement</code> to reconstruct <br>public/private statements with optional name lists and double-colon <br>syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1420/files#diff-29bb67b9e89dcf55c06da03eff7b099893787438130a736fe36a297f8008a881">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_module_structures.f90</strong><dd><code>Add module visibility statement parser</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_module_structures.f90

<ul><li>Import <code>to_lower</code> from lexer and <code>push_visibility_statement</code> from factory<br> <li> Add parser case for "public" and "private" keywords in module body<br> <li> Implement <code>parse_visibility_statement</code> function to parse visibility <br>directives with optional name lists and double-colon syntax<br> <li> Helper subroutine <code>append_name</code> manages dynamic name list allocation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1420/files#diff-0232b7a7ae3e23e8c9dbd533f36e9fca3186de9a774e3a22b1af30d106e48210">+92/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1408_module_visibility.f90</strong><dd><code>Add regression test for visibility preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/codegen/test_issue_1408_module_visibility.f90

<ul><li>New regression test program for issue #1408<br> <li> Tests parsing and code generation of module with private/public <br>visibility directives<br> <li> Verifies that visibility statements are preserved in output<br> <li> Validates both standalone <code>private</code> and <code>public :: name</code> syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1420/files#diff-81e26b3f04ff2dcb07300f803476f3dd147312d7ba7467a571fa7765d4684354">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

