### PR TITLE
fix: add EXTENDS inheritance support to AST (fixes #1625)

### DIFF
--- a/src/ast/nodes/ast_nodes_data.f90
+++ b/src/ast/nodes/ast_nodes_data.f90
@@ -130,6 +130,7 @@ module ast_nodes_data
     ! Derived type node
     type, extends(ast_node), public :: derived_type_node
         character(len=:), allocatable :: name  ! Type name
+        character(len=:), allocatable :: extends_parent  ! Parent type name (F2003)
         character(len=:), allocatable :: attribute_clause  ! Header attributes
         logical :: has_attributes = .false.  ! Whether header has attributes
         integer, allocatable :: component_indices(:)  ! Component indices (stack-based)
@@ -412,6 +413,12 @@ contains
         lhs%constant_type = rhs%constant_type
         ! Copy derived class fields
         if (allocated(rhs%name)) lhs%name = rhs%name
+        ! Handle extends_parent field
+        if (allocated(rhs%extends_parent)) then
+            lhs%extends_parent = rhs%extends_parent
+        else if (allocated(lhs%extends_parent)) then
+            deallocate (lhs%extends_parent)
+        end if
         ! Handle attribute clause
         if (allocated(rhs%attribute_clause)) then
             lhs%attribute_clause = rhs%attribute_clause
@@ -544,15 +551,18 @@ contains
     end function create_declaration
 
     function create_derived_type(name, component_indices, param_indices, &
-                                 line, column) result(node)
+                                 extends_parent, line, column) result(node)
         character(len=*), intent(in) :: name
         integer, intent(in), optional :: component_indices(:)
         integer, intent(in), optional :: param_indices(:)
+        character(len=*), intent(in), optional :: extends_parent
         integer, intent(in), optional :: line, column
         type(derived_type_node) :: node
 
         node%uid = generate_uid()
         node%name = name
+
+        if (present(extends_parent)) node%extends_parent = extends_parent
 
         if (present(component_indices)) then
             if (size(component_indices) > 0) then

--- a/src/codegen/codegen_declarations_core.f90
+++ b/src/codegen/codegen_declarations_core.f90
@@ -405,26 +405,45 @@ contains
     function derived_type_attribute_clause(node) result(clause)
         type(derived_type_node), intent(in) :: node
         character(len=:), allocatable :: clause
+        character(len=:), allocatable :: extends_clause
         integer :: i
         integer :: trimmed_length
 
         clause = ""
-        if (.not. node%has_attributes) return
-        if (.not. allocated(node%attribute_clause)) return
 
-        trimmed_length = len_trim(node%attribute_clause)
-        if (trimmed_length == 0) return
+        ! Build EXTENDS clause if present
+        if (allocated(node%extends_parent)) then
+            extends_clause = ", extends(" // trim(node%extends_parent) // ")"
+        else
+            extends_clause = ""
+        end if
 
-        clause = ""
-        do i = 1, trimmed_length
-            clause = clause // node%attribute_clause(i:i)
-            if (node%attribute_clause(i:i) == "," .and. i < trimmed_length) then
-                if (node%attribute_clause(i + 1:i + 1) /= " " .and. &
-                    node%attribute_clause(i + 1:i + 1) /= new_line('A')) then
-                    clause = clause // " "
-                end if
+        ! Add other attributes if present
+        if (node%has_attributes .and. allocated(node%attribute_clause)) then
+            trimmed_length = len_trim(node%attribute_clause)
+            if (trimmed_length > 0) then
+                clause = ""
+                do i = 1, trimmed_length
+                    clause = clause // node%attribute_clause(i:i)
+                    if (node%attribute_clause(i:i) == "," .and. &
+                        i < trimmed_length) then
+                        if (node%attribute_clause(i + 1:i + 1) /= " " .and. &
+                            node%attribute_clause(i + 1:i + 1) /= new_line('A')) then
+                            clause = clause // " "
+                        end if
+                    end if
+                end do
             end if
-        end do
+        end if
+
+        ! Combine extends_clause with other attributes
+        if (len_trim(extends_clause) > 0) then
+            if (len_trim(clause) > 0) then
+                clause = trim(clause) // extends_clause
+            else
+                clause = extends_clause
+            end if
+        end if
     end function derived_type_attribute_clause
 
     function collect_derived_components(arena, node) result(component_block)


### PR DESCRIPTION
## Summary
- Added `extends_parent` field to `derived_type_node` to represent F2003 type inheritance
- Updated factory function `create_derived_type` to accept optional `extends_parent` parameter
- Updated assignment operator to handle `extends_parent` field copying
- Updated codegen to output `EXTENDS(parent_type)` clause in type headers

## Verification

### Build and Tests
```bash
fpm build
```
**Result**: Clean build, all 68 examples passed

```bash
fpm test
```
**Result**: All tests passed (100% success rate)

### Code Changes

**src/ast/nodes/ast_nodes_data.f90:133**
```fortran
character(len=:), allocatable :: extends_parent  ! Parent type name (F2003)
```

**src/codegen/codegen_declarations_core.f90:414-446**
Updated `derived_type_attribute_clause` to generate EXTENDS clause when present.

## Next Steps
This AST support enables issue #1626 (parser integration) to be implemented.