### PR TITLE
fix: polish: refactor parse_declaration_attributes to meet 50-line so (fixes #1529)

### DIFF
--- a/src/parser/parser_declarations_core_module.f90
+++ b/src/parser/parser_declarations_core_module.f90
@@ -30,84 +30,147 @@ contains
         type(ast_arena_t), intent(inout) :: arena
         type(declaration_attribute_info_t), intent(out) :: attr_info
 
+        logical :: handled_attribute
         type(token_t) :: token
 
         call reset_declaration_attributes(attr_info)
 
-        ! Parse basic attributes (simplified)
         do while (.not. parser%is_at_end())
             token = parser%peek()
-            if (token%text == ",") then
-                token = parser%consume()
-                token = parser%peek()
+            if (token%text /= ",") then
+                exit
+            end if
 
-                select case (token%text)
-                case ("allocatable")
-                    attr_info%is_allocatable = .true.
-                    token = parser%consume()
-                case ("pointer")
-                    attr_info%is_pointer = .true.
-                    token = parser%consume()
-                case ("parameter")
-                    attr_info%is_parameter = .true.
-                    token = parser%consume()
-                case ("external")
-                    attr_info%is_external = .true.
-                    token = parser%consume()
-                case ("dimension")
-                    token = parser%consume()
-                    if (.not. parser%is_at_end()) then
-                        token = parser%peek()
-                        if (token%text == "(") then
-                            token = parser%consume()  ! consume '('
-                            call parse_array_dimensions( &
-                                parser, arena, attr_info%global_dimension_indices)
-                            attr_info%has_global_dimensions = .true.
-                        end if
-                    end if
-                case ("intent")
-                    token = parser%consume()  ! consume 'intent'
-                    if (.not. parser%is_at_end()) then
-                        token = parser%peek()
-                        if (token%text == "(") then
-                            token = parser%consume()  ! consume '('
-                            if (.not. parser%is_at_end()) then
-                                token = parser%peek()
-                                select case (token%text)
-                                case ("in")
-                                    call set_declaration_intent(attr_info, "in")
-                                    token = parser%consume()
-                                case ("out")
-                                    call set_declaration_intent(attr_info, "out")
-                                    token = parser%consume()
-                                case ("inout")
-                                    call set_declaration_intent(attr_info, "inout")
-                                    token = parser%consume()
-                                end select
-                                ! consume closing paren
-                                if (.not. parser%is_at_end()) then
-                                    token = parser%peek()
-                                    if (token%text == ")") then
-                                        token = parser%consume()
-                                    end if
-                                end if
-                            end if
-                        end if
-                    end if
-                case ("optional")
-                    attr_info%is_optional = .true.
-                    token = parser%consume()
-                case ("target")
-                    attr_info%is_target = .true.
-                    token = parser%consume()
-                case default
-                    exit
-                end select
-            else
+            token = parser%consume()
+            handled_attribute = parse_single_declaration_attribute(parser, &
+                                                                   arena, attr_info)
+            if (.not. handled_attribute) then
                 exit
             end if
         end do
     end subroutine parse_declaration_attributes
+
+    logical function parse_single_declaration_attribute(parser, arena, attr_info) &
+        result(handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(declaration_attribute_info_t), intent(inout) :: attr_info
+
+        type(token_t) :: token
+
+        handled = .false.
+
+        if (parser%is_at_end()) then
+            return
+        end if
+
+        token = parser%peek()
+
+        select case (token%text)
+        case ("allocatable")
+            attr_info%is_allocatable = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("pointer")
+            attr_info%is_pointer = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("parameter")
+            attr_info%is_parameter = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("external")
+            attr_info%is_external = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("dimension")
+            token = parser%consume()
+            call handle_dimension_attribute(parser, arena, attr_info, handled)
+        case ("intent")
+            token = parser%consume()
+            call handle_intent_attribute(parser, attr_info, handled)
+        case ("optional")
+            attr_info%is_optional = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("target")
+            attr_info%is_target = .true.
+            token = parser%consume()
+            handled = .true.
+        case default
+            handled = .false.
+        end select
+    end function parse_single_declaration_attribute
+
+    subroutine handle_dimension_attribute(parser, arena, attr_info, handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(declaration_attribute_info_t), intent(inout) :: attr_info
+        logical, intent(out) :: handled
+
+        type(token_t) :: token
+
+        handled = .true.
+
+        if (parser%is_at_end()) then
+            return
+        end if
+
+        token = parser%peek()
+        if (token%text /= "(") then
+            return
+        end if
+
+        token = parser%consume()
+        call parse_array_dimensions(parser, arena, attr_info%global_dimension_indices)
+        attr_info%has_global_dimensions = .true.
+    end subroutine handle_dimension_attribute
+
+    subroutine handle_intent_attribute(parser, attr_info, handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(declaration_attribute_info_t), intent(inout) :: attr_info
+        logical, intent(out) :: handled
+
+        type(token_t) :: token
+
+        handled = .true.
+
+        if (parser%is_at_end()) then
+            return
+        end if
+
+        token = parser%peek()
+        if (token%text /= "(") then
+            return
+        end if
+
+        token = parser%consume()
+        if (parser%is_at_end()) then
+            return
+        end if
+
+        token = parser%peek()
+        select case (token%text)
+        case ("in")
+            call set_declaration_intent(attr_info, "in")
+            token = parser%consume()
+        case ("out")
+            call set_declaration_intent(attr_info, "out")
+            token = parser%consume()
+        case ("inout")
+            call set_declaration_intent(attr_info, "inout")
+            token = parser%consume()
+        case default
+            return
+        end select
+
+        if (.not. parser%is_at_end()) then
+            token = parser%peek()
+            if (token%text == ")") then
+                token = parser%consume()
+            end if
+        end if
+    end subroutine handle_intent_attribute
 
     function parse_declaration(parser, arena) result(decl_index)
         type(parser_state_t), intent(inout) :: parser


### PR DESCRIPTION
## Summary
- extract helper routines for dimension and intent parsing to shrink `parse_declaration_attributes`
- reuse shared dispatcher for simple attribute flags without changing behavior

## Verification
- `make test`
  - All fortfront API integration tests passed
  - All multi-parameter intent tests completed
- Artifacts: n/a (behavior-preserving refactor)
