### PR TITLE
fix: prevent scalars from being marked allocatable (fixes #1547)

### DIFF
--- a/examples/issue_1547_scalar_allocatable.f90
+++ b/examples/issue_1547_scalar_allocatable.f90
@@ -1,0 +1,11 @@
+! Minimal reproducer: scalar marked allocatable
+program test
+    implicit none
+    integer :: x
+
+    x = 1
+    x = 2
+    x = 3
+
+    print *, x
+end program test

--- a/examples/issue_1547_scalar_allocatable.lf
+++ b/examples/issue_1547_scalar_allocatable.lf
@@ -1,0 +1,8 @@
+! Minimal reproducer: scalar marked allocatable
+program test
+    x = 1
+    x = 2
+    x = 3
+
+    print *, x
+end program test

--- a/src/standardizers/standardizer_allocatable.f90
+++ b/src/standardizers/standardizer_allocatable.f90
@@ -146,18 +146,27 @@ contains
 
     logical function variable_requires_allocatable(name, assigned_vars, &
                                                    assignment_counts, var_count, &
-                                                   is_parameter) result(needs_alloc)
+                                                   is_parameter, is_array) result(needs_alloc)
         character(len=*), intent(in) :: name
         character(len=64), intent(in) :: assigned_vars(:)
         integer, intent(in) :: assignment_counts(:)
         integer, intent(in) :: var_count
         logical, intent(in) :: is_parameter
+        logical, intent(in), optional :: is_array
         integer :: idx
 
         idx = locate_variable(name, assigned_vars, var_count)
         needs_alloc = .false.
         if (idx <= 0) return
-        needs_alloc = (assignment_counts(idx) >= 2 .or. is_parameter)
+
+        ! Only mark as allocatable for multiple assignments if it's an array
+        ! Scalars should never be marked allocatable just due to multiple assignments
+        if (present(is_array) .and. is_array) then
+            needs_alloc = (assignment_counts(idx) >= 2 .or. is_parameter)
+        else
+            ! For scalars, only mark as allocatable if it's a parameter
+            needs_alloc = is_parameter
+        end if
     end function variable_requires_allocatable
 
     subroutine record_assignment(arena, stmt, assigned_vars, assignment_counts, &
@@ -425,7 +434,7 @@ contains
             needs_alloc = variable_requires_allocatable(stmt%var_name, &
                                                         assigned_vars, &
                                                         assignment_counts, var_count, &
-                                                        is_parameter)
+                                                        is_parameter, stmt%is_array)
             if (needs_alloc) then
                 if (apply_allocatable_attributes(stmt)) then
                     arena%entries(decl_index)%node = stmt
@@ -516,7 +525,7 @@ contains
                 needs_allocatable = variable_requires_allocatable( &
                                     decl%var_names(i), assigned_vars, &
                                     assignment_counts, &
-                                    var_count, is_parameter)
+                                    var_count, is_parameter, decl%is_array)
                 call append_split_declaration(arena, decl, decl%var_names(i), &
                                               needs_allocatable, prog_index, &
                                               new_indices, new_count)

--- a/test/codegen/test_issue_1547_scalar_allocatable.f90
+++ b/test/codegen/test_issue_1547_scalar_allocatable.f90
@@ -1,0 +1,125 @@
+program test_issue_1547_scalar_allocatable
+    ! Test for issue #1547: Scalars incorrectly marked as allocatable
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    print *, '=== Issue #1547 Scalar Allocatable Tests ==='
+    print *
+
+    ! Test that scalars are not marked allocatable due to multiple assignments
+    if (.not. test_scalar_multiple_assignments()) all_passed = .false.
+    if (.not. test_scalar_single_assignment()) all_passed = .false.
+
+    ! Report results
+    print *
+    if (all_passed) then
+        print *, 'All scalar allocatable tests passed!'
+        stop 0
+    else
+        print *, 'Some scalar allocatable tests failed!'
+        stop 1
+    end if
+
+contains
+
+    logical function test_scalar_multiple_assignments()
+        test_scalar_multiple_assignments = .true.
+        print *, 'Testing scalar with multiple assignments...'
+
+        block
+            character(len=:), allocatable :: input, output, error_msg
+
+            ! Scalar with multiple assignments - should NOT be allocatable
+            input = 'program test' // new_line('a') // &
+                    'x = 1' // new_line('a') // &
+                    'x = 2' // new_line('a') // &
+                    'x = 3' // new_line('a') // &
+                    'print *, x' // new_line('a') // &
+                    'end program test'
+
+            call transform_lazy_fortran_string(input, output, error_msg)
+
+            if (error_msg /= "") then
+                print *, '  FAIL: Transformation error: ', error_msg
+                test_scalar_multiple_assignments = .false.
+                return
+            end if
+
+            if (.not. allocated(output)) then
+                print *, '  FAIL: No output generated'
+                test_scalar_multiple_assignments = .false.
+                return
+            end if
+
+            ! Check that the output does NOT contain "allocatable" for the scalar
+            if (index(output, "allocatable") > 0) then
+                print *, '  FAIL: Scalar incorrectly marked as allocatable'
+                print *, '  Output:', output
+                test_scalar_multiple_assignments = .false.
+                return
+            end if
+
+            ! Check that the output contains the expected declaration
+            if (index(output, "integer :: x") == 0) then
+                print *, '  FAIL: Expected declaration not found'
+                print *, '  Output:', output
+                test_scalar_multiple_assignments = .false.
+                return
+            end if
+        end block
+
+        print *, '  PASS: Scalar with multiple assignments handled correctly'
+    end function test_scalar_multiple_assignments
+
+    logical function test_scalar_single_assignment()
+        test_scalar_single_assignment = .true.
+        print *, 'Testing scalar with single assignment...'
+
+        block
+            character(len=:), allocatable :: input, output, error_msg
+
+            ! Scalar with single assignment - should NOT be allocatable
+            input = 'program test' // new_line('a') // &
+                    'x = 42' // new_line('a') // &
+                    'print *, x' // new_line('a') // &
+                    'end program test'
+
+            call transform_lazy_fortran_string(input, output, error_msg)
+
+            if (error_msg /= "") then
+                print *, '  FAIL: Transformation error: ', error_msg
+                test_scalar_single_assignment = .false.
+                return
+            end if
+
+            if (.not. allocated(output)) then
+                print *, '  FAIL: No output generated'
+                test_scalar_single_assignment = .false.
+                return
+            end if
+
+            ! Check that the output does NOT contain "allocatable" for the scalar
+            if (index(output, "allocatable") > 0) then
+                print *, '  FAIL: Scalar incorrectly marked as allocatable'
+                print *, '  Output:', output
+                test_scalar_single_assignment = .false.
+                return
+            end if
+
+            ! Check that the output contains the expected declaration
+            if (index(output, "integer :: x") == 0) then
+                print *, '  FAIL: Expected declaration not found'
+                print *, '  Output:', output
+                test_scalar_single_assignment = .false.
+                return
+            end if
+        end block
+
+        print *, '  PASS: Scalar with single assignment handled correctly'
+    end function test_scalar_single_assignment
+
+end program test_issue_1547_scalar_allocatable


### PR DESCRIPTION
## Summary
- Fixes issue #1547 where scalars were incorrectly marked as allocatable due to multiple assignments
- Only arrays should be marked allocatable when they have multiple assignments
- Scalars are only marked allocatable if they are parameters

## Changes
- Add `is_array` parameter to `variable_requires_allocatable` function
- Modify logic to distinguish between scalars and arrays for allocatable determination
- Add comprehensive test cases for scalar assignment scenarios
- Add minimal reproducer example

## Test plan
- [x] Test scalars with multiple assignments are not marked allocatable
- [x] Test scalars with single assignments are not marked allocatable  
- [x] Verify existing array allocatable behavior remains unchanged
- [x] Run full test suite locally
- [ ] CI checks pass