### PR TITLE
fix: preserve INQUIRE statements in codegen (fixes #1699)

### DIFF
--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -40,7 +40,8 @@ module ast_factory
         push_read_statement_with_err, push_read_statement_with_end, &
         push_read_statement_with_all_specifiers, push_write_statement_with_iostat, &
         push_write_statement_with_format, push_write_statement_with_runtime_format, &
-        push_format_statement, push_open_statement, push_close_statement
+        push_format_statement, push_open_statement, push_close_statement, &
+        push_inquire_statement
 
     ! Procedure definition nodes
     use ast_factory_procedures, only: &
@@ -93,6 +94,7 @@ module ast_factory
     public :: push_read_statement_with_all_specifiers, push_write_statement_with_iostat
     public :: push_write_statement_with_format, push_write_statement_with_runtime_format
     public :: push_format_statement, push_open_statement, push_close_statement
+    public :: push_inquire_statement
 
     ! Procedure definition nodes
     public :: push_function_def, push_subroutine_def, push_interface_block

--- a/src/ast/factory/ast_factory_io.f90
+++ b/src/ast/factory/ast_factory_io.f90
@@ -2,7 +2,8 @@ module ast_factory_io
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_io, only: print_statement_node, write_statement_node, &
                             read_statement_node, format_statement_node, &
-                            open_statement_node, close_statement_node
+                            open_statement_node, close_statement_node, &
+                            inquire_statement_node
     implicit none
     private
 
@@ -14,6 +15,7 @@ module ast_factory_io
     public :: push_write_statement_with_runtime_format
     public :: push_format_statement
     public :: push_open_statement, push_close_statement
+    public :: push_inquire_statement
 
 contains
 
@@ -275,5 +277,21 @@ contains
         call arena%push(close_stmt, "close_statement", parent_index)
         close_index = arena%size
     end function push_close_statement
+
+    function push_inquire_statement(arena, spec_text, line, column, &
+                                    parent_index) result(inquire_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: spec_text
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: inquire_index
+        type(inquire_statement_node) :: inquire_stmt
+
+        inquire_stmt%spec_list = spec_text
+        if (present(line)) inquire_stmt%line = line
+        if (present(column)) inquire_stmt%column = column
+
+        call arena%push(inquire_stmt, "inquire_statement", parent_index)
+        inquire_index = arena%size
+    end function push_inquire_statement
 
 end module ast_factory_io

--- a/src/ast/nodes/ast_nodes_io.f90
+++ b/src/ast/nodes/ast_nodes_io.f90
@@ -11,6 +11,7 @@ module ast_nodes_io
     public :: create_io_implied_do
     public :: create_open_statement
     public :: create_close_statement
+    public :: create_inquire_statement
 
     ! I/O statement AST nodes
 
@@ -138,6 +139,18 @@ module ast_nodes_io
         procedure :: assign => close_statement_assign
         generic :: assignment(=) => assign
     end type close_statement_node
+
+    ! INQUIRE statement node
+    type, extends(ast_node), public :: inquire_statement_node
+        character(len=:), allocatable :: spec_list
+        integer :: iostat_var_index = 0
+        integer :: err_label_index = 0
+    contains
+        procedure :: accept => inquire_statement_accept
+        procedure :: to_json => inquire_statement_to_json
+        procedure :: assign => inquire_statement_assign
+        generic :: assignment(=) => assign
+    end type inquire_statement_node
 
 contains
 
@@ -546,5 +559,49 @@ contains
         type(close_statement_node) :: node
         node%uid = generate_uid()
     end function create_close_statement
+
+    ! INQUIRE statement implementations
+    subroutine inquire_statement_accept(this, visitor)
+        class(inquire_statement_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+    end subroutine inquire_statement_accept
+
+    subroutine inquire_statement_to_json(this, json, parent)
+        class(inquire_statement_node), intent(in) :: this
+        type(json_core), intent(inout) :: json
+        type(json_value), pointer, intent(in) :: parent
+        type(json_value), pointer :: obj
+
+        call json%create_object(obj, '')
+        call json%add(obj, 'type', 'inquire_statement')
+        call json%add(obj, 'line', this%line)
+        call json%add(obj, 'column', this%column)
+        if (allocated(this%spec_list)) call json%add(obj, 'spec_list', &
+                                                      this%spec_list)
+        call json%add(parent, obj)
+    end subroutine inquire_statement_to_json
+
+    subroutine inquire_statement_assign(lhs, rhs)
+        class(inquire_statement_node), intent(inout) :: lhs
+        class(inquire_statement_node), intent(in) :: rhs
+
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+        if (allocated(rhs%spec_list)) lhs%spec_list = rhs%spec_list
+        lhs%iostat_var_index = rhs%iostat_var_index
+        lhs%err_label_index = rhs%err_label_index
+    end subroutine inquire_statement_assign
+
+    function create_inquire_statement() result(node)
+        type(inquire_statement_node) :: node
+        node%uid = generate_uid()
+    end function create_inquire_statement
 
 end module ast_nodes_io

--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -101,6 +101,8 @@ contains
             code = generate_code_open_statement(arena, node, node_index)
         type is (close_statement_node)
             code = generate_code_close_statement(arena, node, node_index)
+        type is (inquire_statement_node)
+            code = generate_code_inquire_statement(arena, node, node_index)
         type is (format_statement_node)
             code = generate_code_format_statement(arena, node, node_index)
         type is (stop_node)

--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -39,6 +39,7 @@ module codegen_statements
     public :: generate_code_deallocate_statement
     public :: generate_code_open_statement
     public :: generate_code_close_statement
+    public :: generate_code_inquire_statement
     public :: generate_code_pause_statement
     public :: generate_code_nullify_statement
 
@@ -812,6 +813,21 @@ contains
         end if
         call prepend_stmt_label(code, node%stmt_label)
     end function generate_code_close_statement
+
+    function generate_code_inquire_statement(arena, node, node_index) &
+        result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(inquire_statement_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+
+        if (allocated(node%spec_list)) then
+            code = "inquire(" // node%spec_list // ")"
+        else
+            code = "inquire()"
+        end if
+        call prepend_stmt_label(code, node%stmt_label)
+    end function generate_code_inquire_statement
 
     function generate_code_pause_statement(arena, node, node_index) result(code)
         type(ast_arena_t), intent(in) :: arena

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -478,8 +478,9 @@ contains
               'intent', 'use', 'module', 'contains', 'public', 'private', &
               'namelist', 'data', 'type', 'class', 'extends', 'abstract', &
               'procedure', 'interface', 'import', 'generic', 'operator', &
-              'assignment', 'print', 'read', 'write', 'open', 'close', 'call', &
-              'format', 'allocate', 'deallocate', 'select', 'case', 'default', &
+              'assignment', 'print', 'read', 'write', 'open', 'close', 'inquire', &
+              'call', 'format', 'allocate', 'deallocate', 'select', 'case', &
+              'default', &
               'where', 'associate', 'forall', 'block', 'enum', 'file', &
               'submodule', 'rank', 'elseif', 'elsewhere', 'blockdata', &
               'doubleprecision', 'doublecomplex', 'selectcase', 'equivalence', &

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -20,7 +20,8 @@ module parser_execution_statements_module
                                            parse_read_statement, &
                                            parse_format_statement, &
                                            parse_open_statement, &
-                                           parse_close_statement
+                                           parse_close_statement, &
+                                           parse_inquire_statement
     use parser_memory_statements_module, only: parse_allocate_statement, &
                                                parse_deallocate_statement
     use parser_control_statements_module, only: parse_stop_statement, &
@@ -319,6 +320,8 @@ contains
                 stmt_index = parse_open_statement(parser_ref, arena_ref)
             case ("close")
                 stmt_index = parse_close_statement(parser_ref, arena_ref)
+            case ("inquire")
+                stmt_index = parse_inquire_statement(parser_ref, arena_ref)
             case ("format")
                 stmt_index = parse_format_statement(parser_ref, arena_ref)
             case ("allocate")

--- a/src/parser/parser_io_statements.f90
+++ b/src/parser/parser_io_statements.f90
@@ -7,10 +7,12 @@ module parser_io_statements_module
     use parser_state_module
     use parser_expressions_module, only: parse_comparison
     use ast_arena_modern, only: ast_arena_t
-    use ast_nodes_io, only: open_statement_node, close_statement_node
+    use ast_nodes_io, only: open_statement_node, close_statement_node, &
+                            inquire_statement_node
     use ast_factory, only: push_print_statement, push_write_statement, &
                            push_read_statement, push_format_statement, &
-                           push_open_statement, push_close_statement
+                           push_open_statement, push_close_statement, &
+                           push_inquire_statement
     use ast_factory
     implicit none
     private
@@ -18,6 +20,7 @@ module parser_io_statements_module
     public :: parse_print_statement, parse_write_statement, parse_read_statement
     public :: parse_format_statement
     public :: parse_open_statement, parse_close_statement
+    public :: parse_inquire_statement
 
 contains
 
@@ -566,5 +569,49 @@ contains
 
         close_index = push_close_statement(arena, spec_text, line, column)
     end function parse_close_statement
+
+    function parse_inquire_statement(parser, arena) result(inquire_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer :: inquire_index
+        type(token_t) :: token
+        integer :: line, column
+        character(len=:), allocatable :: spec_text
+        character(len=:), allocatable :: lowered
+
+        token = parser%peek()
+        lowered = trim(to_lower(token%text))
+        if (token%kind /= TK_KEYWORD .or. lowered /= "inquire") then
+            inquire_index = 0
+            return
+        end if
+        line = token%line
+        column = token%column
+        token = parser%consume()
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= "(") then
+            inquire_index = 0
+            return
+        end if
+        token = parser%consume()
+
+        spec_text = ""
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                token = parser%consume()
+                exit
+            end if
+
+            if (len(spec_text) > 0 .and. token%text /= ",") then
+                spec_text = spec_text // " "
+            end if
+            spec_text = spec_text // token%text
+            token = parser%consume()
+        end do
+
+        inquire_index = push_inquire_statement(arena, spec_text, line, column)
+    end function parse_inquire_statement
 
 end module parser_io_statements_module


### PR DESCRIPTION
## Summary
Implements comprehensive INQUIRE statement support to fix issue #1699.

## Changes
- **AST Layer**: Added `inquire_statement_node` type with `spec_list` field for storing specifiers
- **Factory Layer**: Added `push_inquire_statement` function for arena-based node creation
- **Parser Layer**: Added `parse_inquire_statement` following OPEN/CLOSE pattern
- **Parser Dispatch**: Added `inquire` case in execution statement dispatcher
- **Codegen Layer**: Added `generate_code_inquire_statement` for output generation
- **Lexer**: Added `inquire` to keyword list for proper tokenization (critical fix)

## Verification

### Before
```fortran
inquire(file='/tmp/test.txt', exist=file_exists, size=file_size)
```
Transformed to (BROKEN):
```fortran
logical :: exist
integer :: size
exist = file_exists
size = file_size
```

### After
```fortran
inquire(file='/tmp/test.txt', exist=file_exists, size=file_size)
```
Transformed to (WORKING):
```fortran
inquire(file = '/tmp/test.txt', exist = file_exists, size = file_size)
```

### Test Results
```bash
$ ./build/gfortran_E3254EA1FA8B869A/app/fortfront /tmp/test_inquire_no_if.f90 | gfortran -xf95 - -o /tmp/test && /tmp/test
 Done
```

All fpm tests pass: `fpm test` completes successfully.

## Architecture
Follows established I/O statement architecture (OPEN/CLOSE pattern) across all 4 required layers:
1. AST node definition
2. Factory function
3. Parser function
4. Code generator

## Root Cause
INQUIRE was not recognized as a keyword in lexer_scanners.f90:465, causing it to be treated as an identifier/array name rather than a statement keyword.
