### PR TITLE
fix: preserve operator/assignment in interface blocks (fixes #1744)

### DIFF
--- a/src/ast/factory/ast_factory_procedures.f90
+++ b/src/ast/factory/ast_factory_procedures.f90
@@ -84,18 +84,30 @@ contains
 
     ! Create interface block node and add to stack
     function push_interface_block(arena, interface_name, procedure_indices, &
-                                  line, column, parent_index, is_abstract) result(interface_index)
+                                  line, column, parent_index, is_abstract, &
+                                  kind, operator_symbol) result(interface_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in), optional :: interface_name
         integer, intent(in), optional :: procedure_indices(:)
         integer, intent(in), optional :: line, column, parent_index
         logical, intent(in), optional :: is_abstract
+        character(len=*), intent(in), optional :: kind
+        character(len=*), intent(in), optional :: operator_symbol
         integer :: interface_index
         type(interface_block_node) :: interface_block
 
         interface_block%uid = generate_uid()
-        if (len_trim(interface_name) > 0) interface_block%name = interface_name
-        interface_block%kind = "interface"
+        if (present(interface_name)) then
+            if (len_trim(interface_name) > 0) interface_block%name = interface_name
+        end if
+        if (present(kind)) then
+            interface_block%kind = kind
+        else
+            interface_block%kind = "interface"
+        end if
+        if (present(operator_symbol)) then
+            if (len_trim(operator_symbol) > 0) interface_block%operator = operator_symbol
+        end if
         if (present(is_abstract)) interface_block%is_abstract = is_abstract
         if (present(procedure_indices)) then
             if (size(procedure_indices) > 0) interface_block%procedure_indices = procedure_indices

--- a/src/codegen/codegen_declarations_programs.f90
+++ b/src/codegen/codegen_declarations_programs.f90
@@ -927,7 +927,16 @@ contains
         else
             code = "interface"
         end if
-        if (allocated(node%name)) then
+        if (allocated(node%kind)) then
+            if (trim(node%kind) == "operator" .or. trim(node%kind) == "assignment") then
+                code = code // " " // trim(node%kind)
+                if (allocated(node%operator)) then
+                    code = code // "(" // trim(node%operator) // ")"
+                end if
+            else if (allocated(node%name)) then
+                if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
+            end if
+        else if (allocated(node%name)) then
             if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
         end if
         code = code // new_line('A')
@@ -938,7 +947,16 @@ contains
         end if
 
         code = code // "end interface"
-        if (allocated(node%name)) then
+        if (allocated(node%kind)) then
+            if (trim(node%kind) == "operator" .or. trim(node%kind) == "assignment") then
+                code = code // " " // trim(node%kind)
+                if (allocated(node%operator)) then
+                    code = code // "(" // trim(node%operator) // ")"
+                end if
+            else if (allocated(node%name)) then
+                if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
+            end if
+        else if (allocated(node%name)) then
             if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
         end if
     end function generate_code_interface_block

--- a/src/parser/parser_interface_blocks.f90
+++ b/src/parser/parser_interface_blocks.f90
@@ -37,7 +37,7 @@ contains
         logical, intent(in), optional :: is_abstract
         integer :: interface_index
 
-        character(len=:), allocatable :: interface_name
+        character(len=:), allocatable :: interface_name, interface_kind, operator_symbol
         integer :: line, column
         integer, allocatable :: body_indices(:)
         type(token_t) :: token
@@ -47,8 +47,8 @@ contains
         is_abstract_interface = .false.
         if (present(is_abstract)) is_abstract_interface = is_abstract
 
-        call begin_interface_block(parser, interface_name, line, column, &
-                                   is_abstract_interface)
+        call begin_interface_block(parser, interface_name, interface_kind, &
+                                   operator_symbol, line, column, is_abstract_interface)
         call prefix_buffer%clear()
 
         allocate (body_indices(0))
@@ -74,7 +74,8 @@ contains
         end do
 
         interface_index = push_interface_block(arena, interface_name, body_indices, &
-                                               line, column, is_abstract=is_abstract_interface)
+                                               line, column, is_abstract=is_abstract_interface, &
+                                               kind=interface_kind, operator_symbol=operator_symbol)
     end function parse_interface_block
 
     logical function try_parse_interface_procedure(parser, arena, prefix_buffer, &
@@ -119,10 +120,12 @@ contains
         proc_parser_callback => parser_func
     end subroutine set_interface_procedure_parser
 
-    subroutine begin_interface_block(parser, interface_name, line, column, &
-                                     is_abstract)
+    subroutine begin_interface_block(parser, interface_name, interface_kind, &
+                                     operator_symbol, line, column, is_abstract)
         type(parser_state_t), intent(inout) :: parser
         character(len=:), allocatable, intent(out) :: interface_name
+        character(len=:), allocatable, intent(out) :: interface_kind
+        character(len=:), allocatable, intent(out) :: operator_symbol
         integer, intent(out) :: line, column
         logical, intent(in), optional :: is_abstract
 
@@ -143,10 +146,31 @@ contains
         line = token%line
         column = token%column
 
+        interface_kind = "interface"
+        operator_symbol = ""
+
         token = parser%peek()
-        if (token%kind == TK_IDENTIFIER) then
-            token = parser%consume()
-            interface_name = token%text
+        if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
+            lowered = to_lower(trim(token%text))
+            if (trim(lowered) == "operator" .or. trim(lowered) == "assignment") then
+                interface_kind = trim(lowered)
+                token = parser%consume()
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. trim(token%text) == "(") then
+                    token = parser%consume()
+                    token = parser%peek()
+                    operator_symbol = trim(token%text)
+                    token = parser%consume()
+                    token = parser%peek()
+                    if (token%kind == TK_OPERATOR .and. trim(token%text) == ")") then
+                        token = parser%consume()
+                    end if
+                end if
+                interface_name = ""
+            else
+                token = parser%consume()
+                interface_name = token%text
+            end if
         else
             interface_name = ""
         end if

--- a/test/test_issue_1744_operator_interface.f90
+++ b/test/test_issue_1744_operator_interface.f90
@@ -1,0 +1,141 @@
+program test_issue_1744_operator_interface
+    use frontend_core, only: lex_source, emit_fortran
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    implicit none
+
+    call test_operator_interface()
+    call test_assignment_interface()
+    print *, ""
+    print *, "Issue 1744 operator interface tests completed."
+
+contains
+
+    subroutine test_operator_interface()
+        character(:), allocatable :: input_code
+        character(:), allocatable :: output_code
+        character(:), allocatable :: error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+        character(len=1), parameter :: nl = new_line('A')
+
+        input_code = "module vector_ops" // nl // &
+                     "    implicit none" // nl // &
+                     "" // nl // &
+                     "    type :: vec3" // nl // &
+                     "        real :: x, y, z" // nl // &
+                     "    end type vec3" // nl // &
+                     "" // nl // &
+                     "    interface operator(+)" // nl // &
+                     "        module procedure vec3_add" // nl // &
+                     "    end interface" // nl // &
+                     "" // nl // &
+                     "end module vector_ops"
+
+        print *, ""
+        print *, "Test: Interface operator(+) preserved"
+        print *, "Input:"
+        print *, trim(input_code)
+
+        arena = create_ast_arena()
+        call lex_source(input_code, tokens, error_msg)
+
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            print *, "Lexing error: ", trim(error_msg)
+            error stop 1
+        end if
+
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            print *, "Parsing error: ", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print *, "Output:"
+        print *, trim(output_code)
+
+        if (index(output_code, "interface operator(+)") == 0) then
+            print *, "FAIL: interface operator(+) missing from output"
+            error stop 1
+        end if
+
+        if (index(output_code, "end interface operator(+)") == 0) then
+            print *, "FAIL: end interface operator(+) missing from output"
+            error stop 1
+        end if
+
+        if (index(output_code, "module procedure vec3_add") == 0) then
+            print *, "FAIL: module procedure statement missing"
+            error stop 1
+        end if
+
+        print *, "[PASS] Interface operator(+) preserved correctly"
+    end subroutine test_operator_interface
+
+    subroutine test_assignment_interface()
+        character(:), allocatable :: input_code
+        character(:), allocatable :: output_code
+        character(:), allocatable :: error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+        character(len=1), parameter :: nl = new_line('A')
+
+        input_code = "module string_ops" // nl // &
+                     "    implicit none" // nl // &
+                     "" // nl // &
+                     "    interface assignment(=)" // nl // &
+                     "        module procedure assign_string" // nl // &
+                     "    end interface" // nl // &
+                     "" // nl // &
+                     "end module string_ops"
+
+        print *, ""
+        print *, "Test: Interface assignment(=) preserved"
+        print *, "Input:"
+        print *, trim(input_code)
+
+        arena = create_ast_arena()
+        call lex_source(input_code, tokens, error_msg)
+
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            print *, "Lexing error: ", trim(error_msg)
+            error stop 1
+        end if
+
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            print *, "Parsing error: ", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print *, "Output:"
+        print *, trim(output_code)
+
+        if (index(output_code, "interface assignment(=)") == 0) then
+            print *, "FAIL: interface assignment(=) missing from output"
+            error stop 1
+        end if
+
+        if (index(output_code, "end interface assignment(=)") == 0) then
+            print *, "FAIL: end interface assignment(=) missing from output"
+            error stop 1
+        end if
+
+        if (index(output_code, "module procedure assign_string") == 0) then
+            print *, "FAIL: module procedure statement missing"
+            error stop 1
+        end if
+
+        print *, "[PASS] Interface assignment(=) preserved correctly"
+    end subroutine test_assignment_interface
+
+end program test_issue_1744_operator_interface


### PR DESCRIPTION
## Summary
Fixes operator overloading and assignment interfaces in modules by preserving `operator(...)` and `assignment(...)` syntax in interface blocks.

## Problem
Interface blocks with operator/assignment syntax were losing their specification during transformation:
- Input: `interface operator(+)`
- Output: `interface` (missing operator specification)
- Result: Compilation error "MODULE PROCEDURE must be in a generic module interface"

## Solution
Extended parser, factory, and codegen to handle operator/assignment interface syntax:
1. Parser extracts operator/assignment keywords and symbols
2. AST stores kind ("operator"/"assignment") and operator symbol
3. Codegen outputs correct syntax: `interface operator(+)` and `end interface operator(+)`

## Verification
```bash
fpm run -- test/test_issue_1744_operator_interface.f90
```

Test cases validate:
- `interface operator(+)` with module procedure
- `interface assignment(=)` with module procedure
- Operator specification in both interface header and end statement

All existing tests pass.

Fixes #1744
