### PR TITLE
fix: polish: refactor parse_declaration_attributes to meet 50-line so (fixes #1522)

### DIFF
--- a/src/parser/parser_declaration_attributes_module.f90
+++ b/src/parser/parser_declaration_attributes_module.f90
@@ -1,0 +1,205 @@
+module parser_declaration_attributes_module
+    use lexer_core, only: token_t
+    use parser_state_module, only: parser_state_t
+    use ast_arena_modern, only: ast_arena_t
+    use parser_expressions_module, only: parse_range
+    use declaration_attribute_utils, only: declaration_attribute_info_t, &
+                                           reset_declaration_attributes, &
+                                           set_declaration_intent
+    implicit none
+    private
+
+    public :: parse_declaration_attributes
+    public :: parse_array_dimensions
+
+contains
+
+    subroutine parse_declaration_attributes(parser, arena, attr_info)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(declaration_attribute_info_t), intent(out) :: attr_info
+
+        logical :: handled_attribute
+        type(token_t) :: token
+        call reset_declaration_attributes(attr_info)
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%text /= ",") then
+                exit
+            end if
+
+            token = parser%consume()
+            handled_attribute = parse_single_declaration_attribute(parser, &
+                                                                   arena, attr_info)
+            if (.not. handled_attribute) then
+                exit
+            end if
+        end do
+    end subroutine parse_declaration_attributes
+
+    logical function parse_single_declaration_attribute(parser, arena, attr_info) &
+        result(handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(declaration_attribute_info_t), intent(inout) :: attr_info
+
+        type(token_t) :: token
+
+        handled = .false.
+
+        if (parser%is_at_end()) then
+            return
+        end if
+
+        token = parser%peek()
+
+        select case (token%text)
+        case ("allocatable")
+            attr_info%is_allocatable = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("pointer")
+            attr_info%is_pointer = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("parameter")
+            attr_info%is_parameter = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("external")
+            attr_info%is_external = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("dimension")
+            token = parser%consume()
+            call handle_dimension_attribute(parser, arena, attr_info, handled)
+        case ("intent")
+            token = parser%consume()
+            call handle_intent_attribute(parser, attr_info, handled)
+        case ("optional")
+            attr_info%is_optional = .true.
+            token = parser%consume()
+            handled = .true.
+        case ("target")
+            attr_info%is_target = .true.
+            token = parser%consume()
+            handled = .true.
+        case default
+            handled = .false.
+        end select
+    end function parse_single_declaration_attribute
+
+    subroutine handle_dimension_attribute(parser, arena, attr_info, handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(declaration_attribute_info_t), intent(inout) :: attr_info
+        logical, intent(out) :: handled
+
+        type(token_t) :: token
+
+        handled = .true.
+
+        if (parser%is_at_end()) then
+            return
+        end if
+
+        token = parser%peek()
+        if (token%text /= "(") then
+            return
+        end if
+
+        token = parser%consume()
+        call parse_array_dimensions(parser, arena, attr_info%global_dimension_indices)
+        attr_info%has_global_dimensions = .true.
+    end subroutine handle_dimension_attribute
+
+    subroutine handle_intent_attribute(parser, attr_info, handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(declaration_attribute_info_t), intent(inout) :: attr_info
+        logical, intent(out) :: handled
+
+        type(token_t) :: token
+
+        handled = .true.
+
+        if (parser%is_at_end()) then
+            return
+        end if
+
+        token = parser%peek()
+        if (token%text /= "(") then
+            return
+        end if
+
+        token = parser%consume()
+        if (parser%is_at_end()) then
+            return
+        end if
+
+        token = parser%peek()
+        select case (token%text)
+        case ("in")
+            call set_declaration_intent(attr_info, "in")
+            token = parser%consume()
+        case ("out")
+            call set_declaration_intent(attr_info, "out")
+            token = parser%consume()
+        case ("inout")
+            call set_declaration_intent(attr_info, "inout")
+            token = parser%consume()
+        case default
+            return
+        end select
+
+        if (.not. parser%is_at_end()) then
+            token = parser%peek()
+            if (token%text == ")") then
+                token = parser%consume()
+            end if
+        end if
+    end subroutine handle_intent_attribute
+
+    subroutine parse_array_dimensions(parser, arena, dimension_indices)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, allocatable, intent(out) :: dimension_indices(:)
+
+        integer, parameter :: max_dims = 10
+        integer :: temp_indices(max_dims)
+        integer :: dim_count
+        integer :: range_index
+        type(token_t) :: token
+
+        dim_count = 0
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%text == ")") then
+                token = parser%consume()
+                exit
+            end if
+
+            range_index = parse_range(parser, arena)
+            if (range_index > 0 .and. dim_count < max_dims) then
+                dim_count = dim_count + 1
+                temp_indices(dim_count) = range_index
+            end if
+
+            token = parser%peek()
+            if (token%text == ",") then
+                token = parser%consume()
+            else if (token%text /= ")") then
+                exit
+            end if
+        end do
+
+        if (dim_count > 0) then
+            allocate (dimension_indices(dim_count))
+            dimension_indices = temp_indices(1:dim_count)
+        else
+            allocate (dimension_indices(0))
+        end if
+    end subroutine parse_array_dimensions
+
+end module parser_declaration_attributes_module

--- a/src/parser/parser_declarations.f90
+++ b/src/parser/parser_declarations.f90
@@ -5,8 +5,8 @@ module parser_declarations
     use parser_declarations_type_spec_module, only: parse_type_specifier
     use parser_declarations_core_module, only: parse_declaration, &
                                                parse_multi_declaration, &
-                                               parse_declaration_with_result, &
-                                               parse_array_dimensions
+                                               parse_declaration_with_result
+    use parser_declaration_attributes_module, only: parse_array_dimensions
     use parser_declarations_derived_module, only: parse_derived_type_def, &
                                                   parse_derived_type_component
     implicit none

--- a/src/parser/parser_declarations_core_module.f90
+++ b/src/parser/parser_declarations_core_module.f90
@@ -10,11 +10,11 @@ module parser_declarations_core_module
     use parser_result_types, only: parse_result_t, success_parse_result, &
                                    error_parse_result
     use error_handling, only: ERROR_PARSER
-    use parser_expressions_module, only: parse_comparison, parse_range
+    use parser_expressions_module, only: parse_comparison
     use parser_type_hooks_module, only: register_type_annotation
-    use declaration_attribute_utils, only: declaration_attribute_info_t, &
-                                           reset_declaration_attributes, &
-                                           set_declaration_intent
+    use parser_declaration_attributes_module, only: parse_declaration_attributes, &
+                                                    parse_array_dimensions
+    use declaration_attribute_utils, only: declaration_attribute_info_t
     implicit none
     private
 
@@ -24,153 +24,6 @@ module parser_declarations_core_module
     public :: parse_array_dimensions
 
 contains
-
-    subroutine parse_declaration_attributes(parser, arena, attr_info)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        type(declaration_attribute_info_t), intent(out) :: attr_info
-
-        logical :: handled_attribute
-        type(token_t) :: token
-
-        call reset_declaration_attributes(attr_info)
-
-        do while (.not. parser%is_at_end())
-            token = parser%peek()
-            if (token%text /= ",") then
-                exit
-            end if
-
-            token = parser%consume()
-            handled_attribute = parse_single_declaration_attribute(parser, &
-                                                                   arena, attr_info)
-            if (.not. handled_attribute) then
-                exit
-            end if
-        end do
-    end subroutine parse_declaration_attributes
-
-    logical function parse_single_declaration_attribute(parser, arena, attr_info) &
-        result(handled)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        type(declaration_attribute_info_t), intent(inout) :: attr_info
-
-        type(token_t) :: token
-
-        handled = .false.
-
-        if (parser%is_at_end()) then
-            return
-        end if
-
-        token = parser%peek()
-
-        select case (token%text)
-        case ("allocatable")
-            attr_info%is_allocatable = .true.
-            token = parser%consume()
-            handled = .true.
-        case ("pointer")
-            attr_info%is_pointer = .true.
-            token = parser%consume()
-            handled = .true.
-        case ("parameter")
-            attr_info%is_parameter = .true.
-            token = parser%consume()
-            handled = .true.
-        case ("external")
-            attr_info%is_external = .true.
-            token = parser%consume()
-            handled = .true.
-        case ("dimension")
-            token = parser%consume()
-            call handle_dimension_attribute(parser, arena, attr_info, handled)
-        case ("intent")
-            token = parser%consume()
-            call handle_intent_attribute(parser, attr_info, handled)
-        case ("optional")
-            attr_info%is_optional = .true.
-            token = parser%consume()
-            handled = .true.
-        case ("target")
-            attr_info%is_target = .true.
-            token = parser%consume()
-            handled = .true.
-        case default
-            handled = .false.
-        end select
-    end function parse_single_declaration_attribute
-
-    subroutine handle_dimension_attribute(parser, arena, attr_info, handled)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        type(declaration_attribute_info_t), intent(inout) :: attr_info
-        logical, intent(out) :: handled
-
-        type(token_t) :: token
-
-        handled = .true.
-
-        if (parser%is_at_end()) then
-            return
-        end if
-
-        token = parser%peek()
-        if (token%text /= "(") then
-            return
-        end if
-
-        token = parser%consume()
-        call parse_array_dimensions(parser, arena, attr_info%global_dimension_indices)
-        attr_info%has_global_dimensions = .true.
-    end subroutine handle_dimension_attribute
-
-    subroutine handle_intent_attribute(parser, attr_info, handled)
-        type(parser_state_t), intent(inout) :: parser
-        type(declaration_attribute_info_t), intent(inout) :: attr_info
-        logical, intent(out) :: handled
-
-        type(token_t) :: token
-
-        handled = .true.
-
-        if (parser%is_at_end()) then
-            return
-        end if
-
-        token = parser%peek()
-        if (token%text /= "(") then
-            return
-        end if
-
-        token = parser%consume()
-        if (parser%is_at_end()) then
-            return
-        end if
-
-        token = parser%peek()
-        select case (token%text)
-        case ("in")
-            call set_declaration_intent(attr_info, "in")
-            token = parser%consume()
-        case ("out")
-            call set_declaration_intent(attr_info, "out")
-            token = parser%consume()
-        case ("inout")
-            call set_declaration_intent(attr_info, "inout")
-            token = parser%consume()
-        case default
-            return
-        end select
-
-        if (.not. parser%is_at_end()) then
-            token = parser%peek()
-            if (token%text == ")") then
-                token = parser%consume()
-            end if
-        end if
-    end subroutine handle_intent_attribute
 
     function parse_declaration(parser, arena) result(decl_index)
         type(parser_state_t), intent(inout) :: parser
@@ -599,52 +452,6 @@ contains
             parse_res = error_parse_result("Failed to parse declaration", ERROR_PARSER)
         end if
     end function parse_declaration_with_result
-
-    ! Parse array dimensions (e.g., (:), (10), (1:n))
-    subroutine parse_array_dimensions(parser, arena, dimension_indices)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer, allocatable, intent(out) :: dimension_indices(:)
-
-        integer, parameter :: max_dims = 10
-        integer :: temp_indices(max_dims)
-        integer :: dim_count, range_index
-        type(token_t) :: token
-
-        dim_count = 0
-
-        ! Parse dimension list until closing parenthesis
-        do while (.not. parser%is_at_end())
-            token = parser%peek()
-            if (token%text == ")") then
-                token = parser%consume()
-                exit
-            end if
-
-            ! Parse dimension specification
-            range_index = parse_range(parser, arena)
-            if (range_index > 0 .and. dim_count < max_dims) then
-                dim_count = dim_count + 1
-                temp_indices(dim_count) = range_index
-            end if
-
-            ! Check for comma
-            token = parser%peek()
-            if (token%text == ",") then
-                token = parser%consume()
-            else if (token%text /= ")") then
-                exit
-            end if
-        end do
-
-        ! Allocate exact size needed
-        if (dim_count > 0) then
-            allocate (dimension_indices(dim_count))
-            dimension_indices = temp_indices(1:dim_count)
-        else
-            allocate (dimension_indices(0))
-        end if
-    end subroutine parse_array_dimensions
 
     ! Helper function to detect and convert complex literals
     function handle_complex_initializer(parser, arena, type_name) result(complex_index)

--- a/test/parser/test_declaration_attribute_parser.f90
+++ b/test/parser/test_declaration_attribute_parser.f90
@@ -1,0 +1,71 @@
+program test_declaration_attribute_parser
+    use frontend, only: lex_source
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_declaration_attributes_module, only: parse_declaration_attributes
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use declaration_attribute_utils, only: declaration_attribute_info_t
+    use lexer_core, only: token_t
+    implicit none
+
+    character(len=*), parameter :: source = &
+                                   ', pointer, dimension(1:10), intent(inout), optional'
+    type(token_t), allocatable :: tokens(:)
+    character(len=:), allocatable :: error_msg
+    type(parser_state_t) :: parser
+    type(ast_arena_t) :: arena
+    type(declaration_attribute_info_t) :: attr_info
+
+    call lex_source(source, tokens, error_msg)
+    if (len_trim(error_msg) > 0) then
+        print *, 'FAIL: lexer error:', trim(error_msg)
+        stop 1
+    end if
+
+    arena = create_ast_arena()
+    parser = create_parser_state(tokens)
+
+    call parse_declaration_attributes(parser, arena, attr_info)
+
+    if (.not. attr_info%is_pointer) then
+        print *, 'FAIL: pointer attribute missing'
+        stop 1
+    end if
+
+    if (.not. attr_info%has_global_dimensions) then
+        print *, 'FAIL: dimension attribute missing'
+        stop 1
+    end if
+
+    if (.not. attr_info%has_intent) then
+        print *, 'FAIL: intent attribute missing'
+        stop 1
+    end if
+
+    if (trim(attr_info%intent) /= 'inout') then
+        print *, 'FAIL: intent value incorrect:', trim(attr_info%intent)
+        stop 1
+    end if
+
+    if (.not. attr_info%is_optional) then
+        print *, 'FAIL: optional attribute missing'
+        stop 1
+    end if
+
+    if (.not. allocated(attr_info%global_dimension_indices)) then
+        print *, 'FAIL: dimension indices not allocated'
+        stop 1
+    end if
+
+    if (size(attr_info%global_dimension_indices) /= 1) then
+        print *, 'FAIL: expected 1 dimension range, got', &
+            size(attr_info%global_dimension_indices)
+        stop 1
+    end if
+
+    if (attr_info%global_dimension_indices(1) <= 0) then
+        print *, 'FAIL: dimension range not recorded'
+        stop 1
+    end if
+
+    print *, 'PASS: parse_declaration_attributes handles multiple attributes'
+end program test_declaration_attribute_parser


### PR DESCRIPTION
## Summary
- move declaration attribute parsing into a dedicated module to satisfy the size target
- keep the call sites focused on dispatch while reusing helpers for dimension and intent parsing
- add a parser-level regression test that covers comma-separated attribute handling

## Verification
- `fpm test --target test_declaration_attribute_parser`
- `make test` *(fails: `test_module_contains_functions` reports "res = *x" and stops before downstream suites; pre-existing parser expression refactor breakage)*
