### PR TITLE
fix: polish: split oversized parser modules to meet 1000-line hard li (fixes #1500)

### DIFF
--- a/src/parser/parser_dispatcher.f90
+++ b/src/parser/parser_dispatcher.f90
@@ -25,7 +25,7 @@ module parser_dispatcher_module
                                                parse_deallocate_statement
     use parser_execution_statements_module, only: parse_call_statement, &
                                                   parse_program_statement
-    use parser_statement_core_module, only: parse_data_statement
+    use parser_statement_data_module, only: parse_data_statement
     use parser_control_flow_router_module, only: route_control_flow
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_misc, only: comment_node, blank_line_node
@@ -47,7 +47,8 @@ module parser_dispatcher_module
 contains
 
     ! Parse a statement by dispatching to appropriate parsing module
-    function parse_statement_dispatcher(tokens, arena, prefix_buffer) result(stmt_index)
+    function parse_statement_dispatcher(tokens, arena, prefix_buffer) &
+        result(stmt_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
@@ -480,6 +481,7 @@ contains
         integer :: num_vars, num_values, i
         type(token_t) :: token
         integer :: target_index, value_index, literal_type
+        integer :: assignment_line, assignment_column
         integer, allocatable :: assignment_indices(:)
 
         stmt_index = 0
@@ -528,10 +530,12 @@ contains
                                                   '.false.'))) then
                 token = parser%consume()
                 ! Determine literal type based on token kind
-                literal_type = get_literal_type_from_token_kind_dispatcher(token%kind, &
-                                                                           token%text)
+                literal_type = &
+                    get_literal_type_from_token_kind_dispatcher(token%kind, &
+                                                                token%text)
                 ! Create literal node immediately
-                value_index = push_literal(arena, token%text, literal_type, token%line, &
+                value_index = push_literal(arena, token%text, literal_type, &
+                                           token%line, &
                                            token%column)
                 value_indices = [value_indices, value_index]
 
@@ -569,12 +573,12 @@ contains
             end if
 
             if (target_index > 0 .and. value_index > 0) then
+                assignment_line = parser%tokens(parser%current_token - 1)%line
+                assignment_column = parser%tokens(parser%current_token - 1)%column
                 assignment_indices = [assignment_indices, &
-                                      push_assignment(arena, target_index, value_index, &
-                                                      parser%tokens(parser%current_token &
-                                                                    - 1)%line, &
-                                                    parser%tokens(parser%current_token - &
-                                                                    1)%column)]
+                                      push_assignment(arena, target_index, &
+                                                      value_index, assignment_line, &
+                                                      assignment_column)]
             end if
         end do
 
@@ -642,7 +646,8 @@ contains
         end select
     end function get_literal_type_from_token_kind_dispatcher
 
-    logical function try_handle_prefix_sequence(parser, arena, prefix_buffer, stmt_index)
+    logical function try_handle_prefix_sequence(parser, arena, prefix_buffer, &
+                                                stmt_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -25,7 +25,7 @@ module parser_execution_statements_module
                                                 parse_exit_statement
     use parser_control_flow_router_module, only: route_control_flow, &
                                                  is_control_flow_keyword
-    use parser_statement_core_module, only: parse_data_statement
+    use parser_statement_data_module, only: parse_data_statement
     use parser_call_module, only: parse_call_statement
     use parser_import_statements_module, only: parse_use_statement
     use ast_arena_modern, only: ast_arena_t

--- a/src/parser/parser_expression_arrays.f90
+++ b/src/parser/parser_expression_arrays.f90
@@ -1,0 +1,556 @@
+module parser_expression_arrays_module
+    use lexer_core, only: token_t, TK_OPERATOR, TK_IDENTIFIER, TK_NEWLINE, TK_COMMENT
+    use parser_state_module, only: parser_state_t
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: component_access_node, identifier_node
+    use ast_factory, only: push_array_literal, push_do_loop, &
+                           push_call_or_subscript_with_slice_detection
+    implicit none
+    private
+
+    abstract interface
+        integer function parse_expr_proc(parser, arena)
+            import :: parser_state_t, ast_arena_t
+            type(parser_state_t), intent(inout) :: parser
+            type(ast_arena_t), intent(inout) :: arena
+        end function parse_expr_proc
+    end interface
+
+    type :: array_parse_helpers_t
+        procedure(parse_expr_proc), pointer, nopass :: parse_comparison => null()
+        procedure(parse_expr_proc), pointer, nopass :: parse_unary => null()
+        procedure(parse_expr_proc), pointer, nopass :: parse_logical_eqv => null()
+        procedure(parse_expr_proc), pointer, nopass :: parse_range => null()
+    end type array_parse_helpers_t
+
+    public :: array_parse_helpers_t
+    public :: parse_modern_array_literal
+    public :: parse_legacy_array_literal
+    public :: parse_array_indexing_postfix
+    public :: parse_square_indexing_postfix
+
+contains
+
+    function parse_simple_array_elements(parser, arena, terminator, style, &
+                                         start_token, helpers) result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: terminator
+        character(len=*), intent(in) :: style
+        type(token_t), intent(in) :: start_token
+        type(array_parse_helpers_t), intent(in) :: helpers
+        integer :: expr_index
+        integer, allocatable :: temp_indices(:)
+        integer, allocatable :: element_indices(:)
+        integer :: element_count
+        type(token_t) :: current
+        integer :: value_index
+
+        if (.not. associated(helpers%parse_comparison) .or. &
+            .not. associated(helpers%parse_unary)) then
+            expr_index = 0
+            return
+        end if
+
+        element_count = 0
+        allocate (temp_indices(20))
+
+        do
+            element_count = element_count + 1
+            if (element_count > size(temp_indices)) then
+                block
+                    integer, allocatable :: new_indices(:)
+                    allocate (new_indices(size(temp_indices) + 20))
+                    new_indices(1:size(temp_indices)) = temp_indices
+                    call move_alloc(new_indices, temp_indices)
+                end block
+            end if
+
+            if (style == "modern") then
+                value_index = helpers%parse_comparison(parser, arena)
+            else
+                value_index = helpers%parse_unary(parser, arena)
+            end if
+
+            if (value_index <= 0) then
+                expr_index = 0
+                return
+            end if
+            temp_indices(element_count) = value_index
+
+            current = parser%peek()
+            if (current%text == ",") then
+                current = parser%consume()
+            else if (current%text == terminator) then
+                current = parser%consume()
+                exit
+            else
+                expr_index = 0
+                return
+            end if
+        end do
+
+        allocate (element_indices(element_count))
+        element_indices = temp_indices(1:element_count)
+        expr_index = push_array_literal(arena, element_indices, &
+                                        start_token%line, start_token%column, &
+                                        syntax_style=style)
+    end function parse_simple_array_elements
+
+    function parse_stride_component(parser, arena, helpers) result(stride_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(array_parse_helpers_t), intent(in) :: helpers
+        integer :: stride_index
+        type(token_t) :: op_token
+        type(token_t) :: next_tok
+
+        stride_index = 0
+        if (.not. associated(helpers%parse_logical_eqv)) return
+
+        if (.not. parser%is_at_end()) then
+            op_token = parser%peek()
+            if (op_token%kind == TK_OPERATOR .and. op_token%text == ":") then
+                op_token = parser%consume()
+                if (.not. parser%is_at_end()) then
+                    next_tok = parser%peek()
+                    if (.not. (next_tok%kind == TK_OPERATOR .and. &
+                               (next_tok%text == ")" .or. next_tok%text == "," .or. &
+                                next_tok%text == "]" .or. next_tok%text == ";"))) then
+                        stride_index = helpers%parse_logical_eqv(parser, arena)
+                    end if
+                end if
+            end if
+        end if
+    end function parse_stride_component
+
+    function parse_legacy_array_literal(parser, arena, helpers) result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(array_parse_helpers_t), intent(in) :: helpers
+        integer :: expr_index
+
+        expr_index = 0
+        if (.not. associated(helpers%parse_comparison) .or. &
+            .not. associated(helpers%parse_unary)) return
+
+        block
+            type(token_t) :: paren_token
+            type(token_t) :: current
+            integer, allocatable :: element_indices(:)
+
+            paren_token = parser%consume()
+            current = parser%consume()
+            current = parser%peek()
+
+            if (current%text == "/") then
+                current = parser%consume()
+                current = parser%peek()
+                if (current%text == ")") then
+                    current = parser%consume()
+                    allocate (element_indices(0))
+                    expr_index = push_array_literal(arena, element_indices, &
+                                                    paren_token%line, &
+                                                    paren_token%column, &
+                                                    syntax_style="legacy")
+                end if
+                return
+            end if
+
+            expr_index = parse_simple_array_elements(parser, arena, "/", "legacy", &
+                                                     paren_token, helpers)
+            if (expr_index <= 0) return
+
+            current = parser%peek()
+            if (current%text /= ")") then
+                expr_index = 0
+                return
+            end if
+            current = parser%consume()
+        end block
+    end function parse_legacy_array_literal
+
+    function parse_modern_array_literal(parser, arena, start_token, helpers) &
+        result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t), intent(in) :: start_token
+        type(array_parse_helpers_t), intent(in) :: helpers
+        integer :: expr_index
+        integer, allocatable :: temp_indices(:)
+        integer, allocatable :: element_indices(:)
+        integer :: element_count
+        type(token_t) :: current
+        type(token_t) :: peek_token
+        integer :: saved_pos
+
+        expr_index = 0
+        if (.not. associated(helpers%parse_comparison) .or. &
+            .not. associated(helpers%parse_unary)) return
+
+        element_count = 0
+        allocate (temp_indices(20))
+
+        do
+            peek_token = parser%peek()
+            if (peek_token%text == "]") then
+                exit
+            else if (peek_token%text == "(") then
+                saved_pos = parser%current_token
+                expr_index = parse_implied_do_constructor(parser, arena, start_token, &
+                                                          helpers)
+                if (expr_index > 0) return
+                parser%current_token = saved_pos
+                expr_index = 0
+            end if
+
+            expr_index = helpers%parse_comparison(parser, arena)
+            if (expr_index <= 0) return
+
+            element_count = element_count + 1
+            if (element_count > size(temp_indices)) then
+                block
+                    integer, allocatable :: new_indices(:)
+                    allocate (new_indices(size(temp_indices) + 20))
+                    new_indices(1:size(temp_indices)) = temp_indices
+                    call move_alloc(new_indices, temp_indices)
+                end block
+            end if
+            temp_indices(element_count) = expr_index
+
+            expr_index = try_parse_implied_do_loop(parser, arena, temp_indices, &
+                                                   element_count, start_token)
+            if (expr_index > 0) exit
+
+            current = parser%peek()
+            if (current%text == ",") then
+                current = parser%consume()
+            else if (current%text == "]") then
+                exit
+            else
+                expr_index = 0
+                return
+            end if
+        end do
+
+        if (expr_index > 0) return
+        allocate (element_indices(element_count))
+        element_indices = temp_indices(1:element_count)
+        expr_index = push_array_literal(arena, element_indices, start_token%line, &
+                                        start_token%column, syntax_style="modern")
+    end function parse_modern_array_literal
+
+    logical function parse_implied_do_header(parser, arena, expr_elem_index, &
+                                             var_name, start_index, end_index, &
+                                             step_index, helpers) result(success)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(out) :: expr_elem_index
+        character(len=:), allocatable, intent(out) :: var_name
+        integer, intent(out) :: start_index
+        integer, intent(out) :: end_index
+        integer, intent(out) :: step_index
+        type(array_parse_helpers_t), intent(in) :: helpers
+        type(token_t) :: current
+
+        success = .false.
+        if (.not. associated(helpers%parse_comparison)) return
+
+        current = parser%consume()
+        expr_elem_index = helpers%parse_comparison(parser, arena)
+
+        current = parser%peek()
+        if (current%text /= ",") return
+        current = parser%consume()
+
+        current = parser%peek()
+        if (current%kind /= TK_IDENTIFIER) return
+        var_name = current%text
+        current = parser%consume()
+
+        current = parser%peek()
+        if (current%text /= "=") return
+        current = parser%consume()
+
+        start_index = helpers%parse_comparison(parser, arena)
+
+        current = parser%peek()
+        if (current%text /= ",") return
+        current = parser%consume()
+
+        end_index = helpers%parse_comparison(parser, arena)
+
+        step_index = 0
+        current = parser%peek()
+        if (current%text == ",") then
+            current = parser%consume()
+            step_index = helpers%parse_comparison(parser, arena)
+        end if
+
+        success = .true.
+    end function parse_implied_do_header
+
+    logical function consume_implied_do_closers(parser) result(success)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: current
+
+        success = .false.
+        current = parser%peek()
+        if (current%text /= ")") return
+        current = parser%consume()
+
+        current = parser%peek()
+        if (current%text /= "]") return
+        current = parser%consume()
+
+        success = .true.
+    end function consume_implied_do_closers
+
+    integer function build_implied_do_node(arena, bracket_token, expr_elem_index, &
+                                           var_name, start_index, end_index, &
+                                           step_index) result(expr_index)
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t), intent(in) :: bracket_token
+        integer, intent(in) :: expr_elem_index
+        character(len=*), intent(in) :: var_name
+        integer, intent(in) :: start_index
+        integer, intent(in) :: end_index
+        integer, intent(in) :: step_index
+        integer :: do_index
+        integer, allocatable :: body_indices(:)
+        integer, allocatable :: element_indices(:)
+
+        allocate (body_indices(1))
+        body_indices(1) = expr_elem_index
+
+        do_index = push_do_loop(arena, var_name, start_index, end_index, step_index, &
+                                body_indices, "", bracket_token%line, &
+                                bracket_token%column)
+
+        allocate (element_indices(1))
+        element_indices(1) = do_index
+        expr_index = push_array_literal(arena, element_indices, &
+                                        bracket_token%line, bracket_token%column, &
+                                        syntax_style="implied_do")
+    end function build_implied_do_node
+
+    function parse_implied_do_constructor(parser, arena, bracket_token, helpers) &
+        result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t), intent(in) :: bracket_token
+        type(array_parse_helpers_t), intent(in) :: helpers
+        integer :: expr_index
+        integer :: expr_elem_index
+        integer :: start_index
+        integer :: end_index
+        integer :: step_index
+        character(len=:), allocatable :: var_name
+
+        expr_index = 0
+        if (.not. parse_implied_do_header(parser, arena, expr_elem_index, var_name, &
+                                          start_index, end_index, step_index, &
+                                          helpers)) return
+        if (.not. consume_implied_do_closers(parser)) return
+
+        expr_index = build_implied_do_node(arena, bracket_token, expr_elem_index, &
+                                           var_name, start_index, end_index, &
+                                           step_index)
+    end function parse_implied_do_constructor
+
+    function try_parse_implied_do_loop(parser, arena, temp_indices, element_count, &
+                                       bracket_token) result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: temp_indices(:)
+        integer, intent(in) :: element_count
+        type(token_t), intent(in) :: bracket_token
+        integer :: expr_index
+        type(token_t) :: next1
+        type(token_t) :: next2
+        integer :: saved_pos
+
+        next1 = parser%peek()
+        if (next1%kind == TK_IDENTIFIER) then
+            saved_pos = parser%current_token
+            next1 = parser%consume()
+            next2 = parser%peek()
+
+            if (next2%kind == TK_OPERATOR .and. next2%text == "=") then
+                block
+                    integer, allocatable :: element_indices(:)
+                    allocate (element_indices(element_count))
+                    element_indices = temp_indices(1:element_count)
+                    expr_index = push_array_literal(arena, element_indices, &
+                                                    bracket_token%line, &
+                                                    bracket_token%column, &
+                                                    syntax_style="modern")
+                end block
+                return
+            else
+                parser%current_token = saved_pos
+            end if
+        end if
+
+        expr_index = 0
+    end function try_parse_implied_do_loop
+
+    function parse_array_indexing_postfix(parser, arena, base_expr, helpers) &
+        result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: base_expr
+        type(array_parse_helpers_t), intent(in) :: helpers
+        integer :: expr_index
+
+        expr_index = base_expr
+        if (.not. associated(helpers%parse_range)) return
+
+        block
+            integer, allocatable :: arg_indices(:)
+            type(token_t) :: paren
+            type(token_t) :: op_token
+            integer :: arg_count
+            character(len=:), allocatable :: name_for_call
+
+            arg_count = 0
+
+            paren = parser%consume()
+
+            op_token = parser%peek()
+            if (op_token%kind /= TK_OPERATOR .or. op_token%text /= ")") then
+                block
+                    integer :: arg_index
+                    arg_index = helpers%parse_range(parser, arena)
+                    if (arg_index > 0) then
+                        arg_count = 1
+                        allocate (arg_indices(1))
+                        arg_indices(1) = arg_index
+
+                        do
+                            op_token = parser%peek()
+                            if (op_token%kind /= TK_OPERATOR .or. &
+                                op_token%text /= ",") exit
+
+                            op_token = parser%consume()
+                            arg_index = helpers%parse_range(parser, arena)
+                            if (arg_index > 0) then
+                                arg_indices = [arg_indices, arg_index]
+                                arg_count = arg_count + 1
+                            else
+                                exit
+                            end if
+                        end do
+                    end if
+                end block
+            end if
+
+            op_token = parser%peek()
+            if (op_token%kind == TK_OPERATOR .and. op_token%text == ")") then
+                paren = parser%consume()
+            end if
+
+            block
+                logical :: name_available
+                name_available = .false.
+                select type (node => arena%entries(expr_index)%node)
+                type is (component_access_node)
+                    if (allocated(node%component_name)) then
+                        name_for_call = node%component_name
+                        name_available = .true.
+                    end if
+                type is (identifier_node)
+                    if (allocated(node%name)) then
+                        name_for_call = node%name
+                        name_available = .true.
+                    end if
+                class default
+                    return
+                end select
+
+                if (.not. name_available) return
+            end block
+
+            if (.not. allocated(arg_indices)) then
+                allocate (arg_indices(0))
+            end if
+
+            expr_index = push_call_or_subscript_with_slice_detection( &
+                         arena, name_for_call, arg_indices, paren%line, paren%column)
+        end block
+    end function parse_array_indexing_postfix
+
+    function parse_square_indexing_postfix(parser, arena, base_expr, helpers) &
+        result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: base_expr
+        type(array_parse_helpers_t), intent(in) :: helpers
+        integer :: expr_index
+
+        expr_index = base_expr
+        if (.not. associated(helpers%parse_range)) return
+
+        block
+            integer, allocatable :: arg_indices(:)
+            type(token_t) :: bracket
+            type(token_t) :: op_token
+            integer :: arg_count
+            character(len=:), allocatable :: name_for_call
+
+            arg_count = 0
+            bracket = parser%consume()
+
+            op_token = parser%peek()
+            if (op_token%kind /= TK_OPERATOR .or. op_token%text /= "]") then
+                block
+                    integer :: arg_index
+                    arg_index = helpers%parse_range(parser, arena)
+                    if (arg_index > 0) then
+                        arg_count = 1
+                        allocate (arg_indices(1))
+                        arg_indices(1) = arg_index
+
+                        do
+                            op_token = parser%peek()
+                            if (op_token%kind /= TK_OPERATOR .or. &
+                                op_token%text /= ",") exit
+
+                            op_token = parser%consume()
+                            arg_index = helpers%parse_range(parser, arena)
+                            if (arg_index > 0) then
+                                arg_indices = [arg_indices, arg_index]
+                                arg_count = arg_count + 1
+                            else
+                                exit
+                            end if
+                        end do
+                    end if
+                end block
+            end if
+
+            op_token = parser%peek()
+            if (op_token%kind == TK_OPERATOR .and. op_token%text == "]") then
+                bracket = parser%consume()
+            end if
+
+            if (allocated(arg_indices)) then
+                select type (node => arena%entries(expr_index)%node)
+                type is (component_access_node)
+                    name_for_call = node%component_name
+                type is (identifier_node)
+                    name_for_call = node%name
+                class default
+                    return
+                end select
+
+                if (allocated(name_for_call)) then
+                    expr_index = push_call_or_subscript_with_slice_detection( &
+                                 arena, name_for_call, arg_indices, bracket%line, &
+                                 bracket%column)
+                end if
+            end if
+        end block
+    end function parse_square_indexing_postfix
+
+end module parser_expression_arrays_module

--- a/src/parser/parser_expression_stacks.f90
+++ b/src/parser/parser_expression_stacks.f90
@@ -1,0 +1,258 @@
+module parser_expression_stacks_module
+    use lexer_core, only: token_t
+    implicit none
+    private
+
+    integer, parameter :: MAX_OPERATOR_LEN = 16
+    integer, parameter :: STACK_DEFAULT_CAPACITY = 32
+
+    type :: operator_entry_t
+        character(len=MAX_OPERATOR_LEN) :: symbol = ""
+        integer :: precedence = 0
+        logical :: right_associative = .false.
+        logical :: is_group = .false.
+        type(token_t) :: token
+    end type operator_entry_t
+
+    type :: operator_stack_t
+        type(operator_entry_t), allocatable :: values(:)
+        integer :: size = 0
+    end type operator_stack_t
+
+    type :: operand_stack_t
+        integer, allocatable :: values(:)
+        integer :: size = 0
+    end type operand_stack_t
+
+    type :: token_stack_t
+        type(token_t), allocatable :: values(:)
+        integer :: size = 0
+    end type token_stack_t
+
+    public :: MAX_OPERATOR_LEN
+    public :: operator_entry_t
+    public :: operator_stack_t
+    public :: operand_stack_t
+    public :: token_stack_t
+    public :: operator_stack_clear
+    public :: operator_stack_ensure_capacity
+    public :: operator_stack_push
+    public :: operator_stack_pop
+    public :: operator_stack_peek
+    public :: operator_stack_is_empty
+    public :: operator_stack_has_open_group
+    public :: operand_stack_clear
+    public :: operand_stack_ensure_capacity
+    public :: operand_stack_push
+    public :: operand_stack_pop
+    public :: operand_stack_peek
+    public :: operand_stack_is_empty
+    public :: token_stack_clear
+    public :: token_stack_ensure_capacity
+    public :: token_stack_push
+    public :: token_stack_pop
+    public :: token_stack_is_empty
+
+contains
+
+    subroutine operator_stack_clear(stack)
+        type(operator_stack_t), intent(inout) :: stack
+
+        stack%size = 0
+    end subroutine operator_stack_clear
+
+    subroutine operator_stack_ensure_capacity(stack, desired)
+        type(operator_stack_t), intent(inout) :: stack
+        integer, intent(in) :: desired
+        type(operator_entry_t), allocatable :: new_values(:)
+        integer :: new_capacity
+
+        if (.not. allocated(stack%values)) then
+            allocate (stack%values(max(STACK_DEFAULT_CAPACITY, desired)))
+            stack%size = 0
+            return
+        end if
+
+        if (size(stack%values) >= desired) return
+
+        new_capacity = max(size(stack%values) * 2, desired)
+        allocate (new_values(new_capacity))
+        if (stack%size > 0) then
+            new_values(1:stack%size) = stack%values(1:stack%size)
+        end if
+        call move_alloc(new_values, stack%values)
+    end subroutine operator_stack_ensure_capacity
+
+    subroutine operator_stack_push(stack, entry)
+        type(operator_stack_t), intent(inout) :: stack
+        type(operator_entry_t), intent(in) :: entry
+
+        call operator_stack_ensure_capacity(stack, stack%size + 1)
+        stack%size = stack%size + 1
+        stack%values(stack%size) = entry
+    end subroutine operator_stack_push
+
+    function operator_stack_pop(stack) result(entry)
+        type(operator_stack_t), intent(inout) :: stack
+        type(operator_entry_t) :: entry
+
+        if (stack%size <= 0) then
+            entry = operator_entry_t()
+            return
+        end if
+
+        entry = stack%values(stack%size)
+        stack%size = stack%size - 1
+    end function operator_stack_pop
+
+    function operator_stack_peek(stack) result(entry)
+        type(operator_stack_t), intent(in) :: stack
+        type(operator_entry_t) :: entry
+
+        if (stack%size <= 0) then
+            entry = operator_entry_t()
+        else
+            entry = stack%values(stack%size)
+        end if
+    end function operator_stack_peek
+
+    logical function operator_stack_is_empty(stack)
+        type(operator_stack_t), intent(in) :: stack
+        operator_stack_is_empty = (stack%size <= 0)
+    end function operator_stack_is_empty
+
+    logical function operator_stack_has_open_group(stack)
+        type(operator_stack_t), intent(in) :: stack
+        integer :: idx
+
+        operator_stack_has_open_group = .false.
+        if (.not. allocated(stack%values)) return
+
+        do idx = stack%size, 1, -1
+            if (stack%values(idx)%is_group) then
+                operator_stack_has_open_group = .true.
+                return
+            end if
+        end do
+    end function operator_stack_has_open_group
+
+    subroutine operand_stack_clear(stack)
+        type(operand_stack_t), intent(inout) :: stack
+
+        stack%size = 0
+    end subroutine operand_stack_clear
+
+    subroutine operand_stack_ensure_capacity(stack, desired)
+        type(operand_stack_t), intent(inout) :: stack
+        integer, intent(in) :: desired
+        integer, allocatable :: new_values(:)
+        integer :: new_capacity
+
+        if (.not. allocated(stack%values)) then
+            allocate (stack%values(max(STACK_DEFAULT_CAPACITY, desired)))
+            stack%size = 0
+            return
+        end if
+
+        if (size(stack%values) >= desired) return
+
+        new_capacity = max(size(stack%values) * 2, desired)
+        allocate (new_values(new_capacity))
+        if (stack%size > 0) then
+            new_values(1:stack%size) = stack%values(1:stack%size)
+        end if
+        call move_alloc(new_values, stack%values)
+    end subroutine operand_stack_ensure_capacity
+
+    subroutine operand_stack_push(stack, value)
+        type(operand_stack_t), intent(inout) :: stack
+        integer, intent(in) :: value
+
+        call operand_stack_ensure_capacity(stack, stack%size + 1)
+        stack%size = stack%size + 1
+        stack%values(stack%size) = value
+    end subroutine operand_stack_push
+
+    integer function operand_stack_pop(stack)
+        type(operand_stack_t), intent(inout) :: stack
+
+        if (stack%size <= 0) then
+            operand_stack_pop = 0
+            return
+        end if
+
+        operand_stack_pop = stack%values(stack%size)
+        stack%size = stack%size - 1
+    end function operand_stack_pop
+
+    integer function operand_stack_peek(stack)
+        type(operand_stack_t), intent(in) :: stack
+
+        if (stack%size <= 0) then
+            operand_stack_peek = 0
+        else
+            operand_stack_peek = stack%values(stack%size)
+        end if
+    end function operand_stack_peek
+
+    logical function operand_stack_is_empty(stack)
+        type(operand_stack_t), intent(in) :: stack
+        operand_stack_is_empty = (stack%size <= 0)
+    end function operand_stack_is_empty
+
+    subroutine token_stack_clear(stack)
+        type(token_stack_t), intent(inout) :: stack
+
+        stack%size = 0
+    end subroutine token_stack_clear
+
+    subroutine token_stack_ensure_capacity(stack, desired)
+        type(token_stack_t), intent(inout) :: stack
+        integer, intent(in) :: desired
+        type(token_t), allocatable :: new_values(:)
+        integer :: new_capacity
+
+        if (.not. allocated(stack%values)) then
+            allocate (stack%values(max(STACK_DEFAULT_CAPACITY, desired)))
+            stack%size = 0
+            return
+        end if
+
+        if (size(stack%values) >= desired) return
+
+        new_capacity = max(size(stack%values) * 2, desired)
+        allocate (new_values(new_capacity))
+        if (stack%size > 0) then
+            new_values(1:stack%size) = stack%values(1:stack%size)
+        end if
+        call move_alloc(new_values, stack%values)
+    end subroutine token_stack_ensure_capacity
+
+    subroutine token_stack_push(stack, value)
+        type(token_stack_t), intent(inout) :: stack
+        type(token_t), intent(in) :: value
+
+        call token_stack_ensure_capacity(stack, stack%size + 1)
+        stack%size = stack%size + 1
+        stack%values(stack%size) = value
+    end subroutine token_stack_push
+
+    function token_stack_pop(stack) result(token)
+        type(token_stack_t), intent(inout) :: stack
+        type(token_t) :: token
+
+        if (stack%size <= 0) then
+            token = token_t()
+            return
+        end if
+
+        token = stack%values(stack%size)
+        stack%size = stack%size - 1
+    end function token_stack_pop
+
+    logical function token_stack_is_empty(stack)
+        type(token_stack_t), intent(in) :: stack
+        token_stack_is_empty = (stack%size <= 0)
+    end function token_stack_is_empty
+
+end module parser_expression_stacks_module

--- a/src/parser/parser_expressions.f90
+++ b/src/parser/parser_expressions.f90
@@ -1,5 +1,4 @@
 module parser_expressions_module
-    use, intrinsic :: iso_fortran_env, only: error_unit
     use lexer_core, only: token_t, TK_EOF, TK_NUMBER, TK_STRING, TK_IDENTIFIER, &
                           TK_OPERATOR, TK_KEYWORD, to_lower
     use ast_arena_modern, only: ast_arena_t
@@ -8,15 +7,34 @@ module parser_expressions_module
     use ast_types, only: LITERAL_INTEGER, LITERAL_REAL, LITERAL_STRING, LITERAL_LOGICAL
     use ast_nodes_loops, only: do_loop_node
     use ast_factory, only: push_binary_op, push_literal, push_identifier, &
-                           push_call_or_subscript, push_array_literal, &
-                           push_range_expression, &
-                           push_call_or_subscript_with_slice_detection, &
-                           push_component_access, push_range_subscript, push_do_loop
+                           push_range_expression
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_expression_helpers_module, only: parse_number_literal, &
                                                 parse_string_literal, &
                                                 parse_boolean_literal, &
                                                 parse_component_access_postfix
+    use parser_expression_arrays_module, only: array_parse_helpers_t, &
+                                               parse_modern_array_literal, &
+                                               parse_legacy_array_literal, &
+                                               parse_array_indexing_postfix, &
+                                               parse_square_indexing_postfix
+    use parser_expression_stacks_module, only: MAX_OPERATOR_LEN, operator_entry_t, &
+                                               operator_stack_t, operand_stack_t, &
+                                               token_stack_t, operator_stack_clear, &
+                                               operator_stack_push, &
+                                               operator_stack_pop, &
+                                               operator_stack_peek, &
+                                               operator_stack_is_empty, &
+                                               operator_stack_has_open_group, &
+                                               operand_stack_clear, &
+                                               operand_stack_push, &
+                                               operand_stack_pop, &
+                                               operand_stack_is_empty, &
+                                               token_stack_clear, token_stack_push, &
+                                               token_stack_pop
+    use parser_token_views_module, only: token_view_t, build_token_view, &
+                                         view_peek_token, view_lower_token, &
+                                         view_consume_token, view_lookahead_token
     implicit none
     private
 
@@ -33,42 +51,7 @@ module parser_expressions_module
     integer, parameter :: PREC_UNARY = 95
     integer, parameter :: PREC_POSTFIX = 110
 
-    integer, parameter :: MAX_OPERATOR_LEN = 16
-    integer, parameter :: STACK_DEFAULT_CAPACITY = 32
     integer, parameter :: PREFIX_MARKER_KIND = -999
-
-    type :: operator_entry_t
-        character(len=MAX_OPERATOR_LEN) :: symbol = ""
-        integer :: precedence = 0
-        logical :: right_associative = .false.
-        logical :: is_group = .false.
-        type(token_t) :: token
-    end type operator_entry_t
-
-    type :: operator_stack_t
-        type(operator_entry_t), allocatable :: values(:)
-        integer :: size = 0
-    end type operator_stack_t
-
-    type :: operand_stack_t
-        integer, allocatable :: values(:)
-        integer :: size = 0
-    end type operand_stack_t
-
-    type :: token_stack_t
-        type(token_t), allocatable :: values(:)
-        integer :: size = 0
-    end type token_stack_t
-
-    type :: token_view_t
-        character(len=:), allocatable :: text(:)
-        character(len=:), allocatable :: lower(:)
-        integer, allocatable :: kind(:)
-        integer, allocatable :: line(:)
-        integer, allocatable :: column(:)
-        integer :: base_index = 1
-        integer :: count = 0
-    end type token_view_t
 
     ! Public expression parsing interface
     public :: parse_expression
@@ -80,410 +63,6 @@ module parser_expressions_module
     public :: parse_expression_until, parse_postfix_chain
 
 contains
-
-    subroutine build_token_view(view, parser)
-        type(token_view_t), intent(inout) :: view
-        type(parser_state_t), intent(in) :: parser
-        integer :: start_idx
-        integer :: end_idx
-        integer :: count
-        integer :: max_len
-
-        call initialize_token_view_state(view, parser, start_idx, end_idx, count)
-        if (count == 0) return
-
-        max_len = compute_max_token_length(parser, start_idx, end_idx)
-        call prepare_token_view_arrays(view, count, max_len)
-        call populate_token_view(view, parser, start_idx, count)
-        view%base_index = start_idx
-        view%count = count
-    end subroutine build_token_view
-
-    subroutine initialize_token_view_state(view, parser, start_idx, end_idx, count)
-        type(token_view_t), intent(inout) :: view
-        type(parser_state_t), intent(in) :: parser
-        integer, intent(out) :: start_idx
-        integer, intent(out) :: end_idx
-        integer, intent(out) :: count
-
-        if (.not. associated(parser%tokens)) then
-            view%count = 0
-            view%base_index = parser%current_token
-            call release_token_view_arrays(view)
-            count = 0
-            start_idx = 0
-            end_idx = -1
-            return
-        end if
-
-        start_idx = max(parser%current_token, 1)
-        end_idx = size(parser%tokens)
-        count = max(end_idx - start_idx + 1, 1)
-    end subroutine initialize_token_view_state
-
-    integer function compute_max_token_length(parser, start_idx, end_idx) &
-        result(max_len)
-        type(parser_state_t), intent(in) :: parser
-        integer, intent(in) :: start_idx
-        integer, intent(in) :: end_idx
-        integer :: idx
-        type(token_t) :: token
-
-        max_len = 1
-        do idx = start_idx, end_idx
-            token = parser%tokens(idx)
-            max_len = max(max_len, len_trim(token%text))
-        end do
-        if (max_len < 1) max_len = 1
-    end function compute_max_token_length
-
-    subroutine prepare_token_view_arrays(view, count, max_len)
-        type(token_view_t), intent(inout) :: view
-        integer, intent(in) :: count
-        integer, intent(in) :: max_len
-
-        call release_token_view_arrays(view)
-        allocate (character(len=max_len) :: view%text(count))
-        allocate (character(len=max_len) :: view%lower(count))
-        allocate (view%kind(count))
-        allocate (view%line(count))
-        allocate (view%column(count))
-    end subroutine prepare_token_view_arrays
-
-    subroutine populate_token_view(view, parser, start_idx, count)
-        type(token_view_t), intent(inout) :: view
-        type(parser_state_t), intent(in) :: parser
-        integer, intent(in) :: start_idx
-        integer, intent(in) :: count
-        integer :: idx
-        type(token_t) :: token
-
-        do idx = 1, count
-            token = parser%tokens(start_idx + idx - 1)
-            view%text(idx) = token%text
-            view%lower(idx) = to_lower(token%text)
-            view%kind(idx) = token%kind
-            view%line(idx) = token%line
-            view%column(idx) = token%column
-        end do
-    end subroutine populate_token_view
-
-    subroutine release_token_view_arrays(view)
-        type(token_view_t), intent(inout) :: view
-
-        if (allocated(view%text)) then
-            block
-                character(len=:), allocatable :: temp(:)
-                call move_alloc(view%text, temp)
-            end block
-        end if
-        if (allocated(view%lower)) then
-            block
-                character(len=:), allocatable :: temp(:)
-                call move_alloc(view%lower, temp)
-            end block
-        end if
-        if (allocated(view%kind)) then
-            block
-                integer, allocatable :: temp(:)
-                call move_alloc(view%kind, temp)
-            end block
-        end if
-        if (allocated(view%line)) then
-            block
-                integer, allocatable :: temp(:)
-                call move_alloc(view%line, temp)
-            end block
-        end if
-        if (allocated(view%column)) then
-            block
-                integer, allocatable :: temp(:)
-                call move_alloc(view%column, temp)
-            end block
-        end if
-    end subroutine release_token_view_arrays
-
-    function view_peek_token(view, parser) result(token)
-        type(token_view_t), intent(in) :: view
-        type(parser_state_t), intent(in) :: parser
-        type(token_t) :: token
-        integer :: idx
-
-        idx = parser%current_token - view%base_index + 1
-        if (idx < 1 .or. idx > view%count) then
-            token = parser%peek()
-            return
-        end if
-
-        token%text = view%text(idx)
-        token%kind = view%kind(idx)
-        token%line = view%line(idx)
-        token%column = view%column(idx)
-    end function view_peek_token
-
-    function view_lower_token(view, parser, offset) result(lowered)
-        type(token_view_t), intent(in) :: view
-        type(parser_state_t), intent(in) :: parser
-        integer, intent(in), optional :: offset
-        character(len=:), allocatable :: lowered
-        integer :: idx
-        integer :: off
-
-        off = 0
-        if (present(offset)) off = offset
-        idx = parser%current_token - view%base_index + 1 + off
-
-        if (idx < 1 .or. idx > view%count) then
-            block
-                type(token_t) :: fallback_token
-                fallback_token = view_peek_token(view, parser)
-                lowered = to_lower(fallback_token%text)
-            end block
-            return
-        end if
-
-        lowered = trim(view%lower(idx))
-    end function view_lower_token
-
-    function view_consume_token(view, parser) result(token)
-        type(token_view_t), intent(in) :: view
-        type(parser_state_t), intent(inout) :: parser
-        type(token_t) :: token
-
-        token = view_peek_token(view, parser)
-        if (.not. parser%is_at_end()) then
-            block
-                type(token_t) :: discarded_token
-                discarded_token = parser%consume()
-            end block
-        end if
-    end function view_consume_token
-
-    function view_lookahead_token(view, parser, offset) result(token)
-        type(token_view_t), intent(in) :: view
-        type(parser_state_t), intent(in) :: parser
-        integer, intent(in) :: offset
-        type(token_t) :: token
-        integer :: idx
-
-        idx = parser%current_token - view%base_index + 1 + offset
-        if (idx < 1 .or. idx > view%count) then
-            token = parser%peek()
-            return
-        end if
-
-        token%text = view%text(idx)
-        token%kind = view%kind(idx)
-        token%line = view%line(idx)
-        token%column = view%column(idx)
-    end function view_lookahead_token
-
-    !=================================================================================
-    ! STACK UTILITIES FOR PRATT PARSER
-    !=================================================================================
-
-    subroutine operator_stack_clear(stack)
-        type(operator_stack_t), intent(inout) :: stack
-
-        stack%size = 0
-    end subroutine operator_stack_clear
-
-    subroutine operator_stack_ensure_capacity(stack, desired)
-        type(operator_stack_t), intent(inout) :: stack
-        integer, intent(in) :: desired
-        type(operator_entry_t), allocatable :: new_values(:)
-        integer :: new_capacity
-
-        if (.not. allocated(stack%values)) then
-            allocate (stack%values(max(STACK_DEFAULT_CAPACITY, desired)))
-            stack%size = 0
-            return
-        end if
-
-        if (size(stack%values) >= desired) return
-
-        new_capacity = max(size(stack%values) * 2, desired)
-        allocate (new_values(new_capacity))
-        if (stack%size > 0) then
-            new_values(1:stack%size) = stack%values(1:stack%size)
-        end if
-        call move_alloc(new_values, stack%values)
-    end subroutine operator_stack_ensure_capacity
-
-    subroutine operator_stack_push(stack, entry)
-        type(operator_stack_t), intent(inout) :: stack
-        type(operator_entry_t), intent(in) :: entry
-
-        call operator_stack_ensure_capacity(stack, stack%size + 1)
-        stack%size = stack%size + 1
-        stack%values(stack%size) = entry
-    end subroutine operator_stack_push
-
-    function operator_stack_pop(stack) result(entry)
-        type(operator_stack_t), intent(inout) :: stack
-        type(operator_entry_t) :: entry
-
-        if (stack%size <= 0) then
-            entry = operator_entry_t()
-            return
-        end if
-
-        entry = stack%values(stack%size)
-        stack%size = stack%size - 1
-    end function operator_stack_pop
-
-    function operator_stack_peek(stack) result(entry)
-        type(operator_stack_t), intent(in) :: stack
-        type(operator_entry_t) :: entry
-
-        if (stack%size <= 0) then
-            entry = operator_entry_t()
-        else
-            entry = stack%values(stack%size)
-        end if
-    end function operator_stack_peek
-
-    logical function operator_stack_is_empty(stack)
-        type(operator_stack_t), intent(in) :: stack
-        operator_stack_is_empty = (stack%size <= 0)
-    end function operator_stack_is_empty
-
-    logical function operator_stack_has_open_group(stack)
-        type(operator_stack_t), intent(in) :: stack
-        integer :: idx
-
-        operator_stack_has_open_group = .false.
-        if (.not. allocated(stack%values)) return
-
-        do idx = stack%size, 1, -1
-            if (stack%values(idx)%is_group) then
-                operator_stack_has_open_group = .true.
-                return
-            end if
-        end do
-    end function operator_stack_has_open_group
-
-    subroutine operand_stack_clear(stack)
-        type(operand_stack_t), intent(inout) :: stack
-
-        stack%size = 0
-    end subroutine operand_stack_clear
-
-    subroutine operand_stack_ensure_capacity(stack, desired)
-        type(operand_stack_t), intent(inout) :: stack
-        integer, intent(in) :: desired
-        integer, allocatable :: new_values(:)
-        integer :: new_capacity
-
-        if (.not. allocated(stack%values)) then
-            allocate (stack%values(max(STACK_DEFAULT_CAPACITY, desired)))
-            stack%size = 0
-            return
-        end if
-
-        if (size(stack%values) >= desired) return
-
-        new_capacity = max(size(stack%values) * 2, desired)
-        allocate (new_values(new_capacity))
-        if (stack%size > 0) then
-            new_values(1:stack%size) = stack%values(1:stack%size)
-        end if
-        call move_alloc(new_values, stack%values)
-    end subroutine operand_stack_ensure_capacity
-
-    subroutine operand_stack_push(stack, value)
-        type(operand_stack_t), intent(inout) :: stack
-        integer, intent(in) :: value
-
-        call operand_stack_ensure_capacity(stack, stack%size + 1)
-        stack%size = stack%size + 1
-        stack%values(stack%size) = value
-    end subroutine operand_stack_push
-
-    integer function operand_stack_pop(stack)
-        type(operand_stack_t), intent(inout) :: stack
-
-        if (stack%size <= 0) then
-            operand_stack_pop = 0
-            return
-        end if
-
-        operand_stack_pop = stack%values(stack%size)
-        stack%size = stack%size - 1
-    end function operand_stack_pop
-
-    integer function operand_stack_peek(stack)
-        type(operand_stack_t), intent(in) :: stack
-
-        if (stack%size <= 0) then
-            operand_stack_peek = 0
-        else
-            operand_stack_peek = stack%values(stack%size)
-        end if
-    end function operand_stack_peek
-
-    logical function operand_stack_is_empty(stack)
-        type(operand_stack_t), intent(in) :: stack
-        operand_stack_is_empty = (stack%size <= 0)
-    end function operand_stack_is_empty
-
-    subroutine token_stack_clear(stack)
-        type(token_stack_t), intent(inout) :: stack
-
-        stack%size = 0
-    end subroutine token_stack_clear
-
-    subroutine token_stack_ensure_capacity(stack, desired)
-        type(token_stack_t), intent(inout) :: stack
-        integer, intent(in) :: desired
-        type(token_t), allocatable, target :: new_values(:)
-        integer :: new_capacity
-
-        if (.not. allocated(stack%values)) then
-            allocate (stack%values(max(STACK_DEFAULT_CAPACITY, desired)))
-            stack%size = 0
-            return
-        end if
-
-        if (size(stack%values) >= desired) return
-
-        new_capacity = max(size(stack%values) * 2, desired)
-        allocate (new_values(new_capacity))
-        if (stack%size > 0) then
-            new_values(1:stack%size) = stack%values(1:stack%size)
-        end if
-        call move_alloc(new_values, stack%values)
-    end subroutine token_stack_ensure_capacity
-
-    subroutine token_stack_push(stack, value)
-        type(token_stack_t), intent(inout) :: stack
-        type(token_t), intent(in) :: value
-
-        call token_stack_ensure_capacity(stack, stack%size + 1)
-        stack%size = stack%size + 1
-        stack%values(stack%size) = value
-    end subroutine token_stack_push
-
-    function token_stack_pop(stack) result(token)
-        type(token_stack_t), intent(inout) :: stack
-        type(token_t) :: token
-
-        if (stack%size <= 0) then
-            token%text = ""
-            token%line = 0
-            token%column = 0
-            token%kind = 0
-            return
-        end if
-
-        token = stack%values(stack%size)
-        stack%size = stack%size - 1
-    end function token_stack_pop
-
-    logical function token_stack_is_empty(stack)
-        type(token_stack_t), intent(in) :: stack
-        token_stack_is_empty = (stack%size <= 0)
-    end function token_stack_is_empty
 
     logical function token_matches(token, text)
         type(token_t), intent(in) :: token
@@ -738,6 +317,12 @@ contains
         integer :: expr_index
         type(token_t) :: token
         character(len=:), allocatable :: lowered
+        type(array_parse_helpers_t) :: array_helpers
+
+        array_helpers%parse_comparison => parse_comparison
+        array_helpers%parse_unary => parse_unary
+        array_helpers%parse_logical_eqv => parse_logical_eqv
+        array_helpers%parse_range => parse_range
 
         expr_index = 0
         token = view_peek_token(view, parser)
@@ -766,7 +351,8 @@ contains
             lowered = view_lower_token(view, parser)
             if (lowered == "[") then
                 token = view_consume_token(view, parser)
-                expr_index = parse_modern_array_literal(parser, arena, token)
+                expr_index = parse_modern_array_literal(parser, arena, token, &
+                                                        array_helpers)
             else if (token_is_boolean_literal(token)) then
                 token = view_consume_token(view, parser)
                 expr_index = parse_boolean_literal(token, arena)
@@ -793,7 +379,7 @@ contains
     end function parse_operand_base
 
     subroutine handle_closing_paren(parser, arena, view, operators, operands, &
-                                     prefix_stack, token, expect_operand)
+                                    prefix_stack, token, expect_operand)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(token_view_t), intent(in) :: view
@@ -826,7 +412,7 @@ contains
     end subroutine handle_closing_paren
 
     subroutine handle_operand_token(parser, arena, view, operands, prefix_stack, &
-                                     token, expect_operand)
+                                    token, expect_operand)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(token_view_t), intent(in) :: view
@@ -835,9 +421,15 @@ contains
         type(token_t), intent(in) :: token
         logical, intent(inout) :: expect_operand
         integer :: current_index
+        type(array_parse_helpers_t) :: array_helpers
+
+        array_helpers%parse_comparison => parse_comparison
+        array_helpers%parse_unary => parse_unary
+        array_helpers%parse_logical_eqv => parse_logical_eqv
+        array_helpers%parse_range => parse_range
 
         if (is_legacy_array_literal_start(parser, view)) then
-            current_index = parse_legacy_array_literal(parser, arena)
+            current_index = parse_legacy_array_literal(parser, arena, array_helpers)
             current_index = apply_prefix_stack(arena, prefix_stack, current_index)
             current_index = parse_postfix_ops(parser, arena, view, current_index)
             call operand_stack_push(operands, current_index)
@@ -857,8 +449,8 @@ contains
     end subroutine handle_operand_token
 
     subroutine handle_infix_operator(parser, view, operators, operands, arena, &
-                                      token, minimum_precedence, expect_operand, &
-                                      should_exit)
+                                     token, minimum_precedence, expect_operand, &
+                                     should_exit)
         type(parser_state_t), intent(inout) :: parser
         type(token_view_t), intent(in) :: view
         type(operator_stack_t), intent(inout) :: operators
@@ -974,7 +566,8 @@ contains
                     cycle
                 end if
 
-                call handle_operand_token(parser, arena, view, operands, prefix_stack, &
+                call handle_operand_token(parser, arena, view, operands, &
+                                          prefix_stack, &
                                           token, expect_operand)
                 cycle
             else
@@ -1217,73 +810,6 @@ contains
             end if
         end if
     end function parse_range
-    !=================================================================================
-    ! HELPER FUNCTIONS FOR ARRAY PARSING
-    !=================================================================================
-
-    ! Simplified array element parsing
-    function parse_simple_array_elements(parser, arena, terminator, style, &
-                                         start_token) &
-        result(expr_index)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        character(len=*), intent(in) :: terminator, style
-        type(token_t), intent(in) :: start_token
-        integer :: expr_index
-
-        integer, allocatable :: element_indices(:), temp_indices(:)
-        integer :: element_count
-        type(token_t) :: current
-
-        element_count = 0
-        allocate (temp_indices(20))
-
-        do
-            element_count = element_count + 1
-            if (element_count > size(temp_indices)) then
-                block
-                    integer, allocatable :: new_indices(:)
-                    allocate (new_indices(size(temp_indices) + 20))
-                    new_indices(1:size(temp_indices)) = temp_indices
-                    call move_alloc(new_indices, temp_indices)
-                end block
-            end if
-
-            ! Parse element based on style
-            if (style == "modern") then
-                temp_indices(element_count) = parse_comparison(parser, arena)
-            else
-                temp_indices(element_count) = parse_unary(parser, arena)
-            end if
-
-            if (temp_indices(element_count) <= 0) then
-                expr_index = 0
-                return
-            end if
-
-            current = parser%peek()
-            if (current%text == ",") then
-                current = parser%consume()
-            else if (current%text == terminator) then
-                current = parser%consume()
-                exit
-            else
-                expr_index = 0
-                return
-            end if
-        end do
-
-        allocate (element_indices(element_count))
-        element_indices = temp_indices(1:element_count)
-        expr_index = push_array_literal(arena, element_indices, &
-                                        start_token%line, start_token%column, &
-                                        syntax_style=style)
-    end function parse_simple_array_elements
-
-    !=================================================================================
-    ! RANGE AND SLICE EXPRESSION PARSING SECTION
-    !=================================================================================
-
     ! Helper function to parse stride (third component of range expression)
     function parse_stride_component(parser, arena) result(stride_index)
         type(parser_state_t), intent(inout) :: parser
@@ -1312,419 +838,11 @@ contains
     ! ARRAY LITERAL PARSING SECTION
     !=================================================================================
 
-    ! Parse legacy array literal: (/ ... /)
-    function parse_legacy_array_literal(parser, arena) result(expr_index)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer :: expr_index
-
-        block
-            type(token_t) :: paren_token, current
-            integer, allocatable :: element_indices(:)
-
-            paren_token = parser%consume()
-            current = parser%consume()  ! consume '/'
-            current = parser%peek()
-
-            ! Check for empty array (//)
-            if (current%text == "/") then
-                current = parser%consume()
-                current = parser%peek()
-                if (current%text == ")") then
-                    current = parser%consume()
-                    allocate (element_indices(0))
-                    expr_index = push_array_literal(arena, element_indices, &
-                                                    paren_token%line, &
-                                                    paren_token%column, &
-                                                    syntax_style="legacy")
-                else
-                    expr_index = 0
-                end if
-                return
-            end if
-
-            ! Parse elements with legacy syntax (closing /))
-            expr_index = parse_simple_array_elements(parser, arena, "/", "legacy", &
-                                                     paren_token)
-
-            ! Consume final closing paren for legacy syntax
-            if (expr_index > 0) then
-                current = parser%peek()
-                if (current%text == ")") then
-                    current = parser%consume()
-                else
-                    expr_index = 0  ! Error: missing closing paren
-                end if
-            end if
-        end block
-    end function parse_legacy_array_literal
-
-    ! Parse modern array literal: [1, 2, 3] with implied do loop support
-    function parse_modern_array_literal(parser, arena, start_token) result(expr_index)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        type(token_t), intent(in) :: start_token
-        integer :: expr_index
-
-        block
-            type(token_t) :: current, next_token
-            integer, allocatable :: element_indices(:), temp_indices(:)
-            integer :: element_count
-            logical :: is_implied_do
-
-            current = parser%peek()
-
-            ! Check for empty array []
-            if (current%text == "]") then
-                current = parser%consume()
-                allocate (element_indices(0))
-                expr_index = push_array_literal(arena, element_indices, &
-                                                start_token%line, start_token%column, &
-                                                syntax_style="modern")
-                return
-            end if
-
-            ! Check for implied do loop: [(expr, var=start,end)]
-            is_implied_do = .false.
-            if (current%kind == TK_OPERATOR .and. current%text == "(") then
-                ! Potential implied do - check for pattern
-                is_implied_do = .true.
-            end if
-
-            if (is_implied_do) then
-                ! Parse implied do loop
-                expr_index = parse_implied_do_constructor(parser, arena, start_token)
-            else
-                ! Parse regular array elements
-                expr_index = parse_simple_array_elements(parser, arena, "]", &
-                                                         "modern", &
-                                                         start_token)
-            end if
-        end block
-    end function parse_modern_array_literal
-
-    logical function parse_implied_do_header(parser, arena, expr_elem_index, &
-                                             var_name, start_index, end_index, &
-                                             step_index) result(success)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(out) :: expr_elem_index, start_index, end_index, step_index
-        character(len=:), allocatable, intent(out) :: var_name
-        type(token_t) :: current
-
-        success = .false.
-        current = parser%consume()
-        expr_elem_index = parse_comparison(parser, arena)
-
-        current = parser%peek()
-        if (current%text /= ",") return
-        current = parser%consume()
-
-        current = parser%peek()
-        if (current%kind /= TK_IDENTIFIER) return
-        var_name = current%text
-        current = parser%consume()
-
-        current = parser%peek()
-        if (current%text /= "=") return
-        current = parser%consume()
-
-        start_index = parse_comparison(parser, arena)
-
-        current = parser%peek()
-        if (current%text /= ",") return
-        current = parser%consume()
-
-        end_index = parse_comparison(parser, arena)
-
-        step_index = 0
-        current = parser%peek()
-        if (current%text == ",") then
-            current = parser%consume()
-            step_index = parse_comparison(parser, arena)
-        end if
-
-        success = .true.
-    end function parse_implied_do_header
-
-    logical function consume_implied_do_closers(parser) result(success)
-        type(parser_state_t), intent(inout) :: parser
-        type(token_t) :: current
-
-        success = .false.
-        current = parser%peek()
-        if (current%text /= ")") return
-        current = parser%consume()
-
-        current = parser%peek()
-        if (current%text /= "]") return
-        current = parser%consume()
-
-        success = .true.
-    end function consume_implied_do_closers
-
-    integer function build_implied_do_node(arena, bracket_token, expr_elem_index, &
-                                           var_name, start_index, end_index, &
-                                           step_index) result(expr_index)
-        type(ast_arena_t), intent(inout) :: arena
-        type(token_t), intent(in) :: bracket_token
-        integer, intent(in) :: expr_elem_index, start_index, end_index, step_index
-        character(len=*), intent(in) :: var_name
-        integer :: do_index
-        integer, allocatable :: body_indices(:), element_indices(:)
-
-        allocate (body_indices(1))
-        body_indices(1) = expr_elem_index
-
-        do_index = push_do_loop(arena, var_name, start_index, end_index, step_index, &
-                                body_indices, "", bracket_token%line, &
-                                bracket_token%column)
-
-        allocate (element_indices(1))
-        element_indices(1) = do_index
-        expr_index = push_array_literal(arena, element_indices, &
-                                        bracket_token%line, bracket_token%column, &
-                                        syntax_style="implied_do")
-    end function build_implied_do_node
-
-    ! Parse implied do constructor: [(expr, var=start,end[,step])]
-    function parse_implied_do_constructor(parser, arena, bracket_token) &
-        result(expr_index)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        type(token_t), intent(in) :: bracket_token
-        integer :: expr_index
-        integer :: expr_elem_index, start_index, end_index, step_index
-        character(len=:), allocatable :: var_name
-
-        expr_index = 0
-        if (.not. parse_implied_do_header(parser, arena, expr_elem_index, var_name, &
-                                          start_index, end_index, step_index)) return
-        if (.not. consume_implied_do_closers(parser)) return
-
-        expr_index = build_implied_do_node(arena, bracket_token, expr_elem_index, &
-                                           var_name, start_index, end_index, step_index)
-    end function parse_implied_do_constructor
-
-    ! Simplified implied do loop parsing (placeholder for full implementation)
-    function try_parse_implied_do_loop(parser, arena, temp_indices, element_count, &
-                                       bracket_token) result(expr_index)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: temp_indices(:)
-        integer, intent(in) :: element_count
-        type(token_t), intent(in) :: bracket_token
-        integer :: expr_index
-
-        ! Simplified: only check for basic implied do pattern
-        type(token_t) :: next1, next2
-        integer :: saved_pos
-
-        next1 = parser%peek()
-        if (next1%kind == TK_IDENTIFIER) then
-            saved_pos = parser%current_token
-            next1 = parser%consume()
-            next2 = parser%peek()
-
-            if (next2%kind == TK_OPERATOR .and. next2%text == "=") then
-                ! Simplified implied do: create basic array for now
-                ! TODO: Full implied do loop implementation
-                block
-                    integer, allocatable :: element_indices(:)
-                    allocate (element_indices(element_count))
-                    element_indices = temp_indices(1:element_count)
-                    expr_index = push_array_literal(arena, element_indices, &
-                                                    bracket_token%line, &
-                                                    bracket_token%column, &
-                                                    syntax_style="modern")
-                end block
-                return
-            else
-                parser%current_token = saved_pos
-            end if
-        end if
-
-        expr_index = 0  ! Not an implied do loop
-    end function try_parse_implied_do_loop
-
     !=================================================================================
     ! POSTFIX OPERATIONS SECTION
     !=================================================================================
 
     ! Parse array indexing or function call postfix operator using parentheses: (...)
-    function parse_array_indexing_postfix(parser, arena, base_expr) result(expr_index)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: base_expr
-        integer :: expr_index
-
-        block
-            integer, allocatable :: arg_indices(:)
-            type(token_t) :: paren, op_token
-            integer :: arg_count
-            character(len=:), allocatable :: name_for_call
-
-            arg_count = 0
-            expr_index = base_expr
-
-            ! Consume opening paren
-            paren = parser%consume()
-
-            ! Parse arguments
-            op_token = parser%peek()
-            if (op_token%kind /= TK_OPERATOR .or. op_token%text /= ")") then
-                ! Parse first argument
-                block
-                    integer :: arg_index
-                    arg_index = parse_range(parser, arena)
-                    if (arg_index > 0) then
-                        arg_count = 1
-                        allocate (arg_indices(1))
-                        arg_indices(1) = arg_index
-
-                        ! Parse additional arguments
-                        do
-                            op_token = parser%peek()
-                            if (op_token%kind /= TK_OPERATOR .or. &
-                                op_token%text /= ",") exit
-
-                            ! Consume comma
-                            op_token = parser%consume()
-
-                            ! Parse next argument
-                            arg_index = parse_range(parser, arena)
-                            if (arg_index > 0) then
-                                arg_indices = [arg_indices, arg_index]
-                                arg_count = arg_count + 1
-                            else
-                                exit
-                            end if
-                        end do
-                    end if
-                end block
-            end if
-
-            ! Consume closing paren if present
-            op_token = parser%peek()
-            if (op_token%kind == TK_OPERATOR .and. op_token%text == ")") then
-                paren = parser%consume()
-            end if
-
-            ! Determine the call target name (identifier or component)
-            block
-                logical :: name_available
-                name_available = .false.
-                select type (node => arena%entries(expr_index)%node)
-                type is (component_access_node)
-                    if (allocated(node%component_name)) then
-                        name_for_call = node%component_name
-                        name_available = .true.
-                    end if
-                type is (identifier_node)
-                    if (allocated(node%name)) then
-                        name_for_call = node%name
-                        name_available = .true.
-                    end if
-                class default
-                    return
-                end select
-
-                if (.not. name_available) return
-            end block
-
-            ! Create call_or_subscript node even when argument list is empty
-            if (.not. allocated(arg_indices)) then
-                allocate (arg_indices(0))
-            end if
-
-            expr_index = push_call_or_subscript_with_slice_detection(arena, &
-                                                                     name_for_call, &
-                                                                     arg_indices, &
-                                                                     paren%line, &
-                                                                     paren%column)
-        end block
-    end function parse_array_indexing_postfix
-
-    ! Parse array indexing postfix operator using square brackets: [...]
-    function parse_square_indexing_postfix(parser, arena, base_expr) result(expr_index)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: base_expr
-        integer :: expr_index
-
-        block
-            integer, allocatable :: arg_indices(:)
-            type(token_t) :: bracket, op_token
-            integer :: arg_count
-            character(len=:), allocatable :: name_for_call
-
-            arg_count = 0
-            expr_index = base_expr
-
-            ! Consume opening bracket
-            bracket = parser%consume()
-
-            ! Parse indices (use same range parser as for parentheses)
-            op_token = parser%peek()
-            if (op_token%kind /= TK_OPERATOR .or. op_token%text /= "]") then
-                block
-                    integer :: arg_index
-                    arg_index = parse_range(parser, arena)
-                    if (arg_index > 0) then
-                        arg_count = 1
-                        allocate (arg_indices(1))
-                        arg_indices(1) = arg_index
-
-                        do
-                            op_token = parser%peek()
-                            if (op_token%kind /= TK_OPERATOR .or. &
-                                op_token%text /= ",") exit
-
-                            ! Consume comma
-                            op_token = parser%consume()
-
-                            ! Parse next index
-                            arg_index = parse_range(parser, arena)
-                            if (arg_index > 0) then
-                                arg_indices = [arg_indices, arg_index]
-                                arg_count = arg_count + 1
-                            else
-                                exit
-                            end if
-                        end do
-                    end if
-                end block
-            end if
-
-            ! Consume closing bracket if present
-            op_token = parser%peek()
-            if (op_token%kind == TK_OPERATOR .and. op_token%text == "]") then
-                bracket = parser%consume()
-            end if
-
-            ! Create call_or_subscript node with slice detection (same as parentheses)
-            if (allocated(arg_indices)) then
-                select type (node => arena%entries(expr_index)%node)
-                type is (component_access_node)
-                    name_for_call = node%component_name
-                type is (identifier_node)
-                    name_for_call = node%name
-                class default
-                    return
-                end select
-
-                if (allocated(name_for_call)) then
-                    expr_index = &
-                        push_call_or_subscript_with_slice_detection(arena, &
-                                                                    name_for_call, &
-                                                                    arg_indices, &
-                                                                    bracket%line, &
-                                                                    bracket%column)
-                end if
-            end if
-        end block
-    end function parse_square_indexing_postfix
-
     ! Parse postfix operators on an expression
     function parse_postfix_ops(parser, arena, view, base_expr) result(expr_index)
         type(parser_state_t), intent(inout) :: parser
@@ -1734,6 +852,12 @@ contains
         integer :: expr_index
         type(token_t) :: op_token
         integer :: loop_count
+        type(array_parse_helpers_t) :: array_helpers
+
+        array_helpers%parse_comparison => parse_comparison
+        array_helpers%parse_unary => parse_unary
+        array_helpers%parse_logical_eqv => parse_logical_eqv
+        array_helpers%parse_range => parse_range
 
         expr_index = base_expr
         loop_count = 0
@@ -1749,9 +873,11 @@ contains
                                                             expr_index, op_token)
                 if (expr_index <= 0) exit
             else if (op_token%kind == TK_OPERATOR .and. op_token%text == "(") then
-                expr_index = parse_array_indexing_postfix(parser, arena, expr_index)
+                expr_index = parse_array_indexing_postfix(parser, arena, expr_index, &
+                                                          array_helpers)
             else if (op_token%kind == TK_OPERATOR .and. op_token%text == "[") then
-                expr_index = parse_square_indexing_postfix(parser, arena, expr_index)
+                expr_index = parse_square_indexing_postfix(parser, arena, expr_index, &
+                                                           array_helpers)
             else
                 exit
             end if

--- a/src/parser/parser_procedure_bodies.f90
+++ b/src/parser/parser_procedure_bodies.f90
@@ -12,7 +12,7 @@ module parser_procedure_bodies_module
                            push_literal, push_binary_op
     use parser_declarations, only: parse_declaration, parse_multi_declaration
     use parser_call_module, only: parse_call_statement
-    use parser_statement_core_module, only: parse_data_statement
+    use parser_statement_data_module, only: parse_data_statement
     use ast_types, only: LITERAL_STRING, LITERAL_INTEGER
     implicit none
     private
@@ -277,8 +277,8 @@ contains
         if (token%kind == TK_IDENTIFIER) then
             function_name = token%text
             token = parser%consume()
-        else if (token%kind == TK_KEYWORD .and. keyword_can_be_function_name(parser, &
-                                                                             token)) then
+        else if (token%kind == TK_KEYWORD .and. &
+                 keyword_can_be_function_name(parser, token)) then
             function_name = token%text
             token = parser%consume()
         else

--- a/src/parser/parser_statement_core.f90
+++ b/src/parser/parser_statement_core.f90
@@ -12,18 +12,18 @@ module parser_statement_core_module
     use parser_call_module, only: parse_call_statement
     use parser_utils, only: analyze_declaration_structure
     use ast_arena_modern, only: ast_arena_t
-    use ast_nodes_core, only: array_literal_node
-    use ast_factory, only: push_assignment, push_identifier, push_namelist_statement, &
-                           push_array_literal
-    use type_system_unified, only: create_mono_type, TARRAY
+    use ast_factory, only: push_assignment, push_identifier
     use parser_statement_callbacks_module, only: statement_callbacks_t, &
                                                  null_statement_callbacks
+    use parser_statement_data_module, only: parse_data_statement, &
+                                            parse_namelist_statement
     implicit none
     private
 
     public :: statement_callbacks_t, null_statement_callbacks
     public :: parse_basic_statement_core, find_statement_end, extend_if_statement_end
     public :: parse_data_statement
+    private :: parse_namelist_statement
 
 contains
 
@@ -515,7 +515,8 @@ contains
             stmt_index = parse_keyword_statement(first_token, parser, arena, &
                                                  parent_index, local_callbacks)
         case (TK_IDENTIFIER)
-            stmt_index = parse_identifier_statement(parser, arena, parent_index, tokens)
+            stmt_index = parse_identifier_statement(parser, arena, &
+                                                    parent_index, tokens)
         end select
 
         if (stmt_index == 0) then
@@ -575,7 +576,8 @@ contains
                    text == "character")
     end function is_declaration_keyword
 
-    integer function parse_keyword_statement(first_token, parser, arena, parent_index, &
+    integer function parse_keyword_statement(first_token, parser, arena, &
+                                             parent_index, &
                                              callbacks) result(stmt_index)
         type(token_t), intent(in) :: first_token
         type(parser_state_t), intent(inout) :: parser
@@ -661,7 +663,8 @@ contains
         op_token = parser%peek()
 
         if (op_token%kind == TK_OPERATOR .and. op_token%text == "(") then
-            stmt_index = parse_complex_assignment(parser, arena, parent_index, tokens, &
+            stmt_index = parse_complex_assignment(parser, arena, &
+                                                  parent_index, tokens, &
                                                   id_token)
         else if (op_token%kind == TK_OPERATOR .and. op_token%text == "=") then
             stmt_index = parse_simple_assignment(parser, arena, parent_index, tokens, &
@@ -829,277 +832,5 @@ contains
         parser%current_token = max(1, parser%current_token)
         call parser%error(trim(message))
     end subroutine report_unparsed_statement
-
-    integer function parse_data_statement(parser, arena, parent_index) &
-        result(stmt_index)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in), optional :: parent_index
-        type(token_t) :: token
-        type(token_t) :: target_token
-        integer :: target_index
-        integer, allocatable :: element_indices(:)
-        integer :: value_index
-        logical :: expect_value
-
-        stmt_index = 0
-
-        ! Consume DATA keyword
-        token = parser%consume()
-
-        call skip_trivia(parser)
-
-        token = parser%peek()
-        if (token%kind /= TK_IDENTIFIER) then
-            call parser%error("Expected identifier after DATA keyword")
-            return
-        end if
-
-        target_token = parser%consume()
-        if (present(parent_index)) then
-            target_index = push_identifier(arena, trim(target_token%text), &
-                                           target_token%line, target_token%column, &
-                                           parent_index)
-        else
-            target_index = push_identifier(arena, trim(target_token%text), &
-                                           target_token%line, target_token%column)
-        end if
-        if (target_index <= 0) return
-
-        call skip_trivia(parser)
-
-        token = parser%peek()
-        if (token%kind /= TK_OPERATOR .or. trim(token%text) /= "/") then
-            call parser%error("Expected '/' to begin DATA value list")
-            return
-        end if
-        token = parser%consume()  ! consume opening slash
-
-        expect_value = .true.
-        call skip_trivia(parser)
-
-        do
-            token = parser%peek()
-            if (token%kind == TK_EOF) then
-                call parser%error("Unexpected end of statement inside DATA value list")
-                return
-            end if
-
-            if (token%kind == TK_OPERATOR .and. trim(token%text) == "/") then
-                if (expect_value) then
-                    call parser%error("DATA statement value list cannot be empty")
-                    return
-                end if
-                exit
-            end if
-
-            value_index = parse_expression_until(parser, arena, [",", "/"])
-            if (value_index <= 0) return
-            call append_index(element_indices, value_index)
-
-            call skip_trivia(parser)
-            token = parser%peek()
-            if (token%kind == TK_OPERATOR) then
-                select case (trim(token%text))
-                case (",")
-                    token = parser%consume()
-                    expect_value = .true.
-                    call skip_trivia(parser)
-                    cycle
-                case ("/")
-                    expect_value = .false.
-                case default
-                    call parser%error("Unexpected token in DATA statement value list")
-                    return
-                end select
-            else
-                call parser%error("Unexpected token in DATA statement value list")
-                return
-            end if
-        end do
-
-        ! Consume closing slash
-        token = parser%consume()
-
-        if (.not. allocated(element_indices)) then
-            call parser%error("DATA statement requires at least one value")
-            return
-        end if
-
-        block
-            integer :: array_index
-            integer :: element_count
-            element_count = size(element_indices)
-            if (present(parent_index)) then
-                array_index = push_array_literal(arena, element_indices, &
-                                                 target_token%line, &
-                                                 target_token%column, &
-                                                 parent_index, syntax_style="legacy")
-            else
-                array_index = push_array_literal(arena, element_indices, &
-                                                 target_token%line, &
-                                                 target_token%column, &
-                                                 syntax_style="legacy")
-            end if
-            if (array_index <= 0) return
-
-            call annotate_array_literal(arena, array_index, element_count)
-
-            if (present(parent_index)) then
-                stmt_index = push_assignment(arena, target_index, array_index, &
-                                             target_token%line, target_token%column, &
-                                             parent_index)
-            else
-                stmt_index = push_assignment(arena, target_index, array_index, &
-                                             target_token%line, target_token%column)
-            end if
-        end block
-    contains
-        subroutine append_index(indices, value)
-            integer, allocatable, intent(inout) :: indices(:)
-            integer, intent(in) :: value
-            integer, allocatable :: tmp(:)
-
-            if (value <= 0) return
-            if (.not. allocated(indices)) then
-                allocate (indices(1))
-                indices(1) = value
-            else
-                allocate (tmp(size(indices) + 1))
-                tmp(1:size(indices)) = indices
-                tmp(size(indices) + 1) = value
-                call move_alloc(tmp, indices)
-            end if
-        end subroutine append_index
-
-        subroutine annotate_array_literal(arena, array_index, element_count)
-            use type_system_unified, only: create_mono_type, TARRAY
-            type(ast_arena_t), intent(inout) :: arena
-            integer, intent(in) :: array_index
-            integer, intent(in) :: element_count
-            if (array_index <= 0 .or. array_index > arena%size) return
-            if (.not. allocated(arena%entries(array_index)%node)) return
-            select type (array_node => arena%entries(array_index)%node)
-            type is (array_literal_node)
-                array_node%inferred_type = create_mono_type(TARRAY, &
-                                                            array_size=element_count)
-            end select
-        end subroutine annotate_array_literal
-
-        ! No identifier annotation needed here; semantic pass will refine type info.
-    end function parse_data_statement
-
-    integer function parse_namelist_statement(parser, arena, parent_index) &
-        result(stmt_index)
-        type(parser_state_t), intent(inout) :: parser
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in), optional :: parent_index
-        type(token_t) :: token
-        character(len=:), allocatable :: group_name
-        character(len=:), allocatable :: names(:)
-        integer :: line, column
-
-        stmt_index = 0
-        token = parser%peek()
-        line = token%line
-        column = token%column
-
-        token = parser%consume()
-
-        if (parser%is_at_end()) return
-        token = parser%peek()
-        if (.not. (token%kind == TK_OPERATOR .and. token%text == "/")) return
-        token = parser%consume()
-
-        if (parser%is_at_end()) return
-        token = parser%peek()
-        if (token%kind /= TK_IDENTIFIER) return
-        group_name = trim(token%text)
-        token = parser%consume()
-
-        if (parser%is_at_end()) return
-        token = parser%peek()
-        if (.not. (token%kind == TK_OPERATOR .and. token%text == "/")) return
-        token = parser%consume()
-
-        do while (.not. parser%is_at_end())
-            token = parser%peek()
-            select case (token%kind)
-            case (TK_IDENTIFIER)
-                call append_name(names, token%text)
-                token = parser%consume()
-            case (TK_OPERATOR)
-                if (token%text == ",") then
-                    token = parser%consume()
-                    cycle
-                else
-                    exit
-                end if
-            case (TK_NEWLINE)
-                token = parser%consume()
-                exit
-            case (TK_COMMENT)
-                exit
-            case default
-                exit
-            end select
-        end do
-
-        if (.not. allocated(group_name)) return
-
-        if (present(parent_index)) then
-            if (allocated(names)) then
-                stmt_index = push_namelist_statement(arena, group_name, names, &
-                                                     line, column, parent_index)
-            else
-                stmt_index = push_namelist_statement(arena, group_name, line=line, &
-                                                     column=column, &
-                                                     parent_index=parent_index)
-            end if
-        else
-            if (allocated(names)) then
-                stmt_index = push_namelist_statement(arena, group_name, names, &
-                                                     line, column)
-            else
-                stmt_index = push_namelist_statement(arena, group_name, line=line, &
-                                                     column=column)
-            end if
-        end if
-    contains
-        subroutine append_name(list, value)
-            character(len=:), allocatable, intent(inout) :: list(:)
-            character(len=*), intent(in) :: value
-            character(len=:), allocatable :: temp(:)
-            integer :: n, current_len, target_len
-
-            if (.not. allocated(list)) then
-                allocate (character(len=len_trim(value)) :: list(1))
-                list(1) = trim(value)
-            else
-                n = size(list)
-                current_len = len(list)
-                target_len = len_trim(value)
-                target_len = max(current_len, target_len)
-                allocate (character(len=target_len) :: temp(n + 1))
-                temp(1:n) = list
-                temp(n + 1) = trim(value)
-                call move_alloc(temp, list)
-            end if
-        end subroutine append_name
-    end function parse_namelist_statement
-
-    subroutine skip_trivia(parser)
-        type(parser_state_t), intent(inout) :: parser
-        type(token_t) :: current
-
-        do
-            current = parser%peek()
-            if (current%kind == TK_WHITESPACE .or. current%kind == TK_COMMENT) then
-                current = parser%consume()
-            else
-                exit
-            end if
-        end do
-    end subroutine skip_trivia
 
 end module parser_statement_core_module

--- a/src/parser/parser_statement_data_module.f90
+++ b/src/parser/parser_statement_data_module.f90
@@ -1,0 +1,289 @@
+module parser_statement_data_module
+    use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_OPERATOR, TK_NEWLINE, &
+                          TK_COMMENT, TK_WHITESPACE
+    use parser_state_module, only: parser_state_t
+    use parser_expressions_module, only: parse_expression_until
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: array_literal_node
+    use ast_factory, only: push_assignment, push_identifier, push_array_literal, &
+                           push_namelist_statement
+    use type_system_unified, only: create_mono_type, TARRAY
+    implicit none
+    private
+
+    public :: parse_data_statement
+    public :: parse_namelist_statement
+
+contains
+
+    integer function parse_data_statement(parser, arena, parent_index) &
+        result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in), optional :: parent_index
+        type(token_t) :: token
+        type(token_t) :: target_token
+        integer :: target_index
+        integer, allocatable :: element_indices(:)
+        integer :: value_index
+        logical :: expect_value
+
+        stmt_index = 0
+
+        token = parser%consume()
+        call skip_trivia(parser)
+
+        token = parser%peek()
+        if (token%kind /= TK_IDENTIFIER) then
+            call parser%error("Expected identifier after DATA keyword")
+            return
+        end if
+
+        target_token = parser%consume()
+        if (present(parent_index)) then
+            target_index = push_identifier(arena, trim(target_token%text), &
+                                           target_token%line, target_token%column, &
+                                           parent_index)
+        else
+            target_index = push_identifier(arena, trim(target_token%text), &
+                                           target_token%line, target_token%column)
+        end if
+        if (target_index <= 0) return
+
+        call skip_trivia(parser)
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. trim(token%text) /= "/") then
+            call parser%error("Expected '/' to begin DATA value list")
+            return
+        end if
+        token = parser%consume()
+
+        expect_value = .true.
+        call skip_trivia(parser)
+
+        do
+            token = parser%peek()
+            if (token%kind == TK_EOF) then
+                call parser%error("Unexpected end of statement inside DATA value list")
+                return
+            end if
+
+            if (token%kind == TK_OPERATOR .and. trim(token%text) == "/") then
+                if (expect_value) then
+                    call parser%error("DATA statement value list cannot be empty")
+                    return
+                end if
+                exit
+            end if
+
+            value_index = parse_expression_until(parser, arena, [",", "/"])
+            if (value_index <= 0) return
+            call append_index(element_indices, value_index)
+
+            call skip_trivia(parser)
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR) then
+                select case (trim(token%text))
+                case (",")
+                    token = parser%consume()
+                    expect_value = .true.
+                    call skip_trivia(parser)
+                    cycle
+                case ("/")
+                    expect_value = .false.
+                case default
+                    call parser%error("Unexpected token in DATA statement value list")
+                    return
+                end select
+            else
+                call parser%error("Unexpected token in DATA statement value list")
+                return
+            end if
+        end do
+
+        token = parser%consume()
+
+        if (.not. allocated(element_indices)) then
+            call parser%error("DATA statement requires at least one value")
+            return
+        end if
+
+        block
+            integer :: array_index
+            integer :: element_count
+            element_count = size(element_indices)
+            if (present(parent_index)) then
+                array_index = push_array_literal(arena, element_indices, &
+                                                 target_token%line, &
+                                                 target_token%column, &
+                                                 parent_index, syntax_style="legacy")
+            else
+                array_index = push_array_literal(arena, element_indices, &
+                                                 target_token%line, &
+                                                 target_token%column, &
+                                                 syntax_style="legacy")
+            end if
+            if (array_index <= 0) return
+
+            call annotate_array_literal(arena, array_index, element_count)
+
+            if (present(parent_index)) then
+                stmt_index = push_assignment(arena, target_index, array_index, &
+                                             target_token%line, target_token%column, &
+                                             parent_index)
+            else
+                stmt_index = push_assignment(arena, target_index, array_index, &
+                                             target_token%line, target_token%column)
+            end if
+        end block
+    contains
+        subroutine append_index(indices, value)
+            integer, allocatable, intent(inout) :: indices(:)
+            integer, intent(in) :: value
+            integer, allocatable :: tmp(:)
+
+            if (value <= 0) return
+            if (.not. allocated(indices)) then
+                allocate (indices(1))
+                indices(1) = value
+            else
+                allocate (tmp(size(indices) + 1))
+                tmp(1:size(indices)) = indices
+                tmp(size(indices) + 1) = value
+                call move_alloc(tmp, indices)
+            end if
+        end subroutine append_index
+
+        subroutine annotate_array_literal(arena, array_index, element_count)
+            type(ast_arena_t), intent(inout) :: arena
+            integer, intent(in) :: array_index
+            integer, intent(in) :: element_count
+
+            if (array_index <= 0 .or. array_index > arena%size) return
+            if (.not. allocated(arena%entries(array_index)%node)) return
+
+            select type (array_node => arena%entries(array_index)%node)
+            type is (array_literal_node)
+                array_node%inferred_type = create_mono_type(TARRAY, &
+                                                            array_size=element_count)
+            end select
+        end subroutine annotate_array_literal
+    end function parse_data_statement
+
+    integer function parse_namelist_statement(parser, arena, parent_index) &
+        result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in), optional :: parent_index
+        type(token_t) :: token
+        character(len=:), allocatable :: group_name
+        character(len=:), allocatable :: names(:)
+        integer :: line
+        integer :: column
+
+        stmt_index = 0
+        token = parser%peek()
+        line = token%line
+        column = token%column
+
+        token = parser%consume()
+
+        if (parser%is_at_end()) return
+        token = parser%peek()
+        if (.not. (token%kind == TK_OPERATOR .and. token%text == "/")) return
+        token = parser%consume()
+
+        if (parser%is_at_end()) return
+        token = parser%peek()
+        if (token%kind /= TK_IDENTIFIER) return
+        group_name = trim(token%text)
+        token = parser%consume()
+
+        if (parser%is_at_end()) return
+        token = parser%peek()
+        if (.not. (token%kind == TK_OPERATOR .and. token%text == "/")) return
+        token = parser%consume()
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            select case (token%kind)
+            case (TK_IDENTIFIER)
+                call append_name(names, token%text)
+                token = parser%consume()
+            case (TK_OPERATOR)
+                if (token%text == ",") then
+                    token = parser%consume()
+                    cycle
+                else
+                    exit
+                end if
+            case (TK_NEWLINE)
+                token = parser%consume()
+                exit
+            case (TK_COMMENT)
+                exit
+            case default
+                exit
+            end select
+        end do
+
+        if (.not. allocated(group_name)) return
+
+        if (present(parent_index)) then
+            if (allocated(names)) then
+                stmt_index = push_namelist_statement(arena, group_name, names, &
+                                                     line, column, parent_index)
+            else
+                stmt_index = push_namelist_statement(arena, group_name, line=line, &
+                                                     column=column, &
+                                                     parent_index=parent_index)
+            end if
+        else
+            if (allocated(names)) then
+                stmt_index = push_namelist_statement(arena, group_name, names, &
+                                                     line, column)
+            else
+                stmt_index = push_namelist_statement(arena, group_name, line=line, &
+                                                     column=column)
+            end if
+        end if
+    contains
+        subroutine append_name(list, value)
+            character(len=:), allocatable, intent(inout) :: list(:)
+            character(len=*), intent(in) :: value
+            character(len=:), allocatable :: temp(:)
+            integer :: n
+            integer :: current_len
+            integer :: target_len
+
+            if (.not. allocated(list)) then
+                allocate (character(len=len_trim(value)) :: list(1))
+                list(1) = trim(value)
+            else
+                n = size(list)
+                current_len = len(list)
+                target_len = len_trim(value)
+                target_len = max(current_len, target_len)
+                allocate (character(len=target_len) :: temp(n + 1))
+                temp(1:n) = list
+                temp(n + 1) = trim(value)
+                call move_alloc(temp, list)
+            end if
+        end subroutine append_name
+    end function parse_namelist_statement
+
+    subroutine skip_trivia(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: current
+
+        do
+            current = parser%peek()
+            if (current%kind == TK_WHITESPACE .or. current%kind == TK_COMMENT) then
+                current = parser%consume()
+            else
+                exit
+            end if
+        end do
+    end subroutine skip_trivia
+
+end module parser_statement_data_module

--- a/src/parser/parser_statement_utilities.f90
+++ b/src/parser/parser_statement_utilities.f90
@@ -19,7 +19,7 @@ module parser_statement_utilities_module
                                                parse_deallocate_statement
     use parser_assignment_module, only: parse_assignment_statement
     use parser_call_module, only: parse_call_statement
-    use parser_statement_core_module, only: parse_data_statement
+    use parser_statement_data_module, only: parse_data_statement
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_associate, push_if, push_literal
     use ast_factory
@@ -53,7 +53,8 @@ contains
                 stmt_index = parse_data_statement(parser, arena)
             case ("call")
                 stmt_index = parse_call_statement(parser, arena)
-            case ("integer", "real", "logical", "character", "complex", "double", "type")
+            case ("integer", "real", "logical", "character", "complex", &
+                  "double", "type")
                 stmt_index = parse_declaration(parser, arena)
             case ("allocate")
                 stmt_index = parse_allocate_statement(parser, arena)

--- a/src/parser/parser_token_views.f90
+++ b/src/parser/parser_token_views.f90
@@ -1,0 +1,247 @@
+module parser_token_views_module
+    use lexer_core, only: token_t, to_lower
+    use parser_state_module, only: parser_state_t
+    implicit none
+    private
+
+    type :: token_view_t
+        character(len=:), allocatable :: text(:)
+        character(len=:), allocatable :: lower(:)
+        integer, allocatable :: kind(:)
+        integer, allocatable :: line(:)
+        integer, allocatable :: column(:)
+        integer :: base_index = 1
+        integer :: count = 0
+    end type token_view_t
+
+    public :: token_view_t
+    public :: build_token_view
+    public :: view_peek_token
+    public :: view_lower_token
+    public :: view_consume_token
+    public :: view_lookahead_token
+
+contains
+
+    subroutine build_token_view(view, parser)
+        type(token_view_t), intent(inout) :: view
+        type(parser_state_t), intent(in) :: parser
+        integer :: start_idx
+        integer :: end_idx
+        integer :: count
+        integer :: max_len
+
+        call initialize_token_view_state(view, parser, start_idx, end_idx, count)
+        if (count == 0) return
+
+        max_len = compute_max_token_length(parser, start_idx, end_idx)
+        call prepare_token_view_arrays(view, count, max_len)
+        call populate_token_view(view, parser, start_idx, count)
+        view%base_index = start_idx
+        view%count = count
+    end subroutine build_token_view
+
+    subroutine initialize_token_view_state(view, parser, start_idx, end_idx, count)
+        type(token_view_t), intent(inout) :: view
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(out) :: start_idx
+        integer, intent(out) :: end_idx
+        integer, intent(out) :: count
+
+        if (.not. associated(parser%tokens)) then
+            view%count = 0
+            view%base_index = parser%current_token
+            call release_token_view_arrays(view)
+            count = 0
+            start_idx = 0
+            end_idx = -1
+            return
+        end if
+
+        start_idx = max(parser%current_token, 1)
+        end_idx = size(parser%tokens)
+        count = end_idx - start_idx + 1
+
+        if (count <= 0) then
+            count = 0
+            start_idx = parser%current_token
+            end_idx = parser%current_token - 1
+            view%count = 0
+            view%base_index = parser%current_token
+            call release_token_view_arrays(view)
+        end if
+    end subroutine initialize_token_view_state
+
+    integer function compute_max_token_length(parser, start_idx, end_idx) &
+        result(max_len)
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(in) :: start_idx
+        integer, intent(in) :: end_idx
+        integer :: idx
+
+        max_len = 0
+        do idx = start_idx, end_idx
+            if (associated(parser%tokens)) then
+                max_len = max(max_len, len_trim(parser%tokens(idx)%text))
+            end if
+        end do
+    end function compute_max_token_length
+
+    subroutine prepare_token_view_arrays(view, count, max_len)
+        type(token_view_t), intent(inout) :: view
+        integer, intent(in) :: count
+        integer, intent(in) :: max_len
+
+        if (count <= 0) then
+            call release_token_view_arrays(view)
+            return
+        end if
+
+        if (allocated(view%text)) then
+            if (size(view%text) /= count .or. len(view%text) < max_len) then
+                call release_token_view_arrays(view)
+            end if
+        end if
+
+        if (.not. allocated(view%text)) then
+            allocate (character(len=max_len) :: view%text(count))
+            allocate (character(len=max_len) :: view%lower(count))
+            allocate (view%kind(count))
+            allocate (view%line(count))
+            allocate (view%column(count))
+        end if
+    end subroutine prepare_token_view_arrays
+
+    subroutine populate_token_view(view, parser, start_idx, count)
+        type(token_view_t), intent(inout) :: view
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(in) :: start_idx
+        integer, intent(in) :: count
+        integer :: idx
+        integer :: target_idx
+
+        do idx = 1, count
+            target_idx = start_idx + idx - 1
+            view%text(idx) = parser%tokens(target_idx)%text
+            view%lower(idx) = to_lower(parser%tokens(target_idx)%text)
+            view%kind(idx) = parser%tokens(target_idx)%kind
+            view%line(idx) = parser%tokens(target_idx)%line
+            view%column(idx) = parser%tokens(target_idx)%column
+        end do
+    end subroutine populate_token_view
+
+    subroutine release_token_view_arrays(view)
+        type(token_view_t), intent(inout) :: view
+
+        if (allocated(view%text)) then
+            block
+                character(len=:), allocatable :: temp(:)
+                call move_alloc(view%text, temp)
+            end block
+        end if
+
+        if (allocated(view%lower)) then
+            block
+                character(len=:), allocatable :: temp(:)
+                call move_alloc(view%lower, temp)
+            end block
+        end if
+
+        if (allocated(view%kind)) then
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(view%kind, temp)
+            end block
+        end if
+
+        if (allocated(view%line)) then
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(view%line, temp)
+            end block
+        end if
+
+        if (allocated(view%column)) then
+            block
+                integer, allocatable :: temp(:)
+                call move_alloc(view%column, temp)
+            end block
+        end if
+    end subroutine release_token_view_arrays
+
+    function view_peek_token(view, parser) result(token)
+        type(token_view_t), intent(in) :: view
+        type(parser_state_t), intent(in) :: parser
+        type(token_t) :: token
+        integer :: idx
+
+        idx = parser%current_token - view%base_index + 1
+        if (idx < 1 .or. idx > view%count) then
+            token = parser%peek()
+            return
+        end if
+
+        token%text = view%text(idx)
+        token%kind = view%kind(idx)
+        token%line = view%line(idx)
+        token%column = view%column(idx)
+    end function view_peek_token
+
+    function view_lower_token(view, parser, offset) result(lowered)
+        type(token_view_t), intent(in) :: view
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(in), optional :: offset
+        character(len=:), allocatable :: lowered
+        integer :: idx
+        integer :: off
+
+        off = 0
+        if (present(offset)) off = offset
+        idx = parser%current_token - view%base_index + 1 + off
+
+        if (idx < 1 .or. idx > view%count) then
+            block
+                type(token_t) :: fallback_token
+                fallback_token = view_peek_token(view, parser)
+                lowered = to_lower(fallback_token%text)
+            end block
+            return
+        end if
+
+        lowered = trim(view%lower(idx))
+    end function view_lower_token
+
+    function view_consume_token(view, parser) result(token)
+        type(token_view_t), intent(in) :: view
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        token = view_peek_token(view, parser)
+        if (.not. parser%is_at_end()) then
+            block
+                type(token_t) :: discarded_token
+                discarded_token = parser%consume()
+            end block
+        end if
+    end function view_consume_token
+
+    function view_lookahead_token(view, parser, offset) result(token)
+        type(token_view_t), intent(in) :: view
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(in) :: offset
+        type(token_t) :: token
+        integer :: idx
+
+        idx = parser%current_token - view%base_index + 1 + offset
+        if (idx < 1 .or. idx > view%count) then
+            token = parser%peek()
+            return
+        end if
+
+        token%text = view%text(idx)
+        token%kind = view%kind(idx)
+        token%line = view%line(idx)
+        token%column = view%column(idx)
+    end function view_lookahead_token
+
+end module parser_token_views_module


### PR DESCRIPTION
## Summary
- split expression parsing helpers into dedicated modules so each parser file stays under the 1000-line ceiling
- extract DATA/NAMELIST handling into `parser_statement_data_module` and point existing dispatchers at the new entry points
- add reusable token view and stack helpers to simplify the core Pratt parser implementation

## Verification
- `make test`
  - `SUCCESS: All examples behaved as expected`
