### PR TITLE
fix: accept computed GOTO without comma before selector (fixes #1749)

### DIFF
--- a/src/parser/parser_control_statements.f90
+++ b/src/parser/parser_control_statements.f90
@@ -231,14 +231,14 @@ contains
                 if (token%kind == TK_OPERATOR .and. token%text == ")") then
                     token = parser%consume()
 
-                    ! Consume comma before selector expression
+                    ! Consume optional comma before selector expression
                     token = parser%peek()
                     if (token%kind == TK_OPERATOR .and. token%text == ",") then
                         token = parser%consume()
-
-                        ! Parse selector expression
-                        selector_index = parse_comparison(parser, arena)
                     end if
+
+                    ! Parse selector expression (required for computed GOTO)
+                    selector_index = parse_comparison(parser, arena)
                 end if
             else if (token%kind == TK_NUMBER .or. token%kind == TK_IDENTIFIER) then
                 label = trim(token%text)
@@ -288,14 +288,14 @@ contains
                     if (token%kind == TK_OPERATOR .and. token%text == ")") then
                         token = parser%consume()
 
-                        ! Consume comma before selector expression
+                        ! Consume optional comma before selector expression
                         token = parser%peek()
                         if (token%kind == TK_OPERATOR .and. token%text == ",") then
                             token = parser%consume()
-
-                            ! Parse selector expression
-                            selector_index = parse_comparison(parser, arena)
                         end if
+
+                        ! Parse selector expression (required for computed GOTO)
+                        selector_index = parse_comparison(parser, arena)
                     end if
                 else if (token%kind == TK_NUMBER .or. token%kind == TK_IDENTIFIER) then
                     label = trim(token%text)


### PR DESCRIPTION
## Summary
Fixed parser to accept both F77 computed GOTO syntaxes:
- `goto (labels), selector` (with comma)
- `goto (labels) selector` (without comma)

## Problem
Parser required comma after label list, causing it to fail parsing selector expression when comma was omitted. This resulted in fallback to INVALID_LABEL placeholder text in output.

## Solution
Made comma optional while still requiring selector expression to be parsed. Both `goto` and `go to` variants fixed.

## Verification
Existing test test_issue_1583_computed_goto now passes:
```
=== Issue #1583: Computed GOTO preservation ===
Testing basic computed goto preservation...
  PASS: No INVALID_LABEL in output
  PASS: computed goto statement present
  PASS: all labels preserved
Testing computed goto AST generation...
  PASS: AST created successfully
  PASS: Output valid
Issue #1583 fixed!
```

Manual verification with reproducer from issue:
```fortran
goto (100, 200, 300) selector
```
Now correctly outputs:
```fortran
go to (100, 200, 300), selector
```