### PR TITLE
fix: preserve bind(c) attribute in interface procedure declarations (fixes #1817)

### DIFF
--- a/src/ast/factory/ast_factory_procedures.f90
+++ b/src/ast/factory/ast_factory_procedures.f90
@@ -20,7 +20,7 @@ contains
     ! Create function definition node and add to stack
     function push_function_def(arena, name, param_indices, return_type, body_indices, &
                                line, column, parent_index, result_variable, &
-                               is_recursive, prefix_keywords) result(func_index)
+                               is_recursive, prefix_keywords, bind_c_clause) result(func_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: name
         integer, intent(in), optional :: param_indices(:)
@@ -30,6 +30,7 @@ contains
         character(len=*), intent(in), optional :: result_variable
         logical, intent(in), optional :: is_recursive
         character(len=16), intent(in), optional :: prefix_keywords(:)
+        character(len=*), intent(in), optional :: bind_c_clause
         integer :: func_index
         type(function_def_node) :: func_def
 
@@ -39,6 +40,9 @@ contains
         if (present(is_recursive)) then
             func_def%is_recursive = is_recursive
         end if
+        if (present(bind_c_clause)) then
+            func_def%bind_c_clause = bind_c_clause
+        end if
         call arena%push(func_def, "function_def", parent_index)
         func_index = arena%size
     end function push_function_def
@@ -46,7 +50,7 @@ contains
     ! Create subroutine definition node and add to stack
     function push_subroutine_def(arena, name, param_indices, body_indices, &
                                  line, column, parent_index, is_recursive, &
-                                 prefix_keywords) result(sub_index)
+                                 prefix_keywords, bind_c_clause) result(sub_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: name
         integer, intent(in), optional :: param_indices(:)
@@ -54,6 +58,7 @@ contains
         integer, intent(in), optional :: line, column, parent_index
         logical, intent(in), optional :: is_recursive
         character(len=16), intent(in), optional :: prefix_keywords(:)
+        character(len=*), intent(in), optional :: bind_c_clause
         integer :: sub_index
         type(subroutine_def_node) :: sub_def
 
@@ -77,6 +82,9 @@ contains
                 sub_def = create_subroutine_def(name, param_indices, body_indices, &
                                                 line, column)
             end if
+        end if
+        if (present(bind_c_clause)) then
+            sub_def%bind_c_clause = bind_c_clause
         end if
         call arena%push(sub_def, "subroutine_def", parent_index)
         sub_index = arena%size

--- a/src/ast/nodes/ast_nodes_procedure.f90
+++ b/src/ast/nodes/ast_nodes_procedure.f90
@@ -25,6 +25,7 @@ module ast_nodes_procedure
         character(len=16), allocatable :: prefix_keywords(:)
         integer, allocatable :: body_indices(:)
         logical :: is_recursive = .false.
+        character(len=:), allocatable :: bind_c_clause
     contains
         procedure :: accept => function_def_accept
         procedure :: to_json => function_def_to_json
@@ -39,6 +40,7 @@ module ast_nodes_procedure
         character(len=16), allocatable :: prefix_keywords(:)
         integer, allocatable :: body_indices(:)
         logical :: is_recursive = .false.
+        character(len=:), allocatable :: bind_c_clause
     contains
         procedure :: accept => subroutine_def_accept
         procedure :: to_json => subroutine_def_to_json
@@ -114,6 +116,7 @@ contains
         if (allocated(rhs%prefix_keywords)) lhs%prefix_keywords = rhs%prefix_keywords
         if (allocated(rhs%param_indices)) lhs%param_indices = rhs%param_indices
         if (allocated(rhs%body_indices)) lhs%body_indices = rhs%body_indices
+        if (allocated(rhs%bind_c_clause)) lhs%bind_c_clause = rhs%bind_c_clause
     end subroutine function_def_assign
 
     ! Implementation for subroutine_def_node
@@ -163,6 +166,7 @@ contains
         if (allocated(rhs%prefix_keywords)) lhs%prefix_keywords = rhs%prefix_keywords
         if (allocated(rhs%body_indices)) lhs%body_indices = rhs%body_indices
         lhs%is_recursive = rhs%is_recursive
+        if (allocated(rhs%bind_c_clause)) lhs%bind_c_clause = rhs%bind_c_clause
     end subroutine subroutine_def_assign
 
     ! Implementation for subroutine_call_node

--- a/src/codegen/codegen_declarations_procedures.f90
+++ b/src/codegen/codegen_declarations_procedures.f90
@@ -80,6 +80,11 @@ contains
         end if
 
         signature = signature // params_clause // result_clause
+        if (allocated(node%bind_c_clause)) then
+            if (len_trim(node%bind_c_clause) > 0) then
+                signature = signature // " " // trim(node%bind_c_clause)
+            end if
+        end if
     end function compose_function_signature
 
     function gather_function_prefix(node, recursive_in_prefix) result(prefix)
@@ -337,6 +342,11 @@ contains
             signature = trim(prefix) // " subroutine " // node%name // params_clause
         else
             signature = "subroutine " // node%name // params_clause
+        end if
+        if (allocated(node%bind_c_clause)) then
+            if (len_trim(node%bind_c_clause) > 0) then
+                signature = signature // " " // trim(node%bind_c_clause)
+            end if
         end if
     end function compose_subroutine_signature
 

--- a/src/parser/parser_procedure_definitions.f90
+++ b/src/parser/parser_procedure_definitions.f90
@@ -7,7 +7,7 @@ module parser_procedure_definitions_module
         parse_function_prefix_keywords, parse_function_signature, &
         parse_function_result_clause, parse_parameter_list, &
         merge_parameter_attributes_if_needed, ensure_recursive_prefix, &
-        parse_subroutine_header
+        parse_subroutine_header, parse_bind_c_clause
     use parser_procedure_definition_bodies_module, only: parse_procedure_body
     use parser_interface_blocks_module, only: parse_interface_block, &
                                               set_interface_procedure_parser
@@ -62,7 +62,7 @@ contains
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         integer :: sub_index
 
-        character(len=:), allocatable :: subroutine_name
+        character(len=:), allocatable :: subroutine_name, bind_c_clause
         integer :: line, column
         integer, allocatable :: param_indices(:), body_indices(:)
         character(len=16), allocatable :: prefix_keywords(:)
@@ -77,6 +77,7 @@ contains
                                             has_recursive_keyword=has_recursive_keyword)
         call parse_subroutine_header(parser, subroutine_name, line, column)
         call parse_parameter_list(parser, arena, param_indices)
+        call parse_bind_c_clause(parser, bind_c_clause)
         call parse_procedure_body(parser, arena, subroutine_name, "subroutine", &
                                   body_indices, infer_recursive_from_body, &
                                   parse_function_proc=parse_function_definition, &
@@ -88,7 +89,8 @@ contains
         sub_index = push_subroutine_def(arena, subroutine_name, param_indices, &
                                         body_indices, line, column, &
                                         is_recursive=has_recursive_keyword, &
-                                        prefix_keywords=prefix_keywords)
+                                        prefix_keywords=prefix_keywords, &
+                                        bind_c_clause=bind_c_clause)
     end function parse_interface_subroutine
 
     function parse_interface_function(parser, arena, prefix_buffer) &
@@ -100,7 +102,7 @@ contains
 
         character(len=:), allocatable :: function_name, return_type_str, &
                                          result_variable_name, &
-                                         return_type_from_prefix
+                                         return_type_from_prefix, bind_c_clause
         integer :: line, column
         integer, allocatable :: param_indices(:), body_indices(:)
         logical :: has_recursive_keyword, is_valid, infer_recursive_from_body
@@ -125,6 +127,7 @@ contains
 
         call parse_parameter_list(parser, arena, param_indices)
         call parse_function_result_clause(parser, result_variable_name)
+        call parse_bind_c_clause(parser, bind_c_clause)
         call parse_procedure_body(parser, arena, function_name, "function", &
                                   body_indices, infer_recursive_from_body, &
                                   parse_function_proc=parse_function_definition, &
@@ -138,7 +141,8 @@ contains
                                        line, column, &
                                        result_variable=result_variable_name, &
                                        is_recursive=has_recursive_keyword, &
-                                       prefix_keywords=prefix_keywords)
+                                       prefix_keywords=prefix_keywords, &
+                                       bind_c_clause=bind_c_clause)
     end function parse_interface_function
 
     function parse_function_definition(parser, arena, prefix_buffer, prefix_list) &

--- a/src/parser/parser_procedure_signatures.f90
+++ b/src/parser/parser_procedure_signatures.f90
@@ -1,6 +1,7 @@
 module parser_procedure_signatures_module
     use string_utils_mod, only: to_lower
-    use lexer_core, only: token_t, TK_IDENTIFIER, TK_KEYWORD, TK_OPERATOR
+    use lexer_core, only: token_t, TK_IDENTIFIER, TK_KEYWORD, TK_OPERATOR, &
+                          TK_NEWLINE, TK_WHITESPACE, TK_STRING
     use parser_state_module, only: parser_state_t
     use parser_parameter_handling_module, only: parse_typed_parameters, &
                                                 merge_parameter_attributes
@@ -18,6 +19,7 @@ module parser_procedure_signatures_module
     public :: merge_parameter_attributes_if_needed
     public :: ensure_recursive_prefix
     public :: parse_subroutine_header
+    public :: parse_bind_c_clause
 
 contains
 
@@ -293,5 +295,74 @@ contains
             subroutine_name = "unnamed_subroutine"
         end if
     end subroutine parse_subroutine_header
+
+    subroutine parse_bind_c_clause(parser, bind_c_clause)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=:), allocatable, intent(out) :: bind_c_clause
+
+        type(token_t) :: token
+        character(len=:), allocatable :: lowered_text
+        character(len=:), allocatable :: clause_text
+
+        bind_c_clause = ""
+        token = parser%peek()
+
+        if (token%kind /= TK_IDENTIFIER .and. token%kind /= TK_KEYWORD) return
+        lowered_text = to_lower(token%text)
+        if (trim(lowered_text) /= "bind") return
+
+        clause_text = "bind"
+        token = parser%consume()
+
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. token%text == "(") then
+            clause_text = trim(clause_text)//"("
+            token = parser%consume()
+
+            token = parser%peek()
+            if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
+                clause_text = trim(clause_text)//trim(token%text)
+                token = parser%consume()
+
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                    clause_text = trim(clause_text)//","
+                    token = parser%consume()
+
+                    token = parser%peek()
+                    if (token%kind == TK_WHITESPACE) then
+                        clause_text = trim(clause_text)//" "
+                        token = parser%consume()
+                    end if
+
+                    token = parser%peek()
+                    if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
+                        clause_text = trim(clause_text)//trim(token%text)
+                        token = parser%consume()
+
+                        token = parser%peek()
+                        if (token%kind == TK_OPERATOR .and. token%text == "=") then
+                            clause_text = trim(clause_text)//"="
+                            token = parser%consume()
+
+                            token = parser%peek()
+                            if (token%kind == TK_STRING) then
+                                clause_text = trim(clause_text)//trim(token%text)
+                                token = parser%consume()
+                            end if
+                        end if
+                    end if
+                end if
+            end if
+
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                clause_text = trim(clause_text)//")"
+                token = parser%consume()
+            end if
+        end if
+
+        bind_c_clause = clause_text
+    end subroutine parse_bind_c_clause
 
 end module parser_procedure_signatures_module

--- a/test/codegen/test_issue_1817_bind_c_attribute.f90
+++ b/test/codegen/test_issue_1817_bind_c_attribute.f90
@@ -1,0 +1,74 @@
+program test_issue_1817_bind_c_attribute
+    use transformation_api, only: compile_source, compilation_options_t
+
+    character(len=:), allocatable :: input_file, output_file
+    character(len=256) :: error_msg
+    type(compilation_options_t) :: options
+    integer :: unit, io_status
+    logical :: found_bind_c_subroutine, found_bind_c_function
+    character(len=256) :: line
+
+    found_bind_c_subroutine = .false.
+    found_bind_c_function = .false.
+
+    input_file = 'test_issue_1817_input.f90'
+    output_file = 'test_issue_1817_output.f90'
+
+    open (newunit=unit, file=input_file, status='replace')
+    write (unit, '(a)') 'program test_bind_c'
+    write (unit, '(a)') '    use iso_c_binding'
+    write (unit, '(a)') '    implicit none'
+    write (unit, '(a)') '    '
+    write (unit, '(a)') '    interface'
+    write (unit, '(a)') '        subroutine c_func(x) bind(c, name="c_func")'
+    write (unit, '(a)') '            import :: c_int'
+    write (unit, '(a)') '            integer(c_int), value :: x'
+    write (unit, '(a)') '        end subroutine c_func'
+    write (unit, '(a)') '        '
+    write (unit, '(a)') '        function c_add(a, b) result(c) bind(c)'
+    write (unit, '(a)') '            import :: c_int'
+    write (unit, '(a)') '            integer(c_int), value :: a, b'
+    write (unit, '(a)') '            integer(c_int) :: c'
+    write (unit, '(a)') '        end function c_add'
+    write (unit, '(a)') '    end interface'
+    write (unit, '(a)') '    '
+    write (unit, '(a)') '    print *, "Testing bind(c)"'
+    write (unit, '(a)') 'end program test_bind_c'
+    close (unit)
+
+    options%output_file = output_file
+
+    call compile_source(input_file, options, error_msg)
+    if (len_trim(error_msg) /= 0) then
+        print *, 'Compiler reported error: ', trim(error_msg)
+        stop 1
+    end if
+
+    open (newunit=unit, file=output_file, status='old', action='read')
+    do
+        read (unit, '(a)', iostat=io_status) line
+        if (io_status /= 0) exit
+
+        if (index(line, 'bind(c') > 0 .and. index(line, 'name="c_func"') > 0 .and. &
+            index(line, 'subroutine c_func') > 0) then
+            found_bind_c_subroutine = .true.
+        end if
+        if (index(line, 'bind(c)') > 0 .and. index(line, 'function c_add') > 0) then
+            found_bind_c_function = .true.
+        end if
+    end do
+    close (unit)
+
+    if (.not. found_bind_c_subroutine) then
+        print *, 'FAIL: bind(c, name=...) not found in subroutine definition'
+        stop 1
+    end if
+
+    if (.not. found_bind_c_function) then
+        print *, 'FAIL: bind(c) not found in function definition'
+        stop 1
+    end if
+
+    print *, 'PASS: bind(c) attributes preserved correctly'
+    stop 0
+end program test_issue_1817_bind_c_attribute


### PR DESCRIPTION
## Summary
Fixes bind(c) attribute mangling in interface procedure declarations

## Changes
- Added bind_c_clause field to AST procedure nodes
- Implemented parse_bind_c_clause parser for bind(c) syntax
- Updated codegen to emit bind(c) attributes correctly
- Added test case covering both bind(c) and bind(c, name="...") forms

## Verification
Test command:
```bash
./build/gfortran_*/app/fortfront /tmp/test_bind_c.f90
```

Input from issue:
```fortran
interface
    subroutine c_func(x) bind(c, name="c_func")
        import :: c_int
        integer(c_int), value :: x
    end subroutine c_func
end interface
```

Output after fix:
```fortran
interface
    subroutine c_func(x) bind(c,name="c_func")
    import :: c_int 
    implicit none
    real :: x
    integer(c_int) :: value
end subroutine c_func
end interface
```

The bind(c) attribute is now correctly preserved. Note: The value attribute and type issues are separate bugs not addressed by this PR.

Test suite: All tests pass
