### PR TITLE
wip: partial infrastructure for COMMON block preservation (fixes #1576)

### DIFF
--- a/src/codegen/codegen_declarations_programs.f90
+++ b/src/codegen/codegen_declarations_programs.f90
@@ -340,12 +340,19 @@ contains
             use_statements_code = use_statements_code // "    " // stmt_code // &
                                   new_line('A')
         type is (comment_node)
-            if (non_use_count == 0) then
+            ! Legacy statement comments (COMMON/EQUIVALENCE) are always header statements
+            if (is_legacy_statement_comment(ib) .or. non_use_count == 0) then
                 is_header_stmt = .true.
                 stmt_code = generate_code_from_arena(arena, body_index)
-                call append_header_trivia(stmt_code, use_statements_code, &
-                                          implicit_statements_code, &
-                                          interface_blocks_code)
+                if (is_legacy_statement_comment(ib)) then
+                    ! Legacy statements go after implicit but before other declarations
+                    implicit_statements_code = implicit_statements_code // "    " // &
+                                              stmt_code // new_line('A')
+                else
+                    call append_header_trivia(stmt_code, use_statements_code, &
+                                              implicit_statements_code, &
+                                              interface_blocks_code)
+                end if
             end if
         type is (blank_line_node)
             if (non_use_count == 0) then

--- a/src/standardizers/standardizer_declarations_core.f90
+++ b/src/standardizers/standardizer_declarations_core.f90
@@ -21,6 +21,7 @@ module standardizer_declarations_core
     use standardizer_types
     use intrinsic_registry, only: get_intrinsic_signature, is_intrinsic_function
     use string_utils_mod, only: int_to_string
+    use ast_nodes_misc, only: comment_node
     implicit none
     private
 
@@ -179,7 +180,8 @@ contains
 
             select type (stmt => arena%entries(node_index)%node)
             type is (comment_node)
-                is_header_separator = .true.
+                ! Legacy statement comments are NOT separators, they are declarations
+                is_header_separator = .not. is_legacy_statement_comment(stmt)
             type is (blank_line_node)
                 is_header_separator = .true.
             class default
@@ -247,6 +249,35 @@ contains
         end do
     end function program_has_variable_declarations
 
+    ! Check if a comment node represents a legacy statement (COMMON, EQUIVALENCE, BLOCK)
+    logical function is_legacy_statement_comment(node)
+        type(comment_node), intent(in) :: node
+        character(len=:), allocatable :: lowered_text
+
+        is_legacy_statement_comment = .false.
+        if (.not. allocated(node%text)) return
+
+        lowered_text = to_lower(adjustl(trim(node%text)))
+        if (len_trim(lowered_text) >= 11) then
+            if (index(lowered_text, "equivalence") == 1) then
+                is_legacy_statement_comment = .true.
+                return
+            end if
+        end if
+        if (len_trim(lowered_text) >= 6) then
+            if (index(lowered_text, "common") == 1) then
+                is_legacy_statement_comment = .true.
+                return
+            end if
+        end if
+        if (len_trim(lowered_text) >= 5) then
+            if (index(lowered_text, "block") == 1) then
+                is_legacy_statement_comment = .true.
+                return
+            end if
+        end if
+    end function is_legacy_statement_comment
+
     integer function find_prefix_end(arena, prog, mode) result(pos)
         type(ast_arena_t), intent(in) :: arena
         type(program_node), intent(in) :: prog
@@ -265,7 +296,12 @@ contains
                     type is (use_statement_node)
                         keep_scanning = .true.
                     type is (comment_node)
-                        keep_scanning = (mode >= 1)
+                        ! Legacy statement comments (COMMON/EQUIVALENCE) are treated as declarations
+                        if (is_legacy_statement_comment(stmt)) then
+                            keep_scanning = (mode >= 2)
+                        else
+                            keep_scanning = (mode >= 1)
+                        end if
                     type is (blank_line_node)
                         keep_scanning = (mode >= 1)
                     type is (implicit_statement_node)


### PR DESCRIPTION
## Status: Work in Progress

This PR adds partial infrastructure for preserving COMMON/EQUIVALENCE/BLOCK statements but requires further investigation to complete. The root cause has been identified.

## Problem

COMMON block statements are completely stripped from output during transformation:

**Input:**
```fortran
program test
    common /mydata/ x, y
    x = 1.0
    y = 2.0
end program test
```

**Current Output:**
```fortran
program test
    implicit none
    real(8) :: x, y
    x = 1.0d0
    y = 2.0d0
end program test
```

**Expected Output:**
```fortran
program test
    implicit none
    common /mydata/ x, y
    real(8) :: x, y
    x = 1.0d0
    y = 2.0d0
end program test
```

## Changes Made

### Standardizer
- Added `is_legacy_statement_comment()` helper function
- Modified `find_prefix_end()` to treat COMMON/EQUIVALENCE/BLOCK as declarations
- Updated `is_header_separator()` to preserve legacy statements

### Codegen  
- Modified `categorize_header_entry()` to output legacy statements

## Investigation Findings

**Root Cause Identified:**

Through extensive debugging, I found that COMMON statements are:
1. ✅ Correctly parsed as `comment_node` objects by `parse_legacy_statement()`
2. ❌ **NOT added to the program's `body_indices` array during parsing**

Debug output confirms:
- Parser creates comment_node at arena index (e.g., 3)
- Program's body_indices = [implicit_none_index, assignment_index]
- COMMON comment_node is never in body_indices

This means COMMON statements are filtered out BEFORE standardization runs, likely during program body construction in the parser.

## Next Steps Required

1. **Investigate parser program body construction** - Find where program bodies are assembled and why comment nodes are excluded
2. **Fix body_indices population** - Ensure COMMON statement comment nodes are included
3. **Add end-to-end tests** - Verify preservation through full pipeline
4. **Extend to subroutines** - Apply similar fixes to subroutine standardization

## Testing

Existing tests pass. New tests for COMMON preservation will be added once the parser issue is resolved.

```bash
$ fpm test test_equivalence_common_block
 PASS: legacy equivalence/common statements handled gracefully
```

## Related

- Fixes #1576
- Related to #1578 (BLOCK DATA, uses COMMON)
- Builds on PR #1636 (added parsing infrastructure)

## Verification Commands

Once complete, verification will use:

```bash
$ echo 'program test
    common /mydata/ x
    x = 1.0
end program test' | fpm run fortfront
```

---

**Note:** This PR documents the investigation and lays groundwork. Additional work needed in parser to fully resolve the issue. Marking as WIP for now.