### PR TITLE
fix: preserve BLOCK constructs with scoped declarations (fixes #1779)

### DIFF
--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -29,8 +29,8 @@ module ast_factory
     ! Control flow nodes
     use ast_factory_control, only: &
         push_if, push_do_loop, push_do_while, push_forall, push_select_case, &
-        push_associate, push_case_block, push_case_range, push_case_default, &
-        push_select_case_with_default, push_select_type, &
+        push_associate, push_block_construct, push_case_block, push_case_range, &
+        push_case_default, push_select_case_with_default, push_select_type, &
         push_select_type_with_default, push_type_guard_block, push_where, &
         push_where_construct, push_where_construct_with_elsewhere
 
@@ -84,8 +84,8 @@ module ast_factory
 
     ! Control flow nodes
     public :: push_if, push_do_loop, push_do_while, push_forall, push_select_case
-    public :: push_associate, push_case_block, push_case_range, push_case_default
-    public :: push_select_case_with_default, push_select_type
+    public :: push_associate, push_block_construct, push_case_block, push_case_range
+    public :: push_case_default, push_select_case_with_default, push_select_type
     public :: push_select_type_with_default, push_type_guard_block, push_where
     public :: push_where_construct, push_where_construct_with_elsewhere
 

--- a/src/ast/factory/ast_factory_control.f90
+++ b/src/ast/factory/ast_factory_control.f90
@@ -6,7 +6,8 @@ module ast_factory_control
     use ast_nodes_control, only: MAX_INDEX_NAME_LENGTH, if_node, select_case_node, &
                                  case_block_node, case_range_node, case_default_node, &
                                  select_type_node, type_guard_block_node, &
-                                 where_node, elsewhere_clause_t, associate_node
+                                 where_node, elsewhere_clause_t, associate_node, &
+                                 block_construct_node
     use ast_nodes_loops, only: do_loop_node, do_while_node, forall_node
     use uid_generator, only: generate_uid
     use error_handling, only: result_t, success_result, create_error_result
@@ -16,7 +17,7 @@ module ast_factory_control
 
     ! Public control flow node creation functions
     public :: push_if, push_do_loop, push_do_while, push_forall, push_select_case
-    public :: push_associate
+    public :: push_associate, push_block_construct
     public :: push_case_block, push_case_range, push_case_default, &
               push_select_case_with_default
     public :: push_select_type, push_select_type_with_default, push_type_guard_block
@@ -197,6 +198,29 @@ contains
         call arena%push(assoc, "associate", parent_index)
         assoc_index = arena%size
     end function push_associate
+
+    function push_block_construct(arena, body_indices, line, column, &
+                                  parent_index) result(block_index)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in), optional :: body_indices(:)
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: block_index
+        type(block_construct_node) :: block_construct
+
+        block_construct%uid = generate_uid()
+
+        if (present(body_indices)) then
+            if (size(body_indices) > 0) then
+                block_construct%body_indices = body_indices
+            end if
+        end if
+
+        if (present(line)) block_construct%line = line
+        if (present(column)) block_construct%column = column
+
+        call arena%push(block_construct, "block_construct", parent_index)
+        block_index = arena%size
+    end function push_block_construct
 
     ! Create forall construct node and add to stack
     function push_forall(arena, index_var, start_index, end_index, step_index, &

--- a/src/ast/nodes/ast_nodes_associate.f90
+++ b/src/ast/nodes/ast_nodes_associate.f90
@@ -7,10 +7,10 @@ module ast_nodes_associate
     private
 
     ! Public types
-    public :: association_t, associate_node
+    public :: association_t, associate_node, block_construct_node
 
     ! Public factory functions
-    public :: create_associate
+    public :: create_associate, create_block_construct
 
     ! Association type for ASSOCIATE construct
     type :: association_t
@@ -28,6 +28,16 @@ module ast_nodes_associate
         procedure :: assign => associate_assign
         generic :: assignment(=) => assign
     end type associate_node
+
+    ! BLOCK construct node (F2008 scoped block)
+    type, extends(ast_node) :: block_construct_node
+        integer, allocatable :: body_indices(:)  ! Body statement indices
+    contains
+        procedure :: accept => block_construct_accept
+        procedure :: to_json => block_construct_to_json
+        procedure :: assign => block_construct_assign
+        generic :: assignment(=) => assign
+    end type block_construct_node
 
 contains
 
@@ -125,5 +135,70 @@ contains
         if (present(line)) node%line = line
         if (present(column)) node%column = column
     end function create_associate
+
+    ! BLOCK construct node implementations
+    subroutine block_construct_accept(this, visitor)
+        class(block_construct_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+    end subroutine block_construct_accept
+
+    subroutine block_construct_to_json(this, json, parent)
+        class(block_construct_node), intent(in) :: this
+        type(json_core), intent(inout) :: json
+        type(json_value), pointer, intent(in) :: parent
+        type(json_value), pointer :: obj, body_array
+        integer :: i
+
+        call json%create_object(obj, '')
+        call json%add(obj, 'type', 'block_construct')
+        call json%add(obj, 'line', this%line)
+        call json%add(obj, 'column', this%column)
+
+        if (allocated(this%body_indices)) then
+            call json%create_array(body_array, 'body_indices')
+            do i = 1, size(this%body_indices)
+                call json%add(body_array, '', this%body_indices(i))
+            end do
+            call json%add(obj, body_array)
+        end if
+
+        call json%add(parent, obj)
+    end subroutine block_construct_to_json
+
+    subroutine block_construct_assign(lhs, rhs)
+        class(block_construct_node), intent(inout) :: lhs
+        class(block_construct_node), intent(in) :: rhs
+
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+
+        if (allocated(rhs%body_indices)) then
+            lhs%body_indices = rhs%body_indices
+        end if
+    end subroutine block_construct_assign
+
+    function create_block_construct(body_indices, line, column) result(node)
+        integer, intent(in), optional :: body_indices(:)
+        integer, intent(in), optional :: line, column
+        type(block_construct_node) :: node
+
+        node%uid = generate_uid()
+
+        if (present(body_indices)) then
+            if (size(body_indices) > 0) then
+                node%body_indices = body_indices
+            end if
+        end if
+
+        if (present(line)) node%line = line
+        if (present(column)) node%column = column
+    end function create_block_construct
 
 end module ast_nodes_associate

--- a/src/ast/nodes/ast_nodes_control.f90
+++ b/src/ast/nodes/ast_nodes_control.f90
@@ -17,7 +17,8 @@ module ast_nodes_control
                                   error_stop_node, continue_node, pause_node, &
                                   nullify_node, create_continue
     use ast_nodes_associate, only: association_t, associate_node, &
-                                   create_associate
+                                   create_associate, block_construct_node, &
+                                   create_block_construct
     implicit none
 
     ! Re-export constants
@@ -34,10 +35,11 @@ module ast_nodes_control
     public :: where_node, where_stmt_node
     public :: cycle_node, exit_node, stop_node, return_node, entry_node, goto_node
     public :: error_stop_node, continue_node, associate_node, pause_node
-    public :: nullify_node
+    public :: nullify_node, block_construct_node
 
     ! Re-export factory functions
     public :: create_do_loop, create_do_while, create_if, create_select_case
     public :: create_select_type, create_associate, create_continue
+    public :: create_block_construct
 
 end module ast_nodes_control

--- a/src/codegen/codegen_control_flow.f90
+++ b/src/codegen/codegen_control_flow.f90
@@ -18,6 +18,7 @@ module codegen_control_flow
     public :: generate_code_where
     public :: generate_code_forall
     public :: generate_code_associate
+    public :: generate_code_block_construct
 
 contains
 
@@ -551,6 +552,29 @@ contains
         code = code // new_line('A') // repeat("    ", indent_level)
         code = code // "end associate"
     end function generate_code_associate
+
+    function generate_code_block_construct(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(block_construct_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+        character(len=:), allocatable :: body_code
+        integer :: indent_level
+
+        indent_level = 0
+        code = "block"
+
+        if (allocated(node%body_indices)) then
+            body_code = generate_grouped_body_internal( &
+                        arena, node%body_indices, indent_level + 1)
+            if (len(body_code) > 0) then
+                code = code // new_line('A') // body_code
+            end if
+        end if
+
+        code = code // new_line('A') // repeat("    ", indent_level)
+        code = code // "end block"
+    end function generate_code_block_construct
 
     ! Internal function to generate grouped body
     function generate_grouped_body_internal(arena, body_indices, indent) result(code)

--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -21,7 +21,7 @@ module codegen_core
                               assignment_node, pointer_assignment_node, program_node, &
                               component_access_node
     use ast_nodes_procedure
-    use ast_nodes_associate, only: associate_node
+    use ast_nodes_associate, only: associate_node, block_construct_node
     use ast_nodes_misc, only: complex_literal_node, comment_node, blank_line_node, &
                               implicit_statement_node, allocate_statement_node, &
                               deallocate_statement_node, use_statement_node, &
@@ -167,6 +167,8 @@ contains
             code = generate_code_forall(arena, node, node_index)
         type is (associate_node)
             code = generate_code_associate(arena, node, node_index)
+        type is (block_construct_node)
+            code = generate_code_block_construct(arena, node, node_index)
 
             ! Declaration and definition nodes
         type is (declaration_node)

--- a/src/parser/parser_array_constructs.f90
+++ b/src/parser/parser_array_constructs.f90
@@ -15,11 +15,11 @@ module parser_array_constructs_module
     use parser_if_constructs_module, only: parse_if, parse_if_condition
     use parser_select_constructs_module, only: parse_select_case
     use ast_arena_modern, only: ast_arena_t
-    use ast_factory, only: push_where, push_associate
+    use ast_factory, only: push_where, push_associate, push_block_construct
     implicit none
     private
 
-    public :: parse_where_construct, parse_associate
+    public :: parse_where_construct, parse_associate, parse_block_construct
 
 contains
 
@@ -31,6 +31,7 @@ contains
         callbacks%parse_if => parse_if
         callbacks%parse_where => parse_where_construct
         callbacks%parse_associate => parse_associate
+        callbacks%parse_block => parse_block_construct
         callbacks%parse_select_case => parse_select_case
     end function build_where_callbacks
 
@@ -557,5 +558,43 @@ contains
         end if
 
     end function parse_associate
+
+    function parse_block_construct(parser, arena) result(block_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer :: block_index
+
+        type(token_t) :: token
+        integer :: line, column
+        integer, allocatable :: body_indices(:)
+        type(statement_callbacks_t) :: callbacks
+        character(len=3), parameter :: block_end_keywords(1) = ['end']
+
+        token = parser%peek()
+        line = token%line
+        column = token%column
+
+        if (token%kind /= TK_KEYWORD .or. token%text /= "block") then
+            block_index = 0
+            return
+        end if
+        token = parser%consume()
+
+        callbacks = build_associate_callbacks()
+        body_indices = parse_statement_body(parser, arena, &
+                                            block_end_keywords, callbacks)
+
+        token = parser%peek()
+        if (token%kind == TK_KEYWORD .and. token%text == "end") then
+            token = parser%consume()
+            token = parser%peek()
+            if (token%kind == TK_KEYWORD .and. token%text == "block") then
+                token = parser%consume()
+            end if
+        end if
+
+        block_index = push_block_construct(arena, body_indices, &
+                                           line=line, column=column)
+    end function parse_block_construct
 
 end module parser_array_constructs_module

--- a/src/parser/parser_control_flow_router.f90
+++ b/src/parser/parser_control_flow_router.f90
@@ -8,7 +8,8 @@ module parser_control_flow_router_module
     use parser_if_constructs_module, only: parse_if
     use parser_do_constructs_module, only: parse_do_loop
     use parser_select_constructs_module, only: parse_select_case, parse_select_type
-    use parser_array_constructs_module, only: parse_where_construct, parse_associate
+    use parser_array_constructs_module, only: parse_where_construct, parse_associate, &
+                                              parse_block_construct
     use parser_forall_module, only: parse_forall
     implicit none
     private
@@ -29,6 +30,7 @@ contains
         callbacks%parse_where => parse_where_construct
         callbacks%parse_forall => parse_forall
         callbacks%parse_associate => parse_associate
+        callbacks%parse_block => parse_block_construct
     end function default_control_flow_callbacks
 
     logical function is_control_flow_keyword(text) result(is_control)
@@ -37,7 +39,7 @@ contains
 
         lowered = to_lower(trim(text))
         select case (lowered)
-        case ("if", "do", "select", "where", "forall", "associate")
+        case ("if", "do", "select", "where", "forall", "associate", "block")
             is_control = .true.
         case default
             is_control = .false.
@@ -89,6 +91,8 @@ contains
             node_index = invoke_no_parent(local_callbacks%parse_forall, parser, arena)
         case ("associate")
             node_index = invoke_no_parent(local_callbacks%parse_associate, parser, arena)
+        case ("block")
+            node_index = invoke_no_parent(local_callbacks%parse_block, parser, arena)
         case default
             node_index = 0
         end select

--- a/src/parser/parser_statement_callbacks.f90
+++ b/src/parser/parser_statement_callbacks.f90
@@ -36,6 +36,8 @@ module parser_statement_callbacks_module
             parse_forall => null()
         procedure(parse_without_parent_interface), pointer, nopass :: &
             parse_associate => null()
+        procedure(parse_without_parent_interface), pointer, nopass :: &
+            parse_block => null()
     end type statement_callbacks_t
 
     public :: null_statement_callbacks

--- a/test/integration/issue_tests/test_issue_1779_block_construct.f90
+++ b/test/integration/issue_tests/test_issue_1779_block_construct.f90
@@ -1,0 +1,15 @@
+program test_block_construct
+    implicit none
+    integer :: x
+
+    x = 10
+    print *, 'Before block:', x
+
+    block
+        integer :: x
+        x = 20
+        print *, 'Inside block:', x
+    end block
+
+    print *, 'After block:', x
+end program test_block_construct


### PR DESCRIPTION
## Summary

Fixes #1779 - BLOCK constructs (F2008 scoping feature) are now correctly preserved instead of being removed with declarations hoisted to parent scope.

## Root Cause

The BLOCK keyword was being dispatched to the control flow router, but no parse_block handler was defined in the callbacks. This caused BLOCK constructs to be silently dropped, with only their body statements emitted and declarations incorrectly hoisted.

## Changes

**AST Layer:**
- Added `block_construct_node` type to `ast_nodes_associate.f90`
- Re-exported through `ast_nodes_control.f90`

**Parser Layer:**
- Created `parse_block_construct()` in `parser_array_constructs.f90`
- Added `parse_block` callback to `statement_callbacks_t`
- Wired into control flow router and all callback builders

**Factory Layer:**
- Added `push_block_construct()` to `ast_factory_control.f90`
- Re-exported through main `ast_factory.f90`

**Codegen Layer:**
- Implemented `generate_code_block_construct()` in `codegen_control_flow.f90`
- Added type case in `codegen_core.f90`

**Test Coverage:**
- Added `test_issue_1779_block_construct.f90` with variable shadowing example

## Verification

Input (from issue):
```fortran
program test_block_construct
    implicit none
    integer :: x = 10
    print *, 'Before block:', x
    block
        integer :: x
        x = 20
        print *, 'Inside block:', x
    end block
    print *, 'After block:', x
end program test_block_construct
```

**Before fix:** BLOCK removed, declarations hoisted, compilation error (duplicate `x`)

**After fix:** BLOCK preserved, compiles successfully:
```
$ fpm run fortfront -- test/integration/issue_tests/test_issue_1779_block_construct.f90 > /tmp/out.f90
$ gfortran /tmp/out.f90 -o /tmp/test && /tmp/test
 Before block:          10
 Inside block:          20
 After block:          10
```

**Test suite:** All existing tests pass - no regressions.