### PR TITLE
fix: polish: split codegen_declarations module to respect size limits (fixes #1474)

### DIFF
--- a/src/codegen/codegen_declarations.f90
+++ b/src/codegen/codegen_declarations.f90
@@ -2,12 +2,15 @@ module codegen_declarations
     use codegen_declarations_subprogram_mod, only: &
         generate_code_function_def, &
         generate_code_subroutine_def
-    use codegen_declarations_declaration_mod, only: &
+    use codegen_declarations_variable_mod, only: &
         generate_code_declaration, &
-        generate_code_parameter_declaration, &
-        generate_code_module, &
+        generate_code_parameter_declaration
+    use codegen_declarations_module_mod, only: &
+        generate_code_module
+    use codegen_declarations_interface_mod, only: &
         generate_code_interface_block, &
-        generate_code_module_procedure, &
+        generate_code_module_procedure
+    use codegen_declarations_type_mod, only: &
         generate_code_derived_type
     use codegen_declarations_program_mod, only: &
         generate_code_program

--- a/src/codegen/codegen_declarations_interface_mod.f90
+++ b/src/codegen/codegen_declarations_interface_mod.f90
@@ -1,0 +1,60 @@
+module codegen_declarations_interface_mod
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_misc, only: interface_block_node, module_procedure_node
+    use codegen_utilities, only: generate_grouped_body
+    implicit none
+    private
+    public :: generate_code_interface_block
+    public :: generate_code_module_procedure
+
+contains
+
+    function generate_code_interface_block(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(interface_block_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+        character(len=:), allocatable :: body_code
+
+        code = "interface"
+        if (allocated(node%name)) then
+            if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
+        end if
+        code = code // new_line('A')
+
+        if (allocated(node%procedure_indices)) then
+            body_code = generate_grouped_body(arena, node%procedure_indices, 1)
+            if (len(body_code) > 0) code = code // body_code
+        end if
+
+        code = code // "end interface"
+        if (allocated(node%name)) then
+            if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
+        end if
+    end function generate_code_interface_block
+
+    function generate_code_module_procedure(node) result(code)
+        type(module_procedure_node), intent(in) :: node
+        character(len=:), allocatable :: code
+        integer :: i
+        character(len=:), allocatable :: name_text
+        logical :: first_name
+
+        code = "module procedure"
+        first_name = .true.
+        if (allocated(node%procedure_names)) then
+            do i = 1, size(node%procedure_names)
+                if (.not. allocated(node%procedure_names(i)%s)) cycle
+                name_text = trim(node%procedure_names(i)%s)
+                if (len_trim(name_text) == 0) cycle
+                if (first_name) then
+                    code = code // " " // name_text
+                    first_name = .false.
+                else
+                    code = code // ", " // name_text
+                end if
+            end do
+        end if
+    end function generate_code_module_procedure
+
+end module codegen_declarations_interface_mod

--- a/src/codegen/codegen_declarations_module_mod.f90
+++ b/src/codegen/codegen_declarations_module_mod.f90
@@ -1,0 +1,136 @@
+module codegen_declarations_module_mod
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_data, only: module_node
+    use ast_nodes_core, only: literal_node
+    use ast_nodes_misc, only: implicit_statement_node
+    use codegen_utilities, only: generate_grouped_body
+    use codegen_arena_interface, only: generate_code_from_arena
+    implicit none
+    private
+    public :: generate_code_module
+
+contains
+
+    function generate_code_module(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(module_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+
+        code = build_module_header(arena, node)
+        code = code // collect_module_declarations(arena, node)
+        code = code // build_contains_section(arena, node)
+        code = code // "end module " // node%name
+    end function generate_code_module
+
+    function build_module_header(arena, node) result(header)
+        type(ast_arena_t), intent(in) :: arena
+        type(module_node), intent(in) :: node
+        character(len=:), allocatable :: header
+
+        header = "module " // node%name // new_line('A')
+        if (.not. module_has_implicit_none(arena, node)) then
+            header = header // "    implicit none" // new_line('A')
+        end if
+    end function build_module_header
+
+    logical function module_has_implicit_none(arena, node) result(has_implicit)
+        type(ast_arena_t), intent(in) :: arena
+        type(module_node), intent(in) :: node
+        integer :: i
+        integer :: decl_index
+
+        has_implicit = .false.
+        if (.not. allocated(node%declaration_indices)) return
+
+        do i = 1, size(node%declaration_indices)
+            decl_index = node%declaration_indices(i)
+            if (decl_index <= 0 .or. decl_index > arena%size) cycle
+            if (.not. allocated(arena%entries(decl_index)%node)) cycle
+
+            select type (decl => arena%entries(decl_index)%node)
+            type is (implicit_statement_node)
+                if (decl%is_none) then
+                    has_implicit = .true.
+                    return
+                end if
+            type is (literal_node)
+                if (allocated(decl%value)) then
+                    if (index(decl%value, "implicit none") > 0) then
+                        has_implicit = .true.
+                        return
+                    end if
+                end if
+            end select
+        end do
+    end function module_has_implicit_none
+
+    function collect_module_declarations(arena, node) result(body_code)
+        type(ast_arena_t), intent(in) :: arena
+        type(module_node), intent(in) :: node
+        character(len=:), allocatable :: body_code
+
+        if (.not. allocated(node%declaration_indices)) then
+            body_code = ""
+            return
+        end if
+
+        body_code = generate_grouped_body(arena, node%declaration_indices, 1)
+    end function collect_module_declarations
+
+    function build_contains_section(arena, node) result(section_code)
+        type(ast_arena_t), intent(in) :: arena
+        type(module_node), intent(in) :: node
+        character(len=:), allocatable :: section_code
+        character(len=:), allocatable :: procedure_code
+        integer :: i
+        logical :: has_entries
+        logical :: has_more
+
+        section_code = ""
+        has_entries = .false.
+
+        if (.not. node%has_contains) return
+        if (.not. allocated(node%procedure_indices)) return
+
+        section_code = "contains" // new_line('A')
+
+        do i = 1, size(node%procedure_indices)
+            procedure_code = collect_contained_procedure(arena, &
+                                                         node%procedure_indices(i))
+            if (len(procedure_code) == 0) cycle
+            has_entries = .true.
+            has_more = i < size(node%procedure_indices)
+            section_code = section_code // format_contained_procedure( &
+                           procedure_code, has_more)
+        end do
+
+        if (.not. has_entries) section_code = ""
+    end function build_contains_section
+
+    function collect_contained_procedure(arena, procedure_index) result(proc_code)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: procedure_index
+        character(len=:), allocatable :: proc_code
+
+        proc_code = ""
+        if (procedure_index <= 0 .or. procedure_index > arena%size) return
+        if (.not. allocated(arena%entries(procedure_index)%node)) return
+
+        proc_code = generate_code_from_arena(arena, procedure_index)
+    end function collect_contained_procedure
+
+    function format_contained_procedure(proc_code, has_more) result(formatted)
+        character(len=*), intent(in) :: proc_code
+        logical, intent(in) :: has_more
+        character(len=:), allocatable :: formatted
+
+        formatted = "    " // proc_code
+        if (has_more) then
+            formatted = formatted // new_line('A') // new_line('A')
+        else
+            formatted = formatted // new_line('A')
+        end if
+    end function format_contained_procedure
+
+end module codegen_declarations_module_mod

--- a/src/codegen/codegen_declarations_type_mod.f90
+++ b/src/codegen/codegen_declarations_type_mod.f90
@@ -1,0 +1,91 @@
+module codegen_declarations_type_mod
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_data, only: derived_type_node
+    use codegen_arena_interface, only: generate_code_from_arena
+    implicit none
+    private
+    public :: generate_code_derived_type
+
+contains
+
+    function generate_code_derived_type(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(derived_type_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+
+        code = build_derived_type_header(node)
+        code = code // collect_derived_components(arena, node)
+        code = code // "end type " // node%name
+    end function generate_code_derived_type
+
+    function build_derived_type_header(node) result(header)
+        type(derived_type_node), intent(in) :: node
+        character(len=:), allocatable :: header
+        character(len=:), allocatable :: clause
+
+        clause = derived_type_attribute_clause(node)
+        if (len_trim(clause) == 0) then
+            header = "type :: " // node%name // new_line('A')
+        else if (clause(1:1) == ",") then
+            header = "type" // clause // " :: " // node%name // new_line('A')
+        else
+            header = "type " // trim(clause) // " :: " // node%name // new_line('A')
+        end if
+    end function build_derived_type_header
+
+    function derived_type_attribute_clause(node) result(clause)
+        type(derived_type_node), intent(in) :: node
+        character(len=:), allocatable :: clause
+        integer :: i
+        integer :: trimmed_length
+
+        clause = ""
+        if (.not. node%has_attributes) return
+        if (.not. allocated(node%attribute_clause)) return
+
+        trimmed_length = len_trim(node%attribute_clause)
+        if (trimmed_length == 0) return
+
+        clause = ""
+        do i = 1, trimmed_length
+            clause = clause // node%attribute_clause(i:i)
+            if (node%attribute_clause(i:i) == "," .and. i < trimmed_length) then
+                if (node%attribute_clause(i + 1:i + 1) /= " " .and. &
+                    node%attribute_clause(i + 1:i + 1) /= new_line('A')) then
+                    clause = clause // " "
+                end if
+            end if
+        end do
+    end function derived_type_attribute_clause
+
+    function collect_derived_components(arena, node) result(component_block)
+        type(ast_arena_t), intent(in) :: arena
+        type(derived_type_node), intent(in) :: node
+        character(len=:), allocatable :: component_block
+        character(len=:), allocatable :: component_code
+        integer :: i
+        integer :: component_index
+
+        component_block = ""
+        if (.not. allocated(node%component_indices)) return
+
+        do i = 1, size(node%component_indices)
+            component_index = node%component_indices(i)
+            if (component_index <= 0 .or. component_index > arena%size) cycle
+            if (.not. allocated(arena%entries(component_index)%node)) cycle
+
+            select type (child => arena%entries(component_index)%node)
+            type is (derived_type_node)
+                cycle
+            class default
+                component_code = generate_code_from_arena(arena, component_index)
+            end select
+
+            if (len_trim(component_code) == 0) cycle
+            component_block = component_block // "    " // component_code // &
+                              new_line('A')
+        end do
+    end function collect_derived_components
+
+end module codegen_declarations_type_mod

--- a/src/codegen/codegen_declarations_variable_mod.f90
+++ b/src/codegen/codegen_declarations_variable_mod.f90
@@ -1,15 +1,13 @@
-module codegen_declarations_declaration_mod
+module codegen_declarations_variable_mod
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_data, only: declaration_node, parameter_declaration_node, &
-                              derived_type_node, intent_type_to_string, module_node
-    use ast_nodes_misc, only: contains_node, comment_node, blank_line_node, &
-                              implicit_statement_node, interface_block_node, &
-                              module_procedure_node, use_statement_node
-    use ast_nodes_core, only: literal_node
+                              intent_type_to_string
     use string_utils_mod, only: int_to_string, to_lower
-    use type_system_unified
-    use codegen_utilities, only: generate_grouped_body, is_character_type_string, &
-                                 normalize_character_type, normalize_character_type_param
+    use type_system_unified, only: TINT, TREAL, TCHAR, TLOGICAL, TCOMPLEX, &
+                                   TDOUBLE, TDERIVED
+    use codegen_utilities, only: is_character_type_string, &
+                                 normalize_character_type, &
+                                 normalize_character_type_param
     use codegen_arena_interface, only: generate_code_from_arena
     use codegen_type_utils, only: get_type_standardization
     use declaration_attribute_utils, only: declaration_attribute_info_t, &
@@ -21,14 +19,9 @@ module codegen_declarations_declaration_mod
     private
     public :: generate_code_declaration
     public :: generate_code_parameter_declaration
-    public :: generate_code_module
-    public :: generate_code_interface_block
-    public :: generate_code_module_procedure
-    public :: generate_code_derived_type
 
 contains
 
-    ! Generate code for declarations
     function generate_code_declaration(arena, node, node_index) result(code)
         type(ast_arena_t), intent(in) :: arena
         type(declaration_node), intent(in) :: node
@@ -54,7 +47,8 @@ contains
         code = fix_character_len_placeholder(code)
     end function generate_code_declaration
 
-    function resolve_declaration_type(node, standardize_types_enabled) result(type_str)
+    function resolve_declaration_type(node, standardize_types_enabled) &
+        result(type_str)
         type(declaration_node), intent(in) :: node
         logical, intent(in) :: standardize_types_enabled
         character(len=:), allocatable :: type_str
@@ -207,8 +201,8 @@ contains
                 entities = entities // trim(node%var_names(i))
                 if (node%is_array .and. allocated(node%dimension_indices)) then
                     if (.not. has_dimension_attr) then
-                        entities = trim(entities) // &
-                                   build_dimension_clause(arena, node%dimension_indices)
+                        entities = trim(entities) // build_dimension_clause( &
+                                   arena, node%dimension_indices)
                     end if
                 end if
             end do
@@ -216,8 +210,8 @@ contains
             entities = node%var_name
             if (node%is_array .and. allocated(node%dimension_indices)) then
                 if (.not. has_dimension_attr) then
-                    entities = trim(entities) // &
-                               build_dimension_clause(arena, node%dimension_indices)
+                    entities = trim(entities) // build_dimension_clause( &
+                               arena, node%dimension_indices)
                 end if
             end if
         end if
@@ -227,7 +221,8 @@ contains
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: dimension_indices(:)
         character(len=:), allocatable :: clause
-        integer :: i, dim_index
+        integer :: i
+        integer :: dim_index
 
         if (size(dimension_indices) == 0) then
             clause = ""
@@ -271,8 +266,8 @@ contains
         end if
     end function build_declaration_initializer
 
-    ! Generate code for parameter declarations
-    function generate_code_parameter_declaration(arena, node, node_index) result(code)
+    function generate_code_parameter_declaration(arena, node, node_index) &
+        result(code)
         type(ast_arena_t), intent(in) :: arena
         type(parameter_declaration_node), intent(in) :: node
         integer, intent(in) :: node_index
@@ -347,6 +342,7 @@ contains
         type(parameter_declaration_node), intent(in) :: node
         character(len=:), allocatable :: dim_clause
         integer :: j
+        integer :: dim_index
 
         dim_clause = ""
 
@@ -356,258 +352,10 @@ contains
         dim_clause = "("
         do j = 1, size(node%dimension_indices)
             if (j > 1) dim_clause = dim_clause // ", "
-            dim_clause = dim_clause // generate_code_from_arena(arena, &
-                                                                node%dimension_indices(j))
+            dim_index = node%dimension_indices(j)
+            dim_clause = dim_clause // generate_code_from_arena(arena, dim_index)
         end do
         dim_clause = dim_clause // ")"
     end function build_parameter_dimensions
 
-    ! Generate code for modules
-    function generate_code_module(arena, node, node_index) result(code)
-        type(ast_arena_t), intent(in) :: arena
-        type(module_node), intent(in) :: node
-        integer, intent(in) :: node_index
-        character(len=:), allocatable :: code
-
-        code = build_module_header(arena, node)
-        code = code // collect_module_declarations(arena, node)
-        code = code // build_contains_section(arena, node)
-        code = code // "end module " // node%name
-    end function generate_code_module
-
-    function build_module_header(arena, node) result(header)
-        type(ast_arena_t), intent(in) :: arena
-        type(module_node), intent(in) :: node
-        character(len=:), allocatable :: header
-
-        header = "module " // node%name // new_line('A')
-        if (.not. module_has_implicit_none(arena, node)) then
-            header = header // "    implicit none" // new_line('A')
-        end if
-    end function build_module_header
-
-    logical function module_has_implicit_none(arena, node) result(has_implicit)
-        type(ast_arena_t), intent(in) :: arena
-        type(module_node), intent(in) :: node
-        integer :: i, decl_index
-
-        has_implicit = .false.
-        if (.not. allocated(node%declaration_indices)) return
-
-        do i = 1, size(node%declaration_indices)
-            decl_index = node%declaration_indices(i)
-            if (decl_index <= 0 .or. decl_index > arena%size) cycle
-            if (.not. allocated(arena%entries(decl_index)%node)) cycle
-
-            select type (decl => arena%entries(decl_index)%node)
-            type is (implicit_statement_node)
-                if (decl%is_none) then
-                    has_implicit = .true.
-                    return
-                end if
-            type is (literal_node)
-                if (allocated(decl%value)) then
-                    if (index(decl%value, 'implicit none') > 0) then
-                        has_implicit = .true.
-                        return
-                    end if
-                end if
-            end select
-        end do
-    end function module_has_implicit_none
-
-    function collect_module_declarations(arena, node) result(body_code)
-        type(ast_arena_t), intent(in) :: arena
-        type(module_node), intent(in) :: node
-        character(len=:), allocatable :: body_code
-
-        if (.not. allocated(node%declaration_indices)) then
-            body_code = ""
-            return
-        end if
-
-        body_code = generate_grouped_body(arena, node%declaration_indices, 1)
-    end function collect_module_declarations
-
-    function build_contains_section(arena, node) result(section_code)
-        type(ast_arena_t), intent(in) :: arena
-        type(module_node), intent(in) :: node
-        character(len=:), allocatable :: section_code
-        character(len=:), allocatable :: procedure_code
-        integer :: i
-        logical :: has_entries
-        logical :: has_more
-
-        section_code = ""
-        has_entries = .false.
-
-        if (.not. node%has_contains) return
-        if (.not. allocated(node%procedure_indices)) return
-
-        section_code = "contains" // new_line('A')
-
-        do i = 1, size(node%procedure_indices)
-            procedure_code = collect_contained_procedure(arena, &
-                                                         node%procedure_indices(i))
-            if (len(procedure_code) == 0) cycle
-            has_entries = .true.
-            has_more = i < size(node%procedure_indices)
-            section_code = section_code // format_contained_procedure( &
-                           procedure_code, has_more)
-        end do
-
-        if (.not. has_entries) section_code = ""
-    end function build_contains_section
-
-    function collect_contained_procedure(arena, procedure_index) result(proc_code)
-        type(ast_arena_t), intent(in) :: arena
-        integer, intent(in) :: procedure_index
-        character(len=:), allocatable :: proc_code
-
-        proc_code = ""
-        if (procedure_index <= 0 .or. procedure_index > arena%size) return
-        if (.not. allocated(arena%entries(procedure_index)%node)) return
-
-        proc_code = generate_code_from_arena(arena, procedure_index)
-    end function collect_contained_procedure
-
-    function format_contained_procedure(proc_code, has_more) result(formatted)
-        character(len=*), intent(in) :: proc_code
-        logical, intent(in) :: has_more
-        character(len=:), allocatable :: formatted
-
-        formatted = "    " // proc_code
-        if (has_more) then
-            formatted = formatted // new_line('A') // new_line('A')
-        else
-            formatted = formatted // new_line('A')
-        end if
-    end function format_contained_procedure
-
-    function generate_code_interface_block(arena, node, node_index) result(code)
-        type(ast_arena_t), intent(in) :: arena
-        type(interface_block_node), intent(in) :: node
-        integer, intent(in) :: node_index
-        character(len=:), allocatable :: code
-        character(len=:), allocatable :: body_code
-
-        code = "interface"
-        if (allocated(node%name)) then
-            if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
-        end if
-        code = code // new_line('A')
-
-        if (allocated(node%procedure_indices)) then
-            body_code = generate_grouped_body(arena, node%procedure_indices, 1)
-            if (len(body_code) > 0) code = code // body_code
-        end if
-
-        code = code // "end interface"
-        if (allocated(node%name)) then
-            if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
-        end if
-    end function generate_code_interface_block
-
-    function generate_code_module_procedure(node) result(code)
-        type(module_procedure_node), intent(in) :: node
-        character(len=:), allocatable :: code
-        integer :: i
-        character(len=:), allocatable :: name_text
-        logical :: first_name
-
-        code = "module procedure"
-        first_name = .true.
-        if (allocated(node%procedure_names)) then
-            do i = 1, size(node%procedure_names)
-                if (.not. allocated(node%procedure_names(i)%s)) cycle
-                name_text = trim(node%procedure_names(i)%s)
-                if (len_trim(name_text) == 0) cycle
-                if (first_name) then
-                    code = code // " " // name_text
-                    first_name = .false.
-                else
-                    code = code // ", " // name_text
-                end if
-            end do
-        end if
-    end function generate_code_module_procedure
-
-    ! Generate code for derived types
-    function generate_code_derived_type(arena, node, node_index) result(code)
-        type(ast_arena_t), intent(in) :: arena
-        type(derived_type_node), intent(in) :: node
-        integer, intent(in) :: node_index
-        character(len=:), allocatable :: code
-
-        code = build_derived_type_header(node)
-        code = code // collect_derived_components(arena, node)
-        code = code // "end type " // node%name
-    end function generate_code_derived_type
-
-    function build_derived_type_header(node) result(header)
-        type(derived_type_node), intent(in) :: node
-        character(len=:), allocatable :: header
-        character(len=:), allocatable :: clause
-
-        clause = derived_type_attribute_clause(node)
-        if (len_trim(clause) == 0) then
-            header = "type :: " // node%name // new_line('A')
-        else if (clause(1:1) == ",") then
-            header = "type" // clause // " :: " // node%name // new_line('A')
-        else
-            header = "type " // trim(clause) // " :: " // node%name // new_line('A')
-        end if
-    end function build_derived_type_header
-
-    function derived_type_attribute_clause(node) result(clause)
-        type(derived_type_node), intent(in) :: node
-        character(len=:), allocatable :: clause
-        integer :: i, trimmed_length
-
-        clause = ""
-        if (.not. node%has_attributes) return
-        if (.not. allocated(node%attribute_clause)) return
-
-        trimmed_length = len_trim(node%attribute_clause)
-        if (trimmed_length == 0) return
-
-        clause = ""
-        do i = 1, trimmed_length
-            clause = clause // node%attribute_clause(i:i)
-            if (node%attribute_clause(i:i) == "," .and. i < trimmed_length) then
-                if (node%attribute_clause(i + 1:i + 1) /= " " .and. &
-                    node%attribute_clause(i + 1:i + 1) /= new_line('A')) then
-                    clause = clause // " "
-                end if
-            end if
-        end do
-    end function derived_type_attribute_clause
-
-    function collect_derived_components(arena, node) result(component_block)
-        type(ast_arena_t), intent(in) :: arena
-        type(derived_type_node), intent(in) :: node
-        character(len=:), allocatable :: component_block
-        character(len=:), allocatable :: component_code
-        integer :: i, component_index
-
-        component_block = ""
-        if (.not. allocated(node%component_indices)) return
-
-        do i = 1, size(node%component_indices)
-            component_index = node%component_indices(i)
-            if (component_index <= 0 .or. component_index > arena%size) cycle
-            if (.not. allocated(arena%entries(component_index)%node)) cycle
-
-            select type (child => arena%entries(component_index)%node)
-            type is (derived_type_node)
-                cycle
-            class default
-                component_code = generate_code_from_arena(arena, component_index)
-            end select
-
-            if (len_trim(component_code) == 0) cycle
-            component_block = component_block // "    " // component_code // &
-                              new_line('A')
-        end do
-    end function collect_derived_components
-end module codegen_declarations_declaration_mod
+end module codegen_declarations_variable_mod


### PR DESCRIPTION
## Summary
- split the declaration codegen responsibilities into variable, module, interface, and type modules, keeping each under the 500 line target
- update the `codegen_declarations` facade to re-export the new modules without changing call sites

## Verification
- make test
  - All fortfront API integration tests passed
