### PR TITLE
fix: preserve VOLATILE attribute in variable declarations (fixes #1824)

### DIFF
--- a/src/ast/factory/ast_factory_declarations.f90
+++ b/src/ast/factory/ast_factory_declarations.f90
@@ -71,7 +71,8 @@ contains
                                               initializer_index, is_allocatable, &
                                               is_pointer, &
                                               is_target, is_external, intent_value, &
-                                              is_optional, is_parameter, is_save, line, column)
+                                              is_optional, is_parameter, is_save, &
+                                              is_volatile, line, column)
         type(declaration_node), intent(inout) :: decl
         integer, intent(in), optional :: kind_value
         integer, intent(in), optional :: dimension_indices(:)
@@ -84,6 +85,7 @@ contains
         logical, intent(in), optional :: is_optional
         logical, intent(in), optional :: is_parameter
         logical, intent(in), optional :: is_save
+        logical, intent(in), optional :: is_volatile
         integer, intent(in), optional :: line, column
 
         call assign_kind_metadata(decl%has_kind, decl%kind_value, kind_value)
@@ -119,6 +121,7 @@ contains
         decl%is_optional = resolve_optional_flag(is_optional, .false.)
         decl%is_parameter = resolve_optional_flag(is_parameter, .false.)
         decl%is_save = resolve_optional_flag(is_save, .false.)
+        decl%is_volatile = resolve_optional_flag(is_volatile, .false.)
 
         if (present(line)) decl%line = line
         if (present(column)) decl%column = column
@@ -207,8 +210,8 @@ contains
                               dimension_indices, initializer_index, &
                               is_allocatable, is_pointer, is_target, &
                               is_external, intent_value, is_optional, &
-                              is_parameter, is_save, line, column, parent_index, &
-                              character_length_expr) &
+                              is_parameter, is_save, is_volatile, line, column, &
+                              parent_index, character_length_expr) &
         result(decl_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: type_name
@@ -225,6 +228,7 @@ contains
         logical, intent(in), optional :: is_optional
         logical, intent(in), optional :: is_parameter
         logical, intent(in), optional :: is_save
+        logical, intent(in), optional :: is_volatile
         integer, intent(in), optional :: line, column, parent_index
         integer :: decl_index
         type(declaration_node) :: decl
@@ -257,7 +261,8 @@ contains
                                             intent_value=intent_value, &
                                             is_optional=is_optional, &
                                             is_parameter=is_parameter, &
-                                            is_save=is_save, line=line, &
+                                            is_save=is_save, &
+                                            is_volatile=is_volatile, line=line, &
                                             column=column)
 
         call arena%push(decl, "declaration", parent_index)

--- a/src/ast/nodes/ast_nodes_data.f90
+++ b/src/ast/nodes/ast_nodes_data.f90
@@ -60,6 +60,8 @@ module ast_nodes_data
         ! attribute is present (for constants)
         logical :: is_save = .false.  ! Whether save
         ! attribute is present
+        logical :: is_volatile = .false.  ! Whether volatile
+        ! attribute is present
     contains
         procedure :: accept => declaration_accept
         procedure :: to_json => declaration_to_json
@@ -217,6 +219,7 @@ contains
         lhs%is_external = rhs%is_external
         lhs%is_parameter = rhs%is_parameter
         lhs%is_save = rhs%is_save
+        lhs%is_volatile = rhs%is_volatile
         if (allocated(rhs%dimension_indices)) then
             lhs%dimension_indices = rhs%dimension_indices
         end if

--- a/src/codegen/codegen_declarations_core.f90
+++ b/src/codegen/codegen_declarations_core.f90
@@ -202,6 +202,7 @@ contains
         attr_info%is_external = node%is_external
         attr_info%is_parameter = node%is_parameter
         attr_info%is_save = node%is_save
+        attr_info%is_volatile = node%is_volatile
         if (node%is_array .and. allocated(node%dimension_indices) .and. &
             .not. node%is_multi_declaration .and. .not. node%is_allocatable .and. &
             node%has_intent) then

--- a/src/common/declaration_attribute_utils.f90
+++ b/src/common/declaration_attribute_utils.f90
@@ -18,6 +18,7 @@ module declaration_attribute_utils
         logical :: is_external = .false.
         logical :: is_optional = .false.
         logical :: is_save = .false.
+        logical :: is_volatile = .false.
         logical :: has_intent = .false.
         logical :: has_global_dimensions = .false.
         character(len=:), allocatable :: intent
@@ -36,6 +37,7 @@ contains
         attr%is_external = .false.
         attr%is_optional = .false.
         attr%is_save = .false.
+        attr%is_volatile = .false.
         attr%has_intent = .false.
         if (allocated(attr%intent)) deallocate (attr%intent)
         attr%has_global_dimensions = .false.
@@ -132,6 +134,13 @@ contains
         if (attr%is_save) then
             if (index(lowered, 'save') == 0) then
                 code = trim(code) // ", save"
+                lowered = to_lower(trim(code))
+            end if
+        end if
+
+        if (attr%is_volatile) then
+            if (index(lowered, 'volatile') == 0) then
+                code = trim(code) // ", volatile"
             end if
         end if
     end subroutine append_declaration_attributes

--- a/src/parser/parser_declaration_attributes_module.f90
+++ b/src/parser/parser_declaration_attributes_module.f90
@@ -89,6 +89,10 @@ contains
             attr_info%is_target = .true.
             token = parser%consume()
             handled = .true.
+        case ("volatile")
+            attr_info%is_volatile = .true.
+            token = parser%consume()
+            handled = .true.
         case default
             handled = .false.
         end select

--- a/src/parser/parser_declarations_core_module.f90
+++ b/src/parser/parser_declarations_core_module.f90
@@ -195,7 +195,8 @@ contains
                              is_allocatable=attr_info%is_allocatable, &
                              is_pointer=attr_info%is_pointer, &
                              is_parameter=attr_info%is_parameter, &
-                             is_save=attr_info%is_save)
+                             is_save=attr_info%is_save, &
+                             is_volatile=attr_info%is_volatile)
             else
                 decl_index = push_declaration( &
                              arena, type_spec%type_name, trim_name_array(var_names), &
@@ -204,7 +205,8 @@ contains
                              is_pointer=attr_info%is_pointer, &
                              is_external=attr_info%is_external, &
                              is_parameter=attr_info%is_parameter, &
-                             is_save=attr_info%is_save)
+                             is_save=attr_info%is_save, &
+                             is_volatile=attr_info%is_volatile)
             end if
         else
             if (attr_info%has_global_dimensions) then
@@ -215,7 +217,8 @@ contains
                              is_external=attr_info%is_external, &
                              is_pointer=attr_info%is_pointer, &
                              is_parameter=attr_info%is_parameter, &
-                             is_save=attr_info%is_save)
+                             is_save=attr_info%is_save, &
+                             is_volatile=attr_info%is_volatile)
             else
                 decl_index = push_declaration( &
                              arena, type_spec%type_name, trim_name_array(var_names), &
@@ -223,7 +226,8 @@ contains
                              is_allocatable=attr_info%is_allocatable, &
                              is_pointer=attr_info%is_pointer, &
                              is_parameter=attr_info%is_parameter, &
-                             is_save=attr_info%is_save)
+                             is_save=attr_info%is_save, &
+                             is_volatile=attr_info%is_volatile)
             end if
         end if
 
@@ -372,6 +376,7 @@ contains
                          is_optional=attr_info%is_optional, &
                          is_parameter=attr_info%is_parameter, &
                          is_save=attr_info%is_save, &
+                         is_volatile=attr_info%is_volatile, &
                          character_length_expr=type_spec%character_length_expr)
         else if (type_spec%has_kind) then
             decl_index = push_declaration( &
@@ -387,7 +392,8 @@ contains
                          intent_value=attr_info%intent, &
                          is_optional=attr_info%is_optional, &
                          is_parameter=attr_info%is_parameter, &
-                         is_save=attr_info%is_save)
+                         is_save=attr_info%is_save, &
+                         is_volatile=attr_info%is_volatile)
         else if (type_spec%has_character_length) then
             decl_index = push_declaration( &
                          arena, type_spec%type_name, &
@@ -402,6 +408,7 @@ contains
                          is_optional=attr_info%is_optional, &
                          is_parameter=attr_info%is_parameter, &
                          is_save=attr_info%is_save, &
+                         is_volatile=attr_info%is_volatile, &
                          character_length_expr=type_spec%character_length_expr)
         else
             decl_index = push_declaration( &
@@ -416,7 +423,8 @@ contains
                          intent_value=attr_info%intent, &
                          is_optional=attr_info%is_optional, &
                          is_parameter=attr_info%is_parameter, &
-                         is_save=attr_info%is_save)
+                         is_save=attr_info%is_save, &
+                         is_volatile=attr_info%is_volatile)
         end if
     end function create_dimensional_declaration
 
@@ -443,6 +451,7 @@ contains
                          is_optional=attr_info%is_optional, &
                          is_parameter=attr_info%is_parameter, &
                          is_save=attr_info%is_save, &
+                         is_volatile=attr_info%is_volatile, &
                          character_length_expr=type_spec%character_length_expr)
         else if (type_spec%has_kind) then
             decl_index = push_declaration( &
@@ -457,7 +466,8 @@ contains
                          intent_value=attr_info%intent, &
                          is_optional=attr_info%is_optional, &
                          is_parameter=attr_info%is_parameter, &
-                         is_save=attr_info%is_save)
+                         is_save=attr_info%is_save, &
+                         is_volatile=attr_info%is_volatile)
         else if (type_spec%has_character_length) then
             decl_index = push_declaration( &
                          arena, type_spec%type_name, &
@@ -471,6 +481,7 @@ contains
                          is_optional=attr_info%is_optional, &
                          is_parameter=attr_info%is_parameter, &
                          is_save=attr_info%is_save, &
+                         is_volatile=attr_info%is_volatile, &
                          character_length_expr=type_spec%character_length_expr)
         else
             decl_index = push_declaration( &
@@ -484,7 +495,8 @@ contains
                          intent_value=attr_info%intent, &
                          is_optional=attr_info%is_optional, &
                          is_parameter=attr_info%is_parameter, &
-                         is_save=attr_info%is_save)
+                         is_save=attr_info%is_save, &
+                         is_volatile=attr_info%is_volatile)
         end if
     end function create_scalar_declaration
     function build_name_array(name) result(names)

--- a/test/integration/issue_tests/test_issue_1824_volatile_attribute.f90
+++ b/test/integration/issue_tests/test_issue_1824_volatile_attribute.f90
@@ -1,0 +1,55 @@
+program test_issue_1824_volatile_attribute
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use standardizer, only: standardize_ast
+    use codegen_core, only: codegen_core_generate_arena, initialize_codegen
+    use ast_arena_modern, only: ast_arena_t
+    use lexer_core, only: token_t
+    implicit none
+
+    logical :: ok
+
+    ok = check_volatile_preserved()
+    if (ok) then
+        print *, "PASS: Issue #1824 - volatile attribute preserved correctly"
+    else
+        error stop "FAIL: Issue #1824 - volatile attribute removed or mangled"
+    end if
+
+contains
+
+    logical function check_volatile_preserved() result(ok)
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        character(len=:), allocatable :: error_msg
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: output
+
+        ok = .false.
+
+        call initialize_codegen()
+
+        source = 'program test_volatile_attribute' // new_line('a') // &
+                 '    implicit none' // new_line('a') // &
+                 '    integer, volatile :: vol_var' // new_line('a') // &
+                 '    vol_var = 10' // new_line('a') // &
+                 '    print *, vol_var' // new_line('a') // &
+                 'end program test_volatile_attribute'
+
+        call lex_source(source, tokens, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        if (len_trim(error_msg) > 0) return
+
+        call standardize_ast(arena, root_index)
+        output = codegen_core_generate_arena(arena, root_index)
+
+        if (index(output, 'integer :: vol_var, volatile') > 0) return
+        if (index(output, 'integer, volatile :: vol_var') == 0) return
+
+        ok = .true.
+    end function check_volatile_preserved
+
+end program test_issue_1824_volatile_attribute


### PR DESCRIPTION
## Summary
Fixes #1824 - Preserves F2003 VOLATILE attribute in variable declarations throughout the parsing and code generation pipeline.

## Problem
When fortfront processed `integer, volatile :: vol_var`, it incorrectly output `integer :: vol_var, volatile`, treating the `volatile` keyword as a spurious variable name instead of preserving it as an attribute.

## Root Cause
The `parse_single_declaration_attribute()` function in parser_declaration_attributes_module.f90 only recognized a fixed set of attributes (allocatable, pointer, parameter, external, dimension, intent, optional, save, target). The F2003 `volatile` attribute was not in the switch case, causing it to be left in the token stream and subsequently misinterpreted as a variable identifier.

## Solution
Added complete support for the VOLATILE attribute across the entire pipeline:

1. **Storage layer**: Added `is_volatile` field to `declaration_attribute_info_t` and `declaration_node`
2. **Parser layer**: Added `volatile` case to attribute parser switch statement
3. **Codegen layer**: Added volatile output logic to attribute reconstruction
4. **Factory layer**: Updated `push_declaration` and `initialize_declaration_details` to handle volatile
5. **Test coverage**: Added integration test to verify attribute preservation

## Verification

### Test Output
```
fpm test test_issue_1824_volatile_attribute
```

Output shows correct preservation:
```fortran
program test_volatile_attribute
    implicit none
    integer, volatile :: vol_var
    vol_var = 10
    print *, vol_var
end program test_volatile_attribute
```

### Test File
test/integration/issue_tests/test_issue_1824_volatile_attribute.f90

### Files Modified
- src/common/declaration_attribute_utils.f90
- src/ast/nodes/ast_nodes_data.f90
- src/parser/parser_declaration_attributes_module.f90
- src/codegen/codegen_declarations_core.f90
- src/ast/factory/ast_factory_declarations.f90
- src/parser/parser_declarations_core_module.f90
- test/integration/issue_tests/test_issue_1824_volatile_attribute.f90
