### PR TITLE
fix: polish: Add recursive keyword support for subroutines in AST (fixes #1489)

### DIFF
--- a/src/analysis/call_graph.f90
+++ b/src/analysis/call_graph.f90
@@ -1397,6 +1397,18 @@ contains
                     return
                 end if
             end do
+        type is (subroutine_def_node)
+            if (proc_node%is_recursive) then
+                is_recursive = .true.
+                return
+            end if
+            if (.not. allocated(proc_node%prefix_keywords)) return
+            do i = 1, size(proc_node%prefix_keywords)
+                if (trim(proc_node%prefix_keywords(i)) == 'recursive') then
+                    is_recursive = .true.
+                    return
+                end if
+            end do
         class default
         end select
     end function procedure_declares_recursive

--- a/src/ast/factory/ast_factory_procedures.f90
+++ b/src/ast/factory/ast_factory_procedures.f90
@@ -45,16 +45,39 @@ contains
 
     ! Create subroutine definition node and add to stack
     function push_subroutine_def(arena, name, param_indices, body_indices, &
-                                 line, column, parent_index) result(sub_index)
+                                 line, column, parent_index, is_recursive, &
+                                 prefix_keywords) result(sub_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: name
         integer, intent(in), optional :: param_indices(:)
         integer, intent(in), optional :: body_indices(:)
         integer, intent(in), optional :: line, column, parent_index
+        logical, intent(in), optional :: is_recursive
+        character(len=16), intent(in), optional :: prefix_keywords(:)
         integer :: sub_index
         type(subroutine_def_node) :: sub_def
 
-        sub_def = create_subroutine_def(name, param_indices, body_indices, line, column)
+        if (present(prefix_keywords)) then
+            if (present(is_recursive)) then
+                sub_def = create_subroutine_def(name, param_indices, body_indices, &
+                                                line, column, &
+                                                prefix_keywords=prefix_keywords, &
+                                                is_recursive=is_recursive)
+            else
+                sub_def = create_subroutine_def(name, param_indices, body_indices, &
+                                                line, column, &
+                                                prefix_keywords=prefix_keywords)
+            end if
+        else
+            if (present(is_recursive)) then
+                sub_def = create_subroutine_def(name, param_indices, body_indices, &
+                                                line, column, &
+                                                is_recursive=is_recursive)
+            else
+                sub_def = create_subroutine_def(name, param_indices, body_indices, &
+                                                line, column)
+            end if
+        end if
         call arena%push(sub_def, "subroutine_def", parent_index)
         sub_index = arena%size
     end function push_subroutine_def

--- a/src/ast/nodes/ast_nodes_procedure.f90
+++ b/src/ast/nodes/ast_nodes_procedure.f90
@@ -36,7 +36,9 @@ module ast_nodes_procedure
     type, extends(ast_node), public :: subroutine_def_node
         character(len=:), allocatable :: name
         integer, allocatable :: param_indices(:)
+        character(len=16), allocatable :: prefix_keywords(:)
         integer, allocatable :: body_indices(:)
+        logical :: is_recursive = .false.
     contains
         procedure :: accept => subroutine_def_accept
         procedure :: to_json => subroutine_def_to_json
@@ -138,6 +140,7 @@ contains
         if (allocated(this%body_indices)) then
             call json%add(obj, 'body_indices', this%body_indices)
         end if
+        call json%add(obj, 'is_recursive', this%is_recursive)
         call json%add(parent, obj)
     end subroutine subroutine_def_to_json
 
@@ -157,7 +160,9 @@ contains
         ! Copy derived class fields
         lhs%name = rhs%name
         if (allocated(rhs%param_indices)) lhs%param_indices = rhs%param_indices
+        if (allocated(rhs%prefix_keywords)) lhs%prefix_keywords = rhs%prefix_keywords
         if (allocated(rhs%body_indices)) lhs%body_indices = rhs%body_indices
+        lhs%is_recursive = rhs%is_recursive
     end subroutine subroutine_def_assign
 
     ! Implementation for subroutine_call_node
@@ -241,11 +246,14 @@ contains
     end function create_function_def
 
     function create_subroutine_def(name, param_indices, body_indices, &
-                                   line, column) result(node)
+                                   line, column, prefix_keywords, is_recursive) &
+        result(node)
         character(len=*), intent(in) :: name
         integer, intent(in), optional :: param_indices(:)
         integer, intent(in), optional :: body_indices(:)
         integer, intent(in), optional :: line, column
+        character(len=16), intent(in), optional :: prefix_keywords(:)
+        logical, intent(in), optional :: is_recursive
         type(subroutine_def_node) :: node
 
         node%uid = generate_uid()
@@ -262,6 +270,14 @@ contains
         end if
         if (present(line)) node%line = line
         if (present(column)) node%column = column
+        if (present(prefix_keywords)) then
+            if (size(prefix_keywords) > 0) then
+                node%prefix_keywords = prefix_keywords
+            end if
+        end if
+        if (present(is_recursive)) then
+            node%is_recursive = is_recursive
+        end if
     end function create_subroutine_def
 
     ! Helper functions for unified procedure interface

--- a/src/codegen/codegen_declarations.f90
+++ b/src/codegen/codegen_declarations.f90
@@ -269,11 +269,27 @@ contains
         type(subroutine_def_node), intent(in) :: node
         integer, intent(in) :: node_index
         character(len=:), allocatable :: code
-        character(len=:), allocatable :: params_code
         integer :: i
+        logical :: recursive_in_prefix
+
+        recursive_in_prefix = .false.
+        code = ""
+
+        if (allocated(node%prefix_keywords)) then
+            do i = 1, size(node%prefix_keywords)
+                if (len_trim(node%prefix_keywords(i)) == 0) cycle
+                code = code // trim(node%prefix_keywords(i)) // " "
+                if (trim(node%prefix_keywords(i)) == "recursive") then
+                    recursive_in_prefix = .true.
+                end if
+            end do
+        end if
+        if (node%is_recursive .and. .not. recursive_in_prefix) then
+            code = "recursive " // code
+        end if
 
         ! Start subroutine definition
-        code = "subroutine " // node%name
+        code = code // "subroutine " // node%name
 
         ! Generate parameters (names only)
         if (allocated(node%param_indices) .and. size(node%param_indices) > 0) then
@@ -307,6 +323,7 @@ contains
             type(parameter_info_t), allocatable :: param_map(:)
             integer, allocatable :: param_indices(:)
             integer, allocatable :: body_indices(:)
+            integer :: j
 
             if (allocated(node%param_indices)) then
                 param_indices = node%param_indices
@@ -321,6 +338,20 @@ contains
             end if
 
             call build_parameter_map(arena, param_indices, body_indices, param_map)
+
+            if (allocated(node%prefix_keywords)) then
+                do j = 1, size(node%prefix_keywords)
+                    select case (trim(node%prefix_keywords(j)))
+                    case ("pure", "elemental")
+                        do i = 1, size(param_map)
+                            if (.not. allocated(param_map(i)%name)) cycle
+                            if (len_trim(param_map(i)%intent_str) == 0) then
+                                param_map(i)%intent_str = "in"
+                            end if
+                        end do
+                    end select
+                end do
+            end if
 
             ! Generate body with indentation, declaration grouping, and parameter mapping
             code = code // generate_grouped_body_with_params(arena, body_indices, 1, &

--- a/src/parser/parser_procedure_bodies.f90
+++ b/src/parser/parser_procedure_bodies.f90
@@ -30,8 +30,39 @@ contains
         character(len=:), allocatable :: subroutine_name
         integer :: line, column
         integer, allocatable :: param_indices(:), body_indices(:)
+        character(len=16), allocatable :: prefix_keywords(:)
+        logical :: has_recursive_keyword
+
+        has_recursive_keyword = .false.
+
+        do
+            token = parser%peek()
+            if (token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER) then
+                select case (trim(to_lower(token%text)))
+                case ("recursive")
+                    has_recursive_keyword = .true.
+                    call append_prefix_keyword(prefix_keywords, "recursive")
+                    token = parser%consume()
+                case ("pure")
+                    call append_prefix_keyword(prefix_keywords, "pure")
+                    token = parser%consume()
+                case ("elemental")
+                    call append_prefix_keyword(prefix_keywords, "elemental")
+                    token = parser%consume()
+                case default
+                    exit
+                end select
+            else
+                exit
+            end if
+        end do
 
         ! Consume subroutine keyword
+        token = parser%peek()
+        if (.not. (token%kind == TK_KEYWORD .and. token%text == "subroutine")) then
+            sub_index = 0
+            return
+        end if
         token = parser%consume()
         line = token%line
         column = token%column
@@ -158,9 +189,23 @@ contains
         end do
 
         ! Create subroutine node
-        sub_index = push_subroutine_def(arena, subroutine_name, param_indices, &
-                                        body_indices, &
-                                        line, column)
+        if (allocated(prefix_keywords)) then
+            if (size(prefix_keywords) == 0) then
+                deallocate (prefix_keywords)
+            end if
+        end if
+
+        if (allocated(prefix_keywords)) then
+            sub_index = push_subroutine_def(arena, subroutine_name, &
+                                            param_indices, body_indices, &
+                                            line, column, &
+                                            is_recursive=has_recursive_keyword, &
+                                            prefix_keywords=prefix_keywords)
+        else
+            sub_index = push_subroutine_def(arena, subroutine_name, param_indices, &
+                                            body_indices, line, column, &
+                                            is_recursive=has_recursive_keyword)
+        end if
     end function parse_subroutine_in_module
 
     ! Safe function parsing for module contexts (avoids circular dependencies)

--- a/src/parser/parser_procedure_definitions.f90
+++ b/src/parser/parser_procedure_definitions.f90
@@ -557,18 +557,29 @@ contains
         character(len=:), allocatable :: subroutine_name
         integer :: line, column
         integer, allocatable :: param_indices(:), body_indices(:)
+        character(len=16), allocatable :: prefix_keywords(:)
+        logical :: has_recursive_keyword
+        logical :: infer_recursive_from_body
 
+        has_recursive_keyword = .false.
+        infer_recursive_from_body = .false.
+        call parse_function_prefix_keywords(parser, prefix_buffer, &
+                                            prefix_keywords=prefix_keywords, &
+                                            has_recursive_keyword=has_recursive_keyword)
         call parse_subroutine_header(parser, subroutine_name, line, column)
         call parse_parameter_list(parser, arena, param_indices)
         call parse_procedure_body(parser, arena, subroutine_name, "subroutine", &
-                                  body_indices)
+                                  body_indices, infer_recursive_from_body)
 
         call merge_parameter_attributes_if_needed(arena, param_indices, &
                                                   body_indices)
+        call ensure_recursive_prefix(has_recursive_keyword, &
+                                     infer_recursive_from_body, prefix_keywords)
 
         sub_index = push_subroutine_def(arena, subroutine_name, param_indices, &
-                                        body_indices, &
-                                        line, column)
+                                        body_indices, line, column, &
+                                        is_recursive=has_recursive_keyword, &
+                                        prefix_keywords=prefix_keywords)
     end function parse_subroutine_definition
 
     subroutine parse_parameter_list(parser, arena, param_indices)

--- a/src/utilities/procedure_classification.f90
+++ b/src/utilities/procedure_classification.f90
@@ -114,8 +114,16 @@ contains
                 end select
             end do
         type is (subroutine_def_node)
-            ! Note: subroutine_def_node does not store prefix keywords directly
-            ! in our AST, so fall back to scanning its body declarations.
+            if (allocated(proc_node%prefix_keywords)) then
+                do i = 1, size(proc_node%prefix_keywords)
+                    keyword = to_lower(trim(proc_node%prefix_keywords(i)))
+                    select case (keyword)
+                    case ('pure', 'elemental')
+                        has_prefix = .true.
+                        return
+                    end select
+                end do
+            end if
             if (allocated(proc_node%body_indices)) then
                 if (body_has_special_prefix(arena, proc_node%body_indices)) then
                     has_prefix = .true.

--- a/test/analysis/test_call_graph_consolidation.f90
+++ b/test/analysis/test_call_graph_consolidation.f90
@@ -10,6 +10,7 @@ program test_call_graph_consolidation
     call test_internal_procedures()
     call test_module_and_program_scopes()
     call test_recursive_function_detection()
+    call test_recursive_subroutine_detection()
 
     if (all_tests_passed) then
         print *, "All call graph consolidation tests PASSED!"
@@ -180,6 +181,58 @@ contains
             call report_failure('Incorrect recursive cycle entry', cycles(1))
         end if
     end subroutine test_recursive_function_detection
+
+    subroutine test_recursive_subroutine_detection()
+        character(len=:), allocatable :: source, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(call_graph_t) :: graph
+        character(len=:), allocatable :: cycles(:)
+        integer :: root_index
+
+        print *, "Testing recursive subroutine detection..."
+
+        source = '' // &
+                 "module recursion_mod" // new_line('a') // &
+                 "contains" // new_line('a') // &
+                 "    recursive subroutine countdown(n)" // new_line('a') // &
+                 "        integer, intent(in) :: n" // new_line('a') // &
+                 "        if (n > 0) then" // new_line('a') // &
+                 "            call countdown(n - 1)" // new_line('a') // &
+                 "        end if" // new_line('a') // &
+                 "    end subroutine countdown" // new_line('a') // &
+                 "end module recursion_mod"
+
+        call lex_source(source, tokens, error_msg)
+        if (error_msg /= '') then
+            call report_failure('Lexing failed for recursive subroutine test', &
+                                error_msg)
+            return
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        if (root_index <= 0) then
+            call report_failure('Parsing failed for recursive subroutine test', &
+                                error_msg)
+            return
+        end if
+
+        graph = build_call_graph(arena, root_index)
+        call assert_procedure(graph, 'recursion_mod::countdown')
+        call assert_edge(graph, 'recursion_mod::countdown', &
+                         'recursion_mod::countdown')
+
+        cycles = get_recursive_cycles(graph)
+        if (size(cycles) /= 1) then
+            call report_failure('Unexpected recursive cycle count', &
+                                'Expected single cycle for recursion_mod::countdown')
+            return
+        end if
+        if (trim(cycles(1)) /= 'recursion_mod::countdown') then
+            call report_failure('Incorrect recursive cycle entry', cycles(1))
+        end if
+    end subroutine test_recursive_subroutine_detection
 
     subroutine assert_procedure(graph, expected)
         type(call_graph_t), intent(in) :: graph


### PR DESCRIPTION
## Summary
- capture subroutine prefix keywords and recursion flags in AST nodes
- update parser, call graph, codegen, and classification to honor recursive subroutines
- add regression coverage for recursive subroutine detection in the call graph

## Verification
- `make test` (PASS)
  - includes call graph consolidation suite confirming self-edge detection
