### PR TITLE
fix: add allocate type-spec support (fixes #1611)

### DIFF
--- a/src/ast/factory/ast_factory_statements.f90
+++ b/src/ast/factory/ast_factory_statements.f90
@@ -368,7 +368,7 @@ contains
     ! Create allocate statement node and add to stack
     function push_allocate(arena, var_indices, shape_indices, stat_var_index, &
                            errmsg_var_index, source_expr_index, mold_expr_index, &
-                           line, column, parent_index) result(alloc_index)
+                           line, column, parent_index, type_spec) result(alloc_index)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in) :: var_indices(:)
         integer, intent(in), optional :: shape_indices(:)
@@ -377,6 +377,7 @@ contains
         integer, intent(in), optional :: source_expr_index
         integer, intent(in), optional :: mold_expr_index
         integer, intent(in), optional :: line, column, parent_index
+        character(len=*), intent(in), optional :: type_spec
         integer :: alloc_index
         type(allocate_statement_node) :: alloc_stmt
 
@@ -389,6 +390,12 @@ contains
         if (present(shape_indices)) then
             if (size(shape_indices) > 0) then
                 alloc_stmt%shape_indices = shape_indices
+            end if
+        end if
+
+        if (present(type_spec)) then
+            if (len_trim(type_spec) > 0) then
+                alloc_stmt%type_spec = trim(type_spec)
             end if
         end if
 

--- a/src/ast/nodes/ast_nodes_misc.f90
+++ b/src/ast/nodes/ast_nodes_misc.f90
@@ -44,6 +44,7 @@ module ast_nodes_misc
         integer, allocatable :: var_indices(:)  ! Variables to allocate
         integer, allocatable :: shape_indices(:)  ! Shape expressions
         ! for each variable
+        character(len=:), allocatable :: type_spec  ! Optional type-spec
         integer :: stat_var_index = 0  ! Optional stat variable index
         integer :: errmsg_var_index = 0  ! Optional errmsg variable index
         integer :: source_expr_index = 0  ! Optional source
@@ -554,6 +555,7 @@ contains
         call json%add(obj, 'type', 'allocate_statement')
         call json%add(obj, 'line', this%line)
         call json%add(obj, 'column', this%column)
+        if (allocated(this%type_spec)) call json%add(obj, 'type_spec', this%type_spec)
         if (this%stat_var_index > 0) call json%add(obj, 'stat_var_index', &
                                                    this%stat_var_index)
         if (this%errmsg_var_index > 0) call json%add(obj, 'errmsg_var_index', &
@@ -580,6 +582,10 @@ contains
             if (allocated(lhs%shape_indices)) deallocate (lhs%shape_indices)
             allocate (lhs%shape_indices(size(rhs%shape_indices)))
             lhs%shape_indices = rhs%shape_indices
+        end if
+        if (allocated(rhs%type_spec)) then
+            if (allocated(lhs%type_spec)) deallocate (lhs%type_spec)
+            lhs%type_spec = rhs%type_spec
         end if
         lhs%stat_var_index = rhs%stat_var_index
         lhs%errmsg_var_index = rhs%errmsg_var_index

--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -608,6 +608,11 @@ contains
 
         args = ""
 
+        ! Add type-spec if present
+        if (allocated(node%type_spec)) then
+            args = node%type_spec // " :: "
+        end if
+
         if (allocated(node%var_indices)) then
             do i = 1, size(node%var_indices)
                 if (i > 1) args = args // ", "

--- a/src/parser/parser_memory_statements.f90
+++ b/src/parser/parser_memory_statements.f90
@@ -133,12 +133,13 @@ module parser_memory_statements_module
                 type(ast_arena_t), intent(inout) :: arena
                 integer :: allocate_index
 
-                type(token_t) :: token
+                type(token_t) :: token, lookahead, type_token, param_token
                 integer, allocatable :: var_indices(:)
                 integer, allocatable :: shape_indices(:)
          integer :: stat_var_index, errmsg_var_index, source_expr_index, mold_expr_index
-                integer :: line, column
+                integer :: line, column, saved_pos
                 logical :: in_variable_list
+                character(len=:), allocatable :: type_spec_str
 
                 ! Initialize
                 stat_var_index = 0
@@ -162,16 +163,70 @@ module parser_memory_statements_module
                 if (token%kind == TK_OPERATOR .and. token%text == "(") then
                     token = parser%consume()  ! consume '('
 
+                    ! Check for type-spec: TypeName :: or TypeName(param) ::
+                    token = parser%peek()
+                    if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
+                        ! Save current position
+                        saved_pos = parser%current_token
+                        type_token = parser%consume()
+                        lookahead = parser%peek()
+                        if (lookahead%kind == TK_OPERATOR .and. lookahead%text == "(") then
+                            ! TypeName(param) :: pattern
+                            token = parser%consume()
+                            lookahead = parser%peek()
+                            if (lookahead%kind == TK_IDENTIFIER) then
+                                param_token = parser%consume()
+                                token = parser%peek()
+                                if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                                    token = parser%consume()
+                                    lookahead = parser%peek()
+                                    if (lookahead%kind == TK_OPERATOR .and. &
+                                        lookahead%text == "::") then
+                                        ! Found type-spec pattern - consume ::
+                                        token = parser%consume()
+                                        type_spec_str = trim(type_token%text) // "(" // &
+                                                       trim(param_token%text) // ")"
+                                    else
+                                        ! Not type-spec, restore position
+                                        parser%current_token = saved_pos
+                                    end if
+                                else
+                                    ! Not type-spec, restore position
+                                    parser%current_token = saved_pos
+                                end if
+                            else
+                                ! Not type-spec, restore position
+                                parser%current_token = saved_pos
+                            end if
+                        else if (lookahead%kind == TK_OPERATOR .and. &
+                                 lookahead%text == "::") then
+                            ! TypeName :: pattern - consume ::
+                            token = parser%consume()
+                            type_spec_str = trim(type_token%text)
+                        else
+                            ! Not type-spec, restore position
+                            parser%current_token = saved_pos
+                        end if
+                    end if
+
                    call parse_parenthesized_list(parser, arena, ")", in_variable_list, &
                                                   process_allocate_item)
                 end if
 
                 ! Create allocate statement node
-                allocate_index = push_allocate(arena, var_indices, shape_indices, &
-                                               stat_var_index, &
-                                               errmsg_var_index, source_expr_index, &
-                                               mold_expr_index, &
-                                               line, column)
+                if (allocated(type_spec_str)) then
+                    allocate_index = push_allocate(arena, var_indices, shape_indices, &
+                                                   stat_var_index, &
+                                                   errmsg_var_index, source_expr_index, &
+                                                   mold_expr_index, &
+                                                   line, column, type_spec=type_spec_str)
+                else
+                    allocate_index = push_allocate(arena, var_indices, shape_indices, &
+                                                   stat_var_index, &
+                                                   errmsg_var_index, source_expr_index, &
+                                                   mold_expr_index, &
+                                                   line, column)
+                end if
             contains
                 subroutine process_allocate_item(local_parser, local_arena, token, &
                                                  in_variable_list)

--- a/test/test_issue_1611_allocate_type_spec.f90
+++ b/test/test_issue_1611_allocate_type_spec.f90
@@ -1,0 +1,154 @@
+program test_issue_1611_allocate_type_spec
+    use frontend_core, only: lex_source, emit_fortran
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    implicit none
+
+    call test_allocate_class_typespec()
+    call test_allocate_type_typespec()
+    call test_allocate_no_typespec()
+    print *, ""
+    print *, "All allocate type-spec tests passed!"
+
+contains
+
+    subroutine test_allocate_class_typespec()
+        character(:), allocatable :: input_code, output_code, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+
+        input_code = "module mymod" // new_line('A') // &
+                     "   type :: mytype" // new_line('A') // &
+                     "      integer :: value" // new_line('A') // &
+                     "   end type mytype" // new_line('A') // &
+                     "contains" // new_line('A') // &
+                     "   function create() result(obj)" // new_line('A') // &
+                     "      class(mytype), allocatable :: obj" // new_line('A') // &
+                     "      allocate(mytype :: obj)" // new_line('A') // &
+                     "   end function create" // new_line('A') // &
+                     "end module mymod"
+
+        print *, "=== Test 1: allocate(TypeName :: var) preservation ==="
+        print *, "Input:"
+        print *, input_code
+
+        call lex_source(input_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Lexer error:", trim(error_msg)
+            error stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Parser error:", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print *, "Output:"
+        print *, output_code
+
+        if (index(output_code, "allocate(mytype :: obj)") > 0) then
+            print *, "PASS: Type-spec correctly preserved"
+        else
+            print *, "FAIL: Type-spec not found in output"
+            print *, "Expected: allocate(mytype :: obj)"
+            error stop 1
+        end if
+    end subroutine test_allocate_class_typespec
+
+    subroutine test_allocate_type_typespec()
+        character(:), allocatable :: input_code, output_code, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+
+        input_code = "program test" // new_line('A') // &
+                     "   type :: circle" // new_line('A') // &
+                     "      real :: radius" // new_line('A') // &
+                     "   end type circle" // new_line('A') // &
+                     "   type(circle), allocatable :: c" // new_line('A') // &
+                     "   allocate(circle :: c)" // new_line('A') // &
+                     "   c%radius = 5.0" // new_line('A') // &
+                     "end program test"
+
+        print *, ""
+        print *, "=== Test 2: allocate with type() instead of class() ==="
+        print *, "Input:"
+        print *, input_code
+
+        call lex_source(input_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Lexer error:", trim(error_msg)
+            error stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Parser error:", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print *, "Output:"
+        print *, output_code
+
+        if (index(output_code, "allocate(circle :: c)") > 0) then
+            print *, "PASS: Type-spec with type() correctly preserved"
+        else
+            print *, "FAIL: Type-spec not found in output"
+            print *, "Expected: allocate(circle :: c)"
+            error stop 1
+        end if
+    end subroutine test_allocate_type_typespec
+
+    subroutine test_allocate_no_typespec()
+        character(:), allocatable :: input_code, output_code, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+
+        input_code = "program test" // new_line('A') // &
+                     "   integer, allocatable :: arr(:)" // new_line('A') // &
+                     "   allocate(arr(10))" // new_line('A') // &
+                     "end program test"
+
+        print *, ""
+        print *, "=== Test 3: allocate without type-spec (backward compat) ==="
+        print *, "Input:"
+        print *, input_code
+
+        call lex_source(input_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Lexer error:", trim(error_msg)
+            error stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Parser error:", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print *, "Output:"
+        print *, output_code
+
+        if (index(output_code, "allocate(arr(10))") > 0) then
+            print *, "PASS: Regular allocate without type-spec works"
+        else
+            print *, "FAIL: Regular allocate broken"
+            print *, "Expected: allocate(arr(10))"
+            error stop 1
+        end if
+    end subroutine test_allocate_no_typespec
+
+end program test_issue_1611_allocate_type_spec


### PR DESCRIPTION
## Summary
Implements support for allocate type-spec syntax required for polymorphic allocations with class() variables (issue #1611).

## Changes
- **AST**: Added `type_spec` field to `allocate_statement_node`
- **Parser**: Detect and parse `TypeName ::` and `TypeName(param) ::` patterns in allocate statements  
- **Codegen**: Output type-spec when present in AST node
- **Tests**: Comprehensive test coverage in `test_issue_1611_allocate_type_spec.f90`

## Root Cause
The parser did not recognize the optional type-spec before the allocation list in `allocate(type-spec :: allocation-list)` syntax. This caused statements like `allocate(myclass_t :: myobject)` to be incorrectly parsed and transformed to `allocate(myclass_t)`, which is invalid Fortran.

## Verification
**Test results:**
```fortran
! Input
allocate(myclass_t :: myobject)

! Output (correct)
allocate(myclass_t :: myobject)

! Previous output (broken)
allocate(myclass_t)
```

**Example from issue #1611 now works:**
```fortran
function myclass_create(val) result(myobject)
   integer, intent(in) :: val
   class(myclass_t), allocatable :: myobject
   allocate(myclass_t :: myobject)
   myobject%value = val
end function
```

Output compiles with gfortran and executes correctly.

## Test Coverage
- Allocate with `class(TypeName)` type-spec
- Allocate with `type(TypeName)` type-spec  
- Backward compatibility for allocate without type-spec
- All existing tests pass (no regressions)

## Related
- Depends on #1608 (CLASS keyword support) - already merged
- Unblocks implementation of factory patterns in F2003 OO code
