### PR TITLE
fix: polish: resolve fprettify indentation configuration mismatch (fixes #1510)

### DIFF
--- a/.fprettify
+++ b/.fprettify
@@ -1,5 +1,6 @@
 indent = 4
-line-length = 90
+line-length = 88
+strict-indent = true
 whitespace-comma = true
 whitespace-assignment = true
 whitespace-decl = true

--- a/.fprettify.rc
+++ b/.fprettify.rc
@@ -1,3 +1,19 @@
 [fprettify]
 indent = 4
 line-length = 88
+strict-indent = true
+whitespace-comma = true
+whitespace-assignment = true
+whitespace-decl = true
+whitespace-relational = true
+whitespace-logical = true
+whitespace-plusminus = true
+whitespace-multdiv = true
+whitespace-print = true
+whitespace-type = false
+whitespace-intrinsics = true
+enable-decl = true
+case = [1, 1, 1, 1]
+strip-comments = true
+comment-spacing = 2
+whitespace-concat = true


### PR DESCRIPTION
## Summary
- sync `.fprettify` and `.fprettify.rc` so both enforce the same 4-space configuration
- enable strict indentation to stop default `fprettify --diff` from proposing 3-space module bodies

## Verification
- `make test`
  - `All fortfront API arena tests passed!`
