### PR TITLE
fix: preserve READ statements in codegen (fixes #1698)

### DIFF
--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -237,9 +237,41 @@ contains
         type(read_statement_node), intent(in) :: node
         integer, intent(in) :: node_index
         character(len=:), allocatable :: code
+        character(len=:), allocatable :: unit_code, format_code, vars_code
+        integer :: i
 
-        ! Generate read statement code
-        code = "read(*, *)"  ! Basic read statement
+        ! Generate unit specifier
+        if (allocated(node%unit_spec)) then
+            unit_code = node%unit_spec
+        else
+            unit_code = "*"
+        end if
+
+        ! Generate format specifier
+        if (allocated(node%format_spec)) then
+            format_code = node%format_spec
+        else
+            format_code = "*"
+        end if
+
+        ! Generate variable list using recursive code generation
+        vars_code = ""
+        if (allocated(node%var_indices)) then
+            do i = 1, size(node%var_indices)
+                if (i > 1) vars_code = vars_code // ", "
+                if (node%var_indices(i) > 0 .and. &
+                    node%var_indices(i) <= arena%size) then
+                    vars_code = vars_code // &
+                        generate_code_from_arena(arena, node%var_indices(i))
+                end if
+            end do
+        end if
+
+        ! Assemble read statement: read(unit, format) vars
+        code = "read(" // unit_code // ", " // format_code // ")"
+        if (len(vars_code) > 0) then
+            code = code // " " // vars_code
+        end if
 
         call prepend_stmt_label(code, node%stmt_label)
     end function generate_code_read_statement

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -17,6 +17,7 @@ module parser_execution_statements_module
     use parser_utils, only: analyze_declaration_structure
     use parser_io_statements_module, only: parse_print_statement, &
                                            parse_write_statement, &
+                                           parse_read_statement, &
                                            parse_format_statement, &
                                            parse_open_statement, &
                                            parse_close_statement
@@ -311,6 +312,8 @@ contains
                 stmt_index = parse_use_statement(parser_ref, arena_ref)
             case ("write")
                 stmt_index = parse_write_statement(parser_ref, arena_ref)
+            case ("read")
+                stmt_index = parse_read_statement(parser_ref, arena_ref)
             case ("open")
                 stmt_index = parse_open_statement(parser_ref, arena_ref)
             case ("close")


### PR DESCRIPTION
## Summary
Fixes READ statement removal during transformation by adding READ to the parser execution statement dispatch table and implementing proper codegen.

## Root Cause
READ statements were silently removed because:
1. `parser_execution_statements.f90` was missing READ from the `parse_general_keyword` case statement
2. When READ was encountered, it fell through to the default case which consumed the token and returned 0
3. The `generate_code_read_statement` function was a stub returning only `read(*, *)`

## Changes
- Add READ case to `parse_general_keyword` in `parser_execution_statements.f90`
- Import `parse_read_statement` from `parser_io_statements_module`
- Implement full `generate_code_read_statement` in `codegen_statements.f90` with:
  - Unit specifier handling
  - Format specifier handling
  - Variable list generation via recursive arena traversal

## Verification

### Reproducer from issue #1698
Input:
```fortran
program test_read
    implicit none
    integer :: x, y
    character(len=50) :: line

    open(unit=10, file='/tmp/test_input.txt', status='replace')
    write(10, *) '42 99'
    write(10, *) 'Hello World'
    close(10)

    open(unit=10, file='/tmp/test_input.txt', status='old')
    read(10, *) x, y
    read(10, '(A)') line
    close(10)

    print *, 'x=', x, 'y=', y
    print *, 'line:', trim(line)
end program test_read
```

Output (transformed code preserves READ and CLOSE):
```fortran
program test_read
    implicit none
    integer :: x, y
    character(len=50) :: line
    open(unit= 10, file= '/tmp/test_input.txt', status= 'replace')
    write(10, *) '42 99'
    write(10, *) 'Hello World'
    close(10)
    open(unit= 10, file= '/tmp/test_input.txt', status= 'old')
    read(10, *) x, y
    read(10, '(A)') line
    close(10)
    print *, 'x=', x, 'y=', y
    print *, 'line:', trim(line)
end program test_read
```

Compiled and executed output:
```
 x=          42 y=          99
 line: Hello World
```

### Test suite
- Existing `test_io_statements.f90` passes (includes READ statements)
- Full test suite passes: `fpm test`

Fixes #1698
