### PR TITLE
fix: preserve STOP statements in codegen (partial fix for #1696)

### DIFF
--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -264,14 +264,17 @@ contains
         type(stop_node), intent(in) :: node
         integer, intent(in) :: node_index
         character(len=:), allocatable :: code
+        character(len=:), allocatable :: code_expr
 
-        ! Generate proper termination with exit call
+        ! Generate proper STOP statement preserving original syntax
         if (allocated(node%stop_message)) then
-            code = "call exit(1) ! " // node%stop_message
-        else if (node%stop_code_index > 0) then
-            code = "call exit(1) ! Termination with code"
+            code = "stop " // node%stop_message
+        else if (node%stop_code_index > 0 .and. &
+                 node%stop_code_index <= arena%size) then
+            code_expr = generate_code_from_arena(arena, node%stop_code_index)
+            code = "stop " // code_expr
         else
-            code = "call exit(1) ! Program termination"
+            code = "stop"
         end if
 
         call prepend_stmt_label(code, node%stmt_label)

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -471,7 +471,8 @@ contains
 
         select case (trim(lower_word))
         case ('program', 'end', 'function', 'subroutine', 'if', &
-              'then', 'else', 'goto', 'cycle', 'exit', &
+              'then', 'else', 'goto', 'cycle', 'exit', 'stop', 'return', 'error', &
+              'continue', &
               'do', 'while', 'for', 'integer', 'real', 'logical', 'character', &
               'complex', 'double', 'precision', &
               'implicit', 'none', 'parameter', 'dimension', 'allocatable', &

--- a/test/integration/issue_tests/test_issue_1696_stop_statements.f90
+++ b/test/integration/issue_tests/test_issue_1696_stop_statements.f90
@@ -1,0 +1,11 @@
+program test_issue_1696_stop_statements
+    implicit none
+    integer :: x
+
+    x = 5
+    if (x > 3) then
+        stop 'Error: x is too large'
+    end if
+
+    print *, 'This should not print'
+end program test_issue_1696_stop_statements


### PR DESCRIPTION
## Summary
Partial fix for #1696 - STOP statements are now preserved in the output, but a secondary issue with spurious empty IF blocks remains.

## Changes Made

### 1. Lexer Keyword List Update
**File**: `src/lexer/lexer_scanners.f90`

Added missing control flow keywords to `is_keyword` function:
- `stop`
- `return`
- `error`
- `continue`

**Root Cause**: These keywords were not recognized by the lexer, causing them to be treated as identifiers. This prevented the parser from handling STOP statements correctly.

### 2. STOP Statement Code Generation Fix
**File**: `src/codegen/codegen_statements.f90`

Rewrote `generate_code_termination` to output proper Fortran STOP syntax instead of converting to exit() calls:
- `stop 'message'` - string messages preserved
- `stop code` - integer codes preserved
- `stop` - bare statements preserved

### 3. Test Case
**File**: `test/integration/issue_tests/test_issue_1696_stop_statements.f90`

Added reproducer from issue #1696 to test suite.

## Verification

STOP statements now work correctly in non-IF contexts:

**Input:**
```fortran
program test
    stop 'Error'
    print *, 'After'
end program test
```

**Output:**
```fortran
program test
    implicit none
    stop 'Error'
    print *, 'After'
end program test
```

## Known Remaining Issue

STOP statements inside IF blocks generate spurious empty IF blocks:

**Input:**
```fortran
program test
    if (x > 3) then
        stop 'Error'
    end if
end program test
```

**Current Output:**
```fortran
program test
    implicit none
    if (x > 3) then
        stop 'Error'
    end if
    if () then
    end if
end program test
```

### Investigation Findings

The spurious empty IF appears to be caused by statement duplication during single-line IF transformation:

1. Single-line IF like `if (x) stop 1` gets converted to block IF
2. The STOP statement is correctly placed inside the IF block
3. BUT the STOP also appears to remain in parent scope, causing duplicate output
4. The duplicate creates parsing artifacts that manifest as empty IF blocks

This requires further investigation into:
- Single-line IF to block IF transformation in parser/standardizer
- Statement body handling in IF constructs
- How `parse_if_body` manages token consumption and advances parser position

## Next Steps

1. Investigate IF statement parsing flow for single-line vs block IFs
2. Check standardizer transformations for statement duplication
3. Fix token consumption in `parse_if_body` to prevent remnant tokens
4. Ensure `consumed_count` from `parse_basic_statement_core` is properly used

## Testing

Build succeeds:
```
$ fpm build
[100%] Project compiled successfully.
```

STOP preservation works (without IF):
```
$ echo "program t; stop 'x'; end program" | fortfront
program t
    implicit none
    stop 'x'
end program t
```

Closes part of #1696
