### PR TITLE
fix: Extract 170-line duplicate body parsing in parser_procedure_defi (fixes #1436)

### DIFF
--- a/src/parser/parser_procedure_definitions.f90
+++ b/src/parser/parser_procedure_definitions.f90
@@ -24,32 +24,21 @@ module parser_procedure_definitions_module
 
 contains
 
-    function parse_function_definition(parser, arena, prefix_buffer, prefix_list) &
-        result(func_index)
+    subroutine parse_function_prefix_keywords(parser, prefix_buffer, prefix_list, &
+                                              prefix_keywords, has_recursive_keyword)
         type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         character(len=16), intent(in), optional :: prefix_list(:)
-        integer :: func_index
+        character(len=16), allocatable, intent(out) :: prefix_keywords(:)
+        logical, intent(out) :: has_recursive_keyword
 
-        type(token_t) :: token
-        character(len=:), allocatable :: function_name, return_type_str, &
-                                         result_variable_name
-        integer :: line, column
-        integer, allocatable :: param_indices(:), body_indices(:)
-        logical :: has_recursive_keyword
-        logical :: infer_recursive_from_body
-        character(len=16), allocatable :: prefix_keywords(:)
-        integer :: i
         character(len=16), allocatable :: pending_prefixes(:)
+        type(token_t) :: token
+        integer :: i
 
-        ! Initialize
-        return_type_str = ""
-        result_variable_name = ""
         has_recursive_keyword = .false.
-        infer_recursive_from_body = .false.
-
         allocate (character(len=16) :: prefix_keywords(0))
+
         if (present(prefix_list)) then
             if (size(prefix_list) > 0) then
                 allocate (character(len=16) :: pending_prefixes(size(prefix_list)))
@@ -61,9 +50,11 @@ contains
         else
             call prefix_buffer%consume(pending_prefixes)
         end if
+
         if (.not. allocated(pending_prefixes)) then
             allocate (character(len=16) :: pending_prefixes(0))
         end if
+
         if (size(pending_prefixes) > 0) then
             do i = 1, size(pending_prefixes)
                 call append_prefix_keyword(prefix_keywords, pending_prefixes(i))
@@ -73,7 +64,6 @@ contains
             end do
         end if
 
-        ! Optional prefix keywords before "function"
         do
             token = parser%peek()
             if (token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER) then
@@ -95,8 +85,20 @@ contains
                 exit
             end if
         end do
+    end subroutine parse_function_prefix_keywords
 
-        ! Check if we have a return type before "function"
+    subroutine parse_function_signature(parser, return_type_str, function_name, &
+                                        line, column, is_valid)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=:), allocatable, intent(out) :: return_type_str, function_name
+        integer, intent(out) :: line, column
+        logical, intent(out) :: is_valid
+
+        type(token_t) :: token
+
+        return_type_str = ""
+        is_valid = .true.
+
         token = parser%peek()
         if (token%kind == TK_KEYWORD) then
             select case (trim(to_lower(token%text)))
@@ -106,18 +108,16 @@ contains
             end select
         end if
 
-        ! Consume function keyword
         token = parser%peek()
         if (token%kind == TK_KEYWORD .and. token%text == "function") then
             line = token%line
             column = token%column
             token = parser%consume()
         else
-            func_index = 0
+            is_valid = .false.
             return
         end if
 
-        ! Get function name
         token = parser%peek()
         if (token%kind == TK_IDENTIFIER) then
             function_name = token%text
@@ -129,22 +129,15 @@ contains
         else
             function_name = "unnamed_function"
         end if
+    end subroutine parse_function_signature
 
-        ! Parse parameters with protective error handling
-        token = parser%peek()
-        if (token%kind == TK_OPERATOR .and. token%text == "(") then
-            token = parser%consume()
-            ! Parse typed parameters safely
-            call parse_typed_parameters(parser, arena, param_indices)
-            token = parser%peek()
-            if (token%kind == TK_OPERATOR .and. token%text == ")") then
-                token = parser%consume()
-            end if
-        else
-            allocate (param_indices(0))
-        end if
+    subroutine parse_function_result_clause(parser, result_variable_name)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=:), allocatable, intent(out) :: result_variable_name
 
-        ! Check for result clause
+        type(token_t) :: token
+
+        result_variable_name = ""
         token = parser%peek()
         if (token%kind == TK_IDENTIFIER .and. token%text == "result") then
             token = parser%consume()
@@ -162,6 +155,50 @@ contains
                 end if
             end if
         end if
+    end subroutine parse_function_result_clause
+
+    function parse_function_definition(parser, arena, prefix_buffer, prefix_list) &
+        result(func_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        character(len=16), intent(in), optional :: prefix_list(:)
+        integer :: func_index
+
+        type(token_t) :: token
+        character(len=:), allocatable :: function_name, return_type_str, &
+                                         result_variable_name
+        integer :: line, column
+        integer, allocatable :: param_indices(:), body_indices(:)
+        logical :: has_recursive_keyword, is_valid
+        logical :: infer_recursive_from_body
+        character(len=16), allocatable :: prefix_keywords(:)
+
+        infer_recursive_from_body = .false.
+
+        call parse_function_prefix_keywords(parser, prefix_buffer, prefix_list, &
+                                            prefix_keywords, has_recursive_keyword)
+
+        call parse_function_signature(parser, return_type_str, function_name, &
+                                      line, column, is_valid)
+        if (.not. is_valid) then
+            func_index = 0
+            return
+        end if
+
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. token%text == "(") then
+            token = parser%consume()
+            call parse_typed_parameters(parser, arena, param_indices)
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                token = parser%consume()
+            end if
+        else
+            allocate (param_indices(0))
+        end if
+
+        call parse_function_result_clause(parser, result_variable_name)
 
         ! Parse function body until "end function"
         call parse_procedure_body(parser, arena, function_name, "function", &


### PR DESCRIPTION
### **User description**
## Summary
- extract shared procedure body parsing logic for functions and subroutines
- add focused helpers for end detection, token collection, and recursion inference reuse

## Verification
- `make test` (PASS, STOP 0)


___

### **PR Type**
Enhancement


___

### **Description**
- Extract 170+ lines of duplicate procedure body parsing logic

- Create reusable `parse_procedure_body` subroutine for functions and subroutines

- Introduce helper functions for end detection, token collection, and recursion inference

- Simplify function and subroutine definition parsing by delegating to shared logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["parse_function_definition"] -->|calls| B["parse_procedure_body"]
  C["parse_subroutine_definition"] -->|calls| B
  B -->|uses| D["check_procedure_end"]
  B -->|uses| E["parse_body_statement"]
  E -->|uses| F["collect_statement_tokens"]
  E -->|uses| G["maybe_mark_recursive_from_body"]
  E -->|uses| H["parse_body_statement_tokens"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser_procedure_definitions.f90</strong><dd><code>Extract shared procedure body parsing into reusable helpers</code></dd></summary>
<hr>

src/parser/parser_procedure_definitions.f90

<ul><li>Extracted 170+ lines of duplicate body parsing logic from <br><code>parse_function_definition</code> and <code>parse_subroutine_definition</code> into new <br><code>parse_procedure_body</code> subroutine<br> <li> Created <code>check_procedure_end</code> function to detect end of procedure <br>(function/subroutine) with parameterized end keyword<br> <li> Created <code>parse_body_statement</code> subroutine to parse individual statements <br>within procedure body<br> <li> Created <code>collect_statement_tokens</code> subroutine to extract tokens for <br>current statement line, handling IF block depth tracking<br> <li> Created <code>maybe_mark_recursive_from_body</code> subroutine to infer recursion <br>from procedure calls in body<br> <li> Created <code>parse_body_statement_tokens</code> function to parse collected <br>statement tokens<br> <li> Simplified <code>parse_function_definition</code> and <code>parse_subroutine_definition</code> <br>by replacing inline body parsing with single call to <br><code>parse_procedure_body</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/1460/files#diff-58c92c40c01509fbf0ae9bf23a07692851590611ed25fe37cf37a91db4cb32de">+246/-356</a></td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

