### PR TITLE
fix: preserve complex literals with kind parameter (fixes #1545)

### DIFF
--- a/examples/issue_1545_complex_literal.lf
+++ b/examples/issue_1545_complex_literal.lf
@@ -1,0 +1,6 @@
+! Issue #1545: Complex literals with kind parameter were broken
+program test
+    implicit none
+    complex(kind=8) :: w = (1.0d0, 2.0d0)
+    print *, w
+end program test

--- a/src/parser/parser_declarations_core_module.f90
+++ b/src/parser/parser_declarations_core_module.f90
@@ -284,9 +284,9 @@ contains
         token = parser%peek()
         if (token%text == "=" .or. token%text == "=>") then
             token = parser%consume()
-            if (type_spec%type_name == "complex") then
+            if (type_spec%base_keyword == "complex") then
                 initializer_index = handle_complex_initializer( &
-                                    parser, arena, type_spec%type_name)
+                                    parser, arena, type_spec%base_keyword)
             else
                 initializer_index = parse_comparison(parser, arena)
             end if
@@ -738,9 +738,9 @@ contains
         token = parser%peek()
         if (token%text == "=" .or. token%text == "=>") then
             token = parser%consume()
-            if (type_spec%type_name == "complex") then
+            if (type_spec%base_keyword == "complex") then
                 init_index = handle_complex_initializer( &
-                             parser, arena, type_spec%type_name)
+                             parser, arena, type_spec%base_keyword)
             else
                 init_index = parse_comparison(parser, arena)
             end if

--- a/test/codegen/test_issue_1545_complex_literal.f90
+++ b/test/codegen/test_issue_1545_complex_literal.f90
@@ -1,0 +1,56 @@
+program test_issue_1545_complex_literal
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+    logical :: success
+
+    print *, "=== Issue #1545: Complex literals with kind parameter ==="
+
+    ! Test complex literals in declaration with kind parameter
+    ! This was the main bug: complex(kind=8) was not recognized
+    source = '! Issue 1545: complex literal with kind' // new_line('a') // &
+             'program test' // new_line('a') // &
+             '    implicit none' // new_line('a') // &
+             '    complex(kind=8) :: w = (1.0d0, 2.0d0)' // new_line('a') // &
+             '    print *, w' // new_line('a') // &
+             'end program test'
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    success = .true.
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) success = .false.
+    end if
+
+    if (.not. allocated(output)) success = .false.
+
+    if (success) then
+        ! Must contain complex literal with both parts
+        if (index(output, '(1.0d0, 2.0d0)') == 0) then
+            if (index(output, '(1.0d0,2.0d0)') == 0) success = .false.
+        end if
+        ! Must NOT be just the real part (this was the bug)
+        if (index(output, 'w = 1.0d0') > 0) success = .false.
+    end if
+
+    if (success) then
+        print *, 'PASSED'
+    else
+        print *, 'FAILED: complex(kind=8) literal imaginary part lost'
+        if (allocated(output)) then
+            print *, 'OUTPUT:'
+            print *, trim(output)
+        end if
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'ERRORS:'
+                print *, trim(error_msg)
+            end if
+        end if
+        stop 1
+    end if
+
+end program test_issue_1545_complex_literal


### PR DESCRIPTION
## Summary
- Fixed complex literal handling when kind parameter is specified
- Changed from checking `type_name` to `base_keyword` for complex type detection

## Verification
**Test commands:**
```bash
fpm test test_issue_1545_complex_literal
fpm test test_complex_literals
```

**Test output:**
```
=== Issue #1545: Complex literals with kind parameter ===
PASSED

Test 2 - Complex double precision:  T
Output: program main
    implicit none
    complex(kind=8) :: w = (1.0d0, 2.0d0)
end program main
```

## Note
This PR fixes the case of complex literals in **declarations with kind parameters**, 
e.g., `complex(kind=8) :: w = (1.0d0, 2.0d0)`.

The original issue also mentions complex literals in **assignments** 
(e.g., `z = (3.0, 4.0)` where z is complex), which requires more extensive 
parser changes and remains a known limitation.