### PR TITLE
fix: add AST traversal utility module (fixes #1638)

### DIFF
--- a/src/ast/ast_traversal_utils.f90
+++ b/src/ast/ast_traversal_utils.f90
@@ -1,0 +1,166 @@
+module ast_traversal_utils
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use ast_arena_modern, only: ast_arena_t
+    use ast_base, only: ast_node
+    implicit none
+    private
+
+    public :: find_nodes_by_type
+    public :: get_ancestor_of_type
+    public :: has_child_of_type
+    public :: get_children
+    public :: traverse_ast
+
+    abstract interface
+        subroutine traverse_callback(arena, node_index, user_data)
+            import :: ast_arena_t
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_index
+            class(*), intent(inout), optional :: user_data
+        end subroutine traverse_callback
+    end interface
+
+    public :: traverse_callback
+
+contains
+
+    function find_nodes_by_type(arena, root_index, node_type_name) &
+        result(node_indices)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: root_index
+        character(len=*), intent(in) :: node_type_name
+        integer, allocatable :: node_indices(:)
+        integer, allocatable :: temp_indices(:)
+        integer :: count, i
+        integer, allocatable :: children(:)
+
+        count = 0
+        allocate (temp_indices(arena%compat_size))
+
+        call collect_matching_nodes(arena, root_index, node_type_name, &
+                                     temp_indices, count)
+
+        allocate (node_indices(count))
+        do i = 1, count
+            node_indices(i) = temp_indices(i)
+        end do
+    end function find_nodes_by_type
+
+    recursive subroutine collect_matching_nodes(arena, node_index, &
+                                                 node_type_name, indices, count)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: node_type_name
+        integer, intent(inout) :: indices(:)
+        integer, intent(inout) :: count
+        integer :: i
+        integer, allocatable :: children(:)
+
+        if (node_index <= 0 .or. node_index > arena%compat_size) return
+
+        if (allocated(arena%entries(node_index)%node_type)) then
+            if (arena%entries(node_index)%node_type == node_type_name) then
+                count = count + 1
+                indices(count) = node_index
+            end if
+        end if
+
+        children = arena%get_children(node_index)
+        do i = 1, size(children)
+            call collect_matching_nodes(arena, children(i), node_type_name, &
+                                         indices, count)
+        end do
+    end subroutine collect_matching_nodes
+
+    function get_ancestor_of_type(arena, node_index, node_type_name) &
+        result(ancestor_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: node_type_name
+        integer :: ancestor_index
+        integer :: current_index
+
+        ancestor_index = 0
+        current_index = node_index
+
+        if (current_index <= 0 .or. current_index > arena%compat_size) return
+
+        current_index = arena%entries(current_index)%parent_index
+
+        do while (current_index > 0 .and. current_index <= arena%compat_size)
+            if (allocated(arena%entries(current_index)%node_type)) then
+                if (arena%entries(current_index)%node_type == node_type_name) then
+                    ancestor_index = current_index
+                    return
+                end if
+            end if
+            current_index = arena%entries(current_index)%parent_index
+        end do
+    end function get_ancestor_of_type
+
+    function has_child_of_type(arena, node_index, node_type_name) &
+        result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: node_type_name
+        logical :: found
+        integer, allocatable :: children(:)
+        integer :: i
+
+        found = .false.
+
+        if (node_index <= 0 .or. node_index > arena%compat_size) return
+
+        children = arena%get_children(node_index)
+
+        do i = 1, size(children)
+            if (allocated(arena%entries(children(i))%node_type)) then
+                if (arena%entries(children(i))%node_type == node_type_name) then
+                    found = .true.
+                    return
+                end if
+            end if
+        end do
+    end function has_child_of_type
+
+    function get_children(arena, node_index) result(child_indices)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer, allocatable :: child_indices(:)
+
+        child_indices = arena%get_children(node_index)
+    end function get_children
+
+    subroutine traverse_ast(arena, root_index, callback, user_data)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: root_index
+        procedure(traverse_callback) :: callback
+        class(*), intent(inout), optional :: user_data
+
+        call traverse_recursive(arena, root_index, callback, user_data)
+    end subroutine traverse_ast
+
+    recursive subroutine traverse_recursive(arena, node_index, callback, &
+                                            user_data)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        procedure(traverse_callback) :: callback
+        class(*), intent(inout), optional :: user_data
+        integer, allocatable :: children(:)
+        integer :: i
+
+        if (node_index <= 0 .or. node_index > arena%compat_size) return
+
+        if (present(user_data)) then
+            call callback(arena, node_index, user_data)
+        else
+            call callback(arena, node_index)
+        end if
+
+        children = arena%get_children(node_index)
+        do i = 1, size(children)
+            call traverse_recursive(arena, children(i), callback, user_data)
+        end do
+    end subroutine traverse_recursive
+
+end module ast_traversal_utils

--- a/test/ast/test_ast_traversal_utils.f90
+++ b/test/ast/test_ast_traversal_utils.f90
@@ -1,0 +1,263 @@
+program test_ast_traversal_utils
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_base, only: ast_node
+    use ast_nodes_core, only: identifier_node, assignment_node, program_node
+    use ast_traversal_utils, only: find_nodes_by_type, get_ancestor_of_type, &
+                                    has_child_of_type, get_children, &
+                                    traverse_ast, traverse_callback
+    implicit none
+
+    type :: traverse_counter_t
+        integer :: count
+    end type traverse_counter_t
+
+    type(ast_arena_t) :: arena
+    integer :: prog_idx, assign1_idx, assign2_idx, id1_idx, id2_idx, id3_idx
+
+    print *, "=== AST Traversal Utils Tests ==="
+    print *
+
+    call test_find_nodes_by_type()
+    call test_get_ancestor_of_type()
+    call test_has_child_of_type()
+    call test_get_children()
+    call test_traverse_ast()
+
+    print *
+    print *, "All AST traversal utils tests passed!"
+
+contains
+
+    subroutine test_find_nodes_by_type()
+        type(program_node) :: prog
+        type(assignment_node) :: assign
+        type(identifier_node) :: id
+        integer, allocatable :: found_indices(:)
+        integer :: i
+
+        print *, "Testing find_nodes_by_type..."
+
+        arena = create_ast_arena(16)
+
+        prog%name = "test"
+        call arena%push(prog, "program_node", 0)
+        prog_idx = arena%compat_size
+
+        id%name = "x"
+        call arena%push(id, "identifier_node", prog_idx)
+        id1_idx = arena%compat_size
+
+        assign%target_index = 0
+        assign%value_index = 0
+        assign%operator = "="
+        call arena%push(assign, "assignment_node", prog_idx)
+        assign1_idx = arena%compat_size
+
+        id%name = "y"
+        call arena%push(id, "identifier_node", assign1_idx)
+        id2_idx = arena%compat_size
+
+        id%name = "z"
+        call arena%push(id, "identifier_node", prog_idx)
+        id3_idx = arena%compat_size
+
+        found_indices = find_nodes_by_type(arena, prog_idx, "identifier_node")
+
+        if (size(found_indices) /= 3) then
+            print *, "  FAIL: Expected 3 identifier nodes, found", &
+                size(found_indices)
+            stop 1
+        end if
+
+        print *, "  PASS: Found", size(found_indices), "identifier nodes"
+
+        found_indices = find_nodes_by_type(arena, prog_idx, "assignment_node")
+
+        if (size(found_indices) /= 1) then
+            print *, "  FAIL: Expected 1 assignment node, found", &
+                size(found_indices)
+            stop 1
+        end if
+
+        print *, "  PASS: Found", size(found_indices), "assignment node"
+
+        found_indices = find_nodes_by_type(arena, prog_idx, "nonexistent")
+
+        if (size(found_indices) /= 0) then
+            print *, "  FAIL: Expected 0 nonexistent nodes, found", &
+                size(found_indices)
+            stop 1
+        end if
+
+        print *, "  PASS: Found 0 nonexistent nodes"
+    end subroutine test_find_nodes_by_type
+
+    subroutine test_get_ancestor_of_type()
+        integer :: ancestor_idx
+
+        print *
+        print *, "Testing get_ancestor_of_type..."
+
+        ancestor_idx = get_ancestor_of_type(arena, id2_idx, "program_node")
+
+        if (ancestor_idx /= prog_idx) then
+            print *, "  FAIL: Expected program ancestor at", prog_idx, &
+                "got", ancestor_idx
+            stop 1
+        end if
+
+        print *, "  PASS: Found program_node ancestor"
+
+        ancestor_idx = get_ancestor_of_type(arena, id2_idx, "assignment_node")
+
+        if (ancestor_idx /= assign1_idx) then
+            print *, "  FAIL: Expected assignment ancestor at", assign1_idx, &
+                "got", ancestor_idx
+            stop 1
+        end if
+
+        print *, "  PASS: Found assignment_node ancestor"
+
+        ancestor_idx = get_ancestor_of_type(arena, prog_idx, "program_node")
+
+        if (ancestor_idx /= 0) then
+            print *, "  FAIL: Root node should have no ancestor, got", &
+                ancestor_idx
+            stop 1
+        end if
+
+        print *, "  PASS: Root node has no ancestor"
+
+        ancestor_idx = get_ancestor_of_type(arena, id2_idx, "nonexistent")
+
+        if (ancestor_idx /= 0) then
+            print *, "  FAIL: Expected no nonexistent ancestor, got", &
+                ancestor_idx
+            stop 1
+        end if
+
+        print *, "  PASS: No nonexistent ancestor found"
+    end subroutine test_get_ancestor_of_type
+
+    subroutine test_has_child_of_type()
+        logical :: has_child
+
+        print *
+        print *, "Testing has_child_of_type..."
+
+        has_child = has_child_of_type(arena, prog_idx, "identifier_node")
+
+        if (.not. has_child) then
+            print *, "  FAIL: Program should have identifier child"
+            stop 1
+        end if
+
+        print *, "  PASS: Program has identifier child"
+
+        has_child = has_child_of_type(arena, prog_idx, "assignment_node")
+
+        if (.not. has_child) then
+            print *, "  FAIL: Program should have assignment child"
+            stop 1
+        end if
+
+        print *, "  PASS: Program has assignment child"
+
+        has_child = has_child_of_type(arena, assign1_idx, "identifier_node")
+
+        if (.not. has_child) then
+            print *, "  FAIL: Assignment should have identifier child"
+            stop 1
+        end if
+
+        print *, "  PASS: Assignment has identifier child"
+
+        has_child = has_child_of_type(arena, id1_idx, "identifier_node")
+
+        if (has_child) then
+            print *, "  FAIL: Leaf identifier should not have children"
+            stop 1
+        end if
+
+        print *, "  PASS: Leaf identifier has no children"
+
+        has_child = has_child_of_type(arena, prog_idx, "nonexistent")
+
+        if (has_child) then
+            print *, "  FAIL: Should not have nonexistent child"
+            stop 1
+        end if
+
+        print *, "  PASS: No nonexistent child found"
+    end subroutine test_has_child_of_type
+
+    subroutine test_get_children()
+        integer, allocatable :: children(:)
+
+        print *
+        print *, "Testing get_children..."
+
+        children = get_children(arena, prog_idx)
+
+        if (size(children) /= 3) then
+            print *, "  FAIL: Expected 3 children of program, found", &
+                size(children)
+            stop 1
+        end if
+
+        print *, "  PASS: Program has", size(children), "children"
+
+        children = get_children(arena, assign1_idx)
+
+        if (size(children) /= 1) then
+            print *, "  FAIL: Expected 1 child of assignment, found", &
+                size(children)
+            stop 1
+        end if
+
+        print *, "  PASS: Assignment has", size(children), "child"
+
+        children = get_children(arena, id1_idx)
+
+        if (size(children) /= 0) then
+            print *, "  FAIL: Expected 0 children of leaf, found", &
+                size(children)
+            stop 1
+        end if
+
+        print *, "  PASS: Leaf identifier has no children"
+    end subroutine test_get_children
+
+    subroutine test_traverse_ast()
+        type(traverse_counter_t) :: counter
+
+        print *
+        print *, "Testing traverse_ast..."
+
+        counter%count = 0
+
+        call traverse_ast(arena, prog_idx, count_callback, counter)
+
+        if (counter%count /= 5) then
+            print *, "  FAIL: Expected 5 nodes traversed, got", counter%count
+            stop 1
+        end if
+
+        print *, "  PASS: Traversed", counter%count, "nodes"
+    end subroutine test_traverse_ast
+
+    subroutine count_callback(arena, node_index, user_data)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        class(*), intent(inout), optional :: user_data
+
+        if (present(user_data)) then
+            select type (user_data)
+            type is (traverse_counter_t)
+                user_data%count = user_data%count + 1
+            end select
+        end if
+    end subroutine count_callback
+
+end program test_ast_traversal_utils


### PR DESCRIPTION
## Summary
Add `ast_traversal_utils` module with helper functions for common AST queries and traversal patterns. This enables downstream tools (fluff linter, ffc compiler) to efficiently navigate and analyze the AST without implementing traversal logic from scratch.

## Implemented Functions

### 1. `find_nodes_by_type`
Recursively finds all nodes matching a specific type under a root node.
```fortran
found = find_nodes_by_type(arena, prog_idx, "identifier_node")
```

### 2. `get_ancestor_of_type`
Walks up the parent chain to find the first matching ancestor type.
```fortran
func_idx = get_ancestor_of_type(arena, stmt_idx, "function_def")
```

### 3. `has_child_of_type`
Checks if a node has a direct child of a given type.
```fortran
if (has_child_of_type(arena, node_idx, "contains_node")) then
```

### 4. `get_children`
Returns all child indices for a node.
```fortran
children = get_children(arena, parent_idx)
```

### 5. `traverse_ast`
Depth-first traversal with callback interface supporting optional user data.
```fortran
call traverse_ast(arena, root_idx, my_callback, user_data)
```

## Verification

### Unit Tests
Created comprehensive test suite in `test/ast/test_ast_traversal_utils.f90`:
- Tests all 5 functions with multi-level AST structure
- Validates edge cases (root nodes, leaf nodes, non-existent types)
- Tests callback interface with user data

### Test Output
```
=== AST Traversal Utils Tests ===

Testing find_nodes_by_type...
  PASS: Found 3 identifier nodes
  PASS: Found 1 assignment node
  PASS: Found 0 nonexistent nodes

Testing get_ancestor_of_type...
  PASS: Found program_node ancestor
  PASS: Found assignment_node ancestor
  PASS: Root node has no ancestor
  PASS: No nonexistent ancestor found

Testing has_child_of_type...
  PASS: Program has identifier child
  PASS: Program has assignment child
  PASS: Assignment has identifier child
  PASS: Leaf identifier has no children
  PASS: No nonexistent child found

Testing get_children...
  PASS: Program has 3 children
  PASS: Assignment has 1 child
  PASS: Leaf identifier has no children

Testing traverse_ast...
  PASS: Traversed 5 nodes

All AST traversal utils tests passed!
```

### Full Test Suite
All existing tests pass without modification:
```bash
fpm test  # All 50+ tests pass
```

## Files Changed
- `src/ast/ast_traversal_utils.f90` - New module with 5 utility functions
- `test/ast/test_ast_traversal_utils.f90` - Comprehensive unit tests

## Implementation Notes
- Uses existing arena compatibility layer (`ast_arena_compat_t`)
- Leverages parent/child relationship tracking in arena entries
- Recursive algorithms for tree traversal
- Zero impact on existing codebase - purely additive

## Related Issues
- Implements requirements from #1638
- Part of fine-grained API effort (#1637)
- Prerequisite for fluff linter development