### PR TITLE
fix: polish: simplify int_to_string implementation (fixes #1456)

### DIFF
--- a/src/utilities/string_utils.f90
+++ b/src/utilities/string_utils.f90
@@ -42,7 +42,7 @@ contains
             write (buffer, '(I0)') val
         end if
 
-        str = trim(adjustl(buffer))
+        str = trim(buffer)
     end function int_to_string
 
 end module string_utils_mod


### PR DESCRIPTION
### **User description**
## Summary
- replace the redundant call to adjustl in int_to_string with trim(buffer) since I0 formatting already left-justifies the output

## Verification
- make test
  - PASS All fortfront API integration tests passed


___

### **PR Type**
Bug fix


___

### **Description**
- Remove redundant `adjustl()` call in `int_to_string()` function

- I0 format specifier already left-justifies output

- Simplify buffer trimming to just `trim(buffer)`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["int_to_string function"] -- "I0 format left-justifies" --> B["Remove redundant adjustl"]
  B -- "Keep trim only" --> C["Simplified implementation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>string_utils.f90</strong><dd><code>Remove redundant adjustl from buffer trimming</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/utilities/string_utils.f90

<ul><li>Removed redundant <code>adjustl()</code> call from <code>trim(adjustl(buffer))</code> expression<br> <li> Changed to <code>trim(buffer)</code> since I0 format specifier already <br>left-justifies output<br> <li> Maintains same functionality with simpler code</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1459/files#diff-eec04cb9879abae592237f15ba930674bbece351fca4025c32a61969630f1fc1">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

