### PR TITLE
fix: Array slice type inference incorrect: integer array produces rea (fixes #1569)

### DIFF
--- a/src/semantic/analyzers/semantic_analyzer.f90
+++ b/src/semantic/analyzers/semantic_analyzer.f90
@@ -57,7 +57,8 @@ module semantic_analyzer
                                  elsewhere_clause_t
     use ast_nodes_data, only: intent_type_to_string, declaration_node, module_node
     use ast_nodes_bounds, only: array_spec_t, array_bounds_t, array_slice_node, &
-                                range_expression_node, get_array_slice_node
+                                array_bounds_node, range_expression_node, &
+                                get_array_slice_node
     ! Removed legacy parameter/temp trackers for lean build
     use constant_transformation, only: fold_constants_in_arena
     use error_handling, only: error_collection_t, create_error_collection, result_t, &
@@ -1271,9 +1272,79 @@ contains
         type(ast_arena_t), intent(inout) :: arena
         type(array_slice_node), intent(in) :: slice_node
         type(mono_type_t) :: typ
+        type(mono_type_t) :: source_type
+        type(mono_type_t) :: walker_type
+        type(mono_type_t) :: base_type
+        type(mono_type_t), allocatable :: args(:)
+        logical, allocatable :: keep_dim(:)
+        integer :: max_dims
+        integer :: dims_to_process
+        integer :: i
+        integer :: bounds_idx
+        logical :: is_range
 
-        ! For now, return real array type
-        typ = create_mono_type(TARRAY)
+        source_type = get_inferred_type_from_arena(ctx, arena, &
+                                                   slice_node%array_index)
+        if (source_type%kind /= TARRAY) then
+            typ = source_type
+            return
+        end if
+
+        walker_type = source_type
+        max_dims = 0
+        do while (walker_type%kind == TARRAY .and. walker_type%has_args())
+            if (walker_type%get_args_count() <= 0) exit
+            max_dims = max_dims + 1
+            walker_type = walker_type%get_arg(1)
+        end do
+        base_type = walker_type
+
+        if (max_dims <= 0) then
+            typ = source_type
+            return
+        end if
+
+        allocate (keep_dim(max_dims))
+        keep_dim = .false.
+        dims_to_process = min(max_dims, slice_node%num_dimensions)
+        do i = 1, dims_to_process
+            bounds_idx = slice_node%bounds_indices(i)
+            is_range = .false.
+            if (bounds_idx > 0 .and. bounds_idx <= arena%size) then
+                if (allocated(arena%entries(bounds_idx)%node)) then
+                    select type (bounds => arena%entries(bounds_idx)%node)
+                    type is (range_expression_node)
+                        is_range = .true.
+                    type is (array_bounds_node)
+                        is_range = .true.
+                    end select
+                end if
+            end if
+            keep_dim(i) = is_range
+        end do
+
+        if (slice_node%num_dimensions < max_dims) then
+            keep_dim(slice_node%num_dimensions + 1:max_dims) = .true.
+        end if
+
+        if (.not. any(keep_dim)) then
+            typ = base_type
+            return
+        end if
+
+        typ = base_type
+        do i = max_dims, 1, -1
+            if (.not. keep_dim(i)) cycle
+            allocate (args(1))
+            args(1) = typ
+            typ = create_mono_type(TARRAY, args=args)
+            typ%size = 0
+            typ%alloc_info%is_allocatable = .true.
+            typ%alloc_info%needs_allocation_check = .true.
+            typ%alloc_info%is_pointer = .false.
+            typ%alloc_info%needs_allocatable_string = .false.
+            deallocate (args)
+        end do
     end function infer_array_slice
 
     ! Infer type of assignment (simplified using extracted module)

--- a/test/codegen/test_array_slicing_codegen.f90
+++ b/test/codegen/test_array_slicing_codegen.f90
@@ -10,6 +10,7 @@ program test_array_slicing_codegen
     if (.not. test_basic_slices()) all_passed = .false.
     if (.not. test_empty_bounds()) all_passed = .false.
     if (.not. test_multidim_slices()) all_passed = .false.
+    if (.not. test_slice_type_inference()) all_passed = .false.
 
     if (all_passed) then
         print *, 'All array slicing codegen tests passed!'
@@ -169,5 +170,54 @@ contains
             return
         end if
     end function test_multidim_slices
+
+    logical function test_slice_type_inference()
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        character(len=:), allocatable :: error_msg, code, source
+        integer :: root
+
+        test_slice_type_inference = .true.
+
+        source = &
+            'program p' // new_line('a') // &
+            '  implicit none' // new_line('a') // &
+            '  integer :: arr(5)' // new_line('a') // &
+            '  arr = [10, 20, 30, 40, 50]' // new_line('a') // &
+            '  subset = arr(2:4)' // new_line('a') // &
+            '  print *, subset' // new_line('a') // &
+            'end program p'
+
+        call lex_source(source, tokens, error_msg)
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, '  FAIL: parse error: ', trim(error_msg)
+                test_slice_type_inference = .false.
+                return
+            end if
+        end if
+
+        call analyze_semantics(arena, root)
+        call emit_fortran(arena, root, code)
+
+        if (.not. allocated(code)) then
+            print *, '  FAIL: no generated code'
+            test_slice_type_inference = .false.
+            return
+        end if
+
+        if (index(code, 'integer, dimension(:), allocatable :: subset') == 0) then
+            print *, '  FAIL: subset slice not inferred as integer allocatable'
+            test_slice_type_inference = .false.
+        end if
+
+        if (index(code, 'real(8), dimension(:), allocatable :: subset') /= 0) then
+            print *, '  FAIL: subset slice still inferred as real(8)'
+            test_slice_type_inference = .false.
+        end if
+    end function test_slice_type_inference
 
 end program test_array_slicing_codegen


### PR DESCRIPTION
## Summary
- propagate the element type when inferring array section types
- flag slice results as allocatable while preserving dimensions driven by ranges
- add regression coverage checking integer slices produce integer declarations

## Verification
- make test
