### PR TITLE
fix: Extract shared allocatable logic in standardizer_allocatable (51 (fixes #1443)

### DIFF
--- a/src/standardizers/standardizer_allocatable.f90
+++ b/src/standardizers/standardizer_allocatable.f90
@@ -214,7 +214,8 @@ contains
                 if (stmt%is_multi_declaration .and. allocated(stmt%var_names)) then
                     call handle_multi_variable_declaration_allocatable(arena, &
                                                                        current_index, &
-                                assigned_vars, assignment_counts, var_count, prog_index, &
+                                            assigned_vars, assignment_counts, var_count, &
+                                                                       prog_index, &
                                                                        needs_split)
 
                     if (needs_split) then
@@ -228,18 +229,7 @@ contains
                         if (trim(assigned_vars(i)) == trim(stmt%var_name)) then
                             if (assignment_counts(i) >= 2 .or. &
                                 is_procedure_parameter(arena, current_index)) then
-                                if (stmt%is_array) then
-                                    stmt%is_allocatable = .true.
-                                    if (allocated(stmt%dimension_indices)) then
-                                        deallocate (stmt%dimension_indices)
-                                        allocate (stmt%dimension_indices(1))
-                                        stmt%dimension_indices(1) = 0
-                                    end if
-                                    arena%entries(current_index)%node = stmt
-                                else if ((allocated(stmt%type_name) .and. &
-                                          trim(stmt%type_name) == "character") .or. &
-                                         (stmt%inferred_type%kind == TCHAR)) then
-                                    stmt%is_allocatable = .true.
+                                if (apply_allocatable_attributes(stmt)) then
                                     arena%entries(current_index)%node = stmt
                                 end if
                             end if
@@ -353,16 +343,7 @@ contains
                     block
                         type(declaration_node) :: tmp
                         tmp = decl
-                        ! Only mark allocatable for arrays or character types
-                        if (tmp%is_array .or. &
-                            (allocated(tmp%type_name) .and. trim(tmp%type_name) == &
-                             "character")) then
-                            tmp%is_allocatable = .true.
-                            if (tmp%is_array .and. allocated(tmp%dimension_indices)) then
-                                deallocate (tmp%dimension_indices)
-                                allocate (tmp%dimension_indices(1))
-                                tmp%dimension_indices(1) = 0  ! Deferred shape for allocatable
-                            end if
+                        if (apply_allocatable_attributes(tmp)) then
                             arena%entries(decl_index)%node = tmp
                         end if
                     end block
@@ -813,6 +794,37 @@ contains
         end function pop
 
     end subroutine collect_string_vars_needing_allocatable
+
+    logical function apply_allocatable_attributes(decl)
+        type(declaration_node), intent(inout) :: decl
+        logical :: is_character
+
+        apply_allocatable_attributes = .false.
+        is_character = .false.
+
+        if (allocated(decl%type_name)) then
+            if (trim(decl%type_name) == "character") then
+                is_character = .true.
+            end if
+        end if
+
+        if (decl%inferred_type%kind == TCHAR) then
+            is_character = .true.
+        end if
+
+        if (decl%is_array) then
+            decl%is_allocatable = .true.
+            if (allocated(decl%dimension_indices)) then
+                deallocate (decl%dimension_indices)
+            end if
+            allocate (decl%dimension_indices(1))
+            decl%dimension_indices(1) = 0
+            apply_allocatable_attributes = .true.
+        else if (is_character) then
+            decl%is_allocatable = .true.
+            apply_allocatable_attributes = .true.
+        end if
+    end function apply_allocatable_attributes
 
     pure function to_lower_ascii_local(text) result(lowered)
         character(len=*), intent(in) :: text


### PR DESCRIPTION
### **User description**
## Summary
- share the allocatable attribute handling via a single helper for declarations
- update both single- and multi-declaration paths to use the shared helper so character inference stays aligned

## Verification
- make test
  - All fortfront API integration tests passed (see STOP 0 summary)


___

### **PR Type**
Enhancement


___

### **Description**
- Extract shared allocatable attribute logic into helper function

- Eliminate code duplication across single and multi-declaration paths

- Ensure consistent character type and array handling in allocatable marking

- Fix formatting alignment in function call parameters


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Duplicated allocatable logic<br/>in two code paths"] -->|"Extract to helper"| B["apply_allocatable_attributes<br/>function"]
  B -->|"Used by"| C["mark_declarations_allocatable<br/>single-declaration path"]
  B -->|"Used by"| D["handle_multi_variable_declaration_allocatable<br/>multi-declaration path"]
  C -->|"Consistent behavior"| E["Aligned character inference<br/>and array handling"]
  D -->|"Consistent behavior"| E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>standardizer_allocatable.f90</strong><dd><code>Extract allocatable logic into reusable helper function</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/standardizers/standardizer_allocatable.f90

<ul><li>Extract duplicated allocatable attribute logic into new <br><code>apply_allocatable_attributes()</code> helper function<br> <li> Replace two separate code blocks (lines 226-239 and 351-360) with <br>single helper function call<br> <li> Helper function handles both array and character type allocatable <br>marking with dimension index management<br> <li> Fix parameter alignment formatting in <br><code>handle_multi_variable_declaration_allocatable()</code> call</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1446/files#diff-eb6db709c95eff701c3b9ae39e966f855890fccb6b4bb4c3036ca8da51fe4fc5">+35/-23</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

