### PR TITLE
fix: polish: add .fprettify.rc to codify 4-space indent standard (fixes #1512)

### DIFF
--- a/.fprettify.rc
+++ b/.fprettify.rc
@@ -1,0 +1,3 @@
+[fprettify]
+indent = 4
+line-length = 88


### PR DESCRIPTION
## Summary
- add `.fprettify.rc` so fprettify respects the repo's 4-space indent and 88-column width

## Verification
- `make test`
  - `fpm test` (pass)
