### PR TITLE
fix: keep array function results ranked

### DIFF
--- a/src/codegen/codegen_declarations.f90
+++ b/src/codegen/codegen_declarations.f90
@@ -63,7 +63,11 @@ contains
         end if
 
         if (len_trim(return_type_code) > 0) then
-            return_type_code = fix_character_len_placeholder(return_type_code)
+            if (should_omit_return_type(arena, node, return_type_code)) then
+                return_type_code = ""
+            else
+                return_type_code = fix_character_len_placeholder(return_type_code)
+            end if
         end if
 
         if (allocated(node%prefix_keywords)) then
@@ -262,6 +266,48 @@ contains
         ! End function
         code = code // "end function " // node%name
     end function generate_code_function_def
+
+    logical function should_omit_return_type(arena, node, return_type_code) result(omit)
+        type(ast_arena_t), intent(in) :: arena
+        type(function_def_node), intent(in) :: node
+        character(len=*), intent(in) :: return_type_code
+        character(len=:), allocatable :: result_name
+        character(len=:), allocatable :: lowered_return
+        integer :: i, decl_index
+
+        omit = .false.
+        result_name = ""
+        if (allocated(node%result_variable)) then
+            result_name = trim(node%result_variable)
+        end if
+        if (len_trim(result_name) == 0 .and. allocated(node%name)) then
+            result_name = trim(node%name)
+        end if
+        if (len_trim(result_name) == 0) return
+
+        if (.not. allocated(node%name)) return
+
+        if (.not. allocated(node%body_indices)) return
+
+        lowered_return = to_lower_ascii_str(trim(return_type_code))
+        if (len_trim(lowered_return) == 0) return
+
+        do i = 1, size(node%body_indices)
+            decl_index = node%body_indices(i)
+            if (decl_index <= 0 .or. decl_index > arena%size) cycle
+            if (.not. allocated(arena%entries(decl_index)%node)) cycle
+            select type (decl => arena%entries(decl_index)%node)
+            type is (declaration_node)
+                if (trim(decl%var_name) /= trim(result_name)) cycle
+                if (.not. decl%is_array) then
+                    if (.not. allocated(decl%dimension_indices)) cycle
+                    if (size(decl%dimension_indices) == 0) cycle
+                end if
+                omit = .true.
+                return
+            end select
+        end do
+    end function should_omit_return_type
 
     ! Generate code for subroutine definitions
     function generate_code_subroutine_def(arena, node, node_index) result(code)

--- a/src/semantic/analyzers/semantic_function_analysis.f90
+++ b/src/semantic/analyzers/semantic_function_analysis.f90
@@ -4,12 +4,13 @@ module semantic_function_analysis
     use type_system_unified, only: type_var_t, mono_type_t, poly_type_t, &
                                    create_mono_type, create_type_var, &
                                    create_poly_type, create_fun_type, &
-                                   TVAR, TINT, TREAL, TCHAR, TLOGICAL, TFUN
+                                   TVAR, TINT, TREAL, TCHAR, TLOGICAL, TFUN, &
+                                   TARRAY
     use ast_base, only: LITERAL_INTEGER, LITERAL_REAL
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: identifier_node, assignment_node, &
                               call_or_subscript_node, literal_node, binary_op_node, &
-                              program_node
+                              program_node, array_literal_node
     use ast_nodes_procedure, only: function_def_node, subroutine_def_node
     use ast_nodes_data, only: declaration_node, parameter_declaration_node
     use scope_manager, only: scope_stack_t
@@ -366,6 +367,52 @@ contains
             if (left_typ%kind == 0) left_typ = right_typ
             if (right_typ%kind == 0) right_typ = left_typ
             typ = get_common_type(left_typ, right_typ)
+        type is (array_literal_node)
+            block
+                integer :: elem_count, elem_idx
+                type(mono_type_t) :: elem_type, other_type
+                type(mono_type_t), allocatable :: args(:)
+
+                elem_count = 0
+                if (allocated(node%element_indices)) then
+                    elem_count = size(node%element_indices)
+                end if
+
+                if (elem_count == 0) then
+                    allocate (args(1))
+                    args(1) = create_mono_type(TINT)
+                    typ = create_mono_type(TARRAY, args=args)
+                    return
+                end if
+
+                elem_type = infer_expression_type_static( &
+                            arena, node%element_indices(1), param_names, param_types)
+                if (elem_type%kind == 0) elem_type = create_mono_type(TREAL)
+
+                do elem_idx = 2, elem_count
+                    other_type = infer_expression_type_static( &
+                                 arena, node%element_indices(elem_idx), &
+                                 param_names, param_types)
+                    if (other_type%kind == 0) cycle
+
+                    if (elem_type%kind == TARRAY .and. other_type%kind /= TARRAY) then
+                        ! Keep existing array element type
+                    else if (elem_type%kind /= TARRAY .and. other_type%kind == &
+                             TARRAY) then
+                        elem_type = other_type
+                    else
+                        elem_type = get_common_type(elem_type, other_type)
+                    end if
+                end do
+
+                allocate (args(1))
+                args(1) = elem_type
+                if (elem_count > 0) then
+                    typ = create_mono_type(TARRAY, args=args, array_size=elem_count)
+                else
+                    typ = create_mono_type(TARRAY, args=args)
+                end if
+            end block
         type is (call_or_subscript_node)
             if (node%inferred_type%kind > 0) typ = node%inferred_type
         end select

--- a/test/codegen/test_issue_1413_array_function_result.f90
+++ b/test/codegen/test_issue_1413_array_function_result.f90
@@ -27,6 +27,8 @@ program test_issue_1413_array_function_result
 
     if (.not. allocated(output)) success = .false.
     if (success) then
+        if (index(output, 'function create_vector()') == 0) success = .false.
+        if (index(output, 'real function create_vector') /= 0) success = .false.
         if (index(output, 'real :: create_vector(3)') == 0) success = .false.
         if (index(output, 'print *, create_vector()') == 0) success = .false.
     end if


### PR DESCRIPTION
## Summary
- teach semantic analysis to propagate array literal rank into function result types (Fixes #1413)
- skip emitting scalar return types when the body already declares an array-valued result
- lock the regression with test_issue_1413_array_function_result.f90

## Testing
- make test
- fpm test --target test_all_examples
