### PR TITLE
fix: preserve multi-line array literals in lazy fortran (fixes #1742)

### DIFF
--- a/src/frontend/frontend_statement_boundary.f90
+++ b/src/frontend/frontend_statement_boundary.f90
@@ -296,19 +296,42 @@ contains
             end do
         else
             ! Single-line statement - find end at newline or semicolon
-            do i = stmt_start, size(tokens)
-                if (tokens(i)%kind == TK_EOF) then
-                    stmt_end = i - 1
-                    exit
-                else if (tokens(i)%kind == TK_NEWLINE .or. &
-                         (tokens(i)%kind == TK_OPERATOR .and. tokens(i)%text &
-                          == ";")) then
-                    stmt_end = i - 1
-                    exit
-                else if (tokens(i)%kind /= TK_COMMENT) then
-                    stmt_end = i
-                end if
-            end do
+            ! Track bracket/paren nesting to handle multi-line array literals
+            block
+                integer :: bracket_depth, paren_depth
+                bracket_depth = 0
+                paren_depth = 0
+                do i = stmt_start, size(tokens)
+                    if (tokens(i)%kind == TK_EOF) then
+                        stmt_end = i - 1
+                        exit
+                    else if (tokens(i)%kind == TK_OPERATOR) then
+                        select case (tokens(i)%text)
+                        case ("[")
+                            bracket_depth = bracket_depth + 1
+                        case ("]")
+                            bracket_depth = bracket_depth - 1
+                        case ("(")
+                            paren_depth = paren_depth + 1
+                        case (")")
+                            paren_depth = paren_depth - 1
+                        case (";")
+                            if (bracket_depth == 0 .and. paren_depth == 0) then
+                                stmt_end = i - 1
+                                exit
+                            end if
+                        end select
+                    else if (tokens(i)%kind == TK_NEWLINE) then
+                        ! Only break on newline if not inside brackets/parens
+                        if (bracket_depth == 0 .and. paren_depth == 0) then
+                            stmt_end = i - 1
+                            exit
+                        end if
+                    else if (tokens(i)%kind /= TK_COMMENT) then
+                        stmt_end = i
+                    end if
+                end do
+            end block
         end if
 
         ! Ensure we don't go beyond bounds

--- a/src/parser/parser_expression_arrays.f90
+++ b/src/parser/parser_expression_arrays.f90
@@ -153,8 +153,8 @@ contains
         end block
     end function parse_legacy_array_literal
 
-    function parse_modern_array_literal(parser, arena, start_token, helpers) &
-        result(expr_index)
+    recursive function parse_modern_array_literal(parser, arena, start_token, &
+                                                   helpers) result(expr_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(token_t), intent(in) :: start_token
@@ -175,6 +175,14 @@ contains
         allocate (temp_indices(20))
 
         do
+            ! Skip newlines and comments inside array literals
+            do
+                peek_token = parser%peek()
+                if (peek_token%kind /= TK_NEWLINE .and. peek_token%kind /= TK_COMMENT) &
+                    exit
+                current = parser%consume()
+            end do
+
             peek_token = parser%peek()
             if (peek_token%text == "]") then
                 current = parser%consume()  ! Consume the closing bracket
@@ -186,10 +194,16 @@ contains
                 if (expr_index > 0) return
                 parser%current_token = saved_pos
                 expr_index = 0
+            else if (peek_token%text == "[") then
+                current = parser%consume()
+                expr_index = parse_modern_array_literal(parser, arena, current, helpers)
+                if (expr_index <= 0) return
             end if
 
-            expr_index = helpers%parse_comparison(parser, arena)
-            if (expr_index <= 0) return
+            if (expr_index <= 0) then
+                expr_index = helpers%parse_comparison(parser, arena)
+                if (expr_index <= 0) return
+            end if
 
             element_count = element_count + 1
             if (element_count > size(temp_indices)) then
@@ -209,6 +223,13 @@ contains
             current = parser%peek()
             if (current%text == ",") then
                 current = parser%consume()
+                ! Skip newlines and comments after comma
+                do
+                    peek_token = parser%peek()
+                    if (peek_token%kind /= TK_NEWLINE .and. &
+                        peek_token%kind /= TK_COMMENT) exit
+                    current = parser%consume()
+                end do
             else if (current%text == "]") then
                 current = parser%consume()  ! Consume the closing bracket
                 exit


### PR DESCRIPTION
## Summary
Fixed multi-line array literal parsing in lazy fortran by tracking bracket/parenthesis nesting depth during statement boundary detection.

## Changes
- **frontend_statement_boundary.f90**: Track bracket/paren depth to avoid breaking statements inside unclosed brackets
- **parser_expression_arrays.f90**: Mark `parse_modern_array_literal` as recursive and skip newlines inside array literals

## Verification

### Test Input
```fortran
A = [[1, 2, 3],
     [4, 5, 6],
     [7, 8, 9]]

print *, A(1, :)
```

### Generated Output
```fortran
program main
    implicit none
    integer :: A(3,3)
    A = reshape([1, 2, 3, 4, 5, 6, 7, 8, 9], [3, 3], order=[2, 1])
    print *, A(1, :)
end program main
```

### Compilation and Execution
```bash
$ fpm run fortfront < test_issue_1742.lf | gfortran -o test -x f95 - && ./test
1           2           3
```

### Before Fix
```fortran
program main
    implicit none
    integer :: B
    [4, 5, 6]
    [7, 8, 9]
    print *, "Matrix A:"
    print *, A(1, :)
```
- Variable A was never declared
- Continuation lines became invalid standalone syntax
- Generated code did not compile

### After Fix
- Multi-line array literals are correctly parsed as single statements
- Proper 2D array declaration and initialization
- Generated code compiles and runs correctly
