### PR TITLE
fix: expand DATA statement repeat counts (fixes #1746)

### DIFF
--- a/src/parser/parser_statement_data_module.f90
+++ b/src/parser/parser_statement_data_module.f90
@@ -143,7 +143,12 @@ contains
             type(ast_arena_t), intent(inout) :: arena
             integer, intent(in) :: value_index
             integer, allocatable, intent(inout) :: indices(:)
-            integer :: repeat_count, i
+            integer :: repeat_count
+            integer :: loop_index
+            integer :: read_status
+            integer :: underscore_pos
+            character(len=:), allocatable :: literal_text
+            character(len=:), allocatable :: count_text
 
             if (value_index <= 0 .or. value_index > arena%size) return
             if (.not. allocated(arena%entries(value_index)%node)) then
@@ -187,8 +192,31 @@ contains
                         return
                     end if
 
-                    read (left_node%value, *, iostat=i) repeat_count
-                    if (i /= 0) then
+                    literal_text = trim(left_node%value)
+                    if (len(literal_text) == 0) then
+                        call append_index(indices, value_index)
+                        return
+                    end if
+
+                    underscore_pos = index(literal_text, "_")
+                    if (underscore_pos > 0) then
+                        if (underscore_pos == 1) then
+                            call append_index(indices, value_index)
+                            return
+                        end if
+                        count_text = literal_text(:underscore_pos - 1)
+                    else
+                        count_text = literal_text
+                    end if
+
+                    count_text = trim(adjustl(count_text))
+                    if (len(count_text) == 0) then
+                        call append_index(indices, value_index)
+                        return
+                    end if
+
+                    read (count_text, *, iostat=read_status) repeat_count
+                    if (read_status /= 0) then
                         call append_index(indices, value_index)
                         return
                     end if
@@ -198,7 +226,7 @@ contains
                         return
                     end if
 
-                    do i = 1, repeat_count
+                    do loop_index = 1, repeat_count
                         call append_index(indices, node%right_index)
                     end do
                     return

--- a/test/codegen/test_issue_1746_data_repeat_counts.f90
+++ b/test/codegen/test_issue_1746_data_repeat_counts.f90
@@ -20,6 +20,14 @@ program test_issue_1746_data_repeat_counts
                     '(/1, 1, 1, 2, 0, 0, 0 /)', &
                     '')
 
+    call check_case("repeat-count-kind", &
+                    'integer :: arr(5)'//new_line('a')// &
+                    'DATA arr /5_1*0/'//new_line('a')// &
+                    'print *, arr(1)', &
+                    'integer :: arr(5)', &
+                    '(/0, 0, 0, 0, 0 /)', &
+                    '5_1*0')
+
     print *, "PASSED"
 
 contains


### PR DESCRIPTION
## Summary
- Expands repeat count syntax `n*value` in DATA statements to explicit values
- Fixes compilation errors from invalid F90 array constructor syntax

## Problem
DATA statements with repeat counts like `DATA arr /5*0/` were converted to `arr = (/5*0 /)`, which Fortran 90 interprets as multiplication (creating a 1-element array with value 0) rather than 5 repetitions of 0. This caused dimension mismatch errors.

## Solution
Modified `parser_statement_data_module.f90` to:
1. Detect binary `*` operations where left operand is an integer literal
2. Expand to N copies of the right operand value
3. Fallback to original behavior for non-repeat-count multiplication

## Verification
```bash
fpm test test_issue_1746_data_repeat_counts
fpm test test_issue_1405_data_statement
```

Test cases:
- Simple repeat: `5*0` → `0, 0, 0, 0, 0`
- Mixed: `3*1, 2, 3*0` → `1, 1, 1, 2, 0, 0, 0`

All existing tests pass.