### PR TITLE
fix: keep module units with trailing main

### DIFF
--- a/examples/issue_1411_generic_module.lf
+++ b/examples/issue_1411_generic_module.lf
@@ -15,12 +15,12 @@ contains
 
     function double_real(x)
         implicit none
-        real, intent(in) :: x
-        real :: double_real
-        double_real = 2.0 * x
+        real(8), intent(in) :: x
+        real(8) :: double_real
+        double_real = 2.0d0 * x
     end function double_real
 end module scalar_ops
 
 use scalar_ops
 print *, double_it(3)
-print *, double_it(1.5)
+print *, double_it(1.5d0)

--- a/src/frontend_parsing.f90
+++ b/src/frontend_parsing.f90
@@ -20,8 +20,10 @@ module frontend_parsing
     use frontend_program_units, only: parse_program_unit, parse_module_unit, &
                                       parse_function_unit, parse_subroutine_unit, &
                                       parse_type_unit, parse_explicit_program_unit, &
-                                      parse_implicit_main_program, not_meaningful_program_unit, &
-                                      has_any_non_comment_content, has_executable_statements
+                                      parse_implicit_main_program, &
+                                      not_meaningful_program_unit, &
+                                      has_any_non_comment_content, &
+                                      has_executable_statements
     use frontend_statement_processing, only: parse_all_statements, &
                                              process_comment_statement, &
                                              process_regular_statement, &
@@ -165,7 +167,8 @@ contains
             end if
         else
             ! Multiple units
-            call handle_multiple_program_units(arena, unit_indices, prog_index, error_msg)
+            call handle_multiple_program_units(arena, unit_indices, &
+                                               prog_index, error_msg)
         end if
     end subroutine parse_tokens
 
@@ -198,7 +201,8 @@ contains
         do i = 1, size(tokens)
             if (tokens(i)%kind == TK_KEYWORD) then
                 if (tokens(i)%text == "program" .or. tokens(i)%text == "module" .or. &
-                    tokens(i)%text == "function" .or. tokens(i)%text == "subroutine") then
+                    tokens(i)%text == "function" .or. tokens(i)%text == &
+                    "subroutine") then
                     has_explicit_program_unit = .true.
                     exit
                 end if
@@ -243,7 +247,8 @@ contains
         if (i <= size(tokens)) then
             if (tokens(i)%kind == TK_KEYWORD) then
                 if (tokens(i)%text == "program" .or. tokens(i)%text == "module" .or. &
-                   tokens(i)%text == "function" .or. tokens(i)%text == "subroutine" .or. &
+                    tokens(i)%text == "function" .or. tokens(i)%text == &
+                    "subroutine" .or. &
                     tokens(i)%text == "type") then
                     is_start = .true.
                 end if
@@ -252,7 +257,8 @@ contains
     end function is_program_unit_start
 
     ! Check if unit has meaningful content
-    function unit_has_meaningful_content(tokens, unit_start, unit_end) result(has_content)
+    function unit_has_meaningful_content(tokens, unit_start, unit_end) &
+        result(has_content)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: unit_start, unit_end
         logical :: has_content
@@ -367,8 +373,13 @@ contains
                         end if
                     else if (to_lower(trim(tokens(i)%text)) == "module" .and. &
                              .not. in_module_contains) then
-                        ! Nested module (rare but possible)
-                        nesting_level = nesting_level + 1
+                        ! Nested module (rare but possible) - ensure this isn't part of
+                        ! "module procedure" or similar interface syntax (issue #1411)
+                        if (i + 1 <= size(tokens)) then
+                            if (tokens(i + 1)%kind == TK_IDENTIFIER) then
+                                nesting_level = nesting_level + 1
+                            end if
+                        end if
                     end if
                 end if
                 unit_end = i
@@ -399,7 +410,8 @@ contains
                         end if
                         ! Also handle standalone "end" for simple procedures
                         if (i == size(tokens) .or. (i + 1 <= size(tokens) .and. &
-                                                   tokens(i + 1)%kind /= TK_KEYWORD)) then
+                                                    tokens(i + 1)%kind /= &
+                                                    TK_KEYWORD)) then
                             unit_end = i
                             exit
                         end if

--- a/test/codegen/test_issue_1411_module_main.f90
+++ b/test/codegen/test_issue_1411_module_main.f90
@@ -1,0 +1,73 @@
+program test_issue_1411_module_main
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+    logical :: success
+
+    print *, "=== Codegen: preserve module + top-level statements ==="
+
+    source = '! module followed by lazy main program' // new_line('a') // &
+             'module scalar_ops' // new_line('a') // &
+             '    implicit none' // new_line('a') // &
+             '    interface double_it' // new_line('a') // &
+             '        module procedure double_int' // new_line('a') // &
+             '        module procedure double_real' // new_line('a') // &
+             '    end interface' // new_line('a') // &
+             'contains' // new_line('a') // &
+             '    function double_int(x)' // new_line('a') // &
+             '        implicit none' // new_line('a') // &
+             '        integer, intent(in) :: x' // new_line('a') // &
+             '        integer :: double_int' // new_line('a') // &
+             '        double_int = 2 * x' // new_line('a') // &
+             '    end function double_int' // new_line('a') // &
+             '' // new_line('a') // &
+             '    function double_real(x)' // new_line('a') // &
+             '        implicit none' // new_line('a') // &
+             '        real(8), intent(in) :: x' // new_line('a') // &
+             '        real(8) :: double_real' // new_line('a') // &
+             '        double_real = 2.0d0 * x' // new_line('a') // &
+             '    end function double_real' // new_line('a') // &
+             'end module scalar_ops' // new_line('a') // &
+             '' // new_line('a') // &
+             'use scalar_ops' // new_line('a') // &
+             'print *, double_it(3)' // new_line('a') // &
+             'print *, double_it(1.5d0)'
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    success = .true.
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) success = .false.
+    end if
+
+    if (.not. allocated(output)) success = .false.
+
+    if (success) then
+        if (index(output, 'module scalar_ops') == 0) success = .false.
+        if (index(output, 'program main') == 0) success = .false.
+        if (index(output, 'use scalar_ops') == 0) success = .false.
+        if (index(output, 'print *, double_it(3)') == 0) success = .false.
+        if (index(output, 'print *, double_it(1.5d0)') == 0) success = .false.
+    end if
+
+    if (success) then
+        print *, 'PASSED'
+    else
+        print *, 'FAILED: module/main round-trip lost statements'
+        if (allocated(output)) then
+            print *, 'OUTPUT:'
+            print *, trim(output)
+        end if
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'ERRORS:'
+                print *, trim(error_msg)
+            end if
+        end if
+        stop 1
+    end if
+
+end program test_issue_1411_module_main


### PR DESCRIPTION
### **User description**
## Summary
- ensure module program-unit detection ignores interface `module procedure` clauses
- preserve trailing lazy main statements as an implicit `program main`
- add regression coverage and align example 1411 to compile cleanly post-transform

## Testing
- make test

Closes #1411


___

### **PR Type**
Bug fix


___

### **Description**
- Fix module unit detection to ignore "module procedure" interface clauses

- Preserve trailing lazy main statements as implicit program main

- Add regression test for issue #1411 with module and top-level statements

- Update example to use proper real(8) precision and double precision literals


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Module with interface<br/>module procedure clauses"] -->|"Improved detection<br/>logic"| B["Correctly identify<br/>module boundaries"]
  B -->|"Preserve trailing<br/>statements"| C["Create implicit<br/>program main"]
  C -->|"Regression test"| D["Validate fix<br/>for issue #1411"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frontend_parsing.f90</strong><dd><code>Fix module boundary detection and improve formatting</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend_parsing.f90

<ul><li>Fixed module unit boundary detection to skip "module procedure" <br>interface syntax by checking if next token is an identifier<br> <li> Added comment explaining the fix for issue #1411 regarding nested <br>module detection<br> <li> Reformatted import statements and function signatures for better code <br>alignment<br> <li> Improved line wrapping in conditional statements for readability</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1422/files#diff-527cf8a0e0c4fa4d1b9fc5ba2aa7ab2c8008332b604928b46aae4a5bdaffb358">+21/-9</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>issue_1411_generic_module.lf</strong><dd><code>Update example to use proper double precision</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/issue_1411_generic_module.lf

<ul><li>Updated real type declarations from <code>real</code> to <code>real(8)</code> for explicit <br>double precision<br> <li> Changed real literals from <code>2.0</code> and <code>1.5</code> to <code>2.0d0</code> and <code>1.5d0</code> for proper <br>double precision notation<br> <li> Ensures example compiles cleanly and demonstrates correct precision <br>handling</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1422/files#diff-c4c2499af3187c2dddcfbb8e1b394b1e60ffcfc85e8af22f38f75ed61c2449b6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_1411_module_main.f90</strong><dd><code>Add regression test for module with lazy main</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/codegen/test_issue_1411_module_main.f90

<ul><li>New regression test file for issue #1411<br> <li> Tests transformation of Fortran source with module followed by lazy <br>main program statements<br> <li> Validates that module definition, use statements, and print statements <br>are preserved<br> <li> Checks for proper error handling and output generation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1422/files#diff-bd8bc1cbf513799711e5152f4f39c194c20267ac1655fe8ad5724abadaac7677">+73/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

