### PR TITLE
fix: add codegen for type-bound procedures (fixes #1629)

### DIFF
--- a/src/codegen/codegen_declarations_core.f90
+++ b/src/codegen/codegen_declarations_core.f90
@@ -530,21 +530,53 @@ contains
     function generate_type_binding_code(binding) result(code)
         type(type_binding_node), intent(in) :: binding
         character(len=:), allocatable :: code
+        character(len=:), allocatable :: accessibility_text
+
+        if (.not. allocated(binding%binding_name)) then
+            code = ""
+            return
+        end if
+
+        accessibility_text = ""
+        if (allocated(binding%accessibility)) then
+            if (len_trim(binding%accessibility) > 0) then
+                accessibility_text = trim(to_lower(binding%accessibility))
+            end if
+        end if
 
         if (binding%is_final) then
             code = "final :: " // trim(binding%binding_name)
-        else
-            code = "procedure"
-            if (allocated(binding%accessibility)) then
-                if (len_trim(binding%accessibility) > 0) then
-                    code = code // ", " // trim(to_lower(binding%accessibility))
-                end if
+            return
+        end if
+
+        if (binding%is_generic) then
+            code = "generic"
+            if (len_trim(accessibility_text) > 0) then
+                code = code // ", " // accessibility_text
             end if
             code = code // " :: " // trim(binding%binding_name)
             if (allocated(binding%implementation)) then
                 if (len_trim(binding%implementation) > 0) then
                     code = code // " => " // trim(binding%implementation)
                 end if
+            end if
+            return
+        end if
+
+        code = "procedure"
+        if (len_trim(accessibility_text) > 0) then
+            code = code // ", " // accessibility_text
+        end if
+        if (binding%is_deferred) then
+            code = code // ", deferred"
+        end if
+        if (.not. binding%pass_arg) then
+            code = code // ", nopass"
+        end if
+        code = code // " :: " // trim(binding%binding_name)
+        if (allocated(binding%implementation)) then
+            if (len_trim(binding%implementation) > 0) then
+                code = code // " => " // trim(binding%implementation)
             end if
         end if
     end function generate_type_binding_code

--- a/test/codegen/test_type_bound_procedures_codegen.f90
+++ b/test/codegen/test_type_bound_procedures_codegen.f90
@@ -10,6 +10,9 @@ program test_type_bound_procedures_codegen
     call test_multiple_bindings()
     call test_final_procedure()
     call test_accessibility_modifiers()
+    call test_generic_binding()
+    call test_deferred_binding()
+    call test_nopass_binding()
 
     print *, "PASS: all type-bound procedure codegen tests passed"
 
@@ -205,5 +208,105 @@ contains
             stop 1
         end if
     end subroutine test_accessibility_modifiers
+
+    subroutine test_generic_binding()
+        character(len=*), parameter :: source = &
+            "type :: atype" // new_line('A') // &
+            "   integer :: x" // new_line('A') // &
+            "contains" // new_line('A') // &
+            "   generic, public :: assign_all => assign_impl" // new_line('A') // &
+            "end type atype"
+        character(len=:), allocatable :: code
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: mod_index
+        character(len=:), allocatable :: error_msg
+
+        call lex_source(source, tokens, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: generic binding lexer error:", trim(error_msg)
+            stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, mod_index, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: generic binding parse error:", trim(error_msg)
+            stop 1
+        end if
+
+        call emit_fortran(arena, mod_index, code)
+        if (index(code, "generic, public :: assign_all => assign_impl") == 0) then
+            print *, "FAIL: generic binding not in generated code"
+            print *, "Generated code:", code
+            stop 1
+        end if
+    end subroutine test_generic_binding
+
+    subroutine test_deferred_binding()
+        character(len=*), parameter :: source = &
+            "type, abstract :: atype" // new_line('A') // &
+            "contains" // new_line('A') // &
+            "   procedure, deferred :: abstract_method" // new_line('A') // &
+            "end type atype"
+        character(len=:), allocatable :: code
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: mod_index
+        character(len=:), allocatable :: error_msg
+
+        call lex_source(source, tokens, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: deferred binding lexer error:", trim(error_msg)
+            stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, mod_index, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: deferred binding parse error:", trim(error_msg)
+            stop 1
+        end if
+
+        call emit_fortran(arena, mod_index, code)
+        if (index(code, "procedure, deferred :: abstract_method") == 0) then
+            print *, "FAIL: deferred binding not in generated code"
+            print *, "Generated code:", code
+            stop 1
+        end if
+    end subroutine test_deferred_binding
+
+    subroutine test_nopass_binding()
+        character(len=*), parameter :: source = &
+            "type :: atype" // new_line('A') // &
+            "contains" // new_line('A') // &
+            "   procedure, private, nopass :: act => act_impl" // new_line('A') // &
+            "end type atype"
+        character(len=:), allocatable :: code
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: mod_index
+        character(len=:), allocatable :: error_msg
+
+        call lex_source(source, tokens, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: nopass binding lexer error:", trim(error_msg)
+            stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, mod_index, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: nopass binding parse error:", trim(error_msg)
+            stop 1
+        end if
+
+        call emit_fortran(arena, mod_index, code)
+        if (index(code, "procedure, private, nopass :: act => act_impl") == 0) then
+            print *, "FAIL: nopass binding not in generated code"
+            print *, "Generated code:", code
+            stop 1
+        end if
+    end subroutine test_nopass_binding
 
 end program test_type_bound_procedures_codegen


### PR DESCRIPTION
## Summary
- Fixed missing codegen for type-bound procedures in derived types
- Type-bound procedures were parsed correctly but silently dropped during code generation
- Now properly outputs `contains` section with all procedure bindings

## Changes
- Modified `generate_code_derived_type` in codegen_declarations_core.f90 to include type bindings
- Added `collect_type_bindings()` function to generate contains section
- Added `generate_type_binding_code()` to format procedure/final statements
- Comprehensive test coverage for all binding types

## Verification

### Manual Testing
```fortran
type :: myclass_t
    integer :: value
contains
    procedure :: get_val => myclass_get_val
    procedure, public :: set_val
    final :: myclass_destroy
end type myclass_t
```

Output now correctly includes:
```fortran
type :: myclass_t 
    integer :: value
contains
    procedure :: get_val => myclass_get_val
    procedure, public :: set_val
    final :: myclass_destroy
end type myclass_t
```

### Test Results
```bash
$ fpm test test_type_bound_procedures_codegen
PASS: all type-bound procedure codegen tests passed

$ fpm test
All tests pass
```

Fixes #1629
