### PR TITLE
fix: preserve legacy array constructor implied-DO loops (fixes #1748)

### DIFF
--- a/src/parser/parser_expression_arrays.f90
+++ b/src/parser/parser_expression_arrays.f90
@@ -111,6 +111,7 @@ contains
             type(token_t) :: paren_token
             type(token_t) :: current
             integer, allocatable :: element_indices(:)
+            integer :: saved_pos
 
             paren_token = parser%consume()
             current = parser%consume()
@@ -128,6 +129,15 @@ contains
                                                     syntax_style="legacy")
                 end if
                 return
+            end if
+
+            if (current%text == "(") then
+                saved_pos = parser%current_token
+                expr_index = parse_legacy_implied_do_constructor(parser, arena, &
+                                                                 paren_token, helpers)
+                if (expr_index > 0) return
+                parser%current_token = saved_pos
+                expr_index = 0
             end if
 
             expr_index = parse_simple_array_elements(parser, arena, "/", "legacy", &
@@ -420,6 +430,42 @@ contains
                                            var_name, start_index, end_index, &
                                            step_index)
     end function parse_implied_do_constructor
+
+    function parse_legacy_implied_do_constructor(parser, arena, paren_token, helpers) &
+        result(expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t), intent(in) :: paren_token
+        type(array_parse_helpers_t), intent(in) :: helpers
+        integer :: expr_index
+        integer :: expr_elem_index
+        integer :: start_index
+        integer :: end_index
+        integer :: step_index
+        character(len=:), allocatable :: var_name
+        type(token_t) :: current
+
+        expr_index = 0
+        if (.not. parse_implied_do_header(parser, arena, expr_elem_index, var_name, &
+                                          start_index, end_index, step_index, &
+                                          helpers)) return
+
+        current = parser%peek()
+        if (current%text /= ")") return
+        current = parser%consume()
+
+        current = parser%peek()
+        if (current%text /= "/") return
+        current = parser%consume()
+
+        current = parser%peek()
+        if (current%text /= ")") return
+        current = parser%consume()
+
+        expr_index = build_implied_do_node(arena, paren_token, expr_elem_index, &
+                                           var_name, start_index, end_index, &
+                                           step_index)
+    end function parse_legacy_implied_do_constructor
 
     function try_parse_implied_do_loop(parser, arena, temp_indices, element_count, &
                                        bracket_token) result(expr_index)

--- a/test/integration/issue_tests/test_issue_1748_legacy_implied_do.f90
+++ b/test/integration/issue_tests/test_issue_1748_legacy_implied_do.f90
@@ -1,0 +1,42 @@
+program test_issue_1748_legacy_implied_do
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    implicit none
+    integer :: arr(10), i
+    integer :: squares(5)
+    real(dp) :: evens(10)
+
+    ! Test basic legacy implied-DO (issue 1748 reproducer)
+    arr = (/ (i, i=1,10) /)
+    if (arr(1) /= 1) then
+        print *, "arr(1) should be 1, got", arr(1)
+        stop 1
+    end if
+    if (arr(10) /= 10) then
+        print *, "arr(10) should be 10, got", arr(10)
+        stop 1
+    end if
+
+    ! Test with expression
+    squares = (/ (i * i, i=1, 5) /)
+    if (squares(1) /= 1) then
+        print *, "squares(1) should be 1, got", squares(1)
+        stop 1
+    end if
+    if (squares(5) /= 25) then
+        print *, "squares(5) should be 25, got", squares(5)
+        stop 1
+    end if
+
+    ! Test with step parameter
+    evens = (/ (2.0d0 * i, i=1, 10) /)
+    if (abs(evens(1) - 2.0d0) > 1.0d-10) then
+        print *, "evens(1) should be 2.0, got", evens(1)
+        stop 1
+    end if
+    if (abs(evens(10) - 20.0d0) > 1.0d-10) then
+        print *, "evens(10) should be 20.0, got", evens(10)
+        stop 1
+    end if
+
+    print *, "All tests passed!"
+end program test_issue_1748_legacy_implied_do


### PR DESCRIPTION
## Summary

Fixes #1748 - Array constructors with implied-DO loops using legacy syntax `(/ ... /)` were being completely removed from the output, causing uninitialized array access and undefined behavior.

## Changes

- Added implied-DO detection in `parse_legacy_array_literal` (lines 134-141)
- Implemented `parse_legacy_implied_do_constructor` to handle `(/ (expr, var=start,end) /)`
- Properly consumes closing tokens `) / )` for legacy syntax
- Reuses existing implied-DO codegen infrastructure

## Verification

Test case `test_issue_1748_legacy_implied_do.f90` validates:
- Basic implied-DO: `(/ (i, i=1,10) /)`
- Expression form: `(/ (i * i, i=1, 5) /)`
- Real arrays: `(/ (2.0d0 * i, i=1, 10) /)`

### Before Fix
```fortran
program test_implicit_loop
    implicit none
    integer :: arr(10)
    integer :: i
    print *, 'Array:', arr
end program test_implicit_loop
```
Statement completely removed!

### After Fix
```fortran
program test_implicit_loop
    implicit none
    integer :: arr(10)
    integer :: i
    arr = (/(i, i=1, 10) /)
    print *, 'Array:', arr
end program test_implicit_loop
```

### Execution
```
$ gfortran output.f90 -o test && ./test
Array:  1  2  3  4  5  6  7  8  9  10
```

All existing tests pass.