### PR TITLE
fix: Consolidate parser/codegen declarations (fixes #1432)

### DIFF
--- a/docs/PARSE_DECLARATION_REFACTORING.md
+++ b/docs/PARSE_DECLARATION_REFACTORING.md
@@ -107,7 +107,7 @@ subroutine parse_declaration_attributes(parser, arena, attr_info)
 - Handles all standard Fortran attributes
 - Complex attribute parsing: `intent(in)`, `dimension(10,20)`
 - Comma-separated attribute lists
-- Structured result in `declaration_attributes_t`
+- Structured result in `declaration_attribute_info_t`
 - Safety loop limit to prevent infinite parsing
 
 ## Refactored `parse_declaration` Function (37 lines)

--- a/src/codegen/codegen_declarations.f90
+++ b/src/codegen/codegen_declarations.f90
@@ -25,6 +25,10 @@ module codegen_declarations
                                  normalize_character_type_param
     use codegen_arena_interface, only: generate_code_from_arena
     use codegen_type_utils, only: get_type_standardization
+    use declaration_attribute_utils, only: declaration_attribute_info_t, &
+                                           reset_declaration_attributes, &
+                                           set_declaration_intent, &
+                                           append_declaration_attributes
     implicit none
     private
 
@@ -393,6 +397,7 @@ contains
         integer :: i, j
         logical :: standardize_types_enabled
         logical :: has_dimension_attr
+        type(declaration_attribute_info_t) :: attr_info
 
         ! Get type standardization setting
         call get_type_standardization(standardize_types_enabled)
@@ -481,53 +486,25 @@ contains
             end if
         end if
 
-        ! Add intent if present
+        call reset_declaration_attributes(attr_info)
         if (node%has_intent .and. allocated(node%intent)) then
-            code = code // ", intent(" // node%intent // ")"
+            call set_declaration_intent(attr_info, node%intent)
         end if
-
-        ! Add allocatable if present or if string needs allocatable
-        if (node%is_allocatable) then
-            if (index(to_lower(trim(code)), 'allocatable') == 0) then
-                code = code // ", allocatable"
-            end if
-        else if (node%inferred_type%kind > 0) then
-            if (node%inferred_type%alloc_info%needs_allocatable_string) then
-                code = code // ", allocatable"
+        attr_info%is_allocatable = node%is_allocatable
+        if (.not. attr_info%is_allocatable) then
+            if (node%inferred_type%kind > 0) then
+                if (node%inferred_type%alloc_info%needs_allocatable_string) then
+                    attr_info%is_allocatable = .true.
+                end if
             end if
         end if
+        attr_info%is_optional = node%is_optional
+        attr_info%is_pointer = node%is_pointer
+        attr_info%is_target = node%is_target
+        attr_info%is_external = node%is_external
+        attr_info%is_parameter = node%is_parameter
 
-        ! Add optional if present
-        if (node%is_optional) then
-            code = code // ", optional"
-        end if
-
-        ! Add pointer if present
-        if (node%is_pointer) then
-            if (index(to_lower(trim(code)), 'pointer') == 0) then
-                code = code // ", pointer"
-            end if
-        end if
-
-        ! Add target if present
-        if (node%is_target) then
-            if (index(to_lower(trim(code)), 'target') == 0) then
-                code = code // ", target"
-            end if
-        end if
-
-        if (node%is_external) then
-            if (index(to_lower(trim(code)), 'external') == 0) then
-                code = code // ", external"
-            end if
-        end if
-
-        ! Add parameter if present
-        if (node%is_parameter) then
-            if (index(to_lower(trim(code)), 'parameter') == 0) then
-                code = code // ", parameter"
-            end if
-        end if
+        call append_declaration_attributes(code, attr_info)
 
         has_dimension_attr = index(to_lower(trim(type_str)), "dimension(") > 0
 
@@ -609,6 +586,7 @@ contains
         character(len=:), allocatable :: code
         character(len=:), allocatable :: intent_str
         integer :: j
+        type(declaration_attribute_info_t) :: attr_info
 
         ! Check if this node has a parent that needs just the name (parameter list)
         ! vs full declaration (in body). For now, generate full declaration when
@@ -625,16 +603,13 @@ contains
                        trim(adjustl(int_to_string(node%kind_value))) // ")"
             end if
 
-            ! Add intent attribute
             intent_str = intent_type_to_string(node%intent_type)
+            call reset_declaration_attributes(attr_info)
             if (len_trim(intent_str) > 0) then
-                code = code // ", intent(" // intent_str // ")"
+                call set_declaration_intent(attr_info, intent_str)
             end if
-
-            ! Add optional attribute
-            if (node%is_optional) then
-                code = code // ", optional"
-            end if
+            attr_info%is_optional = node%is_optional
+            call append_declaration_attributes(code, attr_info)
 
             code = code // " :: " // node%name
 

--- a/src/common/declaration_attribute_utils.f90
+++ b/src/common/declaration_attribute_utils.f90
@@ -1,0 +1,114 @@
+module declaration_attribute_utils
+    use string_utils_mod, only: to_lower
+    implicit none
+    private
+
+    public :: declaration_attribute_info_t
+    public :: reset_declaration_attributes
+    public :: set_declaration_intent
+    public :: append_declaration_attributes
+
+    type :: declaration_attribute_info_t
+        logical :: is_allocatable = .false.
+        logical :: is_pointer = .false.
+        logical :: is_target = .false.
+        logical :: is_parameter = .false.
+        logical :: is_external = .false.
+        logical :: is_optional = .false.
+        logical :: has_intent = .false.
+        logical :: has_global_dimensions = .false.
+        character(len=:), allocatable :: intent
+        integer, allocatable :: global_dimension_indices(:)
+    end type declaration_attribute_info_t
+
+contains
+
+    subroutine reset_declaration_attributes(attr)
+        type(declaration_attribute_info_t), intent(inout) :: attr
+
+        attr%is_allocatable = .false.
+        attr%is_pointer = .false.
+        attr%is_target = .false.
+        attr%is_parameter = .false.
+        attr%is_external = .false.
+        attr%is_optional = .false.
+        attr%has_intent = .false.
+        if (allocated(attr%intent)) deallocate (attr%intent)
+        attr%has_global_dimensions = .false.
+        if (allocated(attr%global_dimension_indices)) then
+            deallocate (attr%global_dimension_indices)
+        end if
+    end subroutine reset_declaration_attributes
+
+    subroutine set_declaration_intent(attr, value)
+        type(declaration_attribute_info_t), intent(inout) :: attr
+        character(len=*), intent(in) :: value
+
+        attr%has_intent = .true.
+        if (allocated(attr%intent)) deallocate (attr%intent)
+        attr%intent = trim(adjustl(value))
+    end subroutine set_declaration_intent
+
+    subroutine append_declaration_attributes(code, attr)
+        character(len=:), allocatable, intent(inout) :: code
+        type(declaration_attribute_info_t), intent(in) :: attr
+        character(len=:), allocatable :: lowered
+
+        if (.not. allocated(code)) then
+            code = ""
+        end if
+
+        lowered = to_lower(trim(code))
+
+        if (attr%has_intent) then
+            if (allocated(attr%intent)) then
+                if (index(lowered, 'intent(') == 0) then
+                    code = trim(code) // ", intent(" // trim(attr%intent) // ")"
+                    lowered = to_lower(trim(code))
+                end if
+            end if
+        end if
+
+        if (attr%is_allocatable) then
+            if (index(lowered, 'allocatable') == 0) then
+                code = trim(code) // ", allocatable"
+                lowered = to_lower(trim(code))
+            end if
+        end if
+
+        if (attr%is_optional) then
+            if (index(lowered, 'optional') == 0) then
+                code = trim(code) // ", optional"
+                lowered = to_lower(trim(code))
+            end if
+        end if
+
+        if (attr%is_pointer) then
+            if (index(lowered, 'pointer') == 0) then
+                code = trim(code) // ", pointer"
+                lowered = to_lower(trim(code))
+            end if
+        end if
+
+        if (attr%is_target) then
+            if (index(lowered, 'target') == 0) then
+                code = trim(code) // ", target"
+                lowered = to_lower(trim(code))
+            end if
+        end if
+
+        if (attr%is_external) then
+            if (index(lowered, 'external') == 0) then
+                code = trim(code) // ", external"
+                lowered = to_lower(trim(code))
+            end if
+        end if
+
+        if (attr%is_parameter) then
+            if (index(lowered, 'parameter') == 0) then
+                code = trim(code) // ", parameter"
+            end if
+        end if
+    end subroutine append_declaration_attributes
+
+end module declaration_attribute_utils

--- a/src/parser/parser_declarations.f90
+++ b/src/parser/parser_declarations.f90
@@ -13,6 +13,9 @@ module parser_declarations
     use error_handling, only: ERROR_PARSER
     use ast_factory, only: push_multi_declaration, push_declaration, push_identifier
     use parser_type_hooks_module, only: register_type_annotation
+    use declaration_attribute_utils, only: declaration_attribute_info_t, &
+                                           reset_declaration_attributes, &
+                                           set_declaration_intent
     use string_utils_mod, only: int_to_string
     implicit none
     private
@@ -42,20 +45,6 @@ module parser_declarations
         logical :: has_character_length = .false.
         character(len=:), allocatable :: character_length_expr
     end type type_specifier_t
-
-    ! Declaration attributes result type for structured attribute information
-    type, public :: declaration_attributes_t
-        logical :: is_allocatable = .false.
-        logical :: is_pointer = .false.
-        logical :: is_target = .false.
-        logical :: is_parameter = .false.
-        logical :: is_external = .false.
-        logical :: is_optional = .false.
-        logical :: has_intent = .false.
-        logical :: has_global_dimensions = .false.
-        character(len=:), allocatable :: intent
-        integer, allocatable :: global_dimension_indices(:)
-    end type declaration_attributes_t
 
 contains
 
@@ -1087,19 +1076,11 @@ contains
     subroutine parse_declaration_attributes(parser, arena, attr_info)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
-        type(declaration_attributes_t), intent(out) :: attr_info
+        type(declaration_attribute_info_t), intent(out) :: attr_info
 
         type(token_t) :: token
 
-        ! Initialize attributes
-        attr_info%is_allocatable = .false.
-        attr_info%is_pointer = .false.
-        attr_info%is_target = .false.
-        attr_info%is_parameter = .false.
-        attr_info%is_external = .false.
-        attr_info%is_optional = .false.
-        attr_info%has_intent = .false.
-        attr_info%has_global_dimensions = .false.
+        call reset_declaration_attributes(attr_info)
 
         ! Parse basic attributes (simplified)
         do while (.not. parser%is_at_end())
@@ -1142,16 +1123,13 @@ contains
                                 token = parser%peek()
                                 select case (token%text)
                                 case ("in")
-                                    attr_info%intent = "in"
-                                    attr_info%has_intent = .true.
+                                    call set_declaration_intent(attr_info, "in")
                                     token = parser%consume()
                                 case ("out")
-                                    attr_info%intent = "out"
-                                    attr_info%has_intent = .true.
+                                    call set_declaration_intent(attr_info, "out")
                                     token = parser%consume()
                                 case ("inout")
-                                    attr_info%intent = "inout"
-                                    attr_info%has_intent = .true.
+                                    call set_declaration_intent(attr_info, "inout")
                                     token = parser%consume()
                                 end select
                                 ! consume closing paren
@@ -1188,7 +1166,7 @@ contains
 
         type(token_t) :: token
         type(type_specifier_t) :: type_spec
-        type(declaration_attributes_t) :: attr_info
+        type(declaration_attribute_info_t) :: attr_info
         integer :: initializer_index
         character(len=:), allocatable :: var_name
         integer, allocatable :: local_dimension_indices(:)
@@ -1590,7 +1568,7 @@ contains
 
         type(token_t) :: token, next_token
         type(type_specifier_t) :: type_spec
-        type(declaration_attributes_t) :: attr_info
+        type(declaration_attribute_info_t) :: attr_info
         character(len=64), allocatable :: var_names(:)
         integer, allocatable :: per_var_dims(:, :)  ! Store dimensions per variable
         logical, allocatable :: has_dims(:)  ! Track which vars have dimensions


### PR DESCRIPTION
## Summary
- add a shared declaration_attribute_utils module for declaration attribute flags
- migrate parser_declarations and codegen_declarations to reuse the shared helpers and drop duplicate string assembly
- update parser documentation to reference the new attribute info type

## Verification
- make test
  - All fortfront API integration tests passed!