### PR TITLE
fix: preserve CONTIGUOUS attribute in variable declarations (fixes #1823)

### DIFF
--- a/src/ast/factory/ast_factory_declarations.f90
+++ b/src/ast/factory/ast_factory_declarations.f90
@@ -73,7 +73,8 @@ contains
                                               is_target, is_external, intent_value, &
                                               is_optional, is_parameter, is_save, &
                                               is_volatile, is_protected, &
-                                              is_asynchronous, line, column)
+                                              is_asynchronous, is_contiguous, &
+                                              line, column)
         type(declaration_node), intent(inout) :: decl
         integer, intent(in), optional :: kind_value
         integer, intent(in), optional :: dimension_indices(:)
@@ -89,6 +90,7 @@ contains
         logical, intent(in), optional :: is_volatile
         logical, intent(in), optional :: is_protected
         logical, intent(in), optional :: is_asynchronous
+        logical, intent(in), optional :: is_contiguous
         integer, intent(in), optional :: line, column
 
         call assign_kind_metadata(decl%has_kind, decl%kind_value, kind_value)
@@ -127,6 +129,7 @@ contains
         decl%is_volatile = resolve_optional_flag(is_volatile, .false.)
         decl%is_protected = resolve_optional_flag(is_protected, .false.)
         decl%is_asynchronous = resolve_optional_flag(is_asynchronous, .false.)
+        decl%is_contiguous = resolve_optional_flag(is_contiguous, .false.)
 
         if (present(line)) decl%line = line
         if (present(column)) decl%column = column
@@ -216,8 +219,8 @@ contains
                               is_allocatable, is_pointer, is_target, &
                               is_external, intent_value, is_optional, &
                               is_parameter, is_save, is_volatile, is_protected, &
-                              is_asynchronous, line, column, parent_index, &
-                              character_length_expr) &
+                              is_asynchronous, is_contiguous, line, column, &
+                              parent_index, character_length_expr) &
         result(decl_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: type_name
@@ -237,6 +240,7 @@ contains
         logical, intent(in), optional :: is_volatile
         logical, intent(in), optional :: is_protected
         logical, intent(in), optional :: is_asynchronous
+        logical, intent(in), optional :: is_contiguous
         integer, intent(in), optional :: line, column, parent_index
         integer :: decl_index
         type(declaration_node) :: decl
@@ -272,7 +276,8 @@ contains
                                             is_save=is_save, &
                                             is_volatile=is_volatile, &
                                             is_protected=is_protected, &
-                                            is_asynchronous=is_asynchronous, line=line, &
+                                            is_asynchronous=is_asynchronous, &
+                                            is_contiguous=is_contiguous, line=line, &
                                             column=column)
 
         call arena%push(decl, "declaration", parent_index)

--- a/src/ast/nodes/ast_nodes_data.f90
+++ b/src/ast/nodes/ast_nodes_data.f90
@@ -66,6 +66,8 @@ module ast_nodes_data
         ! attribute is present
         logical :: is_asynchronous = .false.  ! Whether asynchronous
         ! attribute is present
+        logical :: is_contiguous = .false.  ! Whether contiguous
+        ! attribute is present
     contains
         procedure :: accept => declaration_accept
         procedure :: to_json => declaration_to_json
@@ -226,6 +228,7 @@ contains
         lhs%is_volatile = rhs%is_volatile
         lhs%is_protected = rhs%is_protected
         lhs%is_asynchronous = rhs%is_asynchronous
+        lhs%is_contiguous = rhs%is_contiguous
         if (allocated(rhs%dimension_indices)) then
             lhs%dimension_indices = rhs%dimension_indices
         end if

--- a/src/codegen/codegen_declarations_core.f90
+++ b/src/codegen/codegen_declarations_core.f90
@@ -205,6 +205,7 @@ contains
         attr_info%is_volatile = node%is_volatile
         attr_info%is_protected = node%is_protected
         attr_info%is_asynchronous = node%is_asynchronous
+        attr_info%is_contiguous = node%is_contiguous
         if (node%is_array .and. allocated(node%dimension_indices) .and. &
             .not. node%is_multi_declaration .and. .not. node%is_allocatable .and. &
             node%has_intent) then

--- a/src/common/declaration_attribute_utils.f90
+++ b/src/common/declaration_attribute_utils.f90
@@ -21,6 +21,7 @@ module declaration_attribute_utils
         logical :: is_volatile = .false.
         logical :: is_protected = .false.
         logical :: is_asynchronous = .false.
+        logical :: is_contiguous = .false.
         logical :: has_intent = .false.
         logical :: has_global_dimensions = .false.
         character(len=:), allocatable :: intent
@@ -42,6 +43,7 @@ contains
         attr%is_volatile = .false.
         attr%is_protected = .false.
         attr%is_asynchronous = .false.
+        attr%is_contiguous = .false.
         attr%has_intent = .false.
         if (allocated(attr%intent)) deallocate (attr%intent)
         attr%has_global_dimensions = .false.
@@ -159,6 +161,13 @@ contains
         if (attr%is_asynchronous) then
             if (index(lowered, 'asynchronous') == 0) then
                 code = trim(code) // ", asynchronous"
+                lowered = to_lower(trim(code))
+            end if
+        end if
+
+        if (attr%is_contiguous) then
+            if (index(lowered, 'contiguous') == 0) then
+                code = trim(code) // ", contiguous"
             end if
         end if
     end subroutine append_declaration_attributes

--- a/src/parser/parser_declaration_attributes_module.f90
+++ b/src/parser/parser_declaration_attributes_module.f90
@@ -101,6 +101,10 @@ contains
             attr_info%is_asynchronous = .true.
             token = parser%consume()
             handled = .true.
+        case ("contiguous")
+            attr_info%is_contiguous = .true.
+            token = parser%consume()
+            handled = .true.
         case default
             handled = .false.
         end select

--- a/src/parser/parser_declarations_core_module.f90
+++ b/src/parser/parser_declarations_core_module.f90
@@ -198,7 +198,8 @@ contains
                              is_save=attr_info%is_save, &
                              is_volatile=attr_info%is_volatile, &
                              is_protected=attr_info%is_protected, &
-                             is_asynchronous=attr_info%is_asynchronous)
+                             is_asynchronous=attr_info%is_asynchronous, &
+                             is_contiguous=attr_info%is_contiguous)
             else
                 decl_index = push_declaration( &
                              arena, type_spec%type_name, trim_name_array(var_names), &
@@ -210,7 +211,8 @@ contains
                              is_save=attr_info%is_save, &
                              is_volatile=attr_info%is_volatile, &
                              is_protected=attr_info%is_protected, &
-                             is_asynchronous=attr_info%is_asynchronous)
+                             is_asynchronous=attr_info%is_asynchronous, &
+                             is_contiguous=attr_info%is_contiguous)
             end if
         else
             if (attr_info%has_global_dimensions) then
@@ -224,7 +226,8 @@ contains
                              is_save=attr_info%is_save, &
                              is_volatile=attr_info%is_volatile, &
                              is_protected=attr_info%is_protected, &
-                             is_asynchronous=attr_info%is_asynchronous)
+                             is_asynchronous=attr_info%is_asynchronous, &
+                             is_contiguous=attr_info%is_contiguous)
             else
                 decl_index = push_declaration( &
                              arena, type_spec%type_name, trim_name_array(var_names), &
@@ -235,7 +238,8 @@ contains
                              is_save=attr_info%is_save, &
                              is_volatile=attr_info%is_volatile, &
                              is_protected=attr_info%is_protected, &
-                             is_asynchronous=attr_info%is_asynchronous)
+                             is_asynchronous=attr_info%is_asynchronous, &
+                             is_contiguous=attr_info%is_contiguous)
             end if
         end if
 
@@ -387,6 +391,7 @@ contains
                          is_volatile=attr_info%is_volatile, &
                          is_protected=attr_info%is_protected, &
                          is_asynchronous=attr_info%is_asynchronous, &
+                         is_contiguous=attr_info%is_contiguous, &
                          character_length_expr=type_spec%character_length_expr)
         else if (type_spec%has_kind) then
             decl_index = push_declaration( &
@@ -405,7 +410,8 @@ contains
                          is_save=attr_info%is_save, &
                          is_volatile=attr_info%is_volatile, &
                          is_protected=attr_info%is_protected, &
-                         is_asynchronous=attr_info%is_asynchronous)
+                         is_asynchronous=attr_info%is_asynchronous, &
+                         is_contiguous=attr_info%is_contiguous)
         else if (type_spec%has_character_length) then
             decl_index = push_declaration( &
                          arena, type_spec%type_name, &
@@ -423,6 +429,7 @@ contains
                          is_volatile=attr_info%is_volatile, &
                          is_protected=attr_info%is_protected, &
                          is_asynchronous=attr_info%is_asynchronous, &
+                         is_contiguous=attr_info%is_contiguous, &
                          character_length_expr=type_spec%character_length_expr)
         else
             decl_index = push_declaration( &
@@ -440,7 +447,8 @@ contains
                          is_save=attr_info%is_save, &
                          is_volatile=attr_info%is_volatile, &
                          is_protected=attr_info%is_protected, &
-                         is_asynchronous=attr_info%is_asynchronous)
+                         is_asynchronous=attr_info%is_asynchronous, &
+                         is_contiguous=attr_info%is_contiguous)
         end if
     end function create_dimensional_declaration
 
@@ -470,6 +478,7 @@ contains
                          is_volatile=attr_info%is_volatile, &
                          is_protected=attr_info%is_protected, &
                          is_asynchronous=attr_info%is_asynchronous, &
+                         is_contiguous=attr_info%is_contiguous, &
                          character_length_expr=type_spec%character_length_expr)
         else if (type_spec%has_kind) then
             decl_index = push_declaration( &
@@ -487,7 +496,8 @@ contains
                          is_save=attr_info%is_save, &
                          is_volatile=attr_info%is_volatile, &
                          is_protected=attr_info%is_protected, &
-                         is_asynchronous=attr_info%is_asynchronous)
+                         is_asynchronous=attr_info%is_asynchronous, &
+                         is_contiguous=attr_info%is_contiguous)
         else if (type_spec%has_character_length) then
             decl_index = push_declaration( &
                          arena, type_spec%type_name, &
@@ -504,6 +514,7 @@ contains
                          is_volatile=attr_info%is_volatile, &
                          is_protected=attr_info%is_protected, &
                          is_asynchronous=attr_info%is_asynchronous, &
+                         is_contiguous=attr_info%is_contiguous, &
                          character_length_expr=type_spec%character_length_expr)
         else
             decl_index = push_declaration( &
@@ -520,7 +531,8 @@ contains
                          is_save=attr_info%is_save, &
                          is_volatile=attr_info%is_volatile, &
                          is_protected=attr_info%is_protected, &
-                         is_asynchronous=attr_info%is_asynchronous)
+                         is_asynchronous=attr_info%is_asynchronous, &
+                         is_contiguous=attr_info%is_contiguous)
         end if
     end function create_scalar_declaration
     function build_name_array(name) result(names)

--- a/test/test_issue_1823_contiguous_attribute.f90
+++ b/test/test_issue_1823_contiguous_attribute.f90
@@ -1,0 +1,127 @@
+program test_issue_1823_contiguous_attribute
+    use frontend_core, only: lex_source, emit_fortran
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    implicit none
+
+    call test_contiguous_pointer_basic()
+    print *, ""
+    call test_contiguous_pointer_2d_array()
+    print *, ""
+    print *, "Issue 1823 CONTIGUOUS attribute tests completed."
+
+contains
+
+    subroutine test_contiguous_pointer_basic()
+        character(:), allocatable :: input_code
+        character(:), allocatable :: output_code
+        character(:), allocatable :: error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+        character(len=1), parameter :: nl = new_line('A')
+
+        input_code = &
+            "program test_contiguous_attribute" // nl // &
+            "    implicit none" // nl // &
+            "    " // nl // &
+            "    call test_sub()" // nl // &
+            "    " // nl // &
+            "contains" // nl // &
+            "    subroutine test_sub()" // nl // &
+            "        real, dimension(:), contiguous, pointer :: ptr" // nl // &
+            "        real, dimension(10), target :: arr" // nl // &
+            "        " // nl // &
+            "        arr = [(real(i), i=1,10)]" // nl // &
+            "        ptr => arr" // nl // &
+            "        print *, ptr" // nl // &
+            "    end subroutine test_sub" // nl // &
+            "end program test_contiguous_attribute"
+
+        arena = create_ast_arena()
+        call lex_source(input_code, tokens, error_msg)
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        call emit_fortran(arena, prog_index, output_code)
+
+        if (index(output_code, ', contiguous') == 0) then
+            print *, "FAIL: CONTIGUOUS attribute not preserved"
+            print *, "Output:", output_code
+            error stop 1
+        else
+            print *, "PASS: CONTIGUOUS attribute preserved"
+        end if
+
+        if (index(output_code, ', pointer') == 0) then
+            print *, "FAIL: POINTER attribute not preserved"
+            print *, "Output:", output_code
+            error stop 1
+        else
+            print *, "PASS: POINTER attribute preserved"
+        end if
+
+        if (index(output_code, 'real :: contiguous') /= 0) then
+            print *, "FAIL: CONTIGUOUS treated as variable name"
+            print *, "Output:", output_code
+            error stop 1
+        else
+            print *, "PASS: CONTIGUOUS not treated as variable name"
+        end if
+
+        if (index(output_code, ':: ptr') == 0) then
+            print *, "FAIL: ptr variable name not preserved"
+            print *, "Output:", output_code
+            error stop 1
+        else
+            print *, "PASS: ptr variable name preserved"
+        end if
+    end subroutine test_contiguous_pointer_basic
+
+    subroutine test_contiguous_pointer_2d_array()
+        character(:), allocatable :: input_code
+        character(:), allocatable :: output_code
+        character(:), allocatable :: error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+        character(len=1), parameter :: nl = new_line('A')
+
+        input_code = &
+            "program test" // nl // &
+            "    implicit none" // nl // &
+            "    real, dimension(:,:), contiguous, pointer :: mat_ptr" // nl // &
+            "    real, dimension(5,5), target :: mat" // nl // &
+            "    mat_ptr => mat" // nl // &
+            "end program test"
+
+        arena = create_ast_arena()
+        call lex_source(input_code, tokens, error_msg)
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        call emit_fortran(arena, prog_index, output_code)
+
+        if (index(output_code, ', contiguous') == 0) then
+            print *, "FAIL: CONTIGUOUS attribute not preserved for 2D array"
+            print *, "Output:", output_code
+            error stop 1
+        else
+            print *, "PASS: CONTIGUOUS preserved for 2D array pointer"
+        end if
+
+        if (index(output_code, ', pointer') == 0) then
+            print *, "FAIL: POINTER attribute not preserved for 2D array"
+            print *, "Output:", output_code
+            error stop 1
+        else
+            print *, "PASS: POINTER preserved for 2D array pointer"
+        end if
+
+        if (index(output_code, ':: mat_ptr') == 0) then
+            print *, "FAIL: mat_ptr variable name not preserved"
+            print *, "Output:", output_code
+            error stop 1
+        else
+            print *, "PASS: mat_ptr variable name preserved"
+        end if
+    end subroutine test_contiguous_pointer_2d_array
+
+end program test_issue_1823_contiguous_attribute


### PR DESCRIPTION
## Summary
Fixes #1823 by adding support for preserving the F2008 CONTIGUOUS attribute in variable declarations throughout the parsing and code generation pipeline.

Before this fix:
```fortran
real, dimension(:), contiguous, pointer :: ptr
```

Was incorrectly converted to:
```fortran
real :: contiguous(:), pointer(:)
```

Where `contiguous` and `pointer` became spurious variable names instead of being recognized as attributes.

After this fix, the output correctly preserves both attributes:
```fortran
real, pointer, contiguous :: ptr(:)
```

## Implementation
Following the same pattern as recently fixed ASYNCHRONOUS (#1822), PROTECTED (#1821), and VOLATILE (#1824) attributes, this PR adds:

- `is_contiguous` field to `declaration_attribute_info_t` type
- `is_contiguous` field to `declaration_node` type
- `contiguous` case in `parse_single_declaration_attribute` parser
- Contiguous output logic in `append_declaration_attributes` codegen
- Updated `populate_declaration_attributes` to copy `is_contiguous` flag
- Updated `push_declaration` and `initialize_declaration_details` signatures
- Updated all `push_declaration` call sites to pass `is_contiguous` parameter

## Verification
Added comprehensive test case `test_issue_1823_contiguous_attribute` that validates:
- CONTIGUOUS attribute is preserved for 1D arrays
- POINTER attribute is preserved alongside CONTIGUOUS
- Attributes are not treated as variable names
- Variable name (ptr) is correctly preserved
- Works correctly for multi-dimensional arrays (2D tested)

Test output:
```
PASS: CONTIGUOUS attribute preserved
PASS: POINTER attribute preserved
PASS: CONTIGUOUS not treated as variable name
PASS: ptr variable name preserved
PASS: CONTIGUOUS preserved for 2D array pointer
PASS: POINTER preserved for 2D array pointer
PASS: mat_ptr variable name preserved
```

Verified with original test file from issue:
```bash
$ fpm run -- /tmp/test_contiguous_attribute.f90
program test_contiguous_attribute
    implicit none
    call test_sub()
contains

    subroutine test_sub()
    implicit none
    integer :: i
    real, pointer, contiguous :: ptr(:)
    real, target :: arr(10)
    arr = (/(real(i), i=1, 10) /)
    ptr => arr
    print *, ptr
end subroutine test_sub
end program test_contiguous_attribute
```
