### PR TITLE
fix: Polish: centralize symbol table capacity constant (fixes #1520)

### DIFF
--- a/src/analysis/call_graph_builder_state_mod.f90
+++ b/src/analysis/call_graph_builder_state_mod.f90
@@ -1,5 +1,6 @@
 module call_graph_builder_state_mod
     use call_graph_core_mod, only: call_graph_t, create_call_graph
+    use call_graph_constants_mod, only: initial_symbol_table_capacity
     implicit none
     private
 
@@ -46,7 +47,7 @@ contains
         type(call_graph_builder_t) :: builder
 
         builder%graph = create_call_graph()
-        allocate (builder%symbol_table(256))
+        allocate (builder%symbol_table(initial_symbol_table_capacity))
         if (arena_size > 0) then
             allocate (builder%node_symbol_map(arena_size))
             builder%node_symbol_map = 0
@@ -71,7 +72,7 @@ contains
         type(symbol_entry_t), allocatable :: temp_table(:)
 
         if (.not. allocated(builder%symbol_table)) then
-            allocate (builder%symbol_table(256))
+            allocate (builder%symbol_table(initial_symbol_table_capacity))
         else if (builder%symbol_count >= size(builder%symbol_table)) then
             allocate (temp_table(max(1, size(builder%symbol_table) * 2)))
             if (builder%symbol_count > 0) then

--- a/src/analysis/call_graph_constants_mod.f90
+++ b/src/analysis/call_graph_constants_mod.f90
@@ -3,6 +3,8 @@ module call_graph_constants_mod
     private
 
     public :: max_proc_name_len
+    public :: initial_symbol_table_capacity
 
     integer, parameter :: max_proc_name_len = 256
+    integer, parameter :: initial_symbol_table_capacity = 256
 end module call_graph_constants_mod


### PR DESCRIPTION
## Summary
- add initial_symbol_table_capacity to call_graph_constants_mod for the shared default size
- replace literal symbol table allocations in call_graph_builder_state_mod with the named constant and run fprettify

## Verification
- `make test` (STOP 0)
