### PR TITLE
fix: add abstract interface support (fixes #1612)

### DIFF
--- a/src/ast/factory/ast_factory_procedures.f90
+++ b/src/ast/factory/ast_factory_procedures.f90
@@ -84,17 +84,19 @@ contains
 
     ! Create interface block node and add to stack
     function push_interface_block(arena, interface_name, procedure_indices, &
-                                  line, column, parent_index) result(interface_index)
+                                  line, column, parent_index, is_abstract) result(interface_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in), optional :: interface_name
         integer, intent(in), optional :: procedure_indices(:)
         integer, intent(in), optional :: line, column, parent_index
+        logical, intent(in), optional :: is_abstract
         integer :: interface_index
         type(interface_block_node) :: interface_block
 
         interface_block%uid = generate_uid()
         if (len_trim(interface_name) > 0) interface_block%name = interface_name
         interface_block%kind = "interface"
+        if (present(is_abstract)) interface_block%is_abstract = is_abstract
         if (present(procedure_indices)) then
             if (size(procedure_indices) > 0) interface_block%procedure_indices = procedure_indices
         end if

--- a/src/ast/nodes/ast_nodes_misc.f90
+++ b/src/ast/nodes/ast_nodes_misc.f90
@@ -159,6 +159,7 @@ module ast_nodes_misc
         ! "operator", "assignment"
         character(len=:), allocatable :: operator  ! Operator symbol
         ! (for operator interfaces)
+        logical :: is_abstract = .false.  ! True for abstract interface
         integer, allocatable :: procedure_indices(:)  ! Procedure declaration
         ! arena indices
     contains
@@ -999,6 +1000,7 @@ contains
         if (allocated(this%name)) call json%add(obj, 'name', this%name)
         if (allocated(this%kind)) call json%add(obj, 'kind', this%kind)
         if (allocated(this%operator)) call json%add(obj, 'operator', this%operator)
+        call json%add(obj, 'is_abstract', this%is_abstract)
         call json%add(parent, obj)
     end subroutine interface_block_to_json
 
@@ -1019,6 +1021,7 @@ contains
         if (allocated(rhs%name)) lhs%name = rhs%name
         if (allocated(rhs%kind)) lhs%kind = rhs%kind
         if (allocated(rhs%operator)) lhs%operator = rhs%operator
+        lhs%is_abstract = rhs%is_abstract
         if (allocated(rhs%procedure_indices)) then
             if (allocated(lhs%procedure_indices)) deallocate (lhs%procedure_indices)
             allocate (lhs%procedure_indices(size(rhs%procedure_indices)))

--- a/src/codegen/codegen_declarations_programs.f90
+++ b/src/codegen/codegen_declarations_programs.f90
@@ -915,7 +915,11 @@ contains
         character(len=:), allocatable :: code
         character(len=:), allocatable :: body_code
 
-        code = "interface"
+        if (node%is_abstract) then
+            code = "abstract interface"
+        else
+            code = "interface"
+        end if
         if (allocated(node%name)) then
             if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
         end if

--- a/src/parser/parser_dispatcher.f90
+++ b/src/parser/parser_dispatcher.f90
@@ -93,6 +93,37 @@ contains
                 stmt_index = parse_subroutine_definition(parser, arena, prefix_buffer)
             case ("interface")
                 stmt_index = parse_interface_block(parser, arena, prefix_buffer)
+            case ("abstract")
+                block
+                    integer :: lookahead_idx
+                    type(token_t) :: next_token
+                    logical :: is_abstract_interface
+
+                    is_abstract_interface = .false.
+                    lookahead_idx = parser%current_token + 1
+                    do while (lookahead_idx <= size(parser%tokens))
+                        next_token = parser%tokens(lookahead_idx)
+                        select case (next_token%kind)
+                        case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
+                            lookahead_idx = lookahead_idx + 1
+                            cycle
+                        case (TK_KEYWORD, TK_IDENTIFIER)
+                            if (to_lower(trim(next_token%text)) == "interface") then
+                                is_abstract_interface = .true.
+                            end if
+                            exit
+                        case default
+                            exit
+                        end select
+                    end do
+
+                    if (is_abstract_interface) then
+                        stmt_index = parse_interface_block(parser, arena, prefix_buffer, &
+                                                          is_abstract=.true.)
+                    else
+                        stmt_index = parse_type_or_declaration(parser, arena, prefix_buffer)
+                    end if
+                end block
             case ("module")
                 stmt_index = parse_module(parser, arena)
             case ("block")

--- a/src/parser/parser_interface_blocks.f90
+++ b/src/parser/parser_interface_blocks.f90
@@ -29,11 +29,12 @@ module parser_interface_blocks_module
 
 contains
 
-    function parse_interface_block(parser, arena, prefix_buffer) &
+    function parse_interface_block(parser, arena, prefix_buffer, is_abstract) &
         result(interface_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        logical, intent(in), optional :: is_abstract
         integer :: interface_index
 
         character(len=:), allocatable :: interface_name
@@ -41,8 +42,13 @@ contains
         integer, allocatable :: body_indices(:)
         type(token_t) :: token
         integer :: stmt_index
+        logical :: is_abstract_interface
 
-        call begin_interface_block(parser, interface_name, line, column)
+        is_abstract_interface = .false.
+        if (present(is_abstract)) is_abstract_interface = is_abstract
+
+        call begin_interface_block(parser, interface_name, line, column, &
+                                   is_abstract_interface)
         call prefix_buffer%clear()
 
         allocate (body_indices(0))
@@ -68,7 +74,7 @@ contains
         end do
 
         interface_index = push_interface_block(arena, interface_name, body_indices, &
-                                               line, column)
+                                               line, column, is_abstract=is_abstract_interface)
     end function parse_interface_block
 
     logical function try_parse_interface_procedure(parser, arena, prefix_buffer, &
@@ -113,12 +119,25 @@ contains
         proc_parser_callback => parser_func
     end subroutine set_interface_procedure_parser
 
-    subroutine begin_interface_block(parser, interface_name, line, column)
+    subroutine begin_interface_block(parser, interface_name, line, column, &
+                                     is_abstract)
         type(parser_state_t), intent(inout) :: parser
         character(len=:), allocatable, intent(out) :: interface_name
         integer, intent(out) :: line, column
+        logical, intent(in), optional :: is_abstract
 
         type(token_t) :: token
+        character(len=:), allocatable :: lowered
+
+        if (present(is_abstract)) then
+            if (is_abstract) then
+                token = parser%peek()
+                lowered = to_lower(trim(token%text))
+                if (lowered == "abstract") then
+                    token = parser%consume()
+                end if
+            end if
+        end if
 
         token = parser%consume()
         line = token%line

--- a/test/integration/f2003_features/test_abstract_types.f90
+++ b/test/integration/f2003_features/test_abstract_types.f90
@@ -156,19 +156,18 @@ contains
         call transform_lazy_fortran_string(source, output, error_msg)
 
         if (error_msg /= "") then
-            print *, "  XFAIL: abstract keyword on interface blocks not yet" // &
-                " supported (parser limitation)"
-            passed = .true.
+            print *, "  ERROR: Parsing failed: ", trim(error_msg)
+            passed = .false.
         else if (.not. allocated(output)) then
             print *, "  ERROR: No output generated"
             passed = .false.
         else
-            if (index(output, "interface") == 0) then
-                print *, "  XFAIL: abstract keyword on interface blocks not yet" // &
-                    " supported (parser limitation)"
-                passed = .true.
+            if (index(output, "abstract interface") == 0) then
+                print *, "  ERROR: abstract keyword missing from output"
+                passed = .false.
             else
                 print *, "  PASS: Abstract interface block"
+                passed = .true.
             end if
         end if
     end function test_abstract_interface


### PR DESCRIPTION
## Summary
Adds support for abstract interface blocks, a Fortran 2003 feature required for callback mechanisms and plugin architectures.

## Changes
- Added `is_abstract` field to `interface_block_node` AST type
- Updated AST factory `push_interface_block` to accept optional `is_abstract` parameter
- Extended parser dispatcher to detect `abstract` keyword before `interface`
- Updated interface parser to consume `abstract` keyword when present
- Updated code generation to output `abstract` keyword
- Updated `test_abstract_types` to verify abstract interface preservation

## Verification
Local test run shows all tests pass:
```bash
fpm test
```

Example transformation:
```fortran
abstract interface
    subroutine callback_interface(x)
        integer, intent(in) :: x
    end subroutine callback_interface
end interface
```

Output correctly preserves `abstract interface` keyword.

## Related
Fixes #1612
