### PR TITLE
fix: PURE and ELEMENTAL keywords stripped from function definitions (fixes #1570)

### DIFF
--- a/src/parser/parser_module_structures.f90
+++ b/src/parser/parser_module_structures.f90
@@ -14,7 +14,7 @@ module parser_module_structures_module
     use parser_procedure_definitions_module, only: parse_function_definition, &
                                                    parse_subroutine_definition, &
                                                    parse_interface_block
-    use parser_prefix_buffer_module, only: parser_prefix_buffer_t
+    use parser_prefix_buffer_module, only: parser_prefix_buffer_t, append_prefix_token
     use ast_types, only: LITERAL_STRING
     use parser_implicit_shared_module, only: parse_simple_implicit_statement
     ! Temporarily removed to avoid circular dependency
@@ -261,6 +261,23 @@ contains
             end if
 
             if (in_contains_section) then
+                if (token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER) then
+                    block
+                        character(len=:), allocatable :: lowered
+                        character(len=16), allocatable :: stored(:)
+                        lowered = to_lower(token%text)
+                        select case (trim(lowered))
+                        case ("pure", "elemental", "impure", "recursive", &
+                              "nonrecursive", "non_recursive", "module")
+                            call prefix_buffer%get_all(stored)
+                            call append_prefix_token(stored, trim(lowered))
+                            call prefix_buffer%set(stored)
+                            if (allocated(stored)) deallocate (stored)
+                            token = parser%consume()
+                            cycle
+                        end select
+                    end block
+                end if
                 ! Don't consume function/subroutine - let them be handled by the checks above
                 if (.not. (token%kind == TK_KEYWORD .and. &
                            (token%text == "function" .or. token%text == &

--- a/test/test_module_contains_functions.f90
+++ b/test/test_module_contains_functions.f90
@@ -10,6 +10,7 @@ program test_module_contains_functions
     call test_module_with_function()
     call test_module_with_subroutine()
     call test_module_with_multiple_procedures()
+    call test_module_with_prefix_keywords()
     print *, ""
     print *, "All module contains tests completed."
 
@@ -226,6 +227,69 @@ contains
 
         print *, "[PASS] Module with multiple procedures"
     end subroutine test_module_with_multiple_procedures
+
+    subroutine test_module_with_prefix_keywords()
+        character(:), allocatable :: input_code
+        character(:), allocatable :: output_code
+        character(:), allocatable :: error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+
+        input_code = "module math_funcs" // new_line('A') // &
+                     "contains" // new_line('A') // &
+                     "pure function square(x) result(y)" // new_line('A') // &
+                     "integer :: x" // new_line('A') // &
+                     "integer :: y" // new_line('A') // &
+                     "y = x * x" // new_line('A') // &
+                     "end function square" // new_line('A') // &
+                     "elemental function add_one(x) result(y)" // new_line('A') // &
+                     "integer :: x" // new_line('A') // &
+                     "integer :: y" // new_line('A') // &
+                     "y = x + 1" // new_line('A') // &
+                     "end function add_one" // new_line('A') // &
+                     "end module math_funcs"
+
+        print *, ""
+        print *, "Test: Module with prefix keywords"
+
+        arena = create_ast_arena()
+        call lex_source(input_code, tokens, error_msg)
+
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            print *, "Lexing error: ", trim(error_msg)
+            error stop 1
+        end if
+
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            print *, "Parsing error: ", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print *, "Output:"
+        print *, trim(output_code)
+
+        if (index(output_code, 'pure function square') == 0) then
+            print *, "FAIL: 'pure function square' missing from output"
+            error stop 1
+        end if
+
+        if (index(output_code, 'elemental function add_one') == 0) then
+            print *, "FAIL: 'elemental function add_one' missing from output"
+            error stop 1
+        end if
+
+        if (.not. contains_without_spaces(output_code, 'integer,intent(in)::x')) then
+            print *, "FAIL: Prefix intent inference missing from output"
+            error stop 1
+        end if
+
+        print *, "[PASS] Module with prefix keywords"
+    end subroutine test_module_with_prefix_keywords
 
     logical function contains_without_spaces(text, pattern)
         character(len=*), intent(in) :: text


### PR DESCRIPTION
## Summary
- keep prefix keywords encountered in module contains blocks by storing them in the parser prefix buffer instead of dropping them
- add regression coverage to confirm pure/elemental functions inside modules keep their prefixes and inferred intents

## Verification
- make test
- fpm run --target fortfront <<'SRC'
module math_funcs
  implicit none
contains
  pure function square(x) result(y)
    integer :: x
    integer :: y
    y = x * x
  end function square

  elemental function add_one(x) result(y)
    integer :: x
    integer :: y
    y = x + 1
  end function add_one
end module math_funcs
SRC
