### PR TITLE
fix: polish: eliminate manual deallocate calls in parser modules (fixes #1497)

### DIFF
--- a/src/parser/mixed_construct_detector.f90
+++ b/src/parser/mixed_construct_detector.f90
@@ -81,17 +81,33 @@ contains
 
         ! Resize arrays to actual size
         if (result%num_implicit_ranges > 0) then
-            result%implicit_ranges = result%implicit_ranges(1:result%num_implicit_ranges, :)
+            block
+                integer, allocatable :: trimmed(:, :)
+                allocate (trimmed(result%num_implicit_ranges, 2))
+                trimmed = result%implicit_ranges(1:result%num_implicit_ranges, :)
+                call move_alloc(trimmed, result%implicit_ranges)
+            end block
         else
-            deallocate (result%implicit_ranges)
-            allocate (result%implicit_ranges(0, 2))
+            block
+                integer, allocatable :: empty(:, :)
+                allocate (empty(0, 2))
+                call move_alloc(empty, result%implicit_ranges)
+            end block
         end if
 
         if (result%num_explicit_ranges > 0) then
-            result%explicit_ranges = result%explicit_ranges(1:result%num_explicit_ranges, :)
+            block
+                integer, allocatable :: trimmed(:, :)
+                allocate (trimmed(result%num_explicit_ranges, 2))
+                trimmed = result%explicit_ranges(1:result%num_explicit_ranges, :)
+                call move_alloc(trimmed, result%explicit_ranges)
+            end block
         else
-            deallocate (result%explicit_ranges)
-            allocate (result%explicit_ranges(0, 2))
+            block
+                integer, allocatable :: empty(:, :)
+                allocate (empty(0, 2))
+                call move_alloc(empty, result%explicit_ranges)
+            end block
         end if
     end subroutine detect_mixed_constructs
 
@@ -162,7 +178,8 @@ contains
                         depth = depth + 1
                     else if (trim(tokens(i)%text) == "end") then
                         ! Check next token for "type"
-                        if (i + 1 <= size(tokens) .and. tokens(i + 1)%kind == TK_KEYWORD .and. &
+                        if (i + 1 <= size(tokens) .and. tokens(i + 1)%kind == &
+                            TK_KEYWORD .and. &
                             trim(tokens(i + 1)%text) == "type") then
                             if (depth == 0) then
                                 end_pos = i + 1

--- a/src/parser/parser_array_constructs.f90
+++ b/src/parser/parser_array_constructs.f90
@@ -5,7 +5,9 @@ module parser_array_constructs_module
     use parser_state_module
     use parser_expressions_module, only: parse_expression
     use parser_statement_core_module, only: parse_basic_statement_core, &
-                                            statement_callbacks_t, null_statement_callbacks, find_statement_end
+                                            statement_callbacks_t, &
+                                            null_statement_callbacks, &
+                                            find_statement_end
     use parser_basic_statement_module, only: parse_statement_body
     use parser_if_constructs_module, only: parse_if, parse_if_condition
     use parser_select_constructs_module, only: parse_select_case
@@ -140,7 +142,6 @@ contains
                 where_index = push_where(arena, mask_expr_index, where_body_indices, &
                                          line=line, column=column)
 
-                deallocate (where_body_indices)
                 return
             end if
         else
@@ -168,7 +169,8 @@ contains
                     end if
                 end if
                 elsewhere_body_indices = parse_statement_body(parser, arena, &
-                                                              where_end_keywords, callbacks)
+                                                              where_end_keywords, &
+                                                              callbacks)
 
                 token = parser%peek()
                 if (token%kind == TK_KEYWORD .and. token%text == "elsewhere") then
@@ -250,7 +252,6 @@ contains
                     token = parser%consume()
                 else if (token%kind == TK_OPERATOR .and. token%text == "=") then
                     if (parser%current_token + 1 > size(parser%tokens)) then
-                        deallocate (associations)
                         assoc_index = 0
                         return
                     end if
@@ -259,7 +260,6 @@ contains
                         next_token = parser%tokens(parser%current_token + 1)
                         if (next_token%kind /= TK_OPERATOR .or. &
                             next_token%text /= ">") then
-                            deallocate (associations)
                             assoc_index = 0
                             return
                         end if
@@ -267,7 +267,6 @@ contains
                     token = parser%consume()
                     token = parser%consume()
                 else
-                    deallocate (associations)
                     assoc_index = 0
                     return
                 end if
@@ -276,8 +275,12 @@ contains
                 expr_index = parse_expression( &
                              parser%tokens(parser%current_token:), arena)
                 if (expr_index <= 0) then
-                    deallocate (associations)
-                    if (allocated(body_indices)) deallocate (body_indices)
+                    if (allocated(body_indices)) then
+                        block
+                            integer, allocatable :: temp(:)
+                            call move_alloc(body_indices, temp)
+                        end block
+                    end if
                     assoc_index = 0
                     return
                 end if
@@ -342,7 +345,6 @@ contains
                 token = parser%consume()
                 exit
             else
-                deallocate (associations)
                 assoc_index = 0
                 return
             end if
@@ -441,7 +443,10 @@ contains
 
                 parser%current_token = stmt_end + 1
 
-                deallocate (stmt_tokens)
+                block
+                    type(token_t), allocatable, target :: temp(:)
+                    call move_alloc(stmt_tokens, temp)
+                end block
             end block
         end do
 
@@ -468,8 +473,6 @@ contains
             assoc_index = 0
         end if
 
-        deallocate (associations)
-        deallocate (body_indices)
     end function parse_associate
 
 end module parser_array_constructs_module

--- a/src/parser/parser_assignment.f90
+++ b/src/parser/parser_assignment.f90
@@ -1,5 +1,6 @@
 module parser_assignment_module
-    use lexer_core, only: token_t, TK_IDENTIFIER, TK_OPERATOR, TK_EOF, TK_NUMBER, TK_STRING, &
+    use lexer_core, only: token_t, TK_IDENTIFIER, TK_OPERATOR, TK_EOF, TK_NUMBER, &
+                          TK_STRING, &
                           TK_KEYWORD, TK_NEWLINE
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_expressions_module, only: parse_range
@@ -28,18 +29,25 @@ contains
         is_multi_assignment = is_multi_var_assignment(parser)
 
         if (is_multi_assignment) then
-            call parse_multi_variable_assignment(parser, arena, stmt_index, extra_indices)
+            call parse_multi_variable_assignment(parser, arena, stmt_index, &
+                                                 extra_indices)
         else
             id_token = parser%consume()
             op_token = parser%peek()
 
-            if (allocated(assignment_op)) deallocate (assignment_op)
+            if (allocated(assignment_op)) then
+                block
+                    character(len=:), allocatable :: temp
+                    call move_alloc(assignment_op, temp)
+                end block
+            end if
 
             if (op_token%kind == TK_OPERATOR) then
                 select case (op_token%text)
                 case ("=")
                     op_token = parser%consume()
-                    target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column)
+                    target_index = push_identifier(arena, id_token%text, id_token%line, &
+                                                   id_token%column)
                     value_index = parse_range(parser, arena)
                     if (value_index > 0) then
                         stmt_index = push_assignment(arena, target_index, value_index, &
@@ -47,11 +55,13 @@ contains
                     end if
                 case ("=>")
                     op_token = parser%consume()
-                    target_index = push_identifier(arena, id_token%text, id_token%line, id_token%column)
+                    target_index = push_identifier(arena, id_token%text, id_token%line, &
+                                                   id_token%column)
                     value_index = parse_range(parser, arena)
                     if (value_index > 0) then
                         stmt_index = push_assignment(arena, target_index, value_index, &
-                                                     id_token%line, id_token%column, operator_text=op_token%text)
+                                                     id_token%line, id_token%column, &
+                                                     operator_text=op_token%text)
                     end if
                 case ("(", "%")
                     block
@@ -189,7 +199,8 @@ contains
             token = parser%peek()
             if (token%kind == TK_IDENTIFIER) then
                 token = parser%consume()
-                target_index = push_identifier(arena, token%text, token%line, token%column)
+                target_index = push_identifier(arena, token%text, token%line, &
+                                               token%column)
                 var_indices = [var_indices, target_index]
 
                 token = parser%peek()
@@ -214,10 +225,13 @@ contains
             token = parser%peek()
             if (token%kind == TK_NUMBER .or. token%kind == TK_STRING .or. &
                 token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD .or. &
-                (token%kind == TK_OPERATOR .and. (token%text == '.true.' .or. token%text == '.false.'))) then
+                (token%kind == TK_OPERATOR .and. (token%text == '.true.' .or. &
+                                                  token%text &
+                                                  == '.false.'))) then
                 token = parser%consume()
                 literal_type = get_literal_type_from_token_kind(token%kind, token%text)
-                value_index = push_literal(arena, token%text, literal_type, token%line, token%column)
+                value_index = push_literal(arena, token%text, literal_type, token%line, &
+                                           token%column)
                 value_indices = [value_indices, value_index]
 
                 token = parser%peek()
@@ -250,8 +264,10 @@ contains
             if (target_index > 0 .and. value_index > 0) then
                 assignment_indices = [assignment_indices, &
                                       push_assignment(arena, target_index, value_index, &
-                                                      parser%tokens(parser%current_token - 1)%line, &
-                                                      parser%tokens(parser%current_token - 1)%column)]
+                                                      parser%tokens(parser%current_token &
+                                                                    - 1)%line, &
+                                                      parser%tokens(parser%current_token &
+                                                                    - 1)%column)]
             end if
         end do
 
@@ -260,15 +276,14 @@ contains
 
             if (size(assignment_indices) > 1) then
                 if (present(extra_indices)) then
-                    if (allocated(extra_indices)) deallocate (extra_indices)
-                    allocate (extra_indices(size(assignment_indices) - 1))
                     extra_indices = assignment_indices(2:)
                 end if
             end if
         end if
     end subroutine parse_multi_variable_assignment
 
-    integer function get_literal_type_from_token_kind(token_kind, token_text) result(literal_type)
+    integer function get_literal_type_from_token_kind(token_kind, token_text) &
+        result(literal_type)
         integer, intent(in) :: token_kind
         character(len=*), intent(in) :: token_text
 

--- a/src/parser/parser_basic_statement_module.f90
+++ b/src/parser/parser_basic_statement_module.f90
@@ -240,7 +240,10 @@ contains
                         end do
                     end block
 
-                    deallocate (stmt_tokens)
+                    block
+                        type(token_t), allocatable, target :: temp(:)
+                        call move_alloc(stmt_tokens, temp)
+                    end block
                 end if
 
                 next_index = stmt_end + 1

--- a/src/parser/parser_declarations.f90
+++ b/src/parser/parser_declarations.f90
@@ -118,7 +118,6 @@ contains
         integer :: last_token
 
         if (size(input_tokens) == 0) then
-            if (allocated(output_tokens)) deallocate (output_tokens)
             return
         end if
 
@@ -128,10 +127,7 @@ contains
             first_token = first_token + 1
         end do
 
-        if (first_token > size(input_tokens)) then
-            if (allocated(output_tokens)) deallocate (output_tokens)
-            return
-        end if
+        if (first_token > size(input_tokens)) return
 
         last_token = size(input_tokens)
         do while (last_token >= first_token .and. &
@@ -139,7 +135,6 @@ contains
             last_token = last_token - 1
         end do
 
-        if (allocated(output_tokens)) deallocate (output_tokens)
         allocate (output_tokens(last_token - first_token + 1))
         output_tokens = input_tokens(first_token:last_token)
     end subroutine trim_token_sequence
@@ -168,7 +163,10 @@ contains
         if (depth /= 0) return
 
         if (size(tokens) == 2) then
-            deallocate (tokens)
+            block
+                type(token_t), allocatable :: temp(:)
+                call move_alloc(tokens, temp)
+            end block
         else
             tokens = tokens(2:size(tokens) - 1)
         end if
@@ -178,13 +176,22 @@ contains
         type(type_specifier_t), intent(inout) :: type_spec
 
         if (allocated(type_spec%derived_type_tokens)) then
-            deallocate (type_spec%derived_type_tokens)
+            block
+                type(token_t), allocatable :: temp(:)
+                call move_alloc(type_spec%derived_type_tokens, temp)
+            end block
         end if
         if (allocated(type_spec%derived_parameter_tokens)) then
-            deallocate (type_spec%derived_parameter_tokens)
+            block
+                type(token_t), allocatable :: temp(:)
+                call move_alloc(type_spec%derived_parameter_tokens, temp)
+            end block
         end if
         if (allocated(type_spec%derived_parameter_nodes)) then
-            deallocate (type_spec%derived_parameter_nodes)
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(type_spec%derived_parameter_nodes, temp)
+            end block
         end if
         type_spec%derived_type_name = ""
         type_spec%derived_type_module = ""
@@ -209,8 +216,12 @@ contains
         type_spec%line = token%line
         type_spec%column = token%column
         type_spec%has_character_length = .false.
-        if (allocated(type_spec%character_length_expr)) deallocate &
-            (type_spec%character_length_expr)
+        if (allocated(type_spec%character_length_expr)) then
+            block
+                character(len=:), allocatable :: temp
+                call move_alloc(type_spec%character_length_expr, temp)
+            end block
+        end if
     end subroutine initialize_type_specifier
 
     subroutine split_derived_type_name_and_params(tokens, name_tokens, param_tokens)
@@ -219,9 +230,6 @@ contains
         type(token_t), allocatable, intent(out) :: param_tokens(:)
         integer :: i
         logical :: name_complete
-
-        if (allocated(name_tokens)) deallocate (name_tokens)
-        if (allocated(param_tokens)) deallocate (param_tokens)
 
         name_complete = .false.
         do i = 1, size(tokens)
@@ -349,13 +357,14 @@ contains
 
         call strip_outer_parentheses(working)
         call trim_token_sequence(working, trimmed_working)
-        if (allocated(working)) deallocate (working)
         if (.not. allocated(trimmed_working)) return
-        working = trimmed_working
-        if (allocated(trimmed_working)) deallocate (trimmed_working)
+        call move_alloc(trimmed_working, working)
 
         if (allocated(type_spec%derived_parameter_nodes)) then
-            deallocate (type_spec%derived_parameter_nodes)
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(type_spec%derived_parameter_nodes, temp)
+            end block
         end if
 
         depth = 0
@@ -406,13 +415,28 @@ contains
                 call append_int(type_spec%derived_parameter_nodes, expr_index)
             end if
 
-            if (allocated(parser_tokens)) deallocate (parser_tokens)
-            if (allocated(cleaned)) deallocate (cleaned)
+            if (allocated(parser_tokens)) then
+                block
+                    type(token_t), allocatable :: temp(:)
+                    call move_alloc(parser_tokens, temp)
+                end block
+            end if
+            if (allocated(cleaned)) then
+                block
+                    type(token_t), allocatable :: temp(:)
+                    call move_alloc(cleaned, temp)
+                end block
+            end if
             call reset_current()
         end subroutine finalize_parameter
 
         subroutine reset_current()
-            if (allocated(current)) deallocate (current)
+            if (allocated(current)) then
+                block
+                    type(token_t), allocatable :: temp(:)
+                    call move_alloc(current, temp)
+                end block
+            end if
         end subroutine reset_current
 
     end subroutine process_derived_type_parameters
@@ -428,15 +452,26 @@ contains
         call set_derived_type_name_info(type_spec, name_tokens, arena)
         if (.not. type_spec%is_derived_type) then
             if (allocated(type_spec%derived_parameter_tokens)) then
-                deallocate (type_spec%derived_parameter_tokens)
+                block
+                    type(token_t), allocatable :: temp(:)
+                    call move_alloc(type_spec%derived_parameter_tokens, temp)
+                end block
             end if
-            if (allocated(param_tokens)) deallocate (param_tokens)
+            if (allocated(param_tokens)) then
+                block
+                    type(token_t), allocatable :: temp(:)
+                    call move_alloc(param_tokens, temp)
+                end block
+            end if
             return
         end if
         call process_derived_type_parameters(type_spec, param_tokens, arena)
 
         if (allocated(type_spec%derived_parameter_tokens)) then
-            deallocate (type_spec%derived_parameter_tokens)
+            block
+                type(token_t), allocatable :: temp(:)
+                call move_alloc(type_spec%derived_parameter_tokens, temp)
+            end block
         end if
         if (allocated(param_tokens)) then
             allocate (type_spec%derived_parameter_tokens(size(param_tokens)))
@@ -477,7 +512,12 @@ contains
         invalid_definition = .false.
         found_double_colon = .false.
         if (present(attribute_clause)) then
-            if (allocated(attribute_clause)) deallocate (attribute_clause)
+            if (allocated(attribute_clause)) then
+                block
+                    character(len=:), allocatable :: temp
+                    call move_alloc(attribute_clause, temp)
+                end block
+            end if
         end if
 
         do while (.not. parser%is_at_end())
@@ -550,14 +590,32 @@ contains
                         end do
                         attribute_clause = trim(adjustl(sanitized))
                     end if
-                    if (allocated(sanitized)) deallocate (sanitized)
-                    if (allocated(clause_text)) deallocate (clause_text)
-                    deallocate (cleaned)
+                    if (allocated(sanitized)) then
+                        block
+                            character(len=:), allocatable :: temp
+                            call move_alloc(sanitized, temp)
+                        end block
+                    end if
+                    if (allocated(clause_text)) then
+                        block
+                            character(len=:), allocatable :: temp
+                            call move_alloc(clause_text, temp)
+                        end block
+                    end if
+                    block
+                        type(token_t), allocatable :: temp(:)
+                        call move_alloc(cleaned, temp)
+                    end block
                 end if
             end if
         end if
 
-        if (allocated(attr_tokens)) deallocate (attr_tokens)
+        if (allocated(attr_tokens)) then
+            block
+                type(token_t), allocatable :: temp(:)
+                call move_alloc(attr_tokens, temp)
+            end block
+        end if
     end subroutine skip_type_definition_attributes
 
     logical function parser_is_at_type_definition(parser) result(is_type_def)
@@ -694,8 +752,12 @@ contains
             type_spec%kind_value = -1
             token = parser%consume()
             type_spec%has_character_length = .true.
-            if (allocated(type_spec%character_length_expr)) deallocate &
-                (type_spec%character_length_expr)
+            if (allocated(type_spec%character_length_expr)) then
+                block
+                    character(len=:), allocatable :: temp
+                    call move_alloc(type_spec%character_length_expr, temp)
+                end block
+            end if
             type_spec%character_length_expr = "*"
         case default
             if (token%kind == TK_NUMBER) then
@@ -703,8 +765,12 @@ contains
                 type_spec%has_kind = .true.
                 token = parser%consume()
                 type_spec%has_character_length = .true.
-                if (allocated(type_spec%character_length_expr)) deallocate &
-                    (type_spec%character_length_expr)
+                if (allocated(type_spec%character_length_expr)) then
+                    block
+                        character(len=:), allocatable :: temp
+                        call move_alloc(type_spec%character_length_expr, temp)
+                    end block
+                end if
                 type_spec%character_length_expr = trim(adjustl(token%text))
             end if
         end select
@@ -767,8 +833,6 @@ contains
         type(token_t) :: token
         integer :: depth
 
-        if (allocated(tokens)) deallocate (tokens)
-
         depth = 0
         do while (.not. parser%is_at_end())
             token = parser%peek()
@@ -821,10 +885,18 @@ contains
             if (param_end >= param_start) then
                 param_tokens = parser%tokens(param_start:param_end)
                 call trim_token_sequence(param_tokens, cleaned_tokens)
-                if (allocated(param_tokens)) deallocate (param_tokens)
+                if (allocated(param_tokens)) then
+                    block
+                        type(token_t), allocatable :: temp(:)
+                        call move_alloc(param_tokens, temp)
+                    end block
+                end if
                 if (allocated(cleaned_tokens)) then
                     param_text = trim(adjustl(tokens_to_text(cleaned_tokens)))
-                    deallocate (cleaned_tokens)
+                    block
+                        type(token_t), allocatable :: temp(:)
+                        call move_alloc(cleaned_tokens, temp)
+                    end block
                     if (len_trim(param_text) > 0) then
                         if (.not. first_param) collected_text = collected_text // ", "
                         collected_text = collected_text // param_text
@@ -850,7 +922,6 @@ contains
         type(token_t) :: token
         integer :: depth
 
-        if (allocated(tokens)) deallocate (tokens)
         depth = 0
 
         do while (.not. parser%is_at_end())
@@ -898,19 +969,29 @@ contains
                 call trim_token_sequence(value_tokens, cleaned)
                 if (allocated(cleaned)) then
                     value_text = trim(adjustl(tokens_to_text(cleaned)))
-                    deallocate (cleaned)
+                    block
+                        type(token_t), allocatable :: temp(:)
+                        call move_alloc(cleaned, temp)
+                    end block
                 else
                     value_text = ""
                 end if
-                deallocate (value_tokens)
+                block
+                    type(token_t), allocatable :: temp(:)
+                    call move_alloc(value_tokens, temp)
+                end block
             else
                 value_text = ""
             end if
 
             if (len_trim(value_text) > 0) then
                 type_spec%has_character_length = .true.
-                if (allocated(type_spec%character_length_expr)) deallocate &
-                    (type_spec%character_length_expr)
+                if (allocated(type_spec%character_length_expr)) then
+                    block
+                        character(len=:), allocatable :: temp
+                        call move_alloc(type_spec%character_length_expr, temp)
+                    end block
+                end if
                 type_spec%character_length_expr = trim(value_text)
 
                 if (trim(value_text) == "*") then
@@ -1034,7 +1115,10 @@ contains
             collected_text = tokens_to_text(collected_tokens)
             type_spec%type_name = trim(type_spec%base_keyword) // "(" // &
                 trim(adjustl(collected_text)) // ")"
-            deallocate (collected_tokens)
+            block
+                type(token_t), allocatable :: temp(:)
+                call move_alloc(collected_tokens, temp)
+            end block
         else
             type_spec%type_name = trim(type_spec%base_keyword) // "()"
         end if
@@ -1251,7 +1335,6 @@ contains
                                             allocate (temp_names(old_size * 2))
                                             temp_names(1:old_size) = &
                                                 var_names(1:old_size)
-                                            deallocate (var_names)
                                             call move_alloc(temp_names, var_names)
                                         end block
                                     end if
@@ -1631,7 +1714,6 @@ contains
                     temp_dims(1:old_size, :) = per_var_dims(1:old_size, :)
                     temp_has(1:old_size) = has_dims(1:old_size)
                     temp_init(1:old_size) = init_indices(1:old_size)
-                    deallocate (var_names, per_var_dims, has_dims, init_indices)
                     call move_alloc(temp_names, var_names)
                     call move_alloc(temp_dims, per_var_dims)
                     call move_alloc(temp_has, has_dims)
@@ -1921,7 +2003,10 @@ contains
             if (len_trim(header_attributes) > 0) then
                 has_header_attrs = .true.
             else
-                deallocate (header_attributes)
+                block
+                    character(len=:), allocatable :: temp
+                    call move_alloc(header_attributes, temp)
+                end block
             end if
         end if
 

--- a/src/parser/parser_dispatcher.f90
+++ b/src/parser/parser_dispatcher.f90
@@ -183,7 +183,6 @@ contains
 
                             ! Store additional indices if any
                             if (size(decl_indices) > 1) then
-                                allocate (additional_indices(size(decl_indices) - 1))
                                 additional_indices = decl_indices(2:)
                             end if
                         else
@@ -416,7 +415,10 @@ contains
     ! Clear additional indices after use
     subroutine clear_additional_indices()
         if (allocated(additional_indices)) then
-            deallocate (additional_indices)
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(additional_indices, temp)
+            end block
         end if
     end subroutine clear_additional_indices
 
@@ -581,8 +583,12 @@ contains
             stmt_index = assignment_indices(1)
 
             if (size(assignment_indices) > 1) then
-                if (allocated(additional_indices)) deallocate (additional_indices)
-                allocate (additional_indices(size(assignment_indices) - 1))
+                if (allocated(additional_indices)) then
+                    block
+                        integer, allocatable :: temp(:)
+                        call move_alloc(additional_indices, temp)
+                    end block
+                end if
                 additional_indices = assignment_indices(2:)
             end if
         end if

--- a/src/parser/parser_do_constructs.f90
+++ b/src/parser/parser_do_constructs.f90
@@ -455,7 +455,10 @@ contains
                             else
                                 parser%current_token = stmt_end + 1
                             end if
-                            deallocate (stmt_tokens)
+                            block
+                                type(token_t), allocatable, target :: temp(:)
+                                call move_alloc(stmt_tokens, temp)
+                            end block
                             cycle
                         end if
 
@@ -469,7 +472,10 @@ contains
                         end do
                     end block
 
-                    deallocate (stmt_tokens)
+                    block
+                        type(token_t), allocatable, target :: temp(:)
+                        call move_alloc(stmt_tokens, temp)
+                    end block
                 end if
 
                 if (stmt_end + 1 <= size(parser%tokens)) then
@@ -639,7 +645,10 @@ contains
                         end do
                     end block
 
-                    deallocate (stmt_tokens)
+                    block
+                        type(token_t), allocatable, target :: temp(:)
+                        call move_alloc(stmt_tokens, temp)
+                    end block
                 end if
 
                 parser%current_token = stmt_end + 1
@@ -672,7 +681,12 @@ contains
             end if
         end if
 
-        if (allocated(body_indices)) deallocate (body_indices)
+        if (allocated(body_indices)) then
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(body_indices, temp)
+            end block
+        end if
     end function parse_do_while_from_do
 
 end module parser_do_constructs_module

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -134,7 +134,7 @@ contains
 
             if (token%kind == TK_KEYWORD .and. is_control_flow_keyword(lowered)) then
                 if (allocated(pending_prefixes)) then
-                    deallocate (pending_prefixes)
+                    call reset_pending_prefixes()
                     call prefix_buffer%clear()
                 end if
                 stmt_index = route_control_flow(parser, arena)
@@ -150,14 +150,12 @@ contains
                     case ("contains")
                         token = parser%consume()
                         stmt_index = 0
-                        if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
-                        end if
+                        call reset_pending_prefixes()
                         call prefix_buffer%clear()
                     case ("function")
                         if (allocated(pending_prefixes)) then
                             call prefix_buffer%set(pending_prefixes)
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                         else
                             call prefix_buffer%clear()
                         end if
@@ -167,7 +165,7 @@ contains
                     case ("subroutine")
                         if (allocated(pending_prefixes)) then
                             call prefix_buffer%set(pending_prefixes)
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                         else
                             call prefix_buffer%clear()
                         end if
@@ -176,104 +174,104 @@ contains
                         call prefix_buffer%clear()
                     case ("implicit")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         call parse_simple_implicit(parser, arena, stmt_index)
                     case ("real", "integer", "logical", "character", "complex", &
                           "double", "class")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         call handle_variable_declaration(parser, arena, stmt_index)
                     case ("type")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         call handle_type_declaration(parser, arena, stmt_index)
                     case ("print")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_print_statement(parser, arena)
                     case ("data")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_data_statement(parser, arena)
                     case ("use")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_use_statement(parser, arena)
                     case ("write")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_write_statement(parser, arena)
                     case ("allocate")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_allocate_statement(parser, arena)
                     case ("deallocate")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_deallocate_statement(parser, arena)
                     case ("stop")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_stop_statement(parser, arena)
                     case ("go", "goto")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_goto_statement(parser, arena)
                     case ("error")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_error_stop_statement(parser, arena)
                     case ("return")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_return_statement(parser, arena)
                     case ("cycle")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_cycle_statement(parser, arena)
                     case ("exit")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_exit_statement(parser, arena)
                     case ("call")
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         stmt_index = parse_call_statement(parser, arena)
                     case default
                         if (allocated(pending_prefixes)) then
-                            deallocate (pending_prefixes)
+                            call reset_pending_prefixes()
                             call prefix_buffer%clear()
                         end if
                         token = parser%consume()
@@ -281,7 +279,7 @@ contains
                     end select
                 case (TK_IDENTIFIER)
                     if (allocated(pending_prefixes)) then
-                        deallocate (pending_prefixes)
+                        call reset_pending_prefixes()
                         call prefix_buffer%clear()
                     end if
                     if (trim(to_lower(token%text)) == 'class') then
@@ -307,10 +305,23 @@ contains
                     if (size(additional_execution_indices) > 0) then
                         body_indices = [body_indices, additional_execution_indices]
                     end if
-                    deallocate (additional_execution_indices)
+                    block
+                        integer, allocatable :: temp(:)
+                        call move_alloc(additional_execution_indices, temp)
+                    end block
                 end if
             end if
         end do
+
+    contains
+        subroutine reset_pending_prefixes()
+            if (allocated(pending_prefixes)) then
+                block
+                    character(len=16), allocatable :: temp(:)
+                    call move_alloc(pending_prefixes, temp)
+                end block
+            end if
+        end subroutine reset_pending_prefixes
     end subroutine parse_program_body
 
     ! Parse a simple if statement with optional else block

--- a/src/parser/parser_expressions.f90
+++ b/src/parser/parser_expressions.f90
@@ -14,7 +14,8 @@ module parser_expressions_module
                            push_component_access, push_range_subscript, push_do_loop
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_expression_helpers_module, only: parse_number_literal, &
-                                            parse_string_literal, parse_boolean_literal, &
+                                                parse_string_literal, &
+                                                parse_boolean_literal, &
                                                 parse_component_access_postfix
     implicit none
     private
@@ -71,8 +72,10 @@ module parser_expressions_module
 
     ! Public expression parsing interface
     public :: parse_expression
-    public :: parse_range, parse_logical_eqv, parse_logical_or, parse_logical_and, parse_comparison
-    public :: parse_concatenation, parse_term, parse_factor, parse_power, parse_unary, parse_primary
+    public :: parse_range, parse_logical_eqv, parse_logical_or, parse_logical_and, &
+              parse_comparison
+    public :: parse_concatenation, parse_term, parse_factor, parse_power, parse_unary, &
+              parse_primary
     public :: parse_expression_until, parse_postfix_chain
 
 contains
@@ -90,11 +93,36 @@ contains
         if (.not. associated(parser%tokens)) then
             view%count = 0
             view%base_index = parser%current_token
-            if (allocated(view%text)) deallocate (view%text)
-            if (allocated(view%lower)) deallocate (view%lower)
-            if (allocated(view%kind)) deallocate (view%kind)
-            if (allocated(view%line)) deallocate (view%line)
-            if (allocated(view%column)) deallocate (view%column)
+            if (allocated(view%text)) then
+                block
+                    character(len=:), allocatable :: temp(:)
+                    call move_alloc(view%text, temp)
+                end block
+            end if
+            if (allocated(view%lower)) then
+                block
+                    character(len=:), allocatable :: temp(:)
+                    call move_alloc(view%lower, temp)
+                end block
+            end if
+            if (allocated(view%kind)) then
+                block
+                    integer, allocatable :: temp(:)
+                    call move_alloc(view%kind, temp)
+                end block
+            end if
+            if (allocated(view%line)) then
+                block
+                    integer, allocatable :: temp(:)
+                    call move_alloc(view%line, temp)
+                end block
+            end if
+            if (allocated(view%column)) then
+                block
+                    integer, allocatable :: temp(:)
+                    call move_alloc(view%column, temp)
+                end block
+            end if
             return
         end if
 
@@ -112,11 +140,36 @@ contains
         end do
         if (max_len < 1) max_len = 1
 
-        if (allocated(view%text)) deallocate (view%text)
-        if (allocated(view%lower)) deallocate (view%lower)
-        if (allocated(view%kind)) deallocate (view%kind)
-        if (allocated(view%line)) deallocate (view%line)
-        if (allocated(view%column)) deallocate (view%column)
+        if (allocated(view%text)) then
+            block
+                character(len=:), allocatable :: temp(:)
+                call move_alloc(view%text, temp)
+            end block
+        end if
+        if (allocated(view%lower)) then
+            block
+                character(len=:), allocatable :: temp(:)
+                call move_alloc(view%lower, temp)
+            end block
+        end if
+        if (allocated(view%kind)) then
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(view%kind, temp)
+            end block
+        end if
+        if (allocated(view%line)) then
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(view%line, temp)
+            end block
+        end if
+        if (allocated(view%column)) then
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(view%column, temp)
+            end block
+        end if
 
         allocate (character(len=max_len) :: view%text(count))
         allocate (character(len=max_len) :: view%lower(count))
@@ -444,7 +497,8 @@ contains
         end if
 
         lowered = to_lower(token%text)
-   is_prefix_operator_token = (lowered == "+" .or. lowered == "-" .or. lowered == ".not.")
+        is_prefix_operator_token = (lowered == "+" .or. lowered == "-" .or. lowered &
+                                    == ".not.")
     end function is_prefix_operator_token
 
     function get_infix_operator_entry(token) result(entry)
@@ -568,8 +622,10 @@ contains
             return
         end if
 
-        call operand_stack_push(operands, push_binary_op(arena, left_index, right_index, &
-                             op_entry%symbol, op_entry%token%line, op_entry%token%column))
+        call operand_stack_push(operands, push_binary_op(arena, left_index, &
+                                                         right_index, &
+                                                   op_entry%symbol, op_entry%token%line, &
+                                                         op_entry%token%column))
     end subroutine reduce_single_operator
 
     subroutine reduce_operators_for_incoming(operators, operands, arena, incoming)
@@ -718,7 +774,8 @@ contains
         end select
     end function parse_operand_base
 
-  recursive function parse_expression_with_precedence(parser, arena, minimum_precedence, &
+    recursive function parse_expression_with_precedence(parser, arena, &
+                                                        minimum_precedence, &
                                                         terminators) result(expr_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
@@ -755,14 +812,16 @@ contains
                         call reduce_until_group(operators, operands, arena)
                         op_entry = operator_stack_pop(operators)
                         if (prefix_stack%size > 0) then
-               if (prefix_stack%values(prefix_stack%size)%kind == PREFIX_MARKER_KIND) then
+                            if (prefix_stack%values(prefix_stack%size)%kind == &
+                                PREFIX_MARKER_KIND) then
                                 block
                                     type(token_t) :: discarded_marker
                                     discarded_marker = token_stack_pop(prefix_stack)
                                 end block
                                 if (.not. operand_stack_is_empty(operands)) then
                                     current_index = operand_stack_pop(operands)
-                    current_index = apply_prefix_stack(arena, prefix_stack, current_index)
+                                 current_index = apply_prefix_stack(arena, prefix_stack, &
+                                                                       current_index)
                                     call operand_stack_push(operands, current_index)
                                 end if
                             end if
@@ -786,7 +845,8 @@ contains
 
                 if (is_legacy_array_literal_start(parser, view)) then
                     current_index = parse_legacy_array_literal(parser, arena)
-                    current_index = apply_prefix_stack(arena, prefix_stack, current_index)
+                    current_index = apply_prefix_stack(arena, prefix_stack, &
+                                                       current_index)
                     current_index = parse_postfix_ops(parser, arena, view, current_index)
                     call operand_stack_push(operands, current_index)
                     expect_operand = .false.
@@ -809,7 +869,8 @@ contains
 
                 current_index = parse_operand_base(parser, arena, view)
                 if (current_index > 0) then
-                    current_index = apply_prefix_stack(arena, prefix_stack, current_index)
+                    current_index = apply_prefix_stack(arena, prefix_stack, &
+                                                       current_index)
                     current_index = parse_postfix_ops(parser, arena, view, current_index)
                     call operand_stack_push(operands, current_index)
                 else
@@ -823,7 +884,8 @@ contains
 
                 if (op_entry%precedence < minimum_precedence) exit main_loop
 
-                if (op_entry%precedence == PREC_COMPARISON .and. comparison_active(operators)) exit main_loop
+                if (op_entry%precedence == PREC_COMPARISON .and. &
+                    comparison_active(operators)) exit main_loop
 
                 call reduce_operators_for_incoming(operators, operands, arena, op_entry)
                 call operator_stack_push(operators, op_entry)
@@ -950,11 +1012,12 @@ contains
 
         if (present(terminators)) then
             if (size(terminators) > 0) then
-              allocate (character(len=MAX_OPERATOR_LEN) :: local_terms(size(terminators)))
+                allocate (character(len=MAX_OPERATOR_LEN) :: &
+                          local_terms(size(terminators)))
                 local_terms = terminators
                 expr_index = parse_expression_with_precedence(parser, arena, &
-                                                              PREC_RANGE + 1, local_terms)
-                deallocate (local_terms)
+                                                              PREC_RANGE + 1, &
+                                                              local_terms)
             else
                 expr_index = parse_expression_with_precedence(parser, arena, &
                                                               PREC_RANGE + 1)
@@ -1001,7 +1064,8 @@ contains
                     type(token_t) :: next_tok
                     next_tok = parser%peek()
                     if (.not. (next_tok%kind == TK_OPERATOR .and. &
-         (next_tok%text == ")" .or. next_tok%text == "]" .or. next_tok%text == ","))) then
+                   (next_tok%text == ")" .or. next_tok%text == "]" .or. next_tok%text == &
+                                ","))) then
                         right_index = parse_logical_eqv(parser, arena)
                     else
                         right_index = 0
@@ -1016,7 +1080,8 @@ contains
                 stride_index = parse_stride_component(parser, arena)
 
                 expr_index = push_range_expression(arena, expr_index, right_index, &
-                    stride_index=stride_index, line=op_token%line, column=op_token%column)
+                                          stride_index=stride_index, line=op_token%line, &
+                                                   column=op_token%column)
             end block
             return
         end if
@@ -1033,7 +1098,8 @@ contains
                         type(token_t) :: next_tok
                         next_tok = parser%peek()
                         if (.not. (next_tok%kind == TK_OPERATOR .and. &
-         (next_tok%text == ")" .or. next_tok%text == "]" .or. next_tok%text == ","))) then
+                   (next_tok%text == ")" .or. next_tok%text == "]" .or. next_tok%text == &
+                                    ","))) then
                             right_index = parse_logical_eqv(parser, arena)
                         else
                             right_index = 0
@@ -1048,7 +1114,8 @@ contains
                     stride_index = parse_stride_component(parser, arena)
 
                     expr_index = push_range_expression(arena, expr_index, right_index, &
-                    stride_index=stride_index, line=op_token%line, column=op_token%column)
+                                          stride_index=stride_index, line=op_token%line, &
+                                                       column=op_token%column)
                 end block
             end if
         end if
@@ -1169,7 +1236,8 @@ contains
                     current = parser%consume()
                     allocate (element_indices(0))
                     expr_index = push_array_literal(arena, element_indices, &
-                                                   paren_token%line, paren_token%column, &
+                                                    paren_token%line, &
+                                                    paren_token%column, &
                                                     syntax_style="legacy")
                 else
                     expr_index = 0
@@ -1178,7 +1246,8 @@ contains
             end if
 
             ! Parse elements with legacy syntax (closing /))
-       expr_index = parse_simple_array_elements(parser, arena, "/", "legacy", paren_token)
+            expr_index = parse_simple_array_elements(parser, arena, "/", "legacy", &
+                                                     paren_token)
 
             ! Consume final closing paren for legacy syntax
             if (expr_index > 0) then
@@ -1229,13 +1298,15 @@ contains
                 expr_index = parse_implied_do_constructor(parser, arena, start_token)
             else
                 ! Parse regular array elements
-       expr_index = parse_simple_array_elements(parser, arena, "]", "modern", start_token)
+                expr_index = parse_simple_array_elements(parser, arena, "]", "modern", &
+                                                         start_token)
             end if
         end block
     end function parse_modern_array_literal
 
     ! Parse implied do constructor: [(expr, var=start,end[,step])]
-    function parse_implied_do_constructor(parser, arena, bracket_token) result(expr_index)
+    function parse_implied_do_constructor(parser, arena, bracket_token) &
+        result(expr_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(token_t), intent(in) :: bracket_token
@@ -1371,7 +1442,8 @@ contains
                     allocate (element_indices(element_count))
                     element_indices = temp_indices(1:element_count)
                     expr_index = push_array_literal(arena, element_indices, &
-                                               bracket_token%line, bracket_token%column, &
+                                                    bracket_token%line, &
+                                                    bracket_token%column, &
                                                     syntax_style="modern")
                 end block
                 return
@@ -1462,14 +1534,10 @@ contains
                         name_available = .true.
                     end if
                 class default
-                    if (allocated(arg_indices)) deallocate (arg_indices)
                     return
                 end select
 
-                if (.not. name_available) then
-                    if (allocated(arg_indices)) deallocate (arg_indices)
-                    return
-                end if
+                if (.not. name_available) return
             end block
 
             ! Create call_or_subscript node with slice detection even when no args are present
@@ -1478,7 +1546,8 @@ contains
             end if
 
             expr_index = push_call_or_subscript_with_slice_detection(arena, &
-                                        name_for_call, arg_indices, paren%line, paren%column)
+                                                 name_for_call, arg_indices, paren%line, &
+                                                                     paren%column)
         end block
     end function parse_array_indexing_postfix
 
@@ -1547,15 +1616,16 @@ contains
                 type is (identifier_node)
                     name_for_call = node%name
                 class default
-                    if (allocated(arg_indices)) deallocate (arg_indices)
                     return
                 end select
 
                 if (allocated(name_for_call)) then
                     expr_index = &
                         push_call_or_subscript_with_slice_detection(arena, &
-                                                             name_for_call, arg_indices, &
-                                                             bracket%line, bracket%column)
+                                                                    name_for_call, &
+                                                                    arg_indices, &
+                                                                    bracket%line, &
+                                                                    bracket%column)
                 end if
             end if
         end block
@@ -1581,7 +1651,8 @@ contains
 
             if (op_token%kind == TK_OPERATOR .and. op_token%text == "%") then
                 op_token = view_consume_token(view, parser)
-          expr_index = parse_component_access_postfix(parser, arena, expr_index, op_token)
+                expr_index = parse_component_access_postfix(parser, arena, &
+                                                            expr_index, op_token)
                 if (expr_index <= 0) exit
             else if (op_token%kind == TK_OPERATOR .and. op_token%text == "(") then
                 expr_index = parse_array_indexing_postfix(parser, arena, expr_index)

--- a/src/parser/parser_forall.f90
+++ b/src/parser/parser_forall.f90
@@ -10,7 +10,9 @@ module parser_forall_module
     use ast_factory, only: push_forall
     use ast_nodes_loops, only: forall_triplet_t
     use parser_statement_core_module, only: parse_basic_statement_core, &
-                                            statement_callbacks_t, null_statement_callbacks, find_statement_end
+                                            statement_callbacks_t, &
+                                            null_statement_callbacks, &
+                                            find_statement_end
     implicit none
     private
 
@@ -158,40 +160,30 @@ contains
 
             ! Expect '='
             token = parser%peek()
-            if (token%kind /= TK_OPERATOR .or. token%text /= "=") then
-                deallocate (triplets)
-                deallocate (body_indices)
-                return
-            end if
+            if (token%kind /= TK_OPERATOR .or. token%text /= "=") return
             token = parser%consume()
 
             ! Parse lower bound expression (stop before colon, comma, or closing paren)
             block
                 character(len=1), dimension(3) :: lower_terms
                 lower_terms = [":", ",", ")"]
-                triplets(triplet_count)%lower_expr_index = parse_expression_until(parser, arena, lower_terms)
+                triplets(triplet_count)%lower_expr_index = &
+                    parse_expression_until(parser, arena, lower_terms)
             end block
 
             token = parser%peek()
-            if (token%kind /= TK_OPERATOR .or. token%text /= ":") then
-                deallocate (triplets)
-                deallocate (body_indices)
-                return
-            end if
+            if (token%kind /= TK_OPERATOR .or. token%text /= ":") return
             token = parser%consume()
 
             ! Parse upper bound expression (stop before stride, comma, or closing paren)
             block
                 character(len=1), dimension(3) :: upper_terms
                 upper_terms = [":", ",", ")"]
-                triplets(triplet_count)%upper_expr_index = parse_expression_until(parser, arena, upper_terms)
+                triplets(triplet_count)%upper_expr_index = &
+                    parse_expression_until(parser, arena, upper_terms)
             end block
 
-            if (triplets(triplet_count)%upper_expr_index <= 0) then
-                deallocate (triplets)
-                deallocate (body_indices)
-                return
-            end if
+            if (triplets(triplet_count)%upper_expr_index <= 0) return
 
             token = parser%peek()
             if (token%kind == TK_OPERATOR .and. token%text == ":") then
@@ -199,7 +191,8 @@ contains
                 block
                     character(len=1), dimension(2) :: stride_terms
                     stride_terms = [",", ")"]
-                    triplets(triplet_count)%stride_expr_index = parse_expression_until(parser, arena, stride_terms)
+                    triplets(triplet_count)%stride_expr_index = &
+                        parse_expression_until(parser, arena, stride_terms)
                 end block
             else
                 triplets(triplet_count)%stride_expr_index = 0
@@ -212,7 +205,8 @@ contains
                 token = parser%peek()
                 if (token%kind == TK_IDENTIFIER) then
                     if (parser%current_token + 1 <= size(parser%tokens)) then
-                        if (parser%tokens(parser%current_token + 1)%kind == TK_OPERATOR .and. &
+                        if (parser%tokens(parser%current_token + 1)%kind == &
+                            TK_OPERATOR .and. &
                             parser%tokens(parser%current_token + 1)%text == "=") then
                             cycle
                         end if
@@ -237,8 +231,7 @@ contains
         end if
 
         callbacks = build_forall_callbacks()
-        if (allocated(body_indices)) deallocate (body_indices)
-        allocate (body_indices(0))
+        body_indices = [integer ::]
 
         stmt_start = parser%current_token
         is_inline = .true.
@@ -282,9 +275,15 @@ contains
                                 body_indices = [body_indices, stmt_indices(k)]
                             end if
                         end do
-                        deallocate (stmt_indices)
+                        block
+                            integer, allocatable :: temp(:)
+                            call move_alloc(stmt_indices, temp)
+                        end block
                     end if
-                    deallocate (stmt_tokens)
+                    block
+                        type(token_t), allocatable, target :: temp(:)
+                        call move_alloc(stmt_tokens, temp)
+                    end block
                 end if
                 parser%current_token = stmt_end + 1
             end if
@@ -355,9 +354,15 @@ contains
                             body_indices = [body_indices, stmt_indices(k)]
                         end if
                     end do
-                    deallocate (stmt_indices)
+                    block
+                        integer, allocatable :: temp(:)
+                        call move_alloc(stmt_indices, temp)
+                    end block
                 end if
-                deallocate (stmt_tokens)
+                block
+                    type(token_t), allocatable, target :: temp(:)
+                    call move_alloc(stmt_tokens, temp)
+                end block
 
                 parser%current_token = stmt_end + 1
             end do
@@ -396,7 +401,8 @@ contains
                                                triplets(1)%upper_expr_index, &
                                                triplets(1)%stride_expr_index, &
                                                mask_index=mask_index, &
-                                               body_indices=body_indices, line=line, column=column, &
+                                               body_indices=body_indices, line=line, &
+                                               column=column, &
                                                index_vars_all=index_names, &
                                                start_indices_all=lower_bounds, &
                                                end_indices_all=upper_bounds, &
@@ -406,7 +412,8 @@ contains
                                                triplets(1)%lower_expr_index, &
                                                triplets(1)%upper_expr_index, &
                                                triplets(1)%stride_expr_index, &
-                                               mask_index=mask_index, line=line, column=column, &
+                                               mask_index=mask_index, line=line, &
+                                               column=column, &
                                                index_vars_all=index_names, &
                                                start_indices_all=lower_bounds, &
                                                end_indices_all=upper_bounds, &
@@ -414,13 +421,6 @@ contains
                 end if
             end if
         end if
-
-        deallocate (triplets)
-        if (allocated(body_indices)) deallocate (body_indices)
-        if (allocated(index_names)) deallocate (index_names)
-        if (allocated(lower_bounds)) deallocate (lower_bounds)
-        if (allocated(upper_bounds)) deallocate (upper_bounds)
-        if (allocated(stride_bounds)) deallocate (stride_bounds)
 
     end function parse_forall
 

--- a/src/parser/parser_if_constructs.f90
+++ b/src/parser/parser_if_constructs.f90
@@ -5,7 +5,9 @@ module parser_if_constructs_module
     use parser_state_module
     use parser_expressions_module, only: parse_expression
     use parser_statement_core_module, only: parse_basic_statement_core, &
-                                            statement_callbacks_t, null_statement_callbacks, find_statement_end, &
+                                            statement_callbacks_t, &
+                                            null_statement_callbacks, &
+                                            find_statement_end, &
                                             extend_if_statement_end
     use parser_forall_module, only: parse_forall
     use parser_select_constructs_module, only: parse_select_case
@@ -121,7 +123,8 @@ contains
                     then_token = parser%peek()
 
                     if (then_token%kind == TK_KEYWORD) then
-                        if (then_token%text == "elseif" .or. then_token%text == "else if") then
+                        if (then_token%text == "elseif" .or. then_token%text == &
+                            "else if") then
                             ! Parse elseif block
                             block
                                 integer :: elseif_pair(2)
@@ -132,8 +135,10 @@ contains
                         else if (then_token%text == "else") then
                             ! Check if next token is "if" (for "else if")
                             if (parser%current_token + 1 <= size(parser%tokens)) then
-                                if (parser%tokens(parser%current_token + 1)%kind == TK_KEYWORD .and. &
-                                    parser%tokens(parser%current_token + 1)%text == "if") then
+                                if (parser%tokens(parser%current_token + 1)%kind == &
+                                    TK_KEYWORD .and. &
+                                    parser%tokens(parser%current_token + 1)%text &
+                                    == "if") then
                                     ! Parse as elseif block
                                     block
                                         integer :: elseif_pair(2)
@@ -158,7 +163,8 @@ contains
 
                             else_body_indices = parse_if_body(parser, arena, if_index)
                             exit
-                        else if (then_token%text == "endif" .or. then_token%text == "end if") then
+                        else if (then_token%text == "endif" .or. then_token%text == &
+                                 "end if") then
                             ! End of if statement
                             then_token = parser%consume()
                             exit
@@ -276,7 +282,8 @@ contains
                 if (paren_token%kind == TK_OPERATOR .and. paren_token%text == ")") then
                     paren_token = parser%consume()  ! consume the ')'
                     exit
-                else if (paren_token%kind == TK_KEYWORD .and. paren_token%text == "then") then
+                else if (paren_token%kind == TK_KEYWORD .and. paren_token%text == &
+                         "then") then
                     exit  ! Don't consume 'then', let caller handle it
                 end if
                 paren_token = parser%consume()
@@ -392,7 +399,8 @@ contains
                     if (first_stmt_token%kind == TK_KEYWORD) then
                         if (first_stmt_token%text == "if") then
                             stmt_end = extend_if_statement_end(parser%tokens, &
-                                                               parser%current_token, stmt_end)
+                                                               parser%current_token, &
+                                                               stmt_end)
                         end if
                     end if
                     if (stmt_end < parser%current_token) then
@@ -416,11 +424,11 @@ contains
                     callbacks = build_if_body_callbacks()
                     if (present(parent_index)) then
                         stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
-                                                                  parent_index=parent_index, callbacks=callbacks, &
-                                                                  consumed_count=consumed_tokens)
+                                         parent_index=parent_index, callbacks=callbacks, &
+                                                           consumed_count=consumed_tokens)
                     else
                         stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
-                                                                  callbacks=callbacks, consumed_count=consumed_tokens)
+                                      callbacks=callbacks, consumed_count=consumed_tokens)
                     end if
 
                     if (allocated(stmt_indices) .and. size(stmt_indices) > 0) then
@@ -434,7 +442,10 @@ contains
 
                     parser%current_token = stmt_end + 1
 
-                    deallocate (stmt_tokens)
+                    block
+                        type(token_t), allocatable, target :: temp(:)
+                        call move_alloc(stmt_tokens, temp)
+                    end block
                 end block
             end do
         end block

--- a/src/parser/parser_if_statements.f90
+++ b/src/parser/parser_if_statements.f90
@@ -105,7 +105,6 @@ contains
 
         condition_parser = create_parser_state(condition_tokens)
         condition_index = parse_comparison(condition_parser, arena)
-        deallocate (condition_tokens)
     end function build_if_condition
 
     subroutine parse_then_branch(stmt_tokens, then_pos, else_pos, end_pos, arena, &
@@ -164,8 +163,6 @@ contains
 
         call allocate_if_body_tokens(stmt_tokens, start_idx, end_idx, body_tokens)
         call parse_if_body_statements(body_tokens, arena, body_indices)
-
-        if (allocated(body_tokens)) deallocate (body_tokens)
     end function parse_if_body_tokens
 
     subroutine allocate_if_body_tokens(stmt_tokens, start_idx, end_idx, body_tokens)
@@ -282,8 +279,6 @@ contains
                 body_indices = [body_indices, stmt_index]
             end if
         end if
-
-        deallocate (line_tokens)
     end subroutine parse_if_body_line
 
     subroutine skip_if_body_line_padding(line_parser)

--- a/src/parser/parser_import_resolution.f90
+++ b/src/parser/parser_import_resolution.f90
@@ -123,9 +123,6 @@ contains
             allocate (character(len=0) :: rename_list(0))
         end if
 
-        if (allocated(only_temp)) deallocate (only_temp)
-        if (allocated(rename_temp)) deallocate (rename_temp)
-
     contains
 
         subroutine ensure_only_capacity(required)
@@ -136,12 +133,11 @@ contains
             if (capacity >= required) return
             new_capacity = max(4, capacity)
             do while (new_capacity < required)
-                new_capacity = max(4, new_capacity*2)
+                new_capacity = max(4, new_capacity * 2)
             end do
             allocate (new_array(new_capacity))
             if (capacity > 0 .and. allocated(only_temp)) then
                 new_array(1:count) = only_temp(1:count)
-                deallocate (only_temp)
             end if
             call move_alloc(new_array, only_temp)
             capacity = new_capacity
@@ -155,12 +151,11 @@ contains
             if (rename_capacity >= required) return
             new_capacity = max(4, rename_capacity)
             do while (new_capacity < required)
-                new_capacity = max(4, new_capacity*2)
+                new_capacity = max(4, new_capacity * 2)
             end do
             allocate (new_array(new_capacity))
             if (rename_capacity > 0 .and. allocated(rename_temp)) then
                 new_array(1:rename_count) = rename_temp(1:rename_count)
-                deallocate (rename_temp)
             end if
             call move_alloc(new_array, rename_temp)
             rename_capacity = new_capacity
@@ -257,7 +252,12 @@ contains
         if (token%kind == TK_IDENTIFIER) then
             token = parser%consume()
             module_name = token%text
-            if (allocated(url_spec)) deallocate (url_spec)
+            if (allocated(url_spec)) then
+                block
+                    character(len=:), allocatable :: temp
+                    call move_alloc(url_spec, temp)
+                end block
+            end if
         else if (token%kind == TK_STRING) then
             ! Go-style import with URL
             token = parser%consume()

--- a/src/parser/parser_io_statements.f90
+++ b/src/parser/parser_io_statements.f90
@@ -194,12 +194,22 @@ contains
                                             end_expr_index=end_index, line=line, &
                                             column=column)
         end if
-        if (allocated(var_name)) deallocate (var_name)
+        if (allocated(var_name)) then
+            block
+                character(len=:), allocatable :: temp
+                call move_alloc(var_name, temp)
+            end block
+        end if
         return
 
     contains
         integer function fail_and_restore()
-            if (allocated(var_name)) deallocate (var_name)
+            if (allocated(var_name)) then
+                block
+                    character(len=:), allocatable :: temp
+                    call move_alloc(var_name, temp)
+                end block
+            end if
             parser%current_token = saved_pos
             fail_and_restore = 0
         end function fail_and_restore

--- a/src/parser/parser_parameter_handling.f90
+++ b/src/parser/parser_parameter_handling.f90
@@ -53,7 +53,8 @@ contains
                             if (allocated(body_node%var_names)) then
                                 if (any(body_node%var_names == param_name)) then
                                     ! Update parameter node with attributes
-                                    if (body_node%has_intent .and. allocated(body_node%intent)) then
+                                    if (body_node%has_intent .and. &
+                                        allocated(body_node%intent)) then
                                         select case (body_node%intent)
                                         case ("in")
                                             param_node%intent_type = INTENT_IN
@@ -66,7 +67,8 @@ contains
                                     param_node%is_optional = body_node%is_optional
 
                                     ! Also update type if not already set
-                                    if (param_node%type_name == "" .and. allocated(body_node%type_name)) then
+                                    if (param_node%type_name == "" .and. &
+                                        allocated(body_node%type_name)) then
                                         param_node%type_name = body_node%type_name
                                         param_node%kind_value = body_node%kind_value
                                         param_node%has_kind = body_node%has_kind
@@ -75,9 +77,11 @@ contains
                             end if
                         else
                             ! Single declaration
-                            if (allocated(body_node%var_name) .and. body_node%var_name == param_name) then
+                            if (allocated(body_node%var_name) .and. body_node%var_name &
+                                == param_name) then
                                 ! Update parameter node with attributes
-                                if (body_node%has_intent .and. allocated(body_node%intent)) then
+                                if (body_node%has_intent .and. &
+                                    allocated(body_node%intent)) then
                                     select case (body_node%intent)
                                     case ("in")
                                         param_node%intent_type = INTENT_IN
@@ -90,7 +94,8 @@ contains
                                 param_node%is_optional = body_node%is_optional
 
                                 ! Also update type if not already set
-                                if (param_node%type_name == "" .and. allocated(body_node%type_name)) then
+                                if (param_node%type_name == "" .and. &
+                                    allocated(body_node%type_name)) then
                                     param_node%type_name = body_node%type_name
                                     param_node%kind_value = body_node%kind_value
                                     param_node%has_kind = body_node%has_kind
@@ -172,7 +177,8 @@ contains
                                 paren_count = paren_count + 1
                                 type_expr = type_expr // token%text
                                 token = parser%consume()
-                            else if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                            else if (token%kind == TK_OPERATOR .and. token%text &
+                                     == ")") then
                                 paren_count = paren_count - 1
                                 if (paren_count > 0) then
                                     type_expr = type_expr // token%text
@@ -237,7 +243,8 @@ contains
                                 token = parser%consume()
                             end if
                         end if
-                    else if (token%kind == TK_KEYWORD .and. token%text == "dimension") then
+                    else if (token%kind == TK_KEYWORD .and. token%text == &
+                             "dimension") then
                         ! Skip dimension attribute for now
                         token = parser%consume()
                         token = parser%peek()
@@ -246,7 +253,8 @@ contains
                             token = parser%consume()
                             do while (.not. parser%is_at_end())
                                 token = parser%peek()
-                                if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                                if (token%kind == TK_OPERATOR .and. token%text &
+                                    == ")") then
                                     token = parser%consume()
                                     exit
                                 end if
@@ -268,7 +276,7 @@ contains
                 end if
 
                 ! Now collect all parameter names for this type
-                allocate (temp_params(0))
+                temp_params = [integer ::]
                 do while (.not. parser%is_at_end())
                     token = parser%peek()
 
@@ -293,27 +301,32 @@ contains
                                 ! Parse array dimensions
                                 do while (.not. parser%is_at_end())
                                     token = parser%peek()
-                                    if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                                    if (token%kind == TK_OPERATOR .and. token%text &
+                                        == ")") then
                                         token = parser%consume()  ! consume ')'
                                         exit
                                     end if
 
                                     ! Parse dimension expression (for now, create &
                                     ! identifier or literal nodes)
-                                    if (token%kind == TK_OPERATOR .and. token%text == ":") then
+                                    if (token%kind == TK_OPERATOR .and. token%text &
+                                        == ":") then
                                         ! Assumed shape (:)
                                         block
                                             integer :: dim_index
-                                            dim_index = push_identifier(arena, ":", token%line, token%column)
+                                            dim_index = push_identifier(arena, ":", &
+                                                                 token%line, token%column)
                                             dim_indices = [dim_indices, dim_index]
                                             dim_count = dim_count + 1
                                         end block
                                         token = parser%consume()
-                                    else if (token%kind == TK_OPERATOR .and. token%text == "*") then
+                                    else if (token%kind == TK_OPERATOR .and. token%text &
+                                             == "*") then
                                         ! Assumed size (*)
                                         block
                                             integer :: dim_index
-                                            dim_index = push_identifier(arena, "*", token%line, token%column)
+                                            dim_index = push_identifier(arena, "*", &
+                                                                 token%line, token%column)
                                             dim_indices = [dim_indices, dim_index]
                                             dim_count = dim_count + 1
                                         end block
@@ -322,8 +335,10 @@ contains
                                         ! Explicit size
                                         block
                                             integer :: dim_index
-                                            dim_index = push_literal(arena, token%text, LITERAL_INTEGER, &
-                                                                     token%line, token%column)
+                                            dim_index = push_literal(arena, token%text, &
+                                                                     LITERAL_INTEGER, &
+                                                                     token%line, &
+                                                                     token%column)
                                             dim_indices = [dim_indices, dim_index]
                                             dim_count = dim_count + 1
                                         end block
@@ -332,7 +347,8 @@ contains
                                         ! Variable size
                                         block
                                             integer :: dim_index
-                                            dim_index = push_identifier(arena, token%text, token%line, token%column)
+                                            dim_index = push_identifier(arena, &
+                                                     token%text, token%line, token%column)
                                             dim_indices = [dim_indices, dim_index]
                                             dim_count = dim_count + 1
                                         end block
@@ -344,7 +360,8 @@ contains
 
                                     ! Check for comma (more dimensions)
                                     token = parser%peek()
-                                    if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                                    if (token%kind == TK_OPERATOR .and. token%text &
+                                        == ",") then
                                         token = parser%consume()  ! consume ','
                                     end if
                                 end do
@@ -352,14 +369,16 @@ contains
 
                             ! Create parameter declaration node with array info
                             if (dim_count > 0) then
-                                param_index = push_parameter_declaration(arena, param_name, current_type, &
-                                                                         current_kind, current_intent, &
-                                                                         current_is_optional, dim_indices, line, column)
+                                param_index = push_parameter_declaration(arena, &
+                                                               param_name, current_type, &
+                                                           current_kind, current_intent, &
+                                           current_is_optional, dim_indices, line, column)
                             else
-                                param_index = push_parameter_declaration(arena, param_name, current_type, &
-                                                                         current_kind, current_intent, &
-                                                                         current_is_optional, &
-                                                                         line=line, column=column)
+                                param_index = push_parameter_declaration(arena, &
+                                                               param_name, current_type, &
+                                                           current_kind, current_intent, &
+                                                                    current_is_optional, &
+                                                                 line=line, column=column)
                             end if
                             temp_params = [temp_params, param_index]
                         end block
@@ -373,8 +392,10 @@ contains
                                     type(token_t) :: next_token
                                     next_token = parser%tokens(parser%current_token + 1)
                                     if (next_token%kind == TK_KEYWORD .and. &
-                                        (next_token%text == "real" .or. next_token%text == "integer" .or. &
-                                         next_token%text == "logical" .or. next_token%text == "character")) then
+                                        (next_token%text == "real" .or. next_token%text &
+                                         == "integer" .or. &
+                                         next_token%text == "logical" .or. &
+                                         next_token%text == "character")) then
                                         ! This comma separates different type groups
                                         exit
                                     else
@@ -400,7 +421,6 @@ contains
                 ! Add collected params to main list
                 param_indices = [param_indices, temp_params]
                 param_count = param_count + size(temp_params)
-                deallocate (temp_params)
 
             else if (token%kind == TK_IDENTIFIER .and. .not. parsing_type_spec) then
                 ! Simple parameter without explicit type

--- a/src/parser/parser_prefix_buffer.f90
+++ b/src/parser/parser_prefix_buffer.f90
@@ -28,10 +28,11 @@ contains
         class(parser_prefix_buffer_t), intent(inout) :: this
 
         call ensure_initialized()
-        if (allocated(global_prefixes)) then
-            deallocate (global_prefixes)
-        end if
-        allocate (character(len=16) :: global_prefixes(0))
+        block
+            character(len=16), allocatable :: empty(:)
+            allocate (character(len=16) :: empty(0))
+            call move_alloc(empty, global_prefixes)
+        end block
     end subroutine prefix_buffer_clear
 
     subroutine prefix_buffer_set(this, prefixes)
@@ -42,11 +43,12 @@ contains
         call this%clear()
         if (allocated(prefixes)) then
             if (size(prefixes) > 0) then
-                if (allocated(global_prefixes)) then
-                    deallocate (global_prefixes)
-                end if
-                allocate (character(len=16) :: global_prefixes(size(prefixes)))
-                global_prefixes = prefixes
+                block
+                    character(len=16), allocatable :: new_prefixes(:)
+                    allocate (character(len=16) :: new_prefixes(size(prefixes)))
+                    new_prefixes = prefixes
+                    call move_alloc(new_prefixes, global_prefixes)
+                end block
             end if
         end if
     end subroutine prefix_buffer_set

--- a/src/parser/parser_procedure_bodies.f90
+++ b/src/parser/parser_procedure_bodies.f90
@@ -191,7 +191,10 @@ contains
         ! Create subroutine node
         if (allocated(prefix_keywords)) then
             if (size(prefix_keywords) == 0) then
-                deallocate (prefix_keywords)
+                block
+                    character(len=16), allocatable :: temp(:)
+                    call move_alloc(prefix_keywords, temp)
+                end block
             end if
         end if
 
@@ -275,7 +278,7 @@ contains
             function_name = token%text
             token = parser%consume()
         else if (token%kind == TK_KEYWORD .and. keyword_can_be_function_name(parser, &
-                                                                            token)) then
+                                                                             token)) then
             function_name = token%text
             token = parser%consume()
         else

--- a/src/parser/parser_procedure_definition_bodies.f90
+++ b/src/parser/parser_procedure_definition_bodies.f90
@@ -112,8 +112,6 @@ contains
         stmt_index = parse_body_statement_tokens(stmt_tokens, stmt_size, arena)
 
         parser%current_token = stmt_end + 1
-
-        if (allocated(stmt_tokens)) deallocate (stmt_tokens)
     end subroutine parse_body_statement
 
     subroutine collect_statement_tokens(parser, first_token, stmt_tokens, stmt_size, &

--- a/src/parser/parser_select_constructs.f90
+++ b/src/parser/parser_select_constructs.f90
@@ -115,8 +115,7 @@ contains
         end do
 
         if (.not. success .or. size(value_indices) == 0) then
-            if (allocated(value_indices)) deallocate (value_indices)
-            allocate (value_indices(0))
+            value_indices = [integer ::]
             success = .false.
         end if
 
@@ -242,16 +241,12 @@ contains
                                 call parse_case_value_list(parser, arena, case_token, &
                                                            value_indices, values_ok)
                                 if (.not. values_ok) then
-                                    if (allocated(value_indices)) then
-                                        deallocate (value_indices)
-                                    end if
+                                    value_indices = [integer ::]
                                     select_index = 0
                                     return
                                 end if
                             else
-                                if (allocated(value_indices)) then
-                                    deallocate (value_indices)
-                                end if
+                                value_indices = [integer ::]
                                 select_index = 0
                                 return
                             end if
@@ -298,7 +293,8 @@ contains
                 else if (case_token%text == "end") then
                     ! Check for 'end select'
                     if (parser%current_token + 1 <= size(parser%tokens)) then
-                    if (parser%tokens(parser%current_token + 1)%kind == TK_KEYWORD .and. &
+                    if (parser%tokens(parser%current_token + 1)%kind == &
+                        TK_KEYWORD .and. &
                         parser%tokens(parser%current_token + 1)%text == "select") then
                         ! Found 'end select', consume both tokens and exit
                         case_token = parser%consume()  ! consume 'end'

--- a/src/parser/parser_statement_core.f90
+++ b/src/parser/parser_statement_core.f90
@@ -688,10 +688,7 @@ contains
         allocate (expr_tokens(remaining_count))
         expr_tokens = tokens(parser%current_token:)
         value_index = parse_expression(expr_tokens, arena)
-        if (value_index <= 0) then
-            deallocate (expr_tokens)
-            return
-        end if
+        if (value_index <= 0) return
 
         if (present(parent_index)) then
             target_index = push_identifier(arena, id_token%text, id_token%line, &
@@ -703,7 +700,6 @@ contains
 
         stmt_index = push_assignment(arena, target_index, value_index, id_token%line, &
                                      id_token%column, parent_index)
-        deallocate (expr_tokens)
     end function parse_simple_assignment
 
     integer function parse_complex_assignment(parser, arena, parent_index, tokens, &
@@ -758,11 +754,7 @@ contains
         lhs_tokens(lhs_len)%column = id_token%column
 
         target_index = parse_expression(lhs_tokens, arena)
-        if (target_index <= 0) then
-            deallocate (lhs_tokens)
-            return
-        end if
-        deallocate (lhs_tokens)
+        if (target_index <= 0) return
 
         parser%current_token = left_end + 1
         if (parser%current_token <= size(parser%tokens)) then
@@ -778,7 +770,6 @@ contains
         allocate (rhs_tokens(remaining_count))
         rhs_tokens = tokens(parser%current_token:)
         value_index = parse_expression(rhs_tokens, arena)
-        deallocate (rhs_tokens)
         if (value_index <= 0) return
 
         stmt_index = push_assignment(arena, target_index, value_index, id_token%line, &

--- a/src/parser/parser_statement_utilities.f90
+++ b/src/parser/parser_statement_utilities.f90
@@ -94,7 +94,6 @@ contains
         integer, allocatable :: extra_indices(:)
 
         call parse_assignment_statement(parser, arena, assign_index, extra_indices)
-        if (allocated(extra_indices)) deallocate (extra_indices)
     end function parse_assignment_simple
 
     ! Skip unknown statement (utility function)

--- a/src/parser/parser_utilities.f90
+++ b/src/parser/parser_utilities.f90
@@ -53,8 +53,11 @@ contains
                                 do i = 1, count
                                     new_temp_list(i) = temp_list(i)
                                 end do
-                                deallocate (temp_list)
-                                call move_alloc(new_temp_list, temp_list)
+                                block
+                                    character(len=64), allocatable :: old_temp_list(:)
+                                    call move_alloc(temp_list, old_temp_list)
+                                    call move_alloc(new_temp_list, temp_list)
+                                end block
                             end block
                         end if
 
@@ -77,7 +80,10 @@ contains
             allocate (character(len=0) :: identifier_list(0))
         end if
 
-        deallocate (temp_list)
+        block
+            character(len=64), allocatable :: old_temp_list(:)
+            if (allocated(temp_list)) call move_alloc(temp_list, old_temp_list)
+        end block
     end subroutine parse_identifier_list
 
     ! Helper to count letter ranges for allocation
@@ -153,7 +159,8 @@ contains
                     token = parser%peek()
                     if (token%kind == TK_IDENTIFIER .and. len_trim(token%text) == 1) then
                         token = parser%consume()  ! consume second letter
-                        letter_ranges(i) = trim(letter_ranges(i)) // "-" // trim(token%text)
+                        letter_ranges(i) = trim(letter_ranges(i)) // "-" // &
+                                           trim(token%text)
                     end if
                 end if
 
@@ -260,7 +267,8 @@ contains
                 if (trim(token%text) == "double") then
                     token = parser%consume()  ! consume 'double'
                     token = parser%peek()
-                    if (token%kind == TK_IDENTIFIER .and. trim(token%text) == "precision") then
+                    if (token%kind == TK_IDENTIFIER .and. trim(token%text) == &
+                        "precision") then
                         type_name = "double precision"
                     else
                         ! Put back the token


### PR DESCRIPTION
## Summary
- replace manual `deallocate` usage in parser modules with `move_alloc` or zero-length assignments so allocatables rely on scope exit cleanup
- introduce targeted helpers where needed (e.g., `reset_pending_prefixes`) to keep prefix handling logic intact while eliminating explicit frees
- reshape derived-type and attribute processing to move allocations instead of manually releasing working buffers

## Testing
- make test