### PR TITLE
fix: enable NULLIFY statements in IF blocks (fixes #1704)

### DIFF
--- a/src/parser/parser_statement_utilities.f90
+++ b/src/parser/parser_statement_utilities.f90
@@ -17,7 +17,8 @@ module parser_statement_utilities_module
                                                 parse_goto_statement, &
                                                 parse_error_stop_statement, &
                                                 parse_cycle_statement, &
-                                                parse_exit_statement
+                                                parse_exit_statement, &
+                                                parse_nullify_statement
     use parser_memory_statements_module, only: parse_allocate_statement, &
                                                parse_deallocate_statement
     use parser_assignment_module, only: parse_assignment_statement
@@ -105,6 +106,8 @@ contains
                 stmt_index = parse_cycle_statement(parser, arena)
             case ("exit")
                 stmt_index = parse_exit_statement(parser, arena)
+            case ("nullify")
+                stmt_index = parse_nullify_statement(parser, arena)
             case ("associate")
                 stmt_index = parse_associate_from_definition(parser, arena)
             case ("import")


### PR DESCRIPTION
## Summary
NULLIFY statements inside IF constructs were being silently dropped during transformation. This fix adds NULLIFY keyword recognition to the IF block statement parser.

## Root Cause
`parse_statement_in_if_block()` in `parser_statement_utilities.f90` did not recognize the NULLIFY keyword. When encountered inside IF blocks, NULLIFY statements fell through to the default case which called `skip_unknown_statement()`, returning 0 and preventing them from being added to the IF body_indices array.

## Changes
- Added `parse_nullify_statement` import in `parser_statement_utilities.f90`
- Added NULLIFY case to `parse_statement_in_if_block()` switch statement

## Verification

### Manual Testing
```bash
# Test 1: NULLIFY in program body
echo 'program test
  integer, pointer :: ptr
  nullify(ptr)
end program' | fortfront /dev/stdin | grep -q 'nullify(ptr)'
# Result: PASS - NULLIFY preserved

# Test 2: NULLIFY inside IF block
echo 'program test
  integer, pointer :: ptr
  logical :: reset
  reset = .true.
  if (reset) then
    nullify(ptr)
  end if
end program' | fortfront /dev/stdin | grep -q 'nullify(ptr)'
# Result: PASS - NULLIFY preserved inside IF
```

### Test Suite Results
```bash
fpm test test_nullify_statement
```
Output:
```
PASS: test_basic_nullify
PASS: test_nullify_in_if
All NULLIFY statement tests passed
```

### Full Test Suite
```bash
fpm test
```
Output: All tests pass (0 failures)

Fixes #1704