### PR TITLE
fix: add type extension and inheritance support (fixes #1606)

### DIFF
--- a/src/parser/parser_declarations_derived_module.f90
+++ b/src/parser/parser_declarations_derived_module.f90
@@ -6,6 +6,7 @@ module parser_declarations_derived_module
     use ast_factory, only: push_derived_type, push_type_binding
     use parser_declarations_type_spec_support_module, only: &
         skip_type_definition_attributes
+    use parser_type_spec_attributes_mod, only: extract_extends_from_attributes
     use parser_declarations_core_module, only: parse_declaration
     use string_utils_mod, only: to_lower
     implicit none
@@ -23,6 +24,8 @@ contains
 
         character(len=100) :: type_name
         character(len=:), allocatable :: header_attributes
+        character(len=:), allocatable :: extends_parent
+        character(len=:), allocatable :: remaining_attrs
         logical :: has_header_attrs
         logical :: invalid_type_spec
         integer, allocatable :: component_indices(:)
@@ -38,13 +41,30 @@ contains
             return
         end if
 
+        if (has_header_attrs .and. allocated(header_attributes)) then
+            call extract_extends_from_attributes(header_attributes, &
+                                                 extends_parent, remaining_attrs)
+            if (allocated(remaining_attrs)) then
+                if (len_trim(remaining_attrs) > 0) then
+                    call move_alloc(remaining_attrs, header_attributes)
+                else
+                    has_header_attrs = .false.
+                    block
+                        character(len=:), allocatable :: temp
+                        call move_alloc(header_attributes, temp)
+                        call move_alloc(remaining_attrs, temp)
+                    end block
+                end if
+            end if
+        end if
+
         call collect_derived_type_components(parser, arena, component_indices, &
                                              component_count, binding_indices, &
                                              binding_count)
         type_index = finalize_derived_type(arena, type_name, header_attributes, &
                                            has_header_attrs, component_indices, &
                                            component_count, binding_indices, &
-                                           binding_count)
+                                           binding_count, extends_parent)
     end function parse_derived_type_def
 
     subroutine parse_type_definition_header(parser, type_name, &
@@ -626,7 +646,8 @@ contains
     integer function finalize_derived_type(arena, type_name, header_attributes, &
                                            has_header_attrs, component_indices, &
                                            component_count, binding_indices, &
-                                           binding_count) result(type_index)
+                                           binding_count, extends_parent) &
+        result(type_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: type_name
         character(len=:), allocatable, intent(in) :: header_attributes
@@ -635,40 +656,90 @@ contains
         integer, intent(in) :: component_count
         integer, intent(in) :: binding_indices(:)
         integer, intent(in) :: binding_count
+        character(len=:), allocatable, intent(in), optional :: extends_parent
+        logical :: has_extends
+
+        has_extends = present(extends_parent)
+        if (has_extends) then
+            if (.not. allocated(extends_parent)) has_extends = .false.
+            if (has_extends) then
+                if (len_trim(extends_parent) == 0) has_extends = .false.
+            end if
+        end if
 
         if (component_count > 0 .and. binding_count > 0) then
-            if (has_header_attrs) then
+            if (has_header_attrs .and. has_extends) then
+                type_index = push_derived_type( &
+                    arena, type_name, component_indices, &
+                    attribute_clause=header_attributes, &
+                    binding_indices=binding_indices, &
+                    extends_parent=extends_parent)
+            else if (has_header_attrs) then
                 type_index = push_derived_type( &
                     arena, type_name, component_indices, &
                     attribute_clause=header_attributes, &
                     binding_indices=binding_indices)
+            else if (has_extends) then
+                type_index = push_derived_type( &
+                    arena, type_name, component_indices, &
+                    binding_indices=binding_indices, &
+                    extends_parent=extends_parent)
             else
                 type_index = push_derived_type(arena, type_name, component_indices, &
                                                binding_indices=binding_indices)
             end if
         else if (component_count > 0) then
-            if (has_header_attrs) then
+            if (has_header_attrs .and. has_extends) then
+                type_index = push_derived_type( &
+                    arena, type_name, component_indices, &
+                    attribute_clause=header_attributes, &
+                    extends_parent=extends_parent)
+            else if (has_header_attrs) then
                 type_index = push_derived_type( &
                     arena, type_name, component_indices, &
                     attribute_clause=header_attributes)
+            else if (has_extends) then
+                type_index = push_derived_type( &
+                    arena, type_name, component_indices, &
+                    extends_parent=extends_parent)
             else
                 type_index = push_derived_type(arena, type_name, component_indices)
             end if
         else if (binding_count > 0) then
-            if (has_header_attrs) then
+            if (has_header_attrs .and. has_extends) then
                 type_index = push_derived_type( &
                     arena, type_name, [integer ::], &
-                                       attribute_clause=header_attributes, &
-                                       binding_indices=binding_indices)
+                    attribute_clause=header_attributes, &
+                    binding_indices=binding_indices, &
+                    extends_parent=extends_parent)
+            else if (has_header_attrs) then
+                type_index = push_derived_type( &
+                    arena, type_name, [integer ::], &
+                    attribute_clause=header_attributes, &
+                    binding_indices=binding_indices)
+            else if (has_extends) then
+                type_index = push_derived_type( &
+                    arena, type_name, [integer ::], &
+                    binding_indices=binding_indices, &
+                    extends_parent=extends_parent)
             else
                 type_index = push_derived_type(arena, type_name, [integer ::], &
-                                                        binding_indices=binding_indices)
+                                               binding_indices=binding_indices)
             end if
         else
-            if (has_header_attrs) then
+            if (has_header_attrs .and. has_extends) then
                 type_index = push_derived_type( &
                     arena, type_name, [integer ::], &
-                                       attribute_clause=header_attributes)
+                    attribute_clause=header_attributes, &
+                    extends_parent=extends_parent)
+            else if (has_header_attrs) then
+                type_index = push_derived_type( &
+                    arena, type_name, [integer ::], &
+                    attribute_clause=header_attributes)
+            else if (has_extends) then
+                type_index = push_derived_type( &
+                    arena, type_name, [integer ::], &
+                    extends_parent=extends_parent)
             else
                 type_index = push_derived_type(arena, type_name, [integer ::])
             end if

--- a/src/parser/parser_type_spec_attributes_mod.f90
+++ b/src/parser/parser_type_spec_attributes_mod.f90
@@ -11,6 +11,7 @@ module parser_type_spec_attributes_mod
     public :: is_type_attribute_token
     public :: skip_type_definition_attributes
     public :: parser_is_at_type_definition
+    public :: extract_extends_from_attributes
 
 contains
 
@@ -283,5 +284,88 @@ contains
         pos = parser%current_token + 1
         is_type_def = scan_type_attribute_sequence(parser, pos)
     end function parser_is_at_type_definition
+
+    subroutine extract_extends_from_attributes(attribute_clause, extends_parent, &
+                                               remaining_attrs)
+        character(len=*), intent(in) :: attribute_clause
+        character(len=:), allocatable, intent(out) :: extends_parent
+        character(len=:), allocatable, intent(out) :: remaining_attrs
+        integer :: extends_pos, paren_start, paren_end, depth, i
+        character(len=:), allocatable :: clause_lower, attr_before, attr_after
+
+        if (len_trim(attribute_clause) == 0) then
+            remaining_attrs = ""
+            return
+        end if
+
+        clause_lower = to_lower(trim(adjustl(attribute_clause)))
+        extends_pos = index(clause_lower, "extends")
+
+        if (extends_pos == 0) then
+            remaining_attrs = trim(adjustl(attribute_clause))
+            return
+        end if
+
+        paren_start = index(attribute_clause(extends_pos:), "(")
+        if (paren_start == 0) then
+            remaining_attrs = trim(adjustl(attribute_clause))
+            return
+        end if
+
+        paren_start = extends_pos + paren_start - 1
+        depth = 1
+        paren_end = paren_start
+
+        do i = paren_start + 1, len(attribute_clause)
+            if (attribute_clause(i:i) == "(") then
+                depth = depth + 1
+            else if (attribute_clause(i:i) == ")") then
+                depth = depth - 1
+                if (depth == 0) then
+                    paren_end = i
+                    exit
+                end if
+            end if
+        end do
+
+        if (depth /= 0) then
+            remaining_attrs = trim(adjustl(attribute_clause))
+            return
+        end if
+
+        extends_parent = trim(adjustl( &
+            attribute_clause(paren_start + 1:paren_end - 1)))
+
+        attr_before = ""
+        if (extends_pos > 1) then
+            attr_before = trim(adjustl(attribute_clause(1:extends_pos - 1)))
+            if (len_trim(attr_before) > 0) then
+                if (attr_before(len_trim(attr_before):len_trim(attr_before)) &
+                    == ",") then
+                    attr_before = attr_before(1:len_trim(attr_before) - 1)
+                end if
+            end if
+        end if
+
+        attr_after = ""
+        if (paren_end < len(attribute_clause)) then
+            attr_after = trim(adjustl(attribute_clause(paren_end + 1:)))
+            if (len_trim(attr_after) > 0) then
+                if (attr_after(1:1) == ",") then
+                    attr_after = trim(adjustl(attr_after(2:)))
+                end if
+            end if
+        end if
+
+        if (len_trim(attr_before) > 0 .and. len_trim(attr_after) > 0) then
+            remaining_attrs = trim(attr_before) // ", " // trim(attr_after)
+        else if (len_trim(attr_before) > 0) then
+            remaining_attrs = trim(attr_before)
+        else if (len_trim(attr_after) > 0) then
+            remaining_attrs = trim(attr_after)
+        else
+            remaining_attrs = ""
+        end if
+    end subroutine extract_extends_from_attributes
 
 end module parser_type_spec_attributes_mod

--- a/test/codegen/test_derived_type_extends_codegen.f90
+++ b/test/codegen/test_derived_type_extends_codegen.f90
@@ -1,0 +1,45 @@
+program test_derived_type_extends_codegen
+    use frontend, only: lex_source, parse_tokens, emit_fortran
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use lexer_core, only: token_t
+    implicit none
+
+    character(len=*), parameter :: source = &
+        "type, extends(base_type) :: derived_type" // new_line('A') // &
+        "    integer :: x" // new_line('A') // &
+        "end type derived_type"
+    character(len=:), allocatable :: code
+    type(token_t), allocatable :: tokens(:)
+    type(ast_arena_t) :: arena
+    integer :: mod_index
+    character(len=:), allocatable :: error_msg
+
+    call lex_source(source, tokens, error_msg)
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: lexer error:", trim(error_msg)
+        stop 1
+    end if
+
+    arena = create_ast_arena()
+    call parse_tokens(tokens, arena, mod_index, error_msg)
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: parse error:", trim(error_msg)
+        stop 1
+    end if
+
+    call emit_fortran(arena, mod_index, code)
+    if (index(code, "extends(base_type)") == 0) then
+        print *, "FAIL: extends clause not in generated code"
+        print *, "Generated code:", code
+        stop 1
+    end if
+
+    if (index(code, "derived_type") == 0) then
+        print *, "FAIL: type name not in generated code"
+        print *, "Generated code:", code
+        stop 1
+    end if
+
+    print *, "PASS: derived type with EXTENDS roundtrip codegen"
+
+end program test_derived_type_extends_codegen

--- a/test/codegen/test_extends_with_attributes.f90
+++ b/test/codegen/test_extends_with_attributes.f90
@@ -1,0 +1,45 @@
+program test_extends_with_attributes
+    use frontend, only: lex_source, parse_tokens, emit_fortran
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use lexer_core, only: token_t
+    implicit none
+
+    character(len=*), parameter :: source = &
+        "type, public, extends(base_type) :: derived_type" // new_line('A') // &
+        "    integer :: x" // new_line('A') // &
+        "end type derived_type"
+    character(len=:), allocatable :: code
+    type(token_t), allocatable :: tokens(:)
+    type(ast_arena_t) :: arena
+    integer :: mod_index
+    character(len=:), allocatable :: error_msg
+
+    call lex_source(source, tokens, error_msg)
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: lexer error:", trim(error_msg)
+        stop 1
+    end if
+
+    arena = create_ast_arena()
+    call parse_tokens(tokens, arena, mod_index, error_msg)
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: parse error:", trim(error_msg)
+        stop 1
+    end if
+
+    call emit_fortran(arena, mod_index, code)
+    if (index(code, "extends(base_type)") == 0) then
+        print *, "FAIL: extends clause not in generated code"
+        print *, "Generated code:", code
+        stop 1
+    end if
+
+    if (index(code, "public") == 0) then
+        print *, "FAIL: public attribute not in generated code"
+        print *, "Generated code:", code
+        stop 1
+    end if
+
+    print *, "PASS: extends with other attributes roundtrip"
+
+end program test_extends_with_attributes

--- a/test/parser/test_derived_type_extends.f90
+++ b/test/parser/test_derived_type_extends.f90
@@ -1,18 +1,23 @@
 program test_derived_type_extends
     use frontend, only: lex_source, parse_tokens
     use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_data, only: derived_type_node
+    use fortfront_utils, only: get_node_type
+    use fortfront_types, only: NODE_DERIVED_TYPE
     use lexer_core, only: token_t
     use, intrinsic :: iso_fortran_env, only: dp => real64
     implicit none
 
     character(len=*), parameter :: source = &
         "type, extends(base_type) :: derived_type" // new_line('A') // &
+        "    integer :: x" // new_line('A') // &
         "end type derived_type"
 
     type(token_t), allocatable :: tokens(:)
     type(ast_arena_t) :: arena
-    integer :: mod_index
+    integer :: mod_index, node_type, type_index
     character(len=:), allocatable :: error_msg
+    type(derived_type_node), pointer :: dtype
 
     call lex_source(source, tokens, error_msg)
     if (len_trim(error_msg) > 0) then
@@ -32,6 +37,57 @@ program test_derived_type_extends
         stop 1
     end if
 
-    print *, "PASS: derived type with EXTENDS clause parsed without error"
+    if (arena%size < 1) then
+        print *, "FAIL: arena is empty"
+        stop 1
+    end if
+
+    type_index = 0
+    block
+        integer :: i
+        do i = 1, arena%size
+            node_type = get_node_type(arena, i)
+            if (node_type == NODE_DERIVED_TYPE) then
+                type_index = i
+                exit
+            end if
+        end do
+    end block
+
+    if (type_index == 0) then
+        print *, "FAIL: no derived type node found in arena"
+        stop 1
+    end if
+
+    if (.not. allocated(arena%entries(type_index)%node)) then
+        print *, "FAIL: node not allocated at type_index"
+        stop 1
+    end if
+
+    select type (node => arena%entries(type_index)%node)
+    type is (derived_type_node)
+        dtype => node
+
+        if (.not. allocated(dtype%extends_parent)) then
+            print *, "FAIL: extends_parent not allocated in AST node"
+            stop 1
+        end if
+
+        if (trim(dtype%extends_parent) /= "base_type") then
+            print *, "FAIL: extends_parent mismatch, expected base_type, got:", &
+                trim(dtype%extends_parent)
+            stop 1
+        end if
+
+        if (trim(dtype%name) /= "derived_type") then
+            print *, "FAIL: type name mismatch"
+            stop 1
+        end if
+    class default
+        print *, "FAIL: node is not a derived_type_node"
+        stop 1
+    end select
+
+    print *, "PASS: derived type with EXTENDS parsed and extends_parent set"
 
 end program test_derived_type_extends


### PR DESCRIPTION
## Summary
Implement parsing and AST tracking for Fortran 2003 type extension using the `extends()` attribute. This enables inheritance patterns in derived types.

## Changes
- **Parser enhancement**: Added `extract_extends_from_attributes()` helper to parse and separate `extends(parent_type)` from other type attributes
- **AST integration**: Modified `parse_derived_type_def()` and `finalize_derived_type()` to extract and pass `extends_parent` to the AST factory
- **Test coverage**: Enhanced existing test and added two new tests for roundtrip codegen verification

## Implementation Details
All infrastructure (AST nodes with `extends_parent` field, factory support, codegen) was already in place. This PR only adds the missing extraction step in the main parser to populate the `extends_parent` field.

## Test Plan
- ✅ `test_derived_type_extends`: Validates `extends_parent` field is correctly set in AST
- ✅ `test_derived_type_extends_codegen`: Verifies roundtrip code generation preserves extends clause
- ✅ `test_extends_with_attributes`: Tests extends with other attributes (public, private, etc.)
- ✅ All existing tests pass

## Verification
```bash
fpm test test_derived_type_extends
fpm test test_derived_type_extends_codegen
fpm test test_extends_with_attributes
fpm test
```

All tests pass locally.

Closes #1606