### PR TITLE
fix: preserve assumed-size array dimension x(*) (fixes #1818)

### DIFF
--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -52,7 +52,7 @@ module ast_factory
     ! Array-related nodes
     use ast_factory_arrays, only: &
         push_array_section, push_array_bounds, push_array_slice, &
-        push_range_expression
+        push_range_expression, push_assumed_size_bounds
 
     ! Statement nodes
     use ast_factory_statements, only: &
@@ -105,7 +105,7 @@ module ast_factory
 
     ! Array-related nodes
     public :: push_array_section, push_array_bounds, push_array_slice
-    public :: push_range_expression
+    public :: push_range_expression, push_assumed_size_bounds
 
     ! Statement nodes
     public :: push_use_statement, push_visibility_statement, push_namelist_statement, &

--- a/src/ast/factory/ast_factory_arrays.f90
+++ b/src/ast/factory/ast_factory_arrays.f90
@@ -11,7 +11,7 @@ module ast_factory_arrays
 
     ! Public array node creation functions
     public :: push_array_section, push_array_bounds, push_array_slice
-    public :: push_range_expression
+    public :: push_range_expression, push_assumed_size_bounds
 
 contains
 
@@ -129,5 +129,25 @@ contains
         call arena%push(range, "range_expression", parent_index)
         range_index = arena%size
     end function push_range_expression
+
+    ! Create assumed-size array bounds node and add to stack
+    function push_assumed_size_bounds(arena, line, column, parent_index) &
+        result(bounds_index)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: bounds_index
+        type(array_bounds_node) :: bounds
+
+        bounds%uid = generate_uid()
+        bounds%lower_bound_index = 0
+        bounds%upper_bound_index = 0
+        bounds%stride_index = 0
+        bounds%is_assumed_size = .true.
+        if (present(line)) bounds%line = line
+        if (present(column)) bounds%column = column
+
+        call arena%push(bounds, "array_bounds", parent_index)
+        bounds_index = arena%size
+    end function push_assumed_size_bounds
 
 end module ast_factory_arrays

--- a/src/parser/parser_expressions.f90
+++ b/src/parser/parser_expressions.f90
@@ -7,7 +7,8 @@ module parser_expressions_module
     use ast_types, only: LITERAL_INTEGER, LITERAL_REAL, LITERAL_STRING, LITERAL_LOGICAL
     use ast_nodes_loops, only: do_loop_node
     use ast_factory, only: push_binary_op, push_literal, push_identifier, &
-                           push_range_expression, push_complex_literal
+                           push_range_expression, push_complex_literal, &
+                           push_assumed_size_bounds
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_expression_helpers_module, only: parse_number_literal, &
                                                 parse_string_literal, &
@@ -842,6 +843,14 @@ contains
         type(token_t) :: op_token
 
         op_token = parser%peek()
+        if (op_token%kind == TK_OPERATOR .and. op_token%text == "*") then
+            op_token = parser%consume()
+            expr_index = push_assumed_size_bounds(arena, &
+                                                 line=op_token%line, &
+                                                 column=op_token%column)
+            return
+        end if
+
         if (op_token%kind == TK_OPERATOR .and. op_token%text == ":") then
             op_token = parser%consume()
             expr_index = 0

--- a/test/integration/issue_tests/test_issue_1818_assumed_size_array.f90
+++ b/test/integration/issue_tests/test_issue_1818_assumed_size_array.f90
@@ -1,0 +1,86 @@
+program test_issue_1818_assumed_size_array
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use standardizer, only: standardize_ast
+    use codegen_core, only: codegen_core_generate_arena, initialize_codegen
+    use ast_arena_modern, only: ast_arena_t
+    use lexer_core, only: token_t
+    implicit none
+
+    logical :: ok
+
+    ok = check_assumed_size_preserved()
+    if (ok) then
+        print *, "PASS: Issue #1818 - assumed-size array x(*) preserved"
+    else
+        error stop "FAIL: Issue #1818 - assumed-size array x(*) converted to scalar"
+    end if
+
+contains
+
+    function check_assumed_size_preserved() result(passed)
+        logical :: passed
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: output_code
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+
+        passed = .true.
+
+        call initialize_codegen()
+
+        source = &
+            "program test_assumed_size_array" // new_line('a') // &
+            "    implicit none" // new_line('a') // &
+            "    integer :: arr(5)" // new_line('a') // &
+            "    arr = [1, 2, 3, 4, 5]" // new_line('a') // &
+            "    call print_array(arr, 5)" // new_line('a') // &
+            "contains" // new_line('a') // &
+            "    subroutine print_array(x, n)" // new_line('a') // &
+            "        integer, intent(in) :: n" // new_line('a') // &
+            "        integer, intent(in) :: x(*)" // new_line('a') // &
+            "        integer :: i" // new_line('a') // &
+            "        do i = 1, n" // new_line('a') // &
+            "            print *, x(i)" // new_line('a') // &
+            "        end do" // new_line('a') // &
+            "    end subroutine print_array" // new_line('a') // &
+            "end program test_assumed_size_array"
+
+        call lex_source(source, tokens, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: lexing error:", trim(error_msg)
+            passed = .false.
+            return
+        end if
+
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, "FAIL: parsing error:", trim(error_msg)
+            passed = .false.
+            return
+        end if
+
+        call standardize_ast(arena, root_index)
+
+        output_code = codegen_core_generate_arena(arena, root_index)
+
+        if (index(output_code, "x(*)") <= 0) then
+            print *, "FAIL: assumed-size array x(*) not preserved"
+            print *, "Output:"
+            print *, trim(output_code)
+            passed = .false.
+            return
+        end if
+
+        if (index(output_code, "integer, intent(in) :: x(*)") <= 0) then
+            print *, "FAIL: full declaration not correct"
+            print *, "Output:"
+            print *, trim(output_code)
+            passed = .false.
+        end if
+
+    end function check_assumed_size_preserved
+
+end program test_issue_1818_assumed_size_array


### PR DESCRIPTION
## Summary
Fixes #1818 by correctly preserving assumed-size array dimension specifications `x(*)` in dummy arguments.

## Problem
When fortfront processed F90 code with assumed-size array dummy arguments `x(*)`, it incorrectly converted them to scalar variables, causing rank mismatch compilation errors.

**Input:**
```fortran
subroutine print_array(x, n)
    integer, intent(in) :: n
    integer, intent(in) :: x(*)
    integer :: i
    do i = 1, n
        print *, x(i)
    end do
end subroutine print_array
```

**Before (incorrect):**
```fortran
subroutine print_array(x, n)
    implicit none
    integer, intent(in) :: n
    integer, intent(in) :: x
    integer :: i
    do i = 1, n
        print *, x(i)
    end do
end subroutine print_array
```
Error: Rank mismatch in argument 'x' at (1) (scalar and rank-1)

## Solution
Modified the parser to recognize `*` as an assumed-size dimension specifier:
- Added detection in `parse_range` function to create `array_bounds_node` with `is_assumed_size = .true.`
- Created `push_assumed_size_bounds` factory function
- Codegen already handled `is_assumed_size` correctly (outputs `*`)

## Verification

### Test Output
```fortran
subroutine print_array(x, n)
    implicit none
    integer, intent(in) :: n
    integer, intent(in) :: x(*)
    integer :: i
    do i = 1, n
        print *, x(i)
    end do
end subroutine print_array
```

### Compilation and Execution
```bash
$ fpm run fortfront -- /tmp/test_assumed_size_array.f90 > /tmp/output.f90
$ gfortran /tmp/output.f90 -o /tmp/test.exe
$ /tmp/test.exe
           1
           2
           3
           4
           5
```

### Test Suite
- Added `test_issue_1818_assumed_size_array.f90` integration test
- All existing tests pass (0 failures)
- New test validates assumed-size array preservation

## Changes
- `src/parser/parser_expressions.f90`: Added `*` detection in `parse_range`
- `src/ast/factory/ast_factory_arrays.f90`: Added `push_assumed_size_bounds`
- `src/ast/factory/ast_factory.f90`: Exported new function
- `test/integration/issue_tests/test_issue_1818_assumed_size_array.f90`: New test