### PR TITLE
test: add comprehensive optional polymorphic arguments test (fixes #1620)

### DIFF
--- a/test/integration/core_features/test_optional_polymorphic.f90
+++ b/test/integration/core_features/test_optional_polymorphic.f90
@@ -18,16 +18,16 @@ program test_optional_polymorphic
     print *, "=== Optional Polymorphic Arguments Tests ==="
     print *
 
-    allocate(arr1%values(3))
+    allocate (arr1%values(3))
     arr1%values = [1.0d0, 2.0d0, 3.0d0]
     arr1%size = 3
 
-    allocate(arr2%values(2))
+    allocate (arr2%values(2))
     arr2%values = [10.0d0, 20.0d0]
     arr2%size = 2
 
     narr1%name = "test_array"
-    allocate(narr1%values(4))
+    allocate (narr1%values(4))
     narr1%values = [5.0d0, 6.0d0, 7.0d0, 8.0d0]
     narr1%size = 4
 
@@ -136,19 +136,19 @@ contains
         class(array_t), intent(inout) :: this
         integer, intent(in) :: n
         class(array_t), optional, intent(in) :: optional_arg
+        real(dp), allocatable :: new_values(:)
 
         this%size = n
-        if (allocated(this%values)) then
-            deallocate(this%values)
-        end if
-        allocate(this%values(n))
+
+        allocate (new_values(n))
+        new_values = 0.0d0
 
         if (present(optional_arg)) then
-            this%values(1:min(n, optional_arg%size)) = &
+            new_values(1:min(n, optional_arg%size)) = &
                 optional_arg%values(1:min(n, optional_arg%size))
-        else
-            this%values = 0.0d0
         end if
+
+        call move_alloc(new_values, this%values)
     end subroutine array_init_optional
 
     subroutine process_unlimited(output, optional_data)


### PR DESCRIPTION
## Summary
Adds comprehensive test coverage for optional polymorphic arguments (issue #1620).

## Changes
- Created `test/integration/core_features/test_optional_polymorphic.f90`
- Tests `class(TypeName), optional` with different intent attributes
- Tests `class(*), optional` (unlimited polymorphic)
- Tests type extension compatibility with polymorphic optionals
- Validates `present()` intrinsic and `select type` with optional polymorphic arguments

## Verification
Test successfully compiles and runs with gfortran:

```
fpm test test_optional_polymorphic
```

Output:
```
=== Optional Polymorphic Arguments Tests ===

Test 1: class(array_t), optional argument
  PASS: optional argument absent
  PASS: optional argument present

Test 2: class(*), optional argument
  PASS: unlimited polymorphic without optional
  PASS: unlimited polymorphic with real optional
  PASS: unlimited polymorphic with char optional

Test 3: class(array_t), optional, intent(in)
  PASS: without optional argument
  PASS: with optional argument
  PASS: extended type as optional argument

All optional polymorphic tests passed!
```

All existing tests continue to pass.

Fixes #1620