### PR TITLE
fix: preserve USE statement renames without only clause (fixes #1783)

### DIFF
--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -502,10 +502,10 @@ contains
                 code = code // ", only:"
             end if
         else if (allocated(node%rename_list)) then
-            ! Fallback: emit rename list under only clause even if flag missing
+            ! Rename list without only clause
             call append_rename_list_to_clause(node%rename_list, only_clause)
             if (len_trim(only_clause) > 0) then
-                code = code // ", only: " // trim(only_clause)
+                code = code // ", " // trim(only_clause)
             end if
         end if
 

--- a/src/parser/parser_import_resolution.f90
+++ b/src/parser/parser_import_resolution.f90
@@ -277,7 +277,7 @@ contains
 
         has_only = .false.
 
-        ! Check for optional only clause (simplified for refactoring)
+        ! Check for optional only clause or rename list
         token = parser%peek()
         if (token%kind == TK_OPERATOR .and. token%text == ",") then
             token = parser%consume()  ! consume ','
@@ -300,10 +300,14 @@ contains
                     allocate (character(len=0) :: only_list(0))
                     allocate (character(len=0) :: rename_list(0))
                 end if
+            else
+                ! No only keyword - parse rename list directly
+                allocate (character(len=0) :: only_list(0))
+                call parse_identifier_list(parser, only_list, rename_list)
             end if
         end if
 
-        if (.not. has_only) then
+        if (.not. has_only .and. .not. allocated(rename_list)) then
             allocate (character(len=0) :: only_list(0))
             allocate (character(len=0) :: rename_list(0))
         end if

--- a/test/frontend/test_issue_1783_use_rename_no_only.f90
+++ b/test/frontend/test_issue_1783_use_rename_no_only.f90
@@ -1,0 +1,93 @@
+program test_issue_1783_use_rename_no_only
+    use transformation_api, only: transform_lazy_fortran_string
+
+    call test_use_statement_rename_without_only()
+    call test_use_statement_rename_with_only()
+    print *, ""
+    print *, "All tests passed for issue 1783."
+
+contains
+
+    subroutine test_use_statement_rename_without_only()
+        character(len=:), allocatable :: input_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        integer :: idx_use
+
+        input_code = "module orig_names" // new_line('A') // &
+                     "    implicit none" // new_line('A') // &
+                     "    integer :: value = 42" // new_line('A') // &
+                     "contains" // new_line('A') // &
+                     "    function compute() result(res)" // new_line('A') // &
+                     "        integer :: res" // new_line('A') // &
+                     "        res = value * 2" // new_line('A') // &
+                     "    end function compute" // new_line('A') // &
+                     "end module orig_names" // new_line('A') // new_line('A') // &
+                     "program test_use_rename" // new_line('A') // &
+                     "    use orig_names, my_value => value, my_compute => compute" // &
+                     new_line('A') // &
+                     "    implicit none" // new_line('A') // &
+                     "    print *, 'Value:', my_value" // new_line('A') // &
+                     "    print *, 'Compute:', my_compute()" // new_line('A') // &
+                     "end program test_use_rename"
+
+        call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: unexpected transformation error:", trim(error_msg)
+            error stop 1
+        end if
+
+        idx_use = index(output_code, &
+                        "use orig_names, my_value => value, my_compute => compute")
+        if (idx_use <= 0) then
+            print *, "FAIL: use statement rename syntax without only not preserved"
+            print *, "Output:"
+            print *, trim(output_code)
+            error stop 1
+        end if
+
+        if (index(output_code, "my_value => value") > 0 .and. &
+            index(output_code, "use orig_names, my_value => value") <= 0) then
+            print *, "FAIL: rename converted to pointer assignment"
+            print *, "Output:"
+            print *, trim(output_code)
+            error stop 1
+        end if
+
+        print *, "PASS: USE rename without only preserved"
+    end subroutine test_use_statement_rename_without_only
+
+    subroutine test_use_statement_rename_with_only()
+        character(len=:), allocatable :: input_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        integer :: idx_use
+
+        input_code = "module orig_names" // new_line('A') // &
+                     "    implicit none" // new_line('A') // &
+                     "    integer :: value = 42" // new_line('A') // &
+                     "end module orig_names" // new_line('A') // new_line('A') // &
+                     "program test_use_rename" // new_line('A') // &
+                     "    use orig_names, only: my_value => value" // new_line('A') // &
+                     "    implicit none" // new_line('A') // &
+                     "    print *, my_value" // new_line('A') // &
+                     "end program test_use_rename"
+
+        call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: unexpected transformation error:", trim(error_msg)
+            error stop 1
+        end if
+
+        idx_use = index(output_code, "use orig_names, only: my_value => value")
+        if (idx_use <= 0) then
+            print *, "FAIL: use statement rename syntax with only not preserved"
+            error stop 1
+        end if
+
+        print *, "PASS: USE rename with only preserved"
+    end subroutine test_use_statement_rename_with_only
+
+end program test_issue_1783_use_rename_no_only


### PR DESCRIPTION
Fixes #1783

## Summary

Fixed a bug where USE statement renaming syntax without the `only` clause was incorrectly transformed into pointer assignment statements.

**Before:**
```fortran
use orig_names, my_value => value, my_compute => compute
```
Was incorrectly converted to:
```fortran
use orig_names
my_value => value
my_compute => compute
```

**After:**
```fortran
use orig_names, my_value => value, my_compute => compute
```
The rename syntax is now correctly preserved.

## Root Cause

The parser only handled rename lists when the `only` keyword was present. According to Fortran standard, `USE module, name1 => name2` is valid syntax without `only`.

## Changes

1. **Parser** (`parser_import_resolution.f90`): Parse identifier/rename list even when `only` keyword is absent
2. **Codegen** (`codegen_statements.f90`): Output renames without the `only:` clause when appropriate
3. **Test** (`test_issue_1783_use_rename_no_only.f90`): Added comprehensive tests for both syntaxes

## Verification

Tested with the exact example from issue #1783:
```bash
$ fpm run fortfront -- test.f90
module orig_names
    implicit none
    integer :: value = 42 
contains
    function compute() result(res)
    implicit none
    integer :: res
    res = value*2 
end function compute
end module orig_names

program test_use_rename
    use orig_names, my_value => value, my_compute => compute
    implicit none
    print *, 'Value:', my_value 
    print *, 'Compute:', my_compute()
end program test_use_rename
```

Verified output compiles and runs correctly:
```bash
$ gfortran output.f90 -o test && ./test
Value:          42
Compute:          84
```

All tests pass:
```bash
$ fpm test test_issue_1783_use_rename_no_only
PASS: USE rename without only preserved
PASS: USE rename with only preserved

All tests passed for issue 1783.
```

Existing tests still pass:
```bash
$ fpm test test_issue_1409_use_rename
PASS: USE rename preserved

All tests passed for issue 1409.
```
