### PR TITLE
fix: prevent project root pollution with enhanced .gitignore (fixes #1632)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ packages/*/
 /*.f90
 /*.lf
 /*.json
+/*_out.f90
+/*.mod
+/*.txt
 
 # CMake build artifacts
 cmake_test/


### PR DESCRIPTION
## Summary
Fixes #1632 by adding root-specific .gitignore rules to prevent test artifacts and build outputs from polluting the project root directory.

## Changes
- Added `/*_out.f90`, `/*.mod`, and `/*.txt` patterns to .gitignore
- These complement existing `/*.f90` and `/*.lf` rules
- Root-specific (/) prefix blocks files at project root while allowing them in subdirectories

## Verification
Before fix:
```bash
$ find . -maxdepth 1 -type f \( -name "*.f90" -o -name "*.mod" -o -name "*.lf" -o -name "*_out.f90" -o -name "*.txt" \) | wc -l
58
```

After fix:
- Removed all 58 polluting files
- Built project: `fpm build` - success
- Ran tests: `fpm test` - artifacts created but correctly ignored
- Verified: `git status` shows only .gitignore modification

The .gitignore now properly prevents root pollution while tests continue to function normally.

## Impact
- Resolves recurring hygiene issue (5th occurrence: #1115, #1104, #1086, #1043, #873)
- Prevents accidental commit of test artifacts
- Maintains professional repository appearance
- Files can still exist in test/ and other subdirectories as needed