### PR TITLE
fix: add fine-grained API modules for library consumers (fixes #1637)

### DIFF
--- a/src/ast/ast_api.f90
+++ b/src/ast/ast_api.f90
@@ -1,0 +1,118 @@
+module ast_api
+    ! Public AST API for library consumers
+    ! Provides access to AST node types and arena operations
+    use ast_base, only: &
+        ast_node, &
+        ast_node_wrapper, &
+        ast_visitor_base_t, &
+        visit_interface, &
+        to_json_interface, &
+        string_t, &
+        LITERAL_INTEGER, &
+        LITERAL_REAL, &
+        LITERAL_STRING, &
+        LITERAL_LOGICAL, &
+        LITERAL_ARRAY, &
+        LITERAL_COMPLEX
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: &
+        program_node, &
+        assignment_node, &
+        pointer_assignment_node, &
+        identifier_node, &
+        literal_node, &
+        binary_op_node, &
+        unary_op_node, &
+        call_or_subscript_node, &
+        array_literal_node, &
+        component_access_node, &
+        range_subscript_node
+    use ast_nodes_procedure, only: &
+        function_def_node, &
+        subroutine_def_node, &
+        function_call_node, &
+        subroutine_call_node
+    use ast_nodes_control, only: &
+        if_node, &
+        do_loop_node, &
+        do_while_loop_node, &
+        select_case_node, &
+        case_node, &
+        exit_node, &
+        cycle_node
+    use ast_nodes_data, only: &
+        module_node, &
+        interface_node, &
+        type_def_node, &
+        variable_decl_node
+    use ast_visitor, only: ast_visitor_t
+    use ast_traversal_utils, only: &
+        traverse_ast, &
+        count_nodes, &
+        find_nodes_by_type
+
+    implicit none
+    private
+
+    ! Base types and interfaces
+    public :: ast_node
+    public :: ast_node_wrapper
+    public :: ast_visitor_base_t
+    public :: visit_interface
+    public :: to_json_interface
+    public :: string_t
+
+    ! Literal type constants
+    public :: LITERAL_INTEGER
+    public :: LITERAL_REAL
+    public :: LITERAL_STRING
+    public :: LITERAL_LOGICAL
+    public :: LITERAL_ARRAY
+    public :: LITERAL_COMPLEX
+
+    ! Arena type
+    public :: ast_arena_t
+
+    ! Core node types
+    public :: program_node
+    public :: assignment_node
+    public :: pointer_assignment_node
+    public :: identifier_node
+    public :: literal_node
+    public :: binary_op_node
+    public :: unary_op_node
+    public :: call_or_subscript_node
+    public :: array_literal_node
+    public :: component_access_node
+    public :: range_subscript_node
+
+    ! Procedure node types
+    public :: function_def_node
+    public :: subroutine_def_node
+    public :: function_call_node
+    public :: subroutine_call_node
+
+    ! Control flow node types
+    public :: if_node
+    public :: do_loop_node
+    public :: do_while_loop_node
+    public :: select_case_node
+    public :: case_node
+    public :: exit_node
+    public :: cycle_node
+
+    ! Data structure node types
+    public :: module_node
+    public :: interface_node
+    public :: type_def_node
+    public :: variable_decl_node
+
+    ! Visitor support
+    public :: ast_visitor_t
+
+    ! Traversal utilities
+    public :: traverse_ast
+    public :: count_nodes
+    public :: find_nodes_by_type
+
+end module ast_api

--- a/src/codegen/codegen_api.f90
+++ b/src/codegen/codegen_api.f90
@@ -1,0 +1,41 @@
+module codegen_api
+    ! Public code generation API for library consumers
+    ! Provides Standard Fortran code generation from AST
+    use codegen_arena_interface, only: &
+        generate_code_from_arena, &
+        set_arena_generator
+    use codegen_core, only: &
+        generate_code_polymorphic, &
+        initialize_codegen
+    use codegen_type_utils, only: &
+        set_type_standardization, &
+        get_type_standardization
+    use codegen_basic_utils, only: &
+        add_line_continuations
+    use codegen_indent, only: &
+        set_indent_config, &
+        get_indent_config, &
+        set_line_length_config, &
+        get_line_length_config
+
+    implicit none
+    private
+
+    ! Main code generation functions
+    public :: generate_code_from_arena
+    public :: generate_code_polymorphic
+    public :: initialize_codegen
+
+    ! Configuration functions
+    public :: set_type_standardization
+    public :: get_type_standardization
+    public :: set_indent_config
+    public :: get_indent_config
+    public :: set_line_length_config
+    public :: get_line_length_config
+
+    ! Utility functions
+    public :: add_line_continuations
+    public :: set_arena_generator
+
+end module codegen_api

--- a/src/lexer/lexer_api.f90
+++ b/src/lexer/lexer_api.f90
@@ -1,0 +1,51 @@
+module lexer_api
+    ! Public lexer API for library consumers
+    ! Provides tokenization functionality for Fortran source code
+    use lexer_core, only: &
+        token_t, &
+        tokenize_core, &
+        tokenize_safe, &
+        tokenize_core_safe, &
+        token_type_name, &
+        tokenize_result_t, &
+        lexer_options_t, &
+        TK_EOF, &
+        TK_IDENTIFIER, &
+        TK_NUMBER, &
+        TK_STRING, &
+        TK_OPERATOR, &
+        TK_KEYWORD, &
+        TK_NEWLINE, &
+        TK_COMMENT, &
+        TK_WHITESPACE, &
+        TK_UNKNOWN
+
+    implicit none
+    private
+
+    ! Core types
+    public :: token_t
+    public :: tokenize_result_t
+    public :: lexer_options_t
+
+    ! Token kind constants
+    public :: TK_EOF
+    public :: TK_IDENTIFIER
+    public :: TK_NUMBER
+    public :: TK_STRING
+    public :: TK_OPERATOR
+    public :: TK_KEYWORD
+    public :: TK_NEWLINE
+    public :: TK_COMMENT
+    public :: TK_WHITESPACE
+    public :: TK_UNKNOWN
+
+    ! Main tokenization functions
+    public :: tokenize_core
+    public :: tokenize_safe
+    public :: tokenize_core_safe
+
+    ! Utility functions
+    public :: token_type_name
+
+end module lexer_api

--- a/src/parser/parser_api.f90
+++ b/src/parser/parser_api.f90
@@ -1,0 +1,54 @@
+module parser_api
+    ! Public parser API for library consumers
+    ! Provides parsing functionality to convert tokens into AST
+    use frontend_parsing, only: &
+        parse_tokens, &
+        parse_tokens_safe, &
+        parse_result_with_index_t, &
+        find_program_unit_boundary, &
+        is_function_start, &
+        is_end_function, &
+        parse_program_unit, &
+        is_do_loop_start, &
+        is_do_while_start, &
+        is_select_case_start, &
+        is_end_do, &
+        is_end_select, &
+        is_if_then_start, &
+        is_end_if
+    use ast_arena_modern, only: ast_arena_t
+    use compiler_arena, only: compiler_arena_t, create_compiler_arena, &
+        destroy_compiler_arena
+
+    implicit none
+    private
+
+    ! Core types
+    public :: parse_result_with_index_t
+    public :: ast_arena_t
+    public :: compiler_arena_t
+
+    ! Main parsing functions
+    public :: parse_tokens
+    public :: parse_tokens_safe
+
+    ! Arena management
+    public :: create_compiler_arena
+    public :: destroy_compiler_arena
+
+    ! Parsing utilities for program structure analysis
+    public :: find_program_unit_boundary
+    public :: is_function_start
+    public :: is_end_function
+    public :: parse_program_unit
+
+    ! Control flow detection helpers
+    public :: is_do_loop_start
+    public :: is_do_while_start
+    public :: is_select_case_start
+    public :: is_end_do
+    public :: is_end_select
+    public :: is_if_then_start
+    public :: is_end_if
+
+end module parser_api

--- a/src/semantic/semantic_api.f90
+++ b/src/semantic/semantic_api.f90
@@ -1,0 +1,82 @@
+module semantic_api
+    ! Public semantic analysis API for library consumers
+    ! Provides type inference and semantic validation
+    use semantic_analyzer, only: &
+        semantic_context_t, &
+        create_semantic_context, &
+        analyze_program, &
+        has_semantic_errors
+    use type_system_unified, only: &
+        mono_type_t, &
+        poly_type_t, &
+        type_env_t, &
+        type_var_t, &
+        substitution_t, &
+        create_mono_type, &
+        create_poly_type, &
+        create_type_var, &
+        TVAR, &
+        TINT, &
+        TREAL, &
+        TCHAR, &
+        TLOGICAL, &
+        TFUN, &
+        TARRAY, &
+        TCOMPLEX, &
+        TDOUBLE, &
+        TDERIVED
+    use scope_manager, only: &
+        scope_stack_t, &
+        create_scope_stack, &
+        push_scope, &
+        pop_scope
+    use error_handling, only: &
+        error_collection_t, &
+        result_t
+
+    implicit none
+    private
+
+    ! Main semantic context type
+    public :: semantic_context_t
+
+    ! Context management
+    public :: create_semantic_context
+    public :: analyze_program
+    public :: has_semantic_errors
+
+    ! Type system types
+    public :: mono_type_t
+    public :: poly_type_t
+    public :: type_env_t
+    public :: type_var_t
+    public :: substitution_t
+
+    ! Type constructors
+    public :: create_mono_type
+    public :: create_poly_type
+    public :: create_type_var
+
+    ! Type constants
+    public :: TVAR
+    public :: TINT
+    public :: TREAL
+    public :: TCHAR
+    public :: TLOGICAL
+    public :: TFUN
+    public :: TARRAY
+    public :: TCOMPLEX
+    public :: TDOUBLE
+    public :: TDERIVED
+
+    ! Scope management
+    public :: scope_stack_t
+    public :: create_scope_stack
+    public :: push_scope
+    public :: pop_scope
+
+    ! Error handling
+    public :: error_collection_t
+    public :: result_t
+
+end module semantic_api

--- a/src/transformation_api.f90
+++ b/src/transformation_api.f90
@@ -1,0 +1,33 @@
+module transformation_api
+    ! Public transformation API for library consumers
+    ! Provides high-level transformation from Lazy Fortran to Standard Fortran
+    use frontend_transformation, only: &
+        transform_lazy_fortran_string, &
+        transform_lazy_fortran_string_with_format, &
+        transform_with_context, &
+        format_options_t, &
+        transform_context_t, &
+        INPUT_MODE_LAZY, &
+        INPUT_MODE_STANDARD, &
+        detect_input_mode_from_content
+
+    implicit none
+    private
+
+    ! Main transformation functions
+    public :: transform_lazy_fortran_string
+    public :: transform_lazy_fortran_string_with_format
+    public :: transform_with_context
+
+    ! Context and options types
+    public :: format_options_t
+    public :: transform_context_t
+
+    ! Input mode constants
+    public :: INPUT_MODE_LAZY
+    public :: INPUT_MODE_STANDARD
+
+    ! Utility functions
+    public :: detect_input_mode_from_content
+
+end module transformation_api


### PR DESCRIPTION
## Summary
Add six new fine-grained API modules to enable library consumers (fluff linter, ffc compiler) to import only the functionality they need, rather than using the monolithic `frontend` facade.

## Changes

### New API Modules Created
- **lexer_api.f90**: Tokenization functionality
  - Exports `token_t`, `tokenize_core`, token kind constants (TK_*)
- **parser_api.f90**: Parsing tokens to AST  
  - Exports `parse_tokens`, `ast_arena_t`, parsing utilities
- **ast_api.f90**: AST node types and traversal utilities
  - Exports all major node types (program, assignment, function, etc.)
  - Exports traversal utilities and visitor pattern
- **semantic_api.f90**: Type inference and semantic validation
  - Exports `semantic_context_t`, `analyze_program`, type system
- **codegen_api.f90**: Standard Fortran code generation
  - Exports `generate_code_from_arena`, configuration functions
- **transformation_api.f90**: High-level transformation pipeline
  - Exports `transform_with_context`, format options

## Implementation Notes

This implements **Phase 1** of issue #1637:
- ✅ Created all 6 new fine-grained API modules (plus error_api already existed)
- ⏸️ Existing `frontend` facade remains for backward compatibility
- ⏸️ Consumer migration (Phase 2) deferred to future PR
- ⏸️ Facade deletion (Phase 3) deferred to future PR

## Verification

```bash
fpm build  # Success - all modules compile
fpm test   # Success - all tests pass
```

All tests pass. No breaking changes to existing API.

## Usage Examples

### Fluff (linter) can now use:
```fortran
use lexer_api, only: tokenize_core, token_t
use parser_api, only: parse_tokens, ast_arena_t
use ast_api, only: traverse_ast
use semantic_api, only: analyze_program
```

### FFC (compiler) can now use:
```fortran
use parser_api, only: parse_tokens
use ast_api, only: traverse_ast, program_node
use semantic_api, only: analyze_program
! Custom backend for HLFIR
```

### CLI (transpiler) continues to use:
```fortran
use frontend, only: transform_lazy_fortran_string  ! Unchanged
! OR can now use:
use transformation_api, only: transform_with_context
```

## Related
- Closes #1637 (Phase 1)
- Enables downstream tools: fluff, ffc
- Part of fortitude comparison analysis