### PR TITLE
fix: preserve FORMAT statements and WRITE with label references (fixes #1581)

### DIFF
--- a/src/ast/ast_introspection.f90
+++ b/src/ast/ast_introspection.f90
@@ -126,6 +126,8 @@ contains
             type_id = 21  ! NODE_WRITE_STATEMENT
         type is (read_statement_node)
             type_id = 22  ! NODE_READ_STATEMENT
+        type is (format_statement_node)
+            type_id = 44  ! NODE_FORMAT_STATEMENT
         type is (allocate_statement_node)
             type_id = 23  ! NODE_ALLOCATE_STATEMENT
         type is (deallocate_statement_node)

--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -37,7 +37,8 @@ module ast_factory
         push_print_statement, push_write_statement, push_read_statement, &
         push_read_statement_with_err, push_read_statement_with_end, &
         push_read_statement_with_all_specifiers, push_write_statement_with_iostat, &
-        push_write_statement_with_format, push_write_statement_with_runtime_format
+        push_write_statement_with_format, push_write_statement_with_runtime_format, &
+        push_format_statement
 
     ! Procedure definition nodes
     use ast_factory_procedures, only: &
@@ -88,6 +89,7 @@ module ast_factory
     public :: push_read_statement_with_err, push_read_statement_with_end
     public :: push_read_statement_with_all_specifiers, push_write_statement_with_iostat
     public :: push_write_statement_with_format, push_write_statement_with_runtime_format
+    public :: push_format_statement
 
     ! Procedure definition nodes
     public :: push_function_def, push_subroutine_def, push_interface_block

--- a/src/ast/factory/ast_factory_io.f90
+++ b/src/ast/factory/ast_factory_io.f90
@@ -1,6 +1,7 @@
 module ast_factory_io
     use ast_arena_modern, only: ast_arena_t
-    use ast_nodes_io, only: print_statement_node, write_statement_node, read_statement_node
+    use ast_nodes_io, only: print_statement_node, write_statement_node, &
+                            read_statement_node, format_statement_node
     implicit none
     private
 
@@ -10,6 +11,7 @@ module ast_factory_io
     public :: push_read_statement_with_all_specifiers
     public :: push_write_statement_with_iostat, push_write_statement_with_format
     public :: push_write_statement_with_runtime_format
+    public :: push_format_statement
 
 contains
 
@@ -216,5 +218,21 @@ contains
         call arena%push(write_stmt, "write_statement", parent_index)
         write_index = arena%size
     end function push_write_statement_with_runtime_format
+
+    function push_format_statement(arena, format_spec, line, column, &
+                                    parent_index) result(format_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: format_spec
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: format_index
+        type(format_statement_node) :: format_stmt
+
+        format_stmt%format_spec = format_spec
+        if (present(line)) format_stmt%line = line
+        if (present(column)) format_stmt%column = column
+
+        call arena%push(format_stmt, "format_statement", parent_index)
+        format_index = arena%size
+    end function push_format_statement
 
 end module ast_factory_io

--- a/src/ast/nodes/ast_nodes_io.f90
+++ b/src/ast/nodes/ast_nodes_io.f90
@@ -91,6 +91,16 @@ module ast_nodes_io
         generic :: assignment(=) => assign
     end type format_descriptor_node
 
+    ! Format statement node
+    type, extends(ast_node), public :: format_statement_node
+        character(len=:), allocatable :: format_spec
+    contains
+        procedure :: accept => format_statement_accept
+        procedure :: to_json => format_statement_to_json
+        procedure :: assign => format_statement_assign
+        generic :: assignment(=) => assign
+    end type format_statement_node
+
 contains
 
     ! Stub implementations for print_statement_node
@@ -315,6 +325,43 @@ contains
         lhs%is_literal = rhs%is_literal
         if (allocated(rhs%literal_text)) lhs%literal_text = rhs%literal_text
     end subroutine format_descriptor_assign
+
+    ! Format statement implementations
+    subroutine format_statement_accept(this, visitor)
+        class(format_statement_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+    end subroutine format_statement_accept
+
+    subroutine format_statement_to_json(this, json, parent)
+        class(format_statement_node), intent(in) :: this
+        type(json_core), intent(inout) :: json
+        type(json_value), pointer, intent(in) :: parent
+        type(json_value), pointer :: obj
+
+        call json%create_object(obj, '')
+        call json%add(obj, 'type', 'format_statement')
+        call json%add(obj, 'line', this%line)
+        call json%add(obj, 'column', this%column)
+        if (allocated(this%format_spec)) then
+            call json%add(obj, 'format_spec', this%format_spec)
+        end if
+        call json%add(parent, obj)
+    end subroutine format_statement_to_json
+
+    subroutine format_statement_assign(lhs, rhs)
+        class(format_statement_node), intent(inout) :: lhs
+        class(format_statement_node), intent(in) :: rhs
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+        if (allocated(rhs%format_spec)) lhs%format_spec = rhs%format_spec
+    end subroutine format_statement_assign
 
     ! Factory functions
     function create_print_statement(expression_indices, format_spec, &

--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -91,6 +91,8 @@ contains
             code = generate_code_write_statement(arena, node, node_index)
         type is (read_statement_node)
             code = generate_code_read_statement(arena, node, node_index)
+        type is (format_statement_node)
+            code = generate_code_format_statement(arena, node, node_index)
         type is (stop_node)
             code = generate_code_termination(arena, node, node_index)
         type is (return_node)

--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -18,6 +18,7 @@ module codegen_statements
     public :: generate_code_print_statement
     public :: generate_code_write_statement
     public :: generate_code_read_statement
+    public :: generate_code_format_statement
     public :: generate_code_termination
     public :: generate_code_return
     public :: generate_code_continue
@@ -206,6 +207,22 @@ contains
 
         call prepend_stmt_label(code, node%stmt_label)
     end function generate_code_read_statement
+
+    ! Generate code for format statements
+    function generate_code_format_statement(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(format_statement_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+
+        if (allocated(node%format_spec)) then
+            code = "format " // trim(node%format_spec)
+        else
+            code = "format (*)"
+        end if
+
+        call prepend_stmt_label(code, node%stmt_label)
+    end function generate_code_format_statement
 
     ! Generate code for termination statements
     function generate_code_termination(arena, node, node_index) result(code)

--- a/src/codegen/codegen_utilities.f90
+++ b/src/codegen/codegen_utilities.f90
@@ -352,6 +352,11 @@ contains
                         code = code // indent_lines(stmt_code, indent) // new_line('A')
                         i = i + 1
 
+                    type is (format_statement_node)
+                        stmt_code = generate_code_from_arena(arena, body_indices(i))
+                        code = code // indent_lines(stmt_code, indent) // new_line('A')
+                        i = i + 1
+
                     type is (goto_node)
                         stmt_code = generate_code_from_arena(arena, body_indices(i))
                         code = code // indent_lines(stmt_code, indent) // new_line('A')

--- a/src/fortfront_types.f90
+++ b/src/fortfront_types.f90
@@ -86,6 +86,7 @@ module fortfront_types
     integer, parameter :: NODE_FORMAT_DESCRIPTOR = 41
     integer, parameter :: NODE_COMMENT = 42
     integer, parameter :: NODE_IMPLICIT_STATEMENT = 43
+    integer, parameter :: NODE_FORMAT_STATEMENT = 44
     integer, parameter :: NODE_CONTINUE = 45
     integer, parameter :: NODE_UNKNOWN = 99
 

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -479,7 +479,7 @@ contains
               'public', 'private', 'namelist', 'data', 'type', 'class', 'extends', &
               'abstract', &
               'procedure', 'interface', 'generic', 'operator', 'assignment', 'print', &
-              'read', 'write', 'call', &
+              'read', 'write', 'call', 'format', &
               'allocate', 'deallocate', &
               'select', 'case', 'default', 'where', 'associate', 'forall', 'block', &
               'enum', 'file', 'submodule', 'rank', &

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -14,7 +14,8 @@ module parser_execution_statements_module
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t, append_prefix_token
     use parser_assignment_module, only: parse_assignment_statement
     use parser_utils, only: analyze_declaration_structure
-    use parser_io_statements_module, only: parse_print_statement, parse_write_statement
+    use parser_io_statements_module, only: parse_print_statement, &
+                                           parse_write_statement, parse_format_statement
     use parser_memory_statements_module, only: parse_allocate_statement, &
                                                parse_deallocate_statement
     use parser_control_statements_module, only: parse_stop_statement, &
@@ -305,6 +306,8 @@ contains
                 stmt_index = parse_use_statement(parser_ref, arena_ref)
             case ("write")
                 stmt_index = parse_write_statement(parser_ref, arena_ref)
+            case ("format")
+                stmt_index = parse_format_statement(parser_ref, arena_ref)
             case ("allocate")
                 stmt_index = parse_allocate_statement(parser_ref, arena_ref)
             case ("deallocate")

--- a/src/parser/parser_io_statements.f90
+++ b/src/parser/parser_io_statements.f90
@@ -7,12 +7,13 @@ module parser_io_statements_module
     use parser_expressions_module, only: parse_comparison
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_print_statement, push_write_statement, &
-                           push_read_statement
+                           push_read_statement, push_format_statement
     use ast_factory
     implicit none
     private
 
     public :: parse_print_statement, parse_write_statement, parse_read_statement
+    public :: parse_format_statement
 
 contains
 
@@ -30,6 +31,9 @@ contains
             format_spec = token%text
             token = parser%consume()
         else if (token%kind == TK_IDENTIFIER) then
+            format_spec = token%text
+            token = parser%consume()
+        else if (token%kind == TK_NUMBER) then
             format_spec = token%text
             token = parser%consume()
         else
@@ -375,5 +379,60 @@ contains
         read_index = push_read_statement(arena, unit_spec, var_indices, &
                                          format_spec, line, column)
     end function parse_read_statement
+
+    function parse_format_statement(parser, arena) result(format_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer :: format_index
+
+        type(token_t) :: token
+        integer :: line, column
+        character(len=:), allocatable :: format_spec
+        integer :: paren_depth
+
+        token = parser%peek()
+        line = token%line
+        column = token%column
+
+        if (token%kind /= TK_KEYWORD .or. token%text /= "format") then
+            format_index = 0
+            return
+        end if
+
+        token = parser%consume()
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= "(") then
+            write (error_unit, *) &
+                "Error: Expected '(' after 'format' at line ", token%line
+            format_index = 0
+            return
+        end if
+
+        format_spec = "("
+        token = parser%consume()
+        paren_depth = 1
+
+        do while (.not. parser%is_at_end() .and. paren_depth > 0)
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == "(") then
+                paren_depth = paren_depth + 1
+                format_spec = format_spec // "("
+                token = parser%consume()
+            else if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                paren_depth = paren_depth - 1
+                format_spec = format_spec // ")"
+                token = parser%consume()
+                if (paren_depth == 0) exit
+            else if (token%kind == TK_NEWLINE) then
+                exit
+            else
+                format_spec = format_spec // trim(token%text)
+                token = parser%consume()
+            end if
+        end do
+
+        format_index = push_format_statement(arena, format_spec, line, column)
+    end function parse_format_statement
 
 end module parser_io_statements_module

--- a/src/utilities/fortfront_node_constants.f90
+++ b/src/utilities/fortfront_node_constants.f90
@@ -17,9 +17,9 @@ module fortfront_node_constants
                                NODE_POINTER_ASSIGNMENT, NODE_FORALL, NODE_CASE_RANGE, &
                                NODE_CASE_DEFAULT, NODE_COMPLEX_LITERAL, &
                                NODE_INCLUDE_STATEMENT, NODE_CONTAINS, &
-                               NODE_FORMAT_DESCRIPTOR, NODE_COMMENT, &
-                               NODE_IMPLICIT_STATEMENT, NODE_CONTINUE, &
-                               NODE_UNKNOWN
+                               NODE_FORMAT_DESCRIPTOR, NODE_FORMAT_STATEMENT, &
+                               NODE_COMMENT, NODE_IMPLICIT_STATEMENT, &
+                               NODE_CONTINUE, NODE_UNKNOWN
     implicit none
     public
 end module fortfront_node_constants

--- a/src/utilities/fortfront_utils.f90
+++ b/src/utilities/fortfront_utils.f90
@@ -444,6 +444,8 @@ contains
             node_type = NODE_CONTAINS
         case ("format_descriptor_node", "format_descriptor")
             node_type = NODE_FORMAT_DESCRIPTOR
+        case ("format_statement_node", "format_statement")
+            node_type = NODE_FORMAT_STATEMENT
         case ("comment_node", "comment")
             node_type = NODE_COMMENT
         case ("implicit_statement_node", "implicit_statement")

--- a/test/codegen/test_issue_1581_format_write.f90
+++ b/test/codegen/test_issue_1581_format_write.f90
@@ -1,0 +1,125 @@
+program test_issue_1581_format_write
+    use frontend, only: transform_lazy_fortran_string
+    implicit none
+
+    call test_format_statement_preservation()
+    call test_write_with_label_reference()
+    call test_full_format_write_integration()
+
+contains
+
+    subroutine test_format_statement_preservation()
+        character(len=:), allocatable :: source, generated, error_msg
+
+        print *, "Test: FORMAT statement preservation"
+
+        source = "program test" // new_line('A') // &
+                 "100 format('test')" // new_line('A') // &
+                 "end program test"
+
+        call transform_lazy_fortran_string(source, generated, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: Compilation failed: ", trim(error_msg)
+            stop 1
+        end if
+
+        if (index(generated, "100 format") == 0) then
+            print *, "FAIL: FORMAT statement with label not preserved"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        if (index(generated, "('test')") == 0 .and. index(generated, " ('test')") == 0) then
+            print *, "FAIL: FORMAT specification not preserved"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        print *, "PASS: FORMAT statement preservation"
+    end subroutine test_format_statement_preservation
+
+    subroutine test_write_with_label_reference()
+        character(len=:), allocatable :: source, generated, error_msg
+
+        print *, "Test: WRITE with label reference"
+
+        source = "program test" // new_line('A') // &
+                 "integer :: x" // new_line('A') // &
+                 "x = 42" // new_line('A') // &
+                 "write(*, 100) x" // new_line('A') // &
+                 "100 format(I5)" // new_line('A') // &
+                 "end program test"
+
+        call transform_lazy_fortran_string(source, generated, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: Compilation failed: ", trim(error_msg)
+            stop 1
+        end if
+
+        if (index(generated, "write(*, 100)") == 0) then
+            print *, "FAIL: WRITE with label reference not preserved"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        if (index(generated, "100 format") == 0) then
+            print *, "FAIL: FORMAT statement not generated"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        print *, "PASS: WRITE with label reference"
+    end subroutine test_write_with_label_reference
+
+    subroutine test_full_format_write_integration()
+        character(len=:), allocatable :: source, generated, error_msg
+
+        print *, "Test: Full FORMAT/WRITE integration from issue #1581"
+
+        source = "program test_format" // new_line('A') // &
+                 "implicit none" // new_line('A') // &
+                 "integer :: x" // new_line('A') // &
+                 "real :: y" // new_line('A') // &
+                 "x = 42" // new_line('A') // &
+                 "y = 3.14159" // new_line('A') // &
+                 "write(*, 100) x, y" // new_line('A') // &
+                 "100 format('x = ', I5, ', y = ', F8.5)" // new_line('A') // &
+                 "end program test_format"
+
+        call transform_lazy_fortran_string(source, generated, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: Full integration failed: ", trim(error_msg)
+            stop 1
+        end if
+
+        if (index(generated, "write(*, 100)") == 0) then
+            print *, "FAIL: WRITE statement lost"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        if (index(generated, "100 format") == 0) then
+            print *, "FAIL: FORMAT statement lost"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        if (index(generated, "x, y") == 0) then
+            print *, "FAIL: WRITE arguments lost"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        if (index(generated, "'x = '") == 0) then
+            print *, "FAIL: FORMAT specification lost"
+            print *, "Generated: ", generated
+            stop 1
+        end if
+
+        print *, "PASS: Full FORMAT/WRITE integration"
+    end subroutine test_full_format_write_integration
+
+end program test_issue_1581_format_write


### PR DESCRIPTION
## Summary
- Implements FORMAT statement parsing and code generation
- Fixes WRITE statements with numeric label references  
- Adds 'format' as recognized keyword in lexer
- Includes comprehensive regression tests

## Changes
- **AST**: Added `format_statement_node` type (NODE_FORMAT_STATEMENT = 44)
- **Lexer**: Added 'format' to keyword list in `lexer_scanners.f90`
- **Parser**: 
  - Added `parse_format_statement` to parse FORMAT statements
  - Modified `parse_format_specifier` to accept TK_NUMBER tokens (label references)
  - Registered FORMAT parser in execution statements dispatcher
- **Codegen**: Added `generate_code_format_statement` to emit FORMAT statements
- **Factory**: Added `push_format_statement` factory function
- **Tests**: Added `test_issue_1581_format_write.f90` with 3 test cases

## Verification
Test output showing FORMAT and WRITE preservation:
```fortran
program test_format
    implicit none
    integer :: x
    real(8) :: y
    x = 42 
    y = 3.14159d0
    write(*, 100) x, y 
    100 format ('x = ',I5,', y = ',F8.5)
end program test_format
```

All regression tests pass:
```
✓ FORMAT statement preservation
✓ WRITE with label reference  
✓ Full FORMAT/WRITE integration
```

Fixes #1581