### PR TITLE
fix: support polymorphic arrays in derived types (fixes #1616)

### DIFF
--- a/src/parser/parser_declarations_derived_module.f90
+++ b/src/parser/parser_declarations_derived_module.f90
@@ -896,7 +896,7 @@ contains
         if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
             select case (trim(adjustl(token%text)))
             case ("integer", "real", "complex", "logical", "character", &
-                  "type", "double")
+                  "type", "class", "double")
                 comp_index = parse_declaration(parser, arena)
             case default
                 ! Not a component declaration, return 0

--- a/test/test_issue_1616_polymorphic_arrays.f90
+++ b/test/test_issue_1616_polymorphic_arrays.f90
@@ -1,0 +1,154 @@
+program test_issue_1616_polymorphic_arrays
+    use frontend_core, only: lex_source, emit_fortran
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    implicit none
+
+    call test_allocatable_polymorphic_array()
+    call test_pointer_polymorphic_array()
+    call test_regular_type_array()
+    print *, ""
+    print *, "All polymorphic array tests passed!"
+
+contains
+
+    subroutine test_allocatable_polymorphic_array()
+        character(:), allocatable :: input_code, output_code, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+
+        input_code = "module test_mod" // new_line('A') // &
+                     "   implicit none" // new_line('A') // &
+                     "   type :: List_circle" // new_line('A') // &
+                     "      type(Circle), allocatable :: alloc_type(:)" // new_line('A') // &
+                     "      class(Circle), allocatable :: alloc_class(:)" // new_line('A') // &
+                     "   end type" // new_line('A') // &
+                     "end module"
+
+        print *, "=== Test 1: class(T), allocatable :: arr(:) ==="
+        print *, "Input:"
+        print *, input_code
+
+        call lex_source(input_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Lexer error:", trim(error_msg)
+            error stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Parser error:", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print *, "Output:"
+        print *, output_code
+
+        if (index(output_code, "class(Circle)") > 0 .and. &
+            index(output_code, "allocatable") > 0) then
+            print *, "PASS: Polymorphic allocatable array preserved"
+        else
+            print *, "FAIL: Polymorphic allocatable array not found"
+            print *, "Expected: class(Circle), allocatable :: alloc_class(:)"
+            error stop 1
+        end if
+    end subroutine test_allocatable_polymorphic_array
+
+    subroutine test_pointer_polymorphic_array()
+        character(:), allocatable :: input_code, output_code, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+
+        input_code = "module test_mod" // new_line('A') // &
+                     "   implicit none" // new_line('A') // &
+                     "   type :: List_circle" // new_line('A') // &
+                     "      class(Circle), pointer :: ptr_class(:)" // new_line('A') // &
+                     "   end type" // new_line('A') // &
+                     "end module"
+
+        print *, ""
+        print *, "=== Test 2: class(T), pointer :: arr(:) ==="
+        print *, "Input:"
+        print *, input_code
+
+        call lex_source(input_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Lexer error:", trim(error_msg)
+            error stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Parser error:", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print *, "Output:"
+        print *, output_code
+
+        if (index(output_code, "class(Circle)") > 0 .and. &
+            index(output_code, "pointer") > 0) then
+            print *, "PASS: Polymorphic pointer array preserved"
+        else
+            print *, "FAIL: Polymorphic pointer array not found"
+            print *, "Expected: class(Circle), pointer :: ptr_class(:)"
+            error stop 1
+        end if
+    end subroutine test_pointer_polymorphic_array
+
+    subroutine test_regular_type_array()
+        character(:), allocatable :: input_code, output_code, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+
+        input_code = "module test_mod" // new_line('A') // &
+                     "   implicit none" // new_line('A') // &
+                     "   type :: Container" // new_line('A') // &
+                     "      type(Circle), allocatable :: regular(:)" // new_line('A') // &
+                     "      class(Shape), allocatable :: polymorphic(:)" // new_line('A') // &
+                     "   end type" // new_line('A') // &
+                     "end module"
+
+        print *, ""
+        print *, "=== Test 3: Mixed type and class arrays ==="
+        print *, "Input:"
+        print *, input_code
+
+        call lex_source(input_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Lexer error:", trim(error_msg)
+            error stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        if (error_msg /= "") then
+            print *, "FAIL: Parser error:", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print *, "Output:"
+        print *, output_code
+
+        if (index(output_code, "type(Circle)") > 0 .and. &
+            index(output_code, "class(Shape)") > 0) then
+            print *, "PASS: Mixed type and class arrays preserved"
+        else
+            print *, "FAIL: Mixed arrays not correctly preserved"
+            error stop 1
+        end if
+    end subroutine test_regular_type_array
+
+end program test_issue_1616_polymorphic_arrays


### PR DESCRIPTION
## Summary
- Enabled parsing of `class(T)` arrays with allocatable/pointer attributes in type definitions
- Added `class` keyword to derived type component parser

## Problem
Previously, `class(T), allocatable :: arr(:)` components in derived types were silently dropped during parsing. The parser only recognized `type` but not `class` as a valid component declaration keyword.

## Solution
Added `class` to the keyword list in `parse_derived_type_component` function (line 899 of parser_declarations_derived_module.f90).

## Test Plan
Created comprehensive test suite (`test_issue_1616_polymorphic_arrays.f90`) covering:
- `class(T), allocatable :: arr(:)` - polymorphic allocatable arrays
- `class(T), pointer :: arr(:)` - polymorphic pointer arrays  
- Mixed `type(T)` and `class(T)` arrays in same derived type

## Verification
All 3 new test cases pass. All existing tests pass (full test suite green).

Example output:
```fortran
module test_mod
    implicit none
    type :: Container 
        type(Circle), allocatable :: regular(:)
        class(Shape), allocatable :: polymorphic(:)
    end type Container 
end module test_mod
```

Closes #1616