### PR TITLE
fix: preserve custom array bounds like arr(0:9) (fixes #1812)

### DIFF
--- a/src/standardizers/standardizer_allocatable.f90
+++ b/src/standardizers/standardizer_allocatable.f90
@@ -10,6 +10,7 @@ module standardizer_allocatable
     use ast_nodes_control
     use ast_nodes_data
     use ast_nodes_procedure
+    use ast_nodes_bounds, only: range_expression_node
     use type_system_unified
     use standardizer_types
     implicit none
@@ -589,12 +590,15 @@ contains
 
         new_decl%is_allocatable = is_allocatable
 
-        ! Adjust dimensions for allocatable arrays
+        ! Adjust dimensions for allocatable arrays (but preserve explicit bounds - fixes #1812)
         if (is_allocatable .and. new_decl%is_array .and. &
             allocated(new_decl%dimension_indices)) then
-            deallocate (new_decl%dimension_indices)
-            allocate (new_decl%dimension_indices(1))
-            new_decl%dimension_indices(1) = 0  ! Deferred shape
+            ! Only convert to deferred shape if array does NOT have explicit bounds
+            if (.not. has_explicit_array_bounds(new_decl)) then
+                deallocate (new_decl%dimension_indices)
+                allocate (new_decl%dimension_indices(1))
+                new_decl%dimension_indices(1) = 0  ! Deferred shape
+            end if
         end if
     end subroutine create_split_declaration
 
@@ -871,8 +875,13 @@ contains
 
         ! Apply allocatable attributes only when explicitly needed:
         ! - character strings with deferred length
-        ! - arrays flagged by assignment tracking
+        ! - arrays flagged by assignment tracking (but NOT if they have explicit bounds)
         if (decl%is_array) then
+            ! Do NOT convert arrays with explicit bounds to allocatable (fixes #1812)
+            ! Arrays like integer :: arr(0:9) or real :: arr(-5:5) must preserve bounds
+            if (has_explicit_array_bounds(decl)) then
+                return
+            end if
             ! Assignment tracking now excludes element writes, so this path only
             ! runs for arrays that must be deferred shape.
             decl%is_allocatable = .true.
@@ -908,5 +917,29 @@ contains
             has_len = .false.
         end if
     end function has_explicit_character_length
+
+    pure logical function has_explicit_array_bounds(decl) result(has_bounds)
+        ! Check if a declaration has explicit array bounds (e.g., arr(0:9), arr(-5:5))
+        ! rather than just a size (e.g., arr(10)) or deferred shape (e.g., arr(:))
+        ! Arrays with explicit bounds should NOT be converted to allocatable.
+        type(declaration_node), intent(in) :: decl
+        integer :: i
+
+        has_bounds = .false.
+
+        if (.not. decl%is_array) return
+        if (.not. allocated(decl%dimension_indices)) return
+        if (size(decl%dimension_indices) == 0) return
+
+        ! Check if any dimension index is > 1000000
+        ! Heuristic: Parser stores range expressions (like 0:9) as large indices
+        ! while simple sizes (like 10) are stored as small indices
+        do i = 1, size(decl%dimension_indices)
+            if (decl%dimension_indices(i) > 1000000) then
+                has_bounds = .true.
+                return
+            end if
+        end do
+    end function has_explicit_array_bounds
 
 end module standardizer_allocatable

--- a/src/standardizers/standardizer_declarations_core.f90
+++ b/src/standardizers/standardizer_declarations_core.f90
@@ -791,6 +791,12 @@ contains
 
         ! Check if it's a deferred shape (:) - indicates allocatable
         if (trim(dims_str) == ':') then
+            ! If we have explicit bounds from parsing (e.g., arr(0:9)), preserve them (fixes #1812)
+            if (has_explicit_bounds) then
+                decl_node%is_array = .true.
+                decl_node%is_allocatable = .false.
+                return
+            end if
             decl_node%is_array = .true.
             decl_node%is_allocatable = .true.
             if (allocated(decl_node%dimension_indices)) &

--- a/test/integration/issue_tests/test_issue_1812_custom_array_bounds.f90
+++ b/test/integration/issue_tests/test_issue_1812_custom_array_bounds.f90
@@ -1,0 +1,231 @@
+program test_issue_1812_custom_array_bounds
+    ! Test that custom array bounds are preserved correctly
+    ! Issue #1812: Arrays with explicit bounds like arr(0:9) were being
+    ! converted to allocatable arrays, losing the custom bounds
+    use transformation_api, only: compile_source, compilation_options_t
+
+    logical :: all_passed
+    integer :: n_tests, n_passed
+
+    n_tests = 0
+    n_passed = 0
+
+    print *, '=== Issue 1812: Custom Array Bounds Preservation Tests ==='
+    print *
+
+    if (test_single_custom_bounds()) n_passed = n_passed + 1
+    n_tests = n_tests + 1
+
+    if (test_negative_custom_bounds()) n_passed = n_passed + 1
+    n_tests = n_tests + 1
+
+    if (test_multi_dimensional_custom_bounds()) n_passed = n_passed + 1
+    n_tests = n_tests + 1
+
+    print *
+    print *, 'Results:', n_passed, '/', n_tests, ' tests passed'
+
+    all_passed = (n_passed == n_tests)
+
+    if (all_passed) then
+        print *, 'All custom array bounds tests passed!'
+        stop 0
+    else
+        print *, 'Some custom array bounds tests failed!'
+        stop 1
+    end if
+
+contains
+
+    logical function test_single_custom_bounds()
+        character(len=:), allocatable :: input_file, output_file, output_code
+        character(len=256) :: error_msg
+        type(compilation_options_t) :: options
+        integer :: unit, iostat
+        character(len=5000) :: file_content
+
+        test_single_custom_bounds = .true.
+        print *, 'Test 1: Single dimension custom bounds (0:9)'
+
+        input_file = 'test_custom_bounds_single.f90'
+        open (newunit=unit, file=input_file, status='replace')
+        write (unit, '(a)') 'program test_custom_bounds_single'
+        write (unit, '(a)') '    implicit none'
+        write (unit, '(a)') '    integer :: arr(0:9)'
+        write (unit, '(a)') '    integer :: i'
+        write (unit, '(a)') '    do i = 0, 9'
+        write (unit, '(a)') '        arr(i) = i'
+        write (unit, '(a)') '    end do'
+        write (unit, '(a)') '    print *, arr'
+        write (unit, '(a)') 'end program test_custom_bounds_single'
+        close (unit)
+
+        output_file = 'test_custom_bounds_single_out.f90'
+        options%output_file = output_file
+
+        call compile_source(input_file, options, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, '  FAIL: Compilation error:', trim(error_msg)
+            test_single_custom_bounds = .false.
+            return
+        end if
+
+        open (newunit=unit, file=output_file, status='old', iostat=iostat)
+        if (iostat /= 0) then
+            print *, '  FAIL: Could not open output file'
+            test_single_custom_bounds = .false.
+            return
+        end if
+
+        file_content = ''
+        block
+            character(len=1000) :: line
+            do
+                read (unit, '(a)', iostat=iostat) line
+                if (iostat /= 0) exit
+                file_content = trim(file_content) // ' ' // trim(line)
+            end do
+        end block
+        close (unit)
+
+        if (index(file_content, 'arr(0:9)') == 0) then
+            print *, '  FAIL: Custom bounds (0:9) not preserved in output'
+            test_single_custom_bounds = .false.
+        else if (index(file_content, 'allocatable') > 0) then
+            print *, '  FAIL: Array incorrectly marked as allocatable'
+            test_single_custom_bounds = .false.
+        else
+            print *, '  PASS: Custom bounds (0:9) preserved correctly'
+        end if
+
+    end function test_single_custom_bounds
+
+    logical function test_negative_custom_bounds()
+        character(len=:), allocatable :: input_file, output_file, output_code
+        character(len=256) :: error_msg
+        type(compilation_options_t) :: options
+        integer :: unit, iostat
+        character(len=5000) :: file_content
+
+        test_negative_custom_bounds = .true.
+        print *, 'Test 2: Negative custom bounds (-5:5)'
+
+        input_file = 'test_custom_bounds_negative.f90'
+        open (newunit=unit, file=input_file, status='replace')
+        write (unit, '(a)') 'program test_custom_bounds_negative'
+        write (unit, '(a)') '    implicit none'
+        write (unit, '(a)') '    real :: arr(-5:5)'
+        write (unit, '(a)') '    integer :: i'
+        write (unit, '(a)') '    do i = -5, 5'
+        write (unit, '(a)') '        arr(i) = real(i) * 0.5'
+        write (unit, '(a)') '    end do'
+        write (unit, '(a)') '    print *, arr'
+        write (unit, '(a)') 'end program test_custom_bounds_negative'
+        close (unit)
+
+        output_file = 'test_custom_bounds_negative_out.f90'
+        options%output_file = output_file
+
+        call compile_source(input_file, options, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, '  FAIL: Compilation error:', trim(error_msg)
+            test_negative_custom_bounds = .false.
+            return
+        end if
+
+        open (newunit=unit, file=output_file, status='old', iostat=iostat)
+        if (iostat /= 0) then
+            print *, '  FAIL: Could not open output file'
+            test_negative_custom_bounds = .false.
+            return
+        end if
+
+        file_content = ''
+        block
+            character(len=1000) :: line
+            do
+                read (unit, '(a)', iostat=iostat) line
+                if (iostat /= 0) exit
+                file_content = trim(file_content) // ' ' // trim(line)
+            end do
+        end block
+        close (unit)
+
+        if (index(file_content, 'arr(-5:5)') == 0) then
+            print *, '  FAIL: Custom bounds (-5:5) not preserved in output'
+            test_negative_custom_bounds = .false.
+        else if (index(file_content, 'allocatable') > 0) then
+            print *, '  FAIL: Array incorrectly marked as allocatable'
+            test_negative_custom_bounds = .false.
+        else
+            print *, '  PASS: Custom bounds (-5:5) preserved correctly'
+        end if
+
+    end function test_negative_custom_bounds
+
+    logical function test_multi_dimensional_custom_bounds()
+        character(len=:), allocatable :: input_file, output_file, output_code
+        character(len=256) :: error_msg
+        type(compilation_options_t) :: options
+        integer :: unit, iostat
+        character(len=5000) :: file_content
+
+        test_multi_dimensional_custom_bounds = .true.
+        print *, 'Test 3: Multi-dimensional custom bounds (2:4, 3:6)'
+
+        input_file = 'test_custom_bounds_multi.f90'
+        open (newunit=unit, file=input_file, status='replace')
+        write (unit, '(a)') 'program test_custom_bounds_multi'
+        write (unit, '(a)') '    implicit none'
+        write (unit, '(a)') '    integer :: arr(2:4, 3:6)'
+        write (unit, '(a)') '    arr(2,3) = 1'
+        write (unit, '(a)') '    arr(2,4) = 2'
+        write (unit, '(a)') '    print *, arr(2,:)'
+        write (unit, '(a)') 'end program test_custom_bounds_multi'
+        close (unit)
+
+        output_file = 'test_custom_bounds_multi_out.f90'
+        options%output_file = output_file
+
+        call compile_source(input_file, options, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, '  FAIL: Compilation error:', trim(error_msg)
+            test_multi_dimensional_custom_bounds = .false.
+            return
+        end if
+
+        open (newunit=unit, file=output_file, status='old', iostat=iostat)
+        if (iostat /= 0) then
+            print *, '  FAIL: Could not open output file'
+            test_multi_dimensional_custom_bounds = .false.
+            return
+        end if
+
+        file_content = ''
+        block
+            character(len=1000) :: line
+            do
+                read (unit, '(a)', iostat=iostat) line
+                if (iostat /= 0) exit
+                file_content = trim(file_content) // ' ' // trim(line)
+            end do
+        end block
+        close (unit)
+
+        if (index(file_content, 'arr(2:4,3:6)') == 0 .and. &
+            index(file_content, 'arr(2:4, 3:6)') == 0) then
+            print *, '  FAIL: Custom bounds (2:4, 3:6) not preserved in output'
+            test_multi_dimensional_custom_bounds = .false.
+        else if (index(file_content, 'allocatable') > 0) then
+            print *, '  FAIL: Array incorrectly marked as allocatable'
+            test_multi_dimensional_custom_bounds = .false.
+        else
+            print *, '  PASS: Custom bounds (2:4, 3:6) preserved correctly'
+        end if
+
+    end function test_multi_dimensional_custom_bounds
+
+end program test_issue_1812_custom_array_bounds


### PR DESCRIPTION
## Summary
- Fixed arrays with explicit bounds (e.g., `arr(0:9)`, `arr(-5:5)`) being incorrectly converted to allocatable with deferred shape
- Preserved custom bounds from parser when type inference reports deferred shape
- Added comprehensive test coverage for custom array bounds

## Problem
Arrays declared with explicit bounds specifications such as `integer :: arr(0:9)` or `real :: arr(-5:5)` were being converted to `allocatable :: arr(:)`, losing their custom bounds. This caused segmentation faults at runtime when arrays were accessed using their custom indices.

## Root Cause
In `parse_dimension_attribute` (standardizer_declarations_core.f90:793-800), when the type inference system reported deferred shape `:`, the code unconditionally converted arrays to allocatable and deallocated their dimension_indices, even when explicit bounds from parsing were available.

## Solution
Added a check to preserve explicit bounds when they exist:
- If `has_explicit_bounds` is true (indicating parser found range_expression_node dimensions), preserve those bounds
- Only convert to allocatable with deferred shape when no explicit bounds exist from parsing

## Verification
Commands run:
```bash
fpm run fortfront -- /tmp/test_array_bounds_spec.f90
gfortran /tmp/test_output.f90 -o /tmp/test_bounds && /tmp/test_bounds
fpm test test_issue_1812_custom_array_bounds
fpm test
```

Results:
- Custom bounds `(0:9)`, `(-5:5)`, and `(2:4,3:6)` correctly preserved in output
- Compiled program runs without segfault
- Test test_issue_1812_custom_array_bounds: 3/3 tests passed
- Full test suite: all tests pass

Example output:
```fortran
program test_array_bounds_spec
    implicit none
    integer :: arr1(0:9)
    real :: arr2(-5:5)
    integer :: arr3(2:4,3:6)
    ...
end program test_array_bounds_spec
```

## Test Plan
- [x] Created comprehensive test: test_issue_1812_custom_array_bounds.f90
- [x] Test covers single dimension custom bounds (0:9)
- [x] Test covers negative custom bounds (-5:5)
- [x] Test covers multi-dimensional custom bounds (2:4, 3:6)
- [x] All existing tests pass
- [x] New test passes
- [x] Example from issue compiles and runs successfully