### PR TITLE
fix: preserve array constructors with type specifications (fixes #1741)

### DIFF
--- a/src/parser/parser_expression_arrays.f90
+++ b/src/parser/parser_expression_arrays.f90
@@ -1,5 +1,6 @@
 module parser_expression_arrays_module
-    use lexer_core, only: token_t, TK_OPERATOR, TK_IDENTIFIER, TK_NEWLINE, TK_COMMENT
+    use lexer_core, only: token_t, TK_OPERATOR, TK_IDENTIFIER, TK_KEYWORD, &
+                          TK_NEWLINE, TK_COMMENT
     use parser_state_module, only: parser_state_t
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: component_access_node, identifier_node
@@ -129,6 +130,44 @@ contains
                                                     syntax_style="legacy")
                 end if
                 return
+            end if
+
+            ! Check for type specification: (/ type-spec :: elements /)
+            ! e.g., (/ real :: 1, 2, 3 /) or (/ integer(kind=4) :: 1, 2 /)
+            ! The type spec is skipped because modern Fortran compilers handle
+            ! type conversion automatically.
+            if (current%kind == TK_IDENTIFIER .or. current%kind == TK_KEYWORD) then
+                saved_pos = parser%current_token
+                current = parser%consume()  ! Consume type name
+                ! Handle optional kind selector: integer(kind=4)
+                current = parser%peek()
+                if (current%text == "(") then
+                    ! Skip kind/len parameters
+                    current = parser%consume()  ! Consume (
+                    block
+                        integer :: paren_depth
+                        paren_depth = 1
+                        do while (paren_depth > 0)
+                            current = parser%peek()
+                            if (current%text == "(") then
+                                paren_depth = paren_depth + 1
+                            else if (current%text == ")") then
+                                paren_depth = paren_depth - 1
+                            end if
+                            current = parser%consume()
+                        end do
+                    end block
+                    current = parser%peek()
+                end if
+                if (current%text == "::") then
+                    current = parser%consume()  ! Consume ::
+                    ! Type spec consumed, proceed to parse elements
+                    current = parser%peek()
+                else
+                    ! No ::, restore position
+                    parser%current_token = saved_pos
+                    current = parser%peek()
+                end if
             end if
 
             if (current%text == "(") then

--- a/test/integration/issue_tests/test_issue_1741_array_constructor_type_spec.f90
+++ b/test/integration/issue_tests/test_issue_1741_array_constructor_type_spec.f90
@@ -1,0 +1,46 @@
+! Test array constructor with type specification (issue #1741)
+program test_issue_1741_array_constructor_type_spec
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: transformed
+    character(len=:), allocatable :: error_msg
+
+    source = 'program test_array_constructor_type' // new_line('a') // &
+             '    implicit none' // new_line('a') // &
+             '    real :: real_arr(3)' // new_line('a') // &
+             '' // new_line('a') // &
+             '    real_arr = (/ real :: 1, 2, 3 /)' // new_line('a') // &
+             '' // new_line('a') // &
+             '    print *, real_arr' // new_line('a') // &
+             'end program test_array_constructor_type'
+
+    call transform_lazy_fortran_string(source, transformed, error_msg)
+
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: unexpected error:', trim(error_msg)
+            stop 1
+        end if
+    end if
+
+    ! The assignment statement must be present
+    if (index(transformed, 'real_arr =') == 0) then
+        print *, 'FAIL: assignment statement with type-spec array constructor was removed'
+        print *, 'Transformed code:'
+        print *, transformed
+        stop 1
+    end if
+
+    ! The array constructor should be preserved (type spec stripped)
+    if (index(transformed, '(/') == 0) then
+        print *, 'FAIL: array constructor syntax lost'
+        print *, 'Transformed code:'
+        print *, transformed
+        stop 1
+    end if
+
+    print *, 'PASS: array constructor with type spec preserved'
+
+end program test_issue_1741_array_constructor_type_spec


### PR DESCRIPTION
## Summary
- Fixed issue where array constructors with type specifications caused entire assignment statements to be removed
- Parser now correctly detects and skips type-spec syntax in legacy array constructors
- Type specifications like `(/ real :: 1, 2, 3 /)` are now handled properly

## Verification
Test output showing the fix works:
```fortran
! Input:
real_arr = (/ real :: 1, 2, 3 /)

! Output (type spec stripped, statement preserved):
real_arr = (/1, 2, 3 /)
```

## Test plan
- [x] Added test_issue_1741_array_constructor_type_spec.f90
- [x] All existing tests pass
- [x] Verified with issue reproducer