### PR TITLE
fix: Consolidate integer-to-string conversion functions (3 implementa (fixes #1439)

### DIFF
--- a/src/ast/factory/ast_factory_arrays.f90
+++ b/src/ast/factory/ast_factory_arrays.f90
@@ -5,6 +5,7 @@ module ast_factory_arrays
     use ast_factory_core, only: push_literal
     use ast_base, only: LITERAL_INTEGER
     use uid_generator, only: generate_uid
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -26,8 +27,8 @@ contains
         character(len=20) :: start_str, end_str
 
         ! Convert indices to strings
-        write (start_str, '(I0)') start_idx
-        write (end_str, '(I0)') end_idx
+        start_str = int_to_string(start_idx)
+        end_str = int_to_string(end_idx)
 
         ! Create start and end index literals
         start_literal_idx = push_literal(arena, trim(start_str), LITERAL_INTEGER, line, column)

--- a/src/ast/nodes/ast_nodes_misc.f90
+++ b/src/ast/nodes/ast_nodes_misc.f90
@@ -2,6 +2,7 @@ module ast_nodes_misc
     use json_module
     use ast_base, only: ast_node, visit_interface, to_json_interface, string_t, &
                         ast_visitor_base_t
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -673,9 +674,8 @@ contains
         pure function to_string(val) result(str)
             integer, intent(in) :: val
             character(len=:), allocatable :: str
-            character(len=16) :: buf
-            write (buf, '(I0)') val
-            str = trim(buf)
+
+            str = int_to_string(val)
         end function to_string
     end subroutine visibility_statement_to_json
 
@@ -736,9 +736,8 @@ contains
         pure function to_string(val) result(str)
             integer, intent(in) :: val
             character(len=:), allocatable :: str
-            character(len=16) :: buf
-            write (buf, '(I0)') val
-            str = trim(buf)
+
+            str = int_to_string(val)
         end function to_string
     end subroutine namelist_statement_to_json
 

--- a/src/ast/traversal/ast_visitor.f90
+++ b/src/ast/traversal/ast_visitor.f90
@@ -8,6 +8,7 @@ module ast_visitor
     use ast_nodes_io
     use ast_nodes_data
     use ast_nodes_misc
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -634,17 +635,10 @@ contains
         end if
     end subroutine append_debug
 
-    function int_to_string(val) result(str)
-        integer, intent(in) :: val
-        character(len=20) :: str
-        write (str, '(I0)') val
-    end function int_to_string
-
     function int_array_to_string(arr) result(str)
         integer, intent(in) :: arr(:)
         character(len=:), allocatable :: str
         integer :: i
-        character(len=20) :: temp
 
         if (size(arr) == 0) then
             str = "[integer ::]"  ! Empty array with type spec
@@ -653,9 +647,8 @@ contains
 
         str = "["
         do i = 1, size(arr)
-            write (temp, '(I0)') arr(i)
             if (i > 1) str = str // ","
-            str = str // trim(temp)
+            str = str // int_to_string(arr(i))
         end do
         str = str // "]"
     end function int_array_to_string

--- a/src/codegen/codegen_declarations.f90
+++ b/src/codegen/codegen_declarations.f90
@@ -14,8 +14,9 @@ module codegen_declarations
     use ast_nodes_loops, only: do_loop_node
     use type_system_unified
     use string_types, only: string_t
+    use string_utils_mod, only: int_to_string
     use codegen_indent
-    use codegen_utilities, only: parameter_info_t, int_to_string, &
+    use codegen_utilities, only: parameter_info_t, &
                                  generate_grouped_body, &
                                  generate_grouped_body_with_params, &
                                  generate_grouped_body_context, find_parameter_info, &

--- a/src/codegen/codegen_expressions.f90
+++ b/src/codegen/codegen_expressions.f90
@@ -34,7 +34,6 @@ module codegen_expressions
     public :: get_operator_precedence
     public :: needs_parentheses
     public :: get_node_operator
-    public :: int_to_string
 
 contains
 
@@ -849,16 +848,6 @@ contains
             op = ""
         end select
     end function get_node_operator
-
-    ! Convert integer to string
-    function int_to_string(n) result(str)
-        integer, intent(in) :: n
-        character(len=:), allocatable :: str
-        character(len=32) :: buffer
-
-        write (buffer, '(I0)') n
-        str = trim(buffer)
-    end function int_to_string
 
     ! Check if we have string concatenation (both operands are string literals)
     pure function is_string_concatenation(left_code, right_code) result(is_string)

--- a/src/codegen/codegen_utilities.f90
+++ b/src/codegen/codegen_utilities.f90
@@ -15,6 +15,7 @@ module codegen_utilities
     use codegen_indent
     use type_string_utils, only: is_character_type_string, to_lower_ascii
     use codegen_arena_interface, only: generate_code_from_arena
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -24,7 +25,6 @@ module codegen_utilities
     ! Context for executable code before contains
     logical, save :: context_has_executable_before_contains = .false.
 
-    public :: int_to_string
     public :: find_node_index_in_arena
     public :: same_node
     public :: can_group_declarations
@@ -50,15 +50,6 @@ module codegen_utilities
     end type parameter_info_t
 
 contains
-
-    ! Convert integer to string
-    function int_to_string(num) result(str)
-        integer, intent(in) :: num
-        character(len=:), allocatable :: str
-        character(len=32) :: buffer
-        write (buffer, '(I0)') num
-        str = trim(buffer)
-    end function int_to_string
 
     ! Find node index in arena
     function find_node_index_in_arena(arena, target_node) result(index)

--- a/src/error_handling.f90
+++ b/src/error_handling.f90
@@ -1,4 +1,5 @@
 module error_handling
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -107,7 +108,7 @@ contains
         end select
 
         ! Format error code
-        write (code_str, '(I0)') this%error_code
+        code_str = int_to_string(this%error_code)
 
         ! Build comprehensive message
         message = trim(severity_str)
@@ -406,21 +407,21 @@ contains
             end select
         end do
 
-        write (count_str, '(I0)') this%count
+        count_str = int_to_string(this%count)
         summary = "Total: " // trim(count_str)
 
         if (critical > 0) then
-            write (count_str, '(I0)') critical
+            count_str = int_to_string(critical)
             summary = summary // ", Critical: " // trim(count_str)
         end if
 
         if (errors > 0) then
-            write (count_str, '(I0)') errors
+            count_str = int_to_string(errors)
             summary = summary // ", Errors: " // trim(count_str)
         end if
 
         if (warnings > 0) then
-            write (count_str, '(I0)') warnings
+            count_str = int_to_string(warnings)
             summary = summary // ", Warnings: " // trim(count_str)
         end if
     end function get_summary

--- a/src/parser/parser_declarations.f90
+++ b/src/parser/parser_declarations.f90
@@ -13,6 +13,7 @@ module parser_declarations
     use error_handling, only: ERROR_PARSER
     use ast_factory, only: push_multi_declaration, push_declaration, push_identifier
     use parser_type_hooks_module, only: register_type_annotation
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -977,7 +978,7 @@ contains
                 length_expr = "*"
             case default
                 if (type_spec%kind_value > 0) then
-                    write (buffer, '(I0)') type_spec%kind_value
+                    buffer = int_to_string(type_spec%kind_value)
                     length_expr = trim(buffer)
                 end if
             end select

--- a/src/semantic/analyzers/semantic_assignment_inference.f90
+++ b/src/semantic/analyzers/semantic_assignment_inference.f90
@@ -17,6 +17,7 @@ module semantic_assignment_inference
     use error_handling, only: error_collection_t
     use parser_type_hooks_module, only: type_annotation_t
     use lexer_core, only: to_lower
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -433,7 +434,7 @@ contains
         do i = 1, size(dim_sizes)
             if (i > 1) dims_string = dims_string // ","
             if (dim_sizes(i) > 0) then
-                write (dim_component, '(I0)') dim_sizes(i)
+                dim_component = int_to_string(dim_sizes(i))
                 dims_string = dims_string // trim(dim_component)
             else
                 dims_string = dims_string // ":"

--- a/src/semantic/analyzers/semantic_function_analysis.f90
+++ b/src/semantic/analyzers/semantic_function_analysis.f90
@@ -17,6 +17,7 @@ module semantic_function_analysis
     use semantic_validation_utils, only: update_identifier_type_in_arena, int_to_str
     use semantic_type_operations, only: get_common_type, &
                                         instantiate_type_scheme_op
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -743,7 +744,7 @@ contains
             name = 'logical'
         case (TCHAR)
             if (typ%size > 0) then
-                write (size_buf, '(I0)') typ%size
+                size_buf = int_to_string(typ%size)
                 name = 'character(len=' // trim(size_buf) // ')'
             else
                 name = 'character(len=:), allocatable'

--- a/src/semantic/analyzers/semantic_validation_utils.f90
+++ b/src/semantic/analyzers/semantic_validation_utils.f90
@@ -7,6 +7,7 @@ module semantic_validation_utils
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: identifier_node
     use ast_nodes_bounds, only: array_slice_node
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -19,7 +20,8 @@ contains
     ! Character function to convert integer to string
     character(len=20) function int_to_str(n)
         integer, intent(in) :: n
-        write (int_to_str, '(I0)') n
+
+        int_to_str = int_to_string(n)
     end function int_to_str
 
     ! Helper functions for validate_array_bounds

--- a/src/semantic/events/analysis_events.f90
+++ b/src/semantic/events/analysis_events.f90
@@ -4,6 +4,7 @@ module semantic_events
     use analysis_event_data, only: event_data_base_t
     use semantic_context_types, only: semantic_context_base_t
     use ast_arena_modern, only: ast_arena_t
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -102,13 +103,13 @@ contains
         serialized_data = ""
 
         ! Build serialized representation
-        write (temp_string, '(I0)') event%event_type
+        temp_string = int_to_string(event%event_type)
         serialized_data = "type:" // trim(temp_string)
 
-        write (temp_string, '(I0)') event%node_index
+        temp_string = int_to_string(event%node_index)
         serialized_data = trim(serialized_data) // ";node:" // trim(temp_string)
 
-        write (temp_string, '(I0)') event%source_analyzer_id
+        temp_string = int_to_string(event%source_analyzer_id)
         serialized_data = trim(serialized_data) // ";analyzer:" // trim(temp_string)
 
         if (event%consumed) then

--- a/src/semantic/plugins/plugin_metadata.f90
+++ b/src/semantic/plugins/plugin_metadata.f90
@@ -1,6 +1,7 @@
 module plugin_metadata_module
     !! Plugin metadata management for versioning and dependencies
     !! Provides metadata validation, version comparison, and dependency tracking
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -145,15 +146,15 @@ contains
 
         character(len=16) :: dep_count, cap_count
 
-        write (dep_count, '(I0)') 0
-        write (cap_count, '(I0)') 0
+        dep_count = int_to_string(0)
+        cap_count = int_to_string(0)
 
         if (allocated(metadata%dependencies)) then
-            write (dep_count, '(I0)') size(metadata%dependencies)
+            dep_count = int_to_string(size(metadata%dependencies))
         end if
 
         if (allocated(metadata%capabilities)) then
-            write (cap_count, '(I0)') size(metadata%capabilities)
+            cap_count = int_to_string(size(metadata%capabilities))
         end if
 
         formatted_string = trim(metadata%name) // " v" // trim(metadata%version) // &

--- a/src/standardizers/standardizer_declarations_core.f90
+++ b/src/standardizers/standardizer_declarations_core.f90
@@ -19,6 +19,7 @@ module standardizer_declarations_core
     use lexer_core, only: to_lower
     use standardizer_types
     use intrinsic_registry, only: get_intrinsic_signature, is_intrinsic_function
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -1014,7 +1015,7 @@ contains
 
             type_str = trim(decl%type_name)
             if (decl%has_kind) then
-                write (buffer, '(I0)') decl%kind_value
+                buffer = int_to_string(decl%kind_value)
                 if (len_trim(buffer) > 0) then
                     type_str = trim(type_str) // "(" // trim(buffer) // ")"
                 end if
@@ -1039,7 +1040,7 @@ contains
                             type_str = type_str // ":"
                         end if
                     else if (dim_idx > arena%size) then
-                        write (buffer, '(I0)') dim_idx
+                        buffer = int_to_string(dim_idx)
                         type_str = type_str // trim(buffer)
                     else
                         type_str = type_str // ":"

--- a/src/utilities/fortfront_utils.f90
+++ b/src/utilities/fortfront_utils.f90
@@ -314,15 +314,6 @@ contains
                       '"phase": "complete"}}'
     end subroutine semantic_info_to_json
 
-    ! Helper function for integer to string conversion
-    function str(i) result(s)
-        integer, intent(in) :: i
-        character(len=:), allocatable :: s
-        character(len=12) :: temp
-        write (temp, '(i0)') i
-        s = trim(temp)
-    end function str
-
     ! Find nodes by type name
     function find_nodes_by_type(arena, type_name) result(indices)
         type(ast_arena_t), intent(in) :: arena

--- a/src/utilities/frontend_utilities.f90
+++ b/src/utilities/frontend_utilities.f90
@@ -2,6 +2,7 @@ module frontend_utilities
     ! fortfront - Utility functions module
     ! Contains helper functions and utilities
 
+    use string_utils_mod, only: int_to_string
     implicit none
     private
 
@@ -55,7 +56,8 @@ contains
     function int_to_str(num) result(str)
         integer, intent(in) :: num
         character(len=20) :: str
-        write (str, '(I0)') num
+
+        str = int_to_string(num)
     end function int_to_str
 
 end module frontend_utilities

--- a/src/utilities/string_utils.f90
+++ b/src/utilities/string_utils.f90
@@ -1,0 +1,32 @@
+module string_utils_mod
+    implicit none
+    private
+
+    public :: int_to_string
+
+contains
+
+    pure function int_to_string(val, width) result(str)
+        integer, intent(in) :: val
+        integer, intent(in), optional :: width
+        character(len=:), allocatable :: str
+        character(len=64) :: buffer
+        character(len=16) :: fmt
+        integer :: fmt_width
+
+        if (present(width)) then
+            fmt_width = width
+            if (fmt_width > 0) then
+                write (fmt, '( "(I", I0, ")" )') fmt_width
+                write (buffer, fmt) val
+            else
+                write (buffer, '(I0)') val
+            end if
+        else
+            write (buffer, '(I0)') val
+        end if
+
+        str = trim(adjustl(buffer))
+    end function int_to_string
+
+end module string_utils_mod


### PR DESCRIPTION
### **User description**
## Summary
- add `src/utilities/string_utils.f90` with canonical `int_to_string`
- refactor codegen/semantic/parser utilities to use the shared helper
- drop duplicate integer formatting helpers such as `fortfront_utils::str`

## Verification
- `make test`
  - All fortfront API integration tests passed!


___

### **PR Type**
Bug fix


___

### **Description**
- Consolidate integer-to-string conversion into centralized `string_utils_mod`

- Remove duplicate `int_to_string` implementations from 3 modules

- Replace all `write` statements with unified conversion function

- Update 15 files to use shared utility module


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Multiple modules<br/>with duplicate<br/>int_to_string"] -->|"Consolidate"| B["string_utils_mod<br/>canonical implementation"]
  B -->|"Import & use"| C["15 modules<br/>refactored"]
  D["codegen_utilities"] -->|"Remove duplicate"| B
  E["codegen_expressions"] -->|"Remove duplicate"| B
  F["ast_visitor"] -->|"Remove duplicate"| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>string_utils.f90</strong><dd><code>Create new centralized integer-to-string utility module</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-eec04cb9879abae592237f15ba930674bbece351fca4025c32a61969630f1fc1">+32/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Refactoring</strong></td><td><details><summary>16 files</summary><table>
<tr>
  <td><strong>ast_factory_arrays.f90</strong><dd><code>Replace write statement with int_to_string function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-221fa849db9e8b1ad3c62cff0e149eb86bfd65c06c928961663c7da85ade3094">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ast_nodes_misc.f90</strong><dd><code>Remove duplicate int_to_string, use shared utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-ff6df096f0d9682e85c70584187636e5523628c3272ceb7f112f2ab35814fe49">+5/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ast_visitor.f90</strong><dd><code>Remove duplicate int_to_string, refactor int_array_to_string</code></dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-3ee19ee215ac42210efa3ed1de686cc0660930ea9deb40b8e34cafebebbcf010">+2/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codegen_declarations.f90</strong><dd><code>Import string_utils_mod, remove duplicate int_to_string</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-2f2aaf5d275f4e51553e5ce93f4fab08d9e6dd89a92a8566ff57eb6aab61fa0e">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codegen_expressions.f90</strong><dd><code>Remove duplicate int_to_string implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-3b1738eec18cf24328ed23cb81f11a3f57f703a21111d4353d7e1773900cde23">+0/-11</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>codegen_utilities.f90</strong><dd><code>Remove duplicate int_to_string, import shared utility</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-b0a2107e70b99a22eb33987c481147208821fd4fd9b203e7186c751f92d44c46">+1/-10</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>error_handling.f90</strong><dd><code>Replace write statements with int_to_string calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-c766acdb5d48ce95514a38f6ae07f792f6096733190306f86dd0974b32afc6e2">+6/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>parser_declarations.f90</strong><dd><code>Replace write statement with int_to_string function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-ebbd95623c5af37d8eae5f4f3ecd04bf32a8e1999d49a458a79fc7552409869b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>semantic_assignment_inference.f90</strong><dd><code>Replace write statement with int_to_string call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-2b5b6f0157677f643ca496e287201bb59be3818c6329e27e8d8daab451f4e4ef">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>semantic_function_analysis.f90</strong><dd><code>Replace write statement with int_to_string call</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-81eaa5519d650bc860a272627a3532f7ae59c41bc110b20662254e59d0a65b44">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>semantic_validation_utils.f90</strong><dd><code>Update int_to_str wrapper to use shared utility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-f30ce7f5080044b5bb17815be5006ef01d359fe788b07fa331d86f8e49b8cebe">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>analysis_events.f90</strong><dd><code>Replace write statements with int_to_string calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-ae01f0d13bdfe8d26bd8a0a433a05739597ad8986f3f3ea1ca518d69c7bf17ea">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>plugin_metadata.f90</strong><dd><code>Replace write statements with int_to_string calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-b2e30f88eb8af486a1c15593161ace181f0d390edfa7271b9cb66e865411cca2">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>standardizer_declarations_core.f90</strong><dd><code>Replace write statements with int_to_string calls</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-8263ed56e9692ae445465538abe19bef690ce76ad18ef72f8b13dba2d8a72cd7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>fortfront_utils.f90</strong><dd><code>Remove duplicate str function implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-4a7385820fbe6bbf019e93f25c9a668f3731ac2a901c0f80113f2543651c4695">+0/-9</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>frontend_utilities.f90</strong><dd><code>Update int_to_str to use shared utility module</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1455/files#diff-878156944f379efa828ff25094026b8c53ee8dd1ee3062a0f3844b7c5afefdba">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

