### PR TITLE
fix: Consolidate duplicate parameter handling in ast_factory_declarat (fixes #1442)

### DIFF
--- a/src/ast/factory/ast_factory_declarations.f90
+++ b/src/ast/factory/ast_factory_declarations.f90
@@ -1,295 +1,311 @@
 module ast_factory_declarations
-   use ast_arena_modern, only: ast_arena_t
-   use ast_nodes_data, only: declaration_node, parameter_declaration_node, derived_type_node
-   use ast_nodes_data, only: INTENT_NONE, INTENT_IN, INTENT_OUT, INTENT_INOUT
-   implicit none
-   private
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_data, only: declaration_node, parameter_declaration_node, &
+                              derived_type_node
+    use ast_nodes_data, only: INTENT_NONE, INTENT_IN, INTENT_OUT, INTENT_INOUT
+    implicit none
+    private
 
-   ! Public declaration node creation functions
-   public :: push_declaration, push_multi_declaration, push_parameter_declaration
-   public :: push_derived_type
+    ! Public declaration node creation functions
+    public :: push_declaration, push_multi_declaration, push_parameter_declaration
+    public :: push_derived_type
 
 contains
 
-   subroutine initialize_declaration_details(decl, kind_value, dimension_indices, &
-                                             initializer_index, is_allocatable, is_pointer, &
-                                             is_target, is_external, intent_value, &
-                                             is_optional, is_parameter, line, column)
-      type(declaration_node), intent(inout) :: decl
-      integer, intent(in), optional :: kind_value
-      integer, intent(in), optional :: dimension_indices(:)
-      integer, intent(in), optional :: initializer_index
-      logical, intent(in), optional :: is_allocatable
-      logical, intent(in), optional :: is_pointer
-      logical, intent(in), optional :: is_target
-      logical, intent(in), optional :: is_external
-      character(len=*), intent(in), optional :: intent_value
-      logical, intent(in), optional :: is_optional
-      logical, intent(in), optional :: is_parameter
-      integer, intent(in), optional :: line, column
+    subroutine initialize_declaration_details(decl, kind_value, dimension_indices, &
+                                              initializer_index, is_allocatable, &
+                                              is_pointer, &
+                                              is_target, is_external, intent_value, &
+                                              is_optional, is_parameter, line, column)
+        type(declaration_node), intent(inout) :: decl
+        integer, intent(in), optional :: kind_value
+        integer, intent(in), optional :: dimension_indices(:)
+        integer, intent(in), optional :: initializer_index
+        logical, intent(in), optional :: is_allocatable
+        logical, intent(in), optional :: is_pointer
+        logical, intent(in), optional :: is_target
+        logical, intent(in), optional :: is_external
+        character(len=*), intent(in), optional :: intent_value
+        logical, intent(in), optional :: is_optional
+        logical, intent(in), optional :: is_parameter
+        integer, intent(in), optional :: line, column
 
-      if (present(kind_value)) then
-         decl%kind_value = kind_value
-         decl%has_kind = .true.
-      else
-         decl%kind_value = 0
-         decl%has_kind = .false.
-      end if
+        if (present(kind_value)) then
+            decl%kind_value = kind_value
+            decl%has_kind = .true.
+        else
+            decl%kind_value = 0
+            decl%has_kind = .false.
+        end if
 
-      if (present(initializer_index)) then
-         if (initializer_index > 0) then
-            decl%initializer_index = initializer_index
-            decl%has_initializer = .true.
-         else
+        if (present(initializer_index)) then
+            if (initializer_index > 0) then
+                decl%initializer_index = initializer_index
+                decl%has_initializer = .true.
+            else
+                decl%initializer_index = 0
+                decl%has_initializer = .false.
+            end if
+        else
             decl%initializer_index = 0
             decl%has_initializer = .false.
-         end if
-      else
-         decl%initializer_index = 0
-         decl%has_initializer = .false.
-      end if
+        end if
 
-      if (present(dimension_indices)) then
-         decl%is_array = .true.
-         allocate (decl%dimension_indices, source=dimension_indices)
-      else
-         decl%is_array = .false.
-      end if
+        if (present(dimension_indices)) then
+            decl%is_array = .true.
+            allocate (decl%dimension_indices, source=dimension_indices)
+        else
+            decl%is_array = .false.
+        end if
 
-      if (present(is_allocatable)) then
-         decl%is_allocatable = is_allocatable
-      else
-         decl%is_allocatable = .false.
-      end if
+        if (present(is_allocatable)) then
+            decl%is_allocatable = is_allocatable
+        else
+            decl%is_allocatable = .false.
+        end if
 
-      if (present(is_pointer)) then
-         decl%is_pointer = is_pointer
-      else
-         decl%is_pointer = .false.
-      end if
+        if (present(is_pointer)) then
+            decl%is_pointer = is_pointer
+        else
+            decl%is_pointer = .false.
+        end if
 
-      if (present(is_target)) then
-         decl%is_target = is_target
-      else
-         decl%is_target = .false.
-      end if
+        if (present(is_target)) then
+            decl%is_target = is_target
+        else
+            decl%is_target = .false.
+        end if
 
-      if (present(is_external)) then
-         decl%is_external = is_external
-      else
-         decl%is_external = .false.
-      end if
+        if (present(is_external)) then
+            decl%is_external = is_external
+        else
+            decl%is_external = .false.
+        end if
 
-      if (present(intent_value)) then
-         decl%intent = intent_value
-         decl%has_intent = .true.
-      else
-         decl%has_intent = .false.
-      end if
+        if (present(intent_value)) then
+            decl%intent = intent_value
+            decl%has_intent = .true.
+        else
+            decl%has_intent = .false.
+        end if
 
-      if (present(is_optional)) then
-         decl%is_optional = is_optional
-      else
-         decl%is_optional = .false.
-      end if
+        if (present(is_optional)) then
+            decl%is_optional = is_optional
+        else
+            decl%is_optional = .false.
+        end if
 
-      if (present(is_parameter)) then
-         decl%is_parameter = is_parameter
-      else
-         decl%is_parameter = .false.
-      end if
+        if (present(is_parameter)) then
+            decl%is_parameter = is_parameter
+        else
+            decl%is_parameter = .false.
+        end if
 
-      if (present(line)) decl%line = line
-      if (present(column)) decl%column = column
-   end subroutine initialize_declaration_details
+        if (present(line)) decl%line = line
+        if (present(column)) decl%column = column
+    end subroutine initialize_declaration_details
 
-   ! Create derived type node and add to stack
-   function push_derived_type(arena, name, component_indices, param_indices, &
-                              line, column, parent_index, attribute_clause) result(type_index)
-      type(ast_arena_t), intent(inout) :: arena
-      character(len=*), intent(in) :: name
-      integer, intent(in), optional :: component_indices(:)
-      integer, intent(in), optional :: param_indices(:)
-      integer, intent(in), optional :: line, column, parent_index
-      character(len=*), intent(in), optional :: attribute_clause
-      integer :: type_index
-      type(derived_type_node) :: dtype
+    ! Create derived type node and add to stack
+    function push_derived_type(arena, name, component_indices, param_indices, &
+                               line, column, parent_index, attribute_clause) &
+        result(type_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: name
+        integer, intent(in), optional :: component_indices(:)
+        integer, intent(in), optional :: param_indices(:)
+        integer, intent(in), optional :: line, column, parent_index
+        character(len=*), intent(in), optional :: attribute_clause
+        integer :: type_index
+        type(derived_type_node) :: dtype
 
-      ! Create derived type with index-based components
-      dtype%name = name
+        ! Create derived type with index-based components
+        dtype%name = name
 
-      if (present(attribute_clause)) then
-         if (len_trim(attribute_clause) > 0) then
-            dtype%attribute_clause = trim(attribute_clause)
-            dtype%has_attributes = .true.
-         else
+        if (present(attribute_clause)) then
+            if (len_trim(attribute_clause) > 0) then
+                dtype%attribute_clause = trim(attribute_clause)
+                dtype%has_attributes = .true.
+            else
+                dtype%has_attributes = .false.
+            end if
+        else
             dtype%has_attributes = .false.
-         end if
-      else
-         dtype%has_attributes = .false.
-      end if
+        end if
 
-      if (present(component_indices)) then
-         if (size(component_indices) > 0) then
-            allocate (dtype%component_indices, source=component_indices)
-         end if
-      end if
+        if (present(component_indices)) then
+            if (size(component_indices) > 0) then
+                allocate (dtype%component_indices, source=component_indices)
+            end if
+        end if
 
-      if (present(param_indices)) then
-         if (size(param_indices) > 0) then
-            dtype%has_parameters = .true.
-            allocate (dtype%param_indices, source=param_indices)
-         end if
-      end if
+        if (present(param_indices)) then
+            if (size(param_indices) > 0) then
+                dtype%has_parameters = .true.
+                allocate (dtype%param_indices, source=param_indices)
+            end if
+        end if
 
-      if (present(line)) dtype%line = line
-      if (present(column)) dtype%column = column
+        if (present(line)) dtype%line = line
+        if (present(column)) dtype%column = column
 
-      call arena%push(dtype, "derived_type", parent_index)
-      type_index = arena%size
-   end function push_derived_type
+        call arena%push(dtype, "derived_type", parent_index)
+        type_index = arena%size
+    end function push_derived_type
 
-   ! Create declaration node and add to stack
-   function push_declaration(arena, type_name, var_name, kind_value, &
-                             dimension_indices, &
-                             initializer_index, is_allocatable, is_pointer, is_target, &
-                             is_external, intent_value, is_optional, is_parameter, line, column, &
-                             parent_index) result(decl_index)
-      type(ast_arena_t), intent(inout) :: arena
-      character(len=*), intent(in) :: type_name, var_name
-      integer, intent(in), optional :: kind_value
-      integer, intent(in), optional :: dimension_indices(:)
-      integer, intent(in), optional :: initializer_index
-      logical, intent(in), optional :: is_allocatable
-      logical, intent(in), optional :: is_pointer
-      logical, intent(in), optional :: is_target
-      logical, intent(in), optional :: is_external
-      character(len=*), intent(in), optional :: intent_value
-      logical, intent(in), optional :: is_optional
-      logical, intent(in), optional :: is_parameter
-      integer, intent(in), optional :: line, column, parent_index
-      integer :: decl_index
-      type(declaration_node) :: decl
+    ! Create declaration node and add to stack
+    function push_declaration(arena, type_name, var_name, kind_value, &
+                              dimension_indices, &
+                              initializer_index, is_allocatable, is_pointer, &
+                              is_target, &
+                              is_external, intent_value, is_optional, is_parameter, &
+                              line, column, &
+                              parent_index) result(decl_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: type_name, var_name
+        integer, intent(in), optional :: kind_value
+        integer, intent(in), optional :: dimension_indices(:)
+        integer, intent(in), optional :: initializer_index
+        logical, intent(in), optional :: is_allocatable
+        logical, intent(in), optional :: is_pointer
+        logical, intent(in), optional :: is_target
+        logical, intent(in), optional :: is_external
+        character(len=*), intent(in), optional :: intent_value
+        logical, intent(in), optional :: is_optional
+        logical, intent(in), optional :: is_parameter
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: decl_index
+        type(declaration_node) :: decl
 
-      ! Create declaration with index-based fields
-      decl%type_name = type_name
-      decl%var_name = var_name
+        ! Create declaration with index-based fields
+        decl%type_name = type_name
+        decl%var_name = var_name
 
-      call initialize_declaration_details(decl, kind_value=kind_value, &
-                                          dimension_indices=dimension_indices, &
-                                          initializer_index=initializer_index, &
-                                          is_allocatable=is_allocatable, is_pointer=is_pointer, &
-                                          is_target=is_target, is_external=is_external, &
-                                          intent_value=intent_value, is_optional=is_optional, &
-                                          is_parameter=is_parameter, line=line, column=column)
+        call initialize_declaration_details(decl, kind_value=kind_value, &
+                                            dimension_indices=dimension_indices, &
+                                            initializer_index=initializer_index, &
+                                            is_allocatable=is_allocatable, &
+                                            is_pointer=is_pointer, &
+                                            is_target=is_target, &
+                                            is_external=is_external, &
+                                            intent_value=intent_value, &
+                                            is_optional=is_optional, &
+                                            is_parameter=is_parameter, line=line, &
+                                            column=column)
 
-      call arena%push(decl, "declaration", parent_index)
-      decl_index = arena%size
-   end function push_declaration
+        call arena%push(decl, "declaration", parent_index)
+        decl_index = arena%size
+    end function push_declaration
 
-   ! Create multi-variable declaration node and add to stack
-   function push_multi_declaration(arena, type_name, var_names, kind_value, &
-                                   dimension_indices, &
-                                   initializer_index, is_allocatable, is_pointer, is_target, is_external, intent_value, &
-                                   is_optional, is_parameter, line, column, parent_index) result(decl_index)
-      type(ast_arena_t), intent(inout) :: arena
-      character(len=*), intent(in) :: type_name
-      character(len=*), intent(in) :: var_names(:)
-      integer, intent(in), optional :: kind_value
-      integer, intent(in), optional :: dimension_indices(:)
-      integer, intent(in), optional :: initializer_index
-      logical, intent(in), optional :: is_allocatable
-      logical, intent(in), optional :: is_pointer
-      logical, intent(in), optional :: is_target
-      logical, intent(in), optional :: is_external
-      character(len=*), intent(in), optional :: intent_value
-      logical, intent(in), optional :: is_optional
-      logical, intent(in), optional :: is_parameter
-      integer, intent(in), optional :: line, column, parent_index
-      integer :: decl_index
-      type(declaration_node) :: decl
-      integer :: i
+    ! Create multi-variable declaration node and add to stack
+    function push_multi_declaration(arena, type_name, var_names, kind_value, &
+                                    dimension_indices, &
+                                    initializer_index, is_allocatable, is_pointer, &
+                                    is_target, is_external, intent_value, &
+                                    is_optional, is_parameter, line, column, &
+                                    parent_index) result(decl_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: type_name
+        character(len=*), intent(in) :: var_names(:)
+        integer, intent(in), optional :: kind_value
+        integer, intent(in), optional :: dimension_indices(:)
+        integer, intent(in), optional :: initializer_index
+        logical, intent(in), optional :: is_allocatable
+        logical, intent(in), optional :: is_pointer
+        logical, intent(in), optional :: is_target
+        logical, intent(in), optional :: is_external
+        character(len=*), intent(in), optional :: intent_value
+        logical, intent(in), optional :: is_optional
+        logical, intent(in), optional :: is_parameter
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: decl_index
+        type(declaration_node) :: decl
+        integer :: i
 
-      ! Create multi-variable declaration
-      decl%type_name = type_name
-      decl%is_multi_declaration = .true.
+        ! Create multi-variable declaration
+        decl%type_name = type_name
+        decl%is_multi_declaration = .true.
 
-      ! Set primary variable name to first variable
-      if (size(var_names) > 0) then
-         decl%var_name = trim(var_names(1))
-      end if
+        ! Set primary variable name to first variable
+        if (size(var_names) > 0) then
+            decl%var_name = trim(var_names(1))
+        end if
 
-      ! Allocate and copy variable names
-      allocate (character(len=100) :: decl%var_names(size(var_names)))
-      do i = 1, size(var_names)
-         decl%var_names(i) = trim(var_names(i))
-      end do
+        ! Allocate and copy variable names
+        allocate (character(len=100) :: decl%var_names(size(var_names)))
+        do i = 1, size(var_names)
+            decl%var_names(i) = trim(var_names(i))
+        end do
 
-      call initialize_declaration_details(decl, kind_value=kind_value, &
-                                          dimension_indices=dimension_indices, &
-                                          initializer_index=initializer_index, &
-                                          is_allocatable=is_allocatable, is_pointer=is_pointer, &
-                                          is_target=is_target, is_external=is_external, &
-                                          intent_value=intent_value, is_optional=is_optional, &
-                                          is_parameter=is_parameter, line=line, column=column)
+        call initialize_declaration_details(decl, kind_value=kind_value, &
+                                            dimension_indices=dimension_indices, &
+                                            initializer_index=initializer_index, &
+                                            is_allocatable=is_allocatable, &
+                                            is_pointer=is_pointer, &
+                                            is_target=is_target, &
+                                            is_external=is_external, &
+                                            intent_value=intent_value, &
+                                            is_optional=is_optional, &
+                                            is_parameter=is_parameter, line=line, &
+                                            column=column)
 
-      ! Use the same node category as single declarations so downstream
-      ! codegen/standardizer logic treats both uniformly.
-      call arena%push(decl, "declaration", parent_index)
-      decl_index = arena%size
-   end function push_multi_declaration
+        ! Use the same node category as single declarations so downstream
+        ! codegen/standardizer logic treats both uniformly.
+        call arena%push(decl, "declaration", parent_index)
+        decl_index = arena%size
+    end function push_multi_declaration
 
-   ! Create parameter declaration node and add to stack
-   function push_parameter_declaration(arena, name, type_name, kind_value, &
-                                       intent_value, is_optional, dimension_indices, line, column, &
-                                       parent_index) result(param_index)
-      type(ast_arena_t), intent(inout) :: arena
-      character(len=*), intent(in) :: name, type_name
-      integer, intent(in), optional :: kind_value, intent_value
-      logical, intent(in), optional :: is_optional
-      integer, intent(in), optional :: dimension_indices(:)
-      integer, intent(in), optional :: line, column, parent_index
-      integer :: param_index
-      type(parameter_declaration_node) :: param
+    ! Create parameter declaration node and add to stack
+    function push_parameter_declaration(arena, name, type_name, kind_value, &
+                                        intent_value, is_optional, dimension_indices, &
+                                        line, column, &
+                                        parent_index) result(param_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: name, type_name
+        integer, intent(in), optional :: kind_value, intent_value
+        logical, intent(in), optional :: is_optional
+        integer, intent(in), optional :: dimension_indices(:)
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: param_index
+        type(parameter_declaration_node) :: param
 
-      param%name = name
-      param%type_name = type_name
+        param%name = name
+        param%type_name = type_name
 
-      if (present(kind_value) .and. kind_value > 0) then
-         param%kind_value = kind_value
-      else
-         param%kind_value = 0
-      end if
+        if (present(kind_value) .and. kind_value > 0) then
+            param%kind_value = kind_value
+        else
+            param%kind_value = 0
+        end if
 
-      if (present(intent_value)) then
-         param%intent_type = intent_value
-      else
-         param%intent_type = INTENT_NONE
-      end if
+        if (present(intent_value)) then
+            param%intent_type = intent_value
+        else
+            param%intent_type = INTENT_NONE
+        end if
 
-      if (present(is_optional)) then
-         param%is_optional = is_optional
-      else
-         param%is_optional = .false.
-      end if
+        if (present(is_optional)) then
+            param%is_optional = is_optional
+        else
+            param%is_optional = .false.
+        end if
 
-      ! Handle array dimensions
-      if (present(dimension_indices)) then
-         if (size(dimension_indices) > 0) then
-            param%is_array = .true.
-            allocate (param%dimension_indices, source=dimension_indices)
-         else
+        ! Handle array dimensions
+        if (present(dimension_indices)) then
+            if (size(dimension_indices) > 0) then
+                param%is_array = .true.
+                allocate (param%dimension_indices, source=dimension_indices)
+            else
+                param%is_array = .false.
+            end if
+        else
             param%is_array = .false.
-         end if
-      else
-         param%is_array = .false.
-      end if
+        end if
 
-      if (present(line)) param%line = line
-      if (present(column)) param%column = column
+        if (present(line)) param%line = line
+        if (present(column)) param%column = column
 
-      call arena%push(param, "parameter_declaration", parent_index)
-      param_index = arena%size
-   end function push_parameter_declaration
+        call arena%push(param, "parameter_declaration", parent_index)
+        param_index = arena%size
+    end function push_parameter_declaration
 
 end module ast_factory_declarations


### PR DESCRIPTION
### **User description**
## Summary
- extract `initialize_declaration_details` to centralize optional declaration metadata
- reuse the helper in single and multi declaration builders to eliminate duplication

## Verification
- `make test`
  - All fortfront API integration tests passed


___

### **PR Type**
Bug fix


___

### **Description**
- Extract `initialize_declaration_details` helper subroutine to centralize optional parameter handling

- Reuse helper in `push_declaration` and `push_multi_declaration` to eliminate code duplication

- Fix indentation inconsistencies throughout the module for better code formatting


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Duplicate parameter<br/>initialization code"] -->|Extract| B["initialize_declaration_details<br/>subroutine"]
  B -->|Reuse in| C["push_declaration"]
  B -->|Reuse in| D["push_multi_declaration"]
  E["Indentation fixes"] -->|Applied to| F["Module formatting"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ast_factory_declarations.f90</strong><dd><code>Extract and reuse declaration initialization helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/ast/factory/ast_factory_declarations.f90

<ul><li>Created new <code>initialize_declaration_details</code> subroutine to centralize <br>optional parameter initialization logic<br> <li> Refactored <code>push_declaration</code> to call the helper subroutine instead of <br>duplicating parameter handling code<br> <li> Refactored <code>push_multi_declaration</code> to call the helper subroutine <br>instead of duplicating parameter handling code<br> <li> Fixed indentation throughout the module from 4 spaces to 3 spaces for <br>consistency</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1451/files#diff-78f10c05cb74865855ff219aee142d620ee57ec1b09b6c1ae0e3e62493c27ba1">+283/-323</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

