### PR TITLE
fix: prevent intent(in) from being changed to intent(inout) (fixes #1775)

### DIFF
--- a/src/standardizers/standardizer_subprograms.f90
+++ b/src/standardizers/standardizer_subprograms.f90
@@ -105,8 +105,10 @@ contains
                     if (matched_multi) then
                         call apply_type_standardization(stmt)
                         if (len_trim(stmt_intent) == 0) stmt_intent = default_intent
-                        stmt%intent = stmt_intent
-                        stmt%has_intent = .true.
+                        if (len_trim(stmt_intent) > 0) then
+                            stmt%intent = stmt_intent
+                            stmt%has_intent = .true.
+                        end if
                         arena%entries(current_index)%node = stmt
                     end if
                 else if (is_param_decl) then
@@ -135,8 +137,10 @@ contains
                     end if
                     call apply_type_standardization(stmt)
                     if (len_trim(stmt_intent) == 0) stmt_intent = default_intent
-                    stmt%intent = stmt_intent
-                    stmt%has_intent = .true.
+                    if (len_trim(stmt_intent) > 0) then
+                        stmt%intent = stmt_intent
+                        stmt%has_intent = .true.
+                    end if
                     arena%entries(current_index)%node = stmt
                 end if
             end select
@@ -162,8 +166,18 @@ contains
             character(len=*), intent(inout) :: stmt_intent
             integer, intent(in) :: arena_index
 
-            if (len_trim(param_intent(pidx)) == 0) param_intent(pidx) = default_intent
-            if (len_trim(stmt_intent) == 0) stmt_intent = param_intent(pidx)
+            if (len_trim(stmt_intent) == 0) then
+                if (len_trim(param_intent(pidx)) > 0) then
+                    stmt_intent = param_intent(pidx)
+                else
+                    stmt_intent = default_intent
+                    param_intent(pidx) = default_intent
+                end if
+            else
+                if (len_trim(param_intent(pidx)) == 0) then
+                    param_intent(pidx) = stmt_intent
+                end if
+            end if
 
             if (param_optional(pidx)) stmt%is_optional = .true.
             param_names_found(pidx) = arena_index
@@ -1131,7 +1145,7 @@ contains
             call synchronize_parameter_declarations(arena, sub_def%body_indices, &
                                     param_names, param_names_found, sb_param_optional, &
                                                     sb_param_intent, &
-                                                    "inout", &
+                                                    "", &
                                               standardizer_type_standardization_enabled)
         end if
 

--- a/test/integration/issue_tests/test_issue_1775_intent_in_preserved.f90
+++ b/test/integration/issue_tests/test_issue_1775_intent_in_preserved.f90
@@ -1,0 +1,78 @@
+program test_issue_1775_intent_in_preserved
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use standardizer, only: standardize_ast
+    use codegen_core, only: codegen_core_generate_arena, initialize_codegen
+    use ast_arena_modern, only: ast_arena_t
+    use lexer_core, only: token_t
+    implicit none
+
+    logical :: ok
+
+    ok = check_intent_in_preserved()
+    if (ok) then
+        print *, "PASS: Issue #1775 - intent(in) preserved with keyword args"
+    else
+        error stop "FAIL: Issue #1775 - intent(in) incorrectly changed to inout"
+    end if
+
+contains
+
+    function check_intent_in_preserved() result(passed)
+        logical :: passed
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: output_code
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+
+        passed = .true.
+
+        call initialize_codegen()
+
+        source = &
+            "program test_keyword_args" // new_line('a') // &
+            "    implicit none" // new_line('a') // &
+            "    call process(b=2, a=1, c=3)" // new_line('a') // &
+            "contains" // new_line('a') // &
+            "    subroutine process(a, b, c)" // new_line('a') // &
+            "        integer, intent(in) :: a, b, c" // new_line('a') // &
+            "        print *, 'a=', a, 'b=', b, 'c=', c" // new_line('a') // &
+            "    end subroutine process" // new_line('a') // &
+            "end program test_keyword_args"
+
+        call lex_source(source, tokens, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: lexing error:", trim(error_msg)
+            passed = .false.
+            return
+        end if
+
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: parsing error:", trim(error_msg)
+            passed = .false.
+            return
+        end if
+
+        call standardize_ast(arena, root_index)
+
+        output_code = codegen_core_generate_arena(arena, root_index)
+
+        if (index(output_code, "intent(inout)") > 0) then
+            print *, "FAIL: intent(in) was incorrectly changed to intent(inout)"
+            print *, "Output:"
+            print *, trim(output_code)
+            passed = .false.
+            return
+        end if
+
+        if (index(output_code, "call process(b = 2, a = 1, c = 3)") <= 0) then
+            print *, "FAIL: keyword arguments not preserved"
+            passed = .false.
+        end if
+
+    end function check_intent_in_preserved
+
+end program test_issue_1775_intent_in_preserved


### PR DESCRIPTION
## Summary
- Fixed issue where intent(in) was incorrectly changed to intent(inout) for subroutine parameters
- Changed default intent for subroutine parameters from inout to empty string when synchronizing
- Added regression test to prevent future occurrences

## Verification

Test case from issue #1775:
```fortran
subroutine process(a, b, c)
    integer, intent(in) :: a, b, c
    print *, 'a=', a, 'b=', b, 'c=', c
end subroutine process
```

Before fix: parameters incorrectly changed to `intent(inout)`
After fix: intent(in) preserved (or intent omitted, but NOT changed to inout)

Commands:
```bash
fpm test test_issue_1775_intent_in_preserved
```

Output:
```
PASS: Issue #1775 - intent(in) preserved with keyword args
```

All existing tests pass with no regressions.