### PR TITLE
fix: preserve DEALLOCATE statements in IF blocks (fixes #1781)

### DIFF
--- a/src/parser/parser_statement_core.f90
+++ b/src/parser/parser_statement_core.f90
@@ -13,6 +13,8 @@ module parser_statement_core_module
         parse_cycle_statement, parse_exit_statement, parse_return_statement, &
         parse_stop_statement, parse_goto_statement, parse_error_stop_statement, &
         parse_pause_statement, parse_nullify_statement, parse_continue_statement
+    use parser_memory_statements_module, only: parse_allocate_statement, &
+                                               parse_deallocate_statement
     use parser_declarations, only: parse_declaration, parse_multi_declaration
     use parser_call_module, only: parse_call_statement
     use parser_utils, only: analyze_declaration_structure
@@ -223,6 +225,10 @@ contains
                 stmt_index = parse_rewind_statement(parser, arena)
             case ("endfile")
                 stmt_index = parse_endfile_statement(parser, arena)
+            case ("allocate")
+                stmt_index = parse_allocate_statement(parser, arena)
+            case ("deallocate")
+                stmt_index = parse_deallocate_statement(parser, arena)
             case ("data")
                 stmt_index = parse_data_statement(parser, arena, parent_index)
             case ("cycle")

--- a/test/integration/issue_tests/test_issue_1781_deallocate_preserved.f90
+++ b/test/integration/issue_tests/test_issue_1781_deallocate_preserved.f90
@@ -1,0 +1,110 @@
+program test_issue_1781_deallocate_preserved
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    print *, '=== Issue #1781: DEALLOCATE statements preserved ==='
+
+    if (.not. test_deallocate_in_if_block()) all_passed = .false.
+    if (.not. test_allocate_and_deallocate()) all_passed = .false.
+
+    print *
+    if (all_passed) then
+        print *, 'Issue #1781 fixed!'
+    else
+        print *, 'Issue #1781 test failed!'
+        stop 1
+    end if
+
+contains
+
+    logical function test_deallocate_in_if_block()
+        character(len=:), allocatable :: source, output, error_msg
+
+        test_deallocate_in_if_block = .true.
+        print *, 'Testing DEALLOCATE in IF block...'
+
+        source = 'program test_array_allocation_stat' // new_line('a') // &
+                 '    implicit none' // new_line('a') // &
+                 '    integer, allocatable :: arr(:)' // new_line('a') // &
+                 '    integer :: stat' // new_line('a') // &
+                 '    allocate(arr(10), stat=stat)' // new_line('a') // &
+                 '    if (stat == 0) then' // new_line('a') // &
+                 '        print *, ''Allocation successful''' // new_line('a') // &
+                 '        arr = 42' // new_line('a') // &
+                 '        print *, ''Sum:'', sum(arr)' // new_line('a') // &
+                 '        deallocate(arr)' // new_line('a') // &
+                 '    else' // new_line('a') // &
+                 '        print *, ''Allocation failed''' // new_line('a') // &
+                 '    end if' // new_line('a') // &
+                 'end program test_array_allocation_stat'
+
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, '  FAIL: Unexpected error:', trim(error_msg)
+                test_deallocate_in_if_block = .false.
+                return
+            end if
+        end if
+
+        if (index(output, 'deallocate') == 0) then
+            print *, '  FAIL: deallocate statement missing in output'
+            print *, 'Output:'
+            print *, trim(output)
+            test_deallocate_in_if_block = .false.
+        else
+            print *, '  PASS: deallocate statement preserved'
+        end if
+    end function test_deallocate_in_if_block
+
+    logical function test_allocate_and_deallocate()
+        character(len=:), allocatable :: source, output, error_msg
+        integer :: alloc_pos, dealloc_pos
+
+        test_allocate_and_deallocate = .true.
+        print *, 'Testing both ALLOCATE and DEALLOCATE...'
+
+        source = 'program test_both' // new_line('a') // &
+                 '    implicit none' // new_line('a') // &
+                 '    integer, allocatable :: data(:)' // new_line('a') // &
+                 '    allocate(data(100))' // new_line('a') // &
+                 '    data = 0' // new_line('a') // &
+                 '    if (size(data) > 0) then' // new_line('a') // &
+                 '        print *, ''Data allocated''' // new_line('a') // &
+                 '        deallocate(data)' // new_line('a') // &
+                 '    end if' // new_line('a') // &
+                 'end program test_both'
+
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, '  FAIL: Unexpected error:', trim(error_msg)
+                test_allocate_and_deallocate = .false.
+                return
+            end if
+        end if
+
+        alloc_pos = index(output, 'allocate')
+        dealloc_pos = index(output, 'deallocate')
+
+        if (alloc_pos == 0) then
+            print *, '  FAIL: allocate statement missing'
+            test_allocate_and_deallocate = .false.
+        else if (dealloc_pos == 0) then
+            print *, '  FAIL: deallocate statement missing'
+            test_allocate_and_deallocate = .false.
+        else if (dealloc_pos < alloc_pos) then
+            print *, '  FAIL: deallocate appears before allocate'
+            test_allocate_and_deallocate = .false.
+        else
+            print *, '  PASS: both allocate and deallocate preserved'
+        end if
+    end function test_allocate_and_deallocate
+
+end program test_issue_1781_deallocate_preserved


### PR DESCRIPTION
## Summary
Fixes #1781 - DEALLOCATE statements are now preserved in IF blocks and other control flow constructs.

## Problem
DEALLOCATE statements were silently removed during parsing when inside IF blocks, causing potential memory leaks. The issue affected all control flow contexts (IF, ELSE, ELSEIF blocks).

## Root Cause
The `parse_keyword_statement` function in `parser_statement_core.f90` was missing cases for `allocate` and `deallocate` keywords. While these statements were handled in `parse_statement_in_if_block` (used by older code paths), the modern statement parsing path used by IF block body parsing didn't recognize them.

## Solution
- Added `use parser_memory_statements_module` import
- Added `allocate` and `deallocate` cases to the keyword dispatcher in `parse_keyword_statement`

## Verification

### Test Coverage
New integration test `test_issue_1781_deallocate_preserved.f90` validates:
- DEALLOCATE statements in IF blocks are preserved
- Both ALLOCATE and DEALLOCATE work together
- Order is maintained (allocate before deallocate)

### Manual Verification
```fortran
program test_array_allocation_stat
    implicit none
    integer, allocatable :: arr(:)
    integer :: stat
    allocate(arr(10), stat=stat)
    if (stat == 0) then
        print *, 'Allocation successful'
        arr = 42
        print *, 'Sum:', sum(arr)
        deallocate(arr)  ! <-- Now preserved
    else
        print *, 'Allocation failed'
    end if
end program
```

Output correctly includes `deallocate(arr)` statement.

**Compilation:** SUCCESS - Generated code compiles with gfortran  
**Runtime:** SUCCESS - Executes correctly, prints expected output  
**All tests:** PASS - No regressions in existing test suite
