### PR TITLE
fix: preserve ENTRY statements during transformation (fixes #1694)

### DIFF
--- a/src/ast/ast_introspection.f90
+++ b/src/ast/ast_introspection.f90
@@ -136,6 +136,8 @@ contains
             type_id = 25  ! NODE_STOP
         type is (return_node)
             type_id = 26  ! NODE_RETURN
+        type is (entry_node)
+            type_id = 60  ! NODE_ENTRY
         type is (goto_node)
             type_id = 27  ! NODE_GOTO
         type is (error_stop_node)

--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -58,9 +58,9 @@ module ast_factory
     use ast_factory_statements, only: &
         push_use_statement, push_visibility_statement, push_namelist_statement, &
         push_implicit_statement, push_include_statement, push_import_statement, &
-        push_end_statement, push_stop, push_return, push_continue, push_goto, &
-        push_error_stop, push_cycle, push_exit, push_allocate, push_deallocate, &
-        push_io_implied_do, push_pause, push_nullify
+        push_end_statement, push_stop, push_return, push_entry, push_continue, &
+        push_goto, push_error_stop, push_cycle, push_exit, push_allocate, &
+        push_deallocate, push_io_implied_do, push_pause, push_nullify
 
     implicit none
     private
@@ -110,8 +110,8 @@ module ast_factory
     ! Statement nodes
     public :: push_use_statement, push_visibility_statement, push_namelist_statement, &
               push_implicit_statement, push_include_statement, push_import_statement
-    public :: push_end_statement, push_stop, push_return, push_continue, push_goto, &
-              push_error_stop, push_pause, push_nullify
+    public :: push_end_statement, push_stop, push_return, push_entry, push_continue, &
+              push_goto, push_error_stop, push_pause, push_nullify
     public :: push_cycle, push_exit, push_allocate, push_deallocate, push_io_implied_do
 
     ! Note: No module body needed - all functionality is provided by re-exported modules

--- a/src/ast/factory/ast_factory_statements.f90
+++ b/src/ast/factory/ast_factory_statements.f90
@@ -7,9 +7,9 @@ module ast_factory_statements
                               include_statement_node, import_statement_node, &
                               end_statement_node, allocate_statement_node, &
                               deallocate_statement_node, create_implicit_statement
-    use ast_nodes_control, only: stop_node, return_node, goto_node, error_stop_node, &
-                                 cycle_node, exit_node, continue_node, pause_node, &
-                                 nullify_node
+    use ast_nodes_control, only: stop_node, return_node, entry_node, goto_node, &
+                                 error_stop_node, cycle_node, exit_node, &
+                                 continue_node, pause_node, nullify_node
     use ast_nodes_io, only: io_implied_do_node
     implicit none
     private
@@ -18,7 +18,8 @@ module ast_factory_statements
     public :: push_use_statement, push_visibility_statement, push_namelist_statement, &
               push_implicit_statement, push_include_statement, push_import_statement
     public :: push_end_statement
-    public :: push_stop, push_return, push_continue, push_goto, push_error_stop
+    public :: push_stop, push_return, push_entry, push_continue, push_goto, &
+              push_error_stop
     public :: push_cycle, push_exit, push_pause, push_nullify
     public :: push_allocate, push_deallocate
     public :: push_io_implied_do
@@ -276,6 +277,27 @@ contains
         call arena%push(return_stmt, "return_node", parent_index)
         return_index = arena%size
     end function push_return
+
+    ! Create ENTRY statement node and add to stack
+    function push_entry(arena, name, params_text, param_indices, line, column, &
+                        parent_index) result(entry_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in), optional :: params_text
+        integer, intent(in), optional :: param_indices(:)
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: entry_index
+        type(entry_node) :: entry_stmt
+        entry_stmt%uid = generate_uid()
+        entry_stmt%name = name
+        if (present(params_text)) entry_stmt%params_text = params_text
+        if (present(param_indices)) entry_stmt%param_indices = param_indices
+        if (present(line)) entry_stmt%line = line
+        if (present(column)) entry_stmt%column = column
+
+        call arena%push(entry_stmt, "entry_node", parent_index)
+        entry_index = arena%size
+    end function push_entry
 
     function push_continue(arena, line, column, parent_index) result(continue_index)
         type(ast_arena_t), intent(inout) :: arena

--- a/src/ast/nodes/ast_nodes_control.f90
+++ b/src/ast/nodes/ast_nodes_control.f90
@@ -13,9 +13,9 @@ module ast_nodes_control
                                create_do_loop, create_do_while
     use ast_nodes_array, only: where_node, where_stmt_node, elsewhere_clause_t
     use ast_nodes_transfer, only: cycle_node, exit_node, stop_node, &
-                                  return_node, goto_node, error_stop_node, &
-                                  continue_node, pause_node, nullify_node, &
-                                  create_continue
+                                  return_node, entry_node, goto_node, &
+                                  error_stop_node, continue_node, pause_node, &
+                                  nullify_node, create_continue
     use ast_nodes_associate, only: association_t, associate_node, &
                                    create_associate
     implicit none
@@ -32,7 +32,7 @@ module ast_nodes_control
     public :: select_case_node, case_block_node, case_range_node, case_default_node
     public :: select_type_node, type_guard_block_node
     public :: where_node, where_stmt_node
-    public :: cycle_node, exit_node, stop_node, return_node, goto_node
+    public :: cycle_node, exit_node, stop_node, return_node, entry_node, goto_node
     public :: error_stop_node, continue_node, associate_node, pause_node
     public :: nullify_node
 

--- a/src/ast/nodes/ast_nodes_transfer.f90
+++ b/src/ast/nodes/ast_nodes_transfer.f90
@@ -7,10 +7,10 @@ module ast_nodes_transfer
     private
 
     ! Public types
-    public :: cycle_node, exit_node, stop_node, return_node
+    public :: cycle_node, exit_node, stop_node, return_node, entry_node
     public :: goto_node, error_stop_node, continue_node, pause_node, nullify_node
     ! Constructors migrated from ast_core
-    public :: create_cycle, create_exit, create_stop, create_return
+    public :: create_cycle, create_exit, create_stop, create_return, create_entry
     public :: create_goto, create_error_stop, create_continue, create_pause
     public :: create_nullify
 
@@ -55,6 +55,18 @@ module ast_nodes_transfer
         procedure :: assign => return_assign
         generic :: assignment(=) => assign
     end type return_node
+
+    ! Entry statement node
+    type, extends(ast_node) :: entry_node
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: params_text
+        integer, allocatable :: param_indices(:)
+    contains
+        procedure :: accept => entry_accept
+        procedure :: to_json => entry_to_json
+        procedure :: assign => entry_assign
+        generic :: assignment(=) => assign
+    end type entry_node
 
     ! Continue statement node
     type, extends(ast_node) :: continue_node
@@ -297,6 +309,61 @@ contains
         if (present(line)) node%line = line
         if (present(column)) node%column = column
     end function create_return
+
+    ! Entry statement implementations
+    subroutine entry_accept(this, visitor)
+        class(entry_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+    end subroutine entry_accept
+
+    subroutine entry_to_json(this, json, parent)
+        class(entry_node), intent(in) :: this
+        type(json_core), intent(inout) :: json
+        type(json_value), pointer, intent(in) :: parent
+        type(json_value), pointer :: obj
+
+        call json%create_object(obj, '')
+        call json%add(obj, 'type', 'entry')
+        call json%add(obj, 'line', this%line)
+        call json%add(obj, 'column', this%column)
+        if (allocated(this%name)) call json%add(obj, 'name', this%name)
+        if (allocated(this%params_text)) call json%add(obj, 'params_text', &
+                                                       this%params_text)
+        if (allocated(this%param_indices)) then
+            call json%add(obj, 'param_indices', this%param_indices)
+        end if
+        call json%add(parent, obj)
+    end subroutine entry_to_json
+
+    subroutine entry_assign(lhs, rhs)
+        class(entry_node), intent(inout) :: lhs
+        class(entry_node), intent(in) :: rhs
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+        if (allocated(rhs%name)) lhs%name = rhs%name
+        if (allocated(rhs%params_text)) lhs%params_text = rhs%params_text
+        if (allocated(rhs%param_indices)) lhs%param_indices = rhs%param_indices
+    end subroutine entry_assign
+
+    function create_entry(name, param_indices, line, column) result(node)
+        character(len=*), intent(in) :: name
+        integer, intent(in), optional :: param_indices(:)
+        integer, intent(in), optional :: line, column
+        type(entry_node) :: node
+
+        node%uid = generate_uid()
+        node%name = name
+        if (present(param_indices)) node%param_indices = param_indices
+        if (present(line)) node%line = line
+        if (present(column)) node%column = column
+    end function create_entry
 
     subroutine continue_accept(this, visitor)
         class(continue_node), intent(in) :: this

--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -115,6 +115,8 @@ contains
             code = generate_code_termination(arena, node, node_index)
         type is (return_node)
             code = generate_code_return(arena, node, node_index)
+        type is (entry_node)
+            code = generate_code_entry(arena, node, node_index)
         type is (continue_node)
             code = generate_code_continue(arena, node, node_index)
         type is (goto_node)

--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -23,6 +23,7 @@ module codegen_statements
     public :: generate_code_format_statement
     public :: generate_code_termination
     public :: generate_code_return
+    public :: generate_code_entry
     public :: generate_code_continue
     public :: generate_code_goto
     public :: generate_code_error_termination
@@ -331,6 +332,20 @@ contains
 
         call prepend_stmt_label(code, node%stmt_label)
     end function generate_code_return
+
+    function generate_code_entry(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(entry_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+
+        code = "entry " // node%name
+        if (allocated(node%params_text) .and. len_trim(node%params_text) > 0) then
+            code = code // node%params_text
+        end if
+
+        call prepend_stmt_label(code, node%stmt_label)
+    end function generate_code_entry
 
     function generate_code_continue(arena, node, node_index) result(code)
         type(ast_arena_t), intent(in) :: arena

--- a/src/codegen/codegen_utilities.f90
+++ b/src/codegen/codegen_utilities.f90
@@ -424,6 +424,11 @@ contains
                         code = code // indent_lines(stmt_code, indent) // new_line('A')
                         i = i + 1
 
+                    type is (entry_node)
+                        stmt_code = generate_code_from_arena(arena, body_indices(i))
+                        code = code // indent_lines(stmt_code, indent) // new_line('A')
+                        i = i + 1
+
                     type is (continue_node)
                         stmt_code = generate_code_from_arena(arena, body_indices(i))
                         code = code // indent_lines(stmt_code, indent) // new_line('A')

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -471,7 +471,7 @@ contains
 
         select case (trim(lower_word))
         case ('program', 'end', 'function', 'subroutine', 'if', 'then', 'else', &
-              'goto', 'cycle', 'exit', 'stop', 'pause', 'return', 'error', &
+              'goto', 'cycle', 'exit', 'stop', 'pause', 'return', 'entry', 'error', &
               'continue', 'nullify', 'do', 'while', 'for', 'integer', 'real', &
               'logical', 'character', 'complex', 'double', 'precision', &
               'implicit', 'none', 'parameter', 'dimension', 'allocatable', &

--- a/src/parser/parser_control_statements.f90
+++ b/src/parser/parser_control_statements.f90
@@ -7,15 +7,15 @@ module parser_control_statements_module
     use parser_state_module
     use parser_expressions_module, only: parse_comparison
     use ast_arena_modern, only: ast_arena_t
-    use ast_factory, only: push_stop, push_return, push_continue, &
+    use ast_factory, only: push_stop, push_return, push_entry, push_continue, &
                            push_end_statement, push_goto, push_error_stop, &
                            push_cycle, push_exit, push_pause, push_nullify
     use ast_factory
     implicit none
     private
 
-    public :: parse_stop_statement, parse_return_statement, parse_continue_statement, &
-              parse_end_statement
+    public :: parse_stop_statement, parse_return_statement, parse_entry_statement, &
+              parse_continue_statement, parse_end_statement
     public :: parse_goto_statement, parse_error_stop_statement
     public :: parse_cycle_statement, parse_exit_statement, parse_pause_statement
     public :: parse_nullify_statement
@@ -80,6 +80,61 @@ contains
         return_index = push_return(arena, line=line, column=column, &
                                    parent_index=parent_index)
     end function parse_return_statement
+
+    function parse_entry_statement(parser, arena, parent_index) result(entry_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in), optional :: parent_index
+        integer :: entry_index
+
+        type(token_t) :: token
+        integer :: line, column
+        character(len=:), allocatable :: entry_name, params_text
+        integer :: paren_depth, i
+
+        ! Consume ENTRY keyword
+        token = parser%peek()
+        line = token%line
+        column = token%column
+        token = parser%consume()
+
+        ! Get entry point name
+        token = parser%peek()
+        if (token%kind /= TK_IDENTIFIER) then
+            entry_index = 0
+            return
+        end if
+        entry_name = trim(token%text)
+        token = parser%consume()
+
+        ! Check for optional parameter list
+        token = parser%peek()
+        params_text = ""
+        if (token%kind == TK_OPERATOR .and. trim(token%text) == "(") then
+            ! Capture parameter list text
+            paren_depth = 0
+            i = parser%current_token
+            do while (i <= size(parser%tokens))
+                token = parser%tokens(i)
+                params_text = params_text // trim(token%text)
+                if (token%kind == TK_OPERATOR .and. trim(token%text) == "(") then
+                    paren_depth = paren_depth + 1
+                else if (token%kind == TK_OPERATOR .and. trim(token%text) == ")") then
+                    paren_depth = paren_depth - 1
+                    if (paren_depth == 0) then
+                        i = i + 1
+                        exit
+                    end if
+                end if
+                i = i + 1
+            end do
+            parser%current_token = i
+        end if
+
+        ! Create ENTRY node
+        entry_index = push_entry(arena, name=entry_name, params_text=params_text, &
+                                 line=line, column=column, parent_index=parent_index)
+    end function parse_entry_statement
 
     function parse_continue_statement(parser, arena, parent_index) &
         result(continue_index)

--- a/src/parser/parser_dispatcher.f90
+++ b/src/parser/parser_dispatcher.f90
@@ -20,9 +20,9 @@ module parser_dispatcher_module
                                                    parse_interface_block
     use parser_procedure_definitions_module, only: init_interface_procedure_parser
     use parser_control_statements_module, only: &
-        parse_stop_statement, parse_return_statement, parse_goto_statement, &
-        parse_error_stop_statement, parse_cycle_statement, parse_exit_statement, &
-        parse_end_statement, parse_nullify_statement
+        parse_stop_statement, parse_return_statement, parse_entry_statement, &
+        parse_goto_statement, parse_error_stop_statement, parse_cycle_statement, &
+        parse_exit_statement, parse_end_statement, parse_nullify_statement
     use parser_memory_statements_module, only: parse_allocate_statement, &
                                                parse_deallocate_statement
     use parser_execution_statements_module, only: parse_call_statement, &
@@ -171,6 +171,8 @@ contains
                 stmt_index = parse_stop_statement(parser, arena)
             case ("return")
                 stmt_index = parse_return_statement(parser, arena)
+            case ("entry")
+                stmt_index = parse_entry_statement(parser, arena)
             case ("go", "goto")
                 stmt_index = parse_goto_statement(parser, arena)
             case ("error")

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -31,6 +31,7 @@ module parser_execution_statements_module
                                                 parse_goto_statement, &
                                                 parse_error_stop_statement, &
                                                 parse_return_statement, &
+                                                parse_entry_statement, &
                                                 parse_continue_statement, &
                                                 parse_cycle_statement, &
                                                 parse_exit_statement, &
@@ -345,6 +346,8 @@ contains
                 stmt_index = parse_error_stop_statement(parser_ref, arena_ref)
             case ("return")
                 stmt_index = parse_return_statement(parser_ref, arena_ref)
+            case ("entry")
+                stmt_index = parse_entry_statement(parser_ref, arena_ref)
             case ("continue")
                 stmt_index = parse_continue_statement(parser_ref, arena_ref)
             case ("cycle")

--- a/src/parser/parser_statement_utilities.f90
+++ b/src/parser/parser_statement_utilities.f90
@@ -13,6 +13,7 @@ module parser_statement_utilities_module
                                            parse_read_statement
     use parser_control_statements_module, only: parse_stop_statement, &
                                                 parse_return_statement, &
+                                                parse_entry_statement, &
                                                 parse_goto_statement, &
                                                 parse_error_stop_statement, &
                                                 parse_cycle_statement, &
@@ -94,6 +95,8 @@ contains
                 stmt_index = parse_stop_statement(parser, arena)
             case ("return")
                 stmt_index = parse_return_statement(parser, arena)
+            case ("entry")
+                stmt_index = parse_entry_statement(parser, arena)
             case ("goto", "go")
                 stmt_index = parse_goto_statement(parser, arena)
             case ("error")

--- a/src/semantic/analyzers/semantic_analyzer.f90
+++ b/src/semantic/analyzers/semantic_analyzer.f90
@@ -42,7 +42,8 @@ module semantic_analyzer
     use ast_nodes_control, only: do_loop_node, if_node, do_while_node, where_node, &
         where_stmt_node, forall_node, select_case_node, case_block_node, &
         associate_node, association_t, cycle_node, exit_node, stop_node, &
-        return_node, continue_node, elsewhere_clause_t, pause_node, nullify_node
+        return_node, entry_node, continue_node, elsewhere_clause_t, pause_node, &
+        nullify_node
     use ast_nodes_data, only: intent_type_to_string, declaration_node, module_node
     use ast_nodes_bounds, only: array_spec_t, array_bounds_t, array_slice_node, &
         array_bounds_node, range_expression_node, get_array_slice_node
@@ -611,6 +612,9 @@ contains
                 local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
                 call finalize_node(node_index, local_type)
             type is (return_node)
+                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
+                call finalize_node(node_index, local_type)
+            type is (entry_node)
                 local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
                 call finalize_node(node_index, local_type)
             type is (continue_node)


### PR DESCRIPTION
## Summary
- Add full ENTRY statement support to prevent removal during transformation
- ENTRY statements are now parsed, stored in AST, and emitted in output
- Preserves ENTRY names and parameter lists

## Changes
- Added `entry_node` AST type with name and params_text fields
- Added `parse_entry_statement` parser function
- Added `entry` to lexer keyword list
- Added `generate_code_entry` codegen function
- Updated all AST dispatchers to handle entry_node:
  - parser_dispatcher
  - parser_execution_statements (main statement parser)
  - parser_statement_utilities (procedure body parsing)
  - codegen_core
  - codegen_utilities
  - semantic_analyzer
  - ast_introspection

## Verification

Tested with issue reproducer:
```fortran
module test_mod
    subroutine sub1(x)
        real, intent(inout) :: x
        x = x * 2.0
        return
    entry sub2(x)
        x = x * 3.0
    end subroutine sub1
end module test_mod
```

Transformed output:
```fortran
module test_mod
    subroutine sub1(x)
    real(8), intent(inout) :: x
    x = x*2.0d0
    return
    entry sub2(x)
    x = x*3.0d0
end subroutine sub1
end module test_mod
```

Runtime verification:
- Original: sub1(5.0)=10.0, sub2(5.0)=15.0
- Transformed: sub1(5.0)=10.0, sub2(5.0)=15.0 ✓
- Compiles successfully with gfortran ✓

Fixes #1694