### PR TITLE
fix: remove XFAIL marker from passing test (fixes #957)

### DIFF
--- a/test/test_issue_957_parameter_attributes.f90
+++ b/test/test_issue_957_parameter_attributes.f90
@@ -9,12 +9,8 @@ program test_issue_957_parameter_attributes
     if (test_passed) then
         print *, "PASS: Issue #957 parameter attributes test"
     else
-        ! XFAIL: Parser doesn't include parameter declarations in body AST
-        ! See https://github.com/lazy-fortran/fortfront/issues/957
-        print *, "XFAIL: Issue #957 parameter attributes test - parser limitation"
-        print *, "Parser doesn't store parameter declarations in subroutine body"
-        ! Don't fail CI until parser is fixed
-        ! stop 1
+        print *, "FAIL: Issue #957 parameter attributes test"
+        stop 1
     end if
 
 contains


### PR DESCRIPTION
## Summary
Remove XFAIL marker from test_issue_957_parameter_attributes.f90 since issue #957 has been resolved and the test now consistently passes.

## Changes
- Removed XFAIL workaround code from test_issue_957_parameter_attributes.f90
- Test now properly fails if parameter attributes are not preserved
- Updated test to use standard PASS/FAIL reporting

## Verification
Test execution confirms parameter attributes are correctly preserved:
```
fpm test test_issue_957_parameter_attributes
PASS: Issue #957 parameter attributes test
```

All parameter attributes work correctly:
- intent(in) preserved
- intent(out) preserved  
- optional attribute preserved

Full test suite passes without regressions.