### PR TITLE
fix: Unify character type detection functions (2 near-identical imple (fixes #1440)

### DIFF
--- a/src/codegen/codegen_utilities.f90
+++ b/src/codegen/codegen_utilities.f90
@@ -13,6 +13,7 @@ module codegen_utilities
     use type_system_unified
     use string_types, only: string_t
     use codegen_indent
+    use type_string_utils, only: is_character_type_string, to_lower_ascii
     use codegen_arena_interface, only: generate_code_from_arena
     implicit none
     private
@@ -1121,40 +1122,6 @@ contains
             end if
         end do
     end function is_parameter_name
-
-    ! Helper to detect character type declarations irrespective of spacing/case
-    pure logical function is_character_type_string(type_str)
-        character(len=*), intent(in) :: type_str
-        character(len=:), allocatable :: trimmed
-        character(len=:), allocatable :: lowered
-
-        trimmed = adjustl(trim(type_str))
-        if (len_trim(trimmed) < len("character")) then
-            is_character_type_string = .false.
-            return
-        end if
-
-        lowered = to_lower_ascii(trimmed)
-        is_character_type_string = index(lowered, "character") == 1
-    end function is_character_type_string
-
-    ! ASCII-only lowercase conversion helper for type comparisons
-    pure function to_lower_ascii(str) result(lower_str)
-        character(len=*), intent(in) :: str
-        character(len=len(str)) :: lower_str
-        integer :: i, position
-        character(len=*), parameter :: uppercase_letters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ'
-        character(len=*), parameter :: lowercase_letters = 'abcdefghijklmnopqrstuvwxyz'
-
-        lower_str = str
-
-        if (len(str) == 0) return
-
-        do i = 1, len(str)
-            position = index(uppercase_letters, str(i:i))
-            if (position > 0) lower_str(i:i) = lowercase_letters(position:position)
-        end do
-    end function to_lower_ascii
 
     ! Extract character length specification (len or old-style *) from type text
     subroutine extract_character_length(type_str, has_length, length_spec)

--- a/src/standardizers/standardizer_subprograms.f90
+++ b/src/standardizers/standardizer_subprograms.f90
@@ -11,6 +11,7 @@ module standardizer_subprograms
     use type_system_unified
     use ast_nodes_data, only: INTENT_NONE, INTENT_IN, INTENT_OUT, INTENT_INOUT
     use lexer_core, only: to_lower
+    use type_string_utils, only: is_character_type_string
     implicit none
     private
 
@@ -340,8 +341,11 @@ contains
             is_match = .false.
             return
         end if
-        is_match = (index(lowered, 'character') == 1) .and. &
-                   (index(lowered, 'len=') > 0) .and. &
+        if (.not. is_character_type_string(type_name)) then
+            is_match = .false.
+            return
+        end if
+        is_match = (index(lowered, 'len=') > 0) .and. &
                    (index(lowered, 'len=*') == 0) .and. &
                    (index(lowered, 'len=:') == 0)
     end function is_character_length_decl

--- a/src/utilities/type_string_utils.f90
+++ b/src/utilities/type_string_utils.f90
@@ -1,0 +1,41 @@
+module type_string_utils
+    implicit none
+    private
+
+    public :: is_character_type_string
+    public :: to_lower_ascii
+
+contains
+
+    pure logical function is_character_type_string(type_str) result(is_character)
+        character(len=*), intent(in) :: type_str
+        character(len=:), allocatable :: trimmed
+        character(len=:), allocatable :: lowered
+
+        trimmed = adjustl(trim(type_str))
+        if (len_trim(trimmed) < len("character")) then
+            is_character = .false.
+            return
+        end if
+
+        lowered = to_lower_ascii(trimmed)
+        is_character = index(lowered, "character") == 1
+    end function is_character_type_string
+
+    pure function to_lower_ascii(text) result(lower_text)
+        character(len=*), intent(in) :: text
+        character(len=len(text)) :: lower_text
+        integer :: i, position
+        character(len=*), parameter :: uppercase_letters = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        character(len=*), parameter :: lowercase_letters = "abcdefghijklmnopqrstuvwxyz"
+
+        lower_text = text
+        if (len(text) == 0) return
+
+        do i = 1, len(text)
+            position = index(uppercase_letters, text(i:i))
+            if (position > 0) lower_text(i:i) = lowercase_letters(position:position)
+        end do
+    end function to_lower_ascii
+
+end module type_string_utils

--- a/test/utilities/test_type_string_utils.f90
+++ b/test/utilities/test_type_string_utils.f90
@@ -1,0 +1,57 @@
+program test_type_string_utils
+    use type_string_utils, only: is_character_type_string
+    implicit none
+
+    integer :: total, passed
+
+    total = 0
+    passed = 0
+
+    call expect_true(is_character_type_string("character(len=4)"), &
+                     "detects character type prefix")
+    call expect_true(is_character_type_string("   CHARACTER(LEN=10)"), &
+                     "handles leading spaces and case")
+    call expect_true(is_character_type_string("character(kind=4)"), &
+                     "accepts kind specifier")
+    call expect_false(is_character_type_string("integer(4)"), &
+                      "rejects integer type")
+    call expect_false(is_character_type_string("char(len=4)"), &
+                      "rejects partial match")
+    call expect_false(is_character_type_string(""), "rejects empty input")
+
+    print *, ""
+    print *, "=== Test Summary ==="
+    write (*, '(A,I0,A,I0)') "Passed ", passed, "/", total
+    if (passed /= total) error stop 1
+
+contains
+
+    subroutine expect_true(condition, name)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: name
+
+        total = total + 1
+        write (*, '(A,A)', advance='no') "Testing: ", name
+        if (condition) then
+            passed = passed + 1
+            print *, " ... PASSED"
+        else
+            print *, " ... FAILED"
+        end if
+    end subroutine expect_true
+
+    subroutine expect_false(condition, name)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: name
+
+        total = total + 1
+        write (*, '(A,A)', advance='no') "Testing: ", name
+        if (.not. condition) then
+            passed = passed + 1
+            print *, " ... PASSED"
+        else
+            print *, " ... FAILED"
+        end if
+    end subroutine expect_false
+
+end program test_type_string_utils


### PR DESCRIPTION
### **User description**
## Summary
- add shared type_string_utils module for character type detection
- reuse helper in codegen and standardizer code paths
- cover detection with a focused utility test

## Verification
- make test
  - passes `test_type_string_utils` and full suite


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Extract character type detection into shared utility module

- Eliminate duplicate implementations across codegen and standardizer

- Add comprehensive unit tests for type detection functions

- Reuse unified helpers for consistent type checking behavior


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["codegen_utilities.f90<br/>duplicate functions"] -->|refactor| C["type_string_utils.f90<br/>shared module"]
  B["standardizer_subprograms.f90<br/>duplicate functions"] -->|refactor| C
  C -->|import| A
  C -->|import| B
  C -->|test| D["test_type_string_utils.f90<br/>unit tests"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>type_string_utils.f90</strong><dd><code>New shared character type detection utility module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utilities/type_string_utils.f90

<ul><li>New module containing <code>is_character_type_string()</code> function for <br>detecting character type declarations<br> <li> Implements <code>to_lower_ascii()</code> helper for ASCII-only case conversion<br> <li> Handles spacing, case variations, and length/kind specifiers<br> <li> Provides reusable utilities for type string analysis</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1452/files#diff-f135f85805314281d60cae3937e180b4959549721ef88e16bf2f8bd469957183">+41/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen_utilities.f90</strong><dd><code>Remove duplicate functions, import shared utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_utilities.f90

<ul><li>Remove duplicate <code>is_character_type_string()</code> and <code>to_lower_ascii()</code> <br>functions<br> <li> Add import of <code>type_string_utils</code> module with both functions<br> <li> Maintain existing functionality while eliminating code duplication</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1452/files#diff-b0a2107e70b99a22eb33987c481147208821fd4fd9b203e7186c751f92d44c46">+1/-34</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>standardizer_subprograms.f90</strong><dd><code>Use shared character type detection function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/standardizers/standardizer_subprograms.f90

<ul><li>Add import of <code>is_character_type_string()</code> from <code>type_string_utils</code><br> <li> Refactor <code>is_character_length_decl()</code> to use shared character detection <br>function<br> <li> Simplify logic by delegating character type checking to unified <br>utility</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1452/files#diff-58c938d01f168fc2fc16f9667b440d103183e12e66e7d0a8393737c5a49d2504">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_type_string_utils.f90</strong><dd><code>Comprehensive unit tests for type detection utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/utilities/test_type_string_utils.f90

<ul><li>New test program with six test cases covering character type detection<br> <li> Tests handle leading spaces, case variations, kind specifiers<br> <li> Validates rejection of non-character types and partial matches<br> <li> Includes test summary reporting with pass/fail counts</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1452/files#diff-e71ba667ec3928e8943146c30564f7fdb35c305f35789c8c23209c486ec268fd">+57/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

