### PR TITLE
fix: add missing intrinsics to registry (fixes #1856)

### DIFF
--- a/examples/lf/intrinsic_dot_product.lf
+++ b/examples/lf/intrinsic_dot_product.lf
@@ -1,0 +1,5 @@
+! Test case for dot_product intrinsic (issues #1854, #1856)
+v1 = [1.0, 2.0, 3.0]
+v2 = [4.0, 5.0, 6.0]
+dp = dot_product(v1, v2)
+print *, 'Dot product:', dp

--- a/examples/lf/intrinsic_functions.lf
+++ b/examples/lf/intrinsic_functions.lf
@@ -1,0 +1,58 @@
+! Test case for intrinsic functions that were incorrectly declared as external
+! Covers issues #1853, #1854, #1856
+
+! Mathematical functions
+x = 5.0
+y = -3.0
+result = sign(x, y)
+print *, 'Sign:', result
+
+! Array/Matrix functions
+v1 = [1.0, 2.0, 3.0]
+v2 = [4.0, 5.0, 6.0]
+dp = dot_product(v1, v2)
+print *, 'Dot product:', dp
+
+mat1 = reshape([1.0, 2.0, 3.0, 4.0], [2, 2])
+mat2 = reshape([5.0, 6.0, 7.0, 8.0], [2, 2])
+mat_result = matmul(mat1, mat2)
+print *, 'Matrix multiply:', mat_result
+
+transposed = transpose(mat1)
+print *, 'Transpose:', transposed
+
+prod = product(v1)
+print *, 'Product:', prod
+
+! Logical array functions
+logical_arr = [.true., .false., .true.]
+any_result = any(logical_arr)
+all_result = all(logical_arr)
+print *, 'Any:', any_result
+print *, 'All:', all_result
+
+! Array inquiry functions
+arr = [10.0, 5.0, 8.0, 3.0]
+min_loc = minloc(arr)
+max_loc = maxloc(arr)
+print *, 'Min location:', min_loc
+print *, 'Max location:', max_loc
+
+packed = pack(arr, arr > 5.0)
+print *, 'Packed:', packed
+
+! Type inquiry functions
+max_int = huge(1)
+eps = epsilon(1.0)
+k = kind(1.0)
+print *, 'Huge:', max_int
+print *, 'Epsilon:', eps
+print *, 'Kind:', k
+
+selected_kind = selected_int_kind(9)
+print *, 'Selected kind:', selected_kind
+
+lb = lbound(mat1)
+ub = ubound(mat1)
+print *, 'Lower bounds:', lb
+print *, 'Upper bounds:', ub

--- a/examples/lf/intrinsic_sign.lf
+++ b/examples/lf/intrinsic_sign.lf
@@ -1,0 +1,5 @@
+! Test case for sign intrinsic (issue #1856)
+x = 5.0
+y = -3.0
+result = sign(x, y)
+print *, 'Sign:', result

--- a/src/utilities/intrinsic_registry.f90
+++ b/src/utilities/intrinsic_registry.f90
@@ -69,7 +69,7 @@ contains
 
     ! Initialize the intrinsic function registry
     subroutine initialize_intrinsic_registry()
-        integer, parameter :: NUM_INTRINSICS = 36
+        integer, parameter :: NUM_INTRINSICS = 52
         integer :: i
 
         if (registry_initialized) return
@@ -145,6 +145,12 @@ contains
         intrinsic_functions(i) = intrinsic_signature_t( &
                                  name="atan", return_type="real", arg_types="real", &
                                  description="Arc tangent function")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="sign", return_type="real", &
+                                 arg_types="real,real", &
+                                 description="Sign transfer function")
     end subroutine register_mathematical_intrinsics
 
     subroutine register_type_conversion_intrinsics(i)
@@ -230,6 +236,60 @@ contains
                                  name="reshape", return_type="array", &
                                  arg_types="array,integer_array", &
                                  description="Reshape array to new dimensions")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="dot_product", return_type="numeric", &
+                                 arg_types="array,array", &
+                                 description="Dot product of two vectors")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="matmul", return_type="array", &
+                                 arg_types="array,array", &
+                                 description="Matrix multiplication")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="transpose", return_type="array", &
+                                 arg_types="array", &
+                                 description="Matrix transpose")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="product", return_type="numeric", &
+                                 arg_types="array", &
+                                 description="Product of array elements")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="any", return_type="logical", &
+                                 arg_types="logical_array", &
+                                 description="True if any element is true")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="all", return_type="logical", &
+                                 arg_types="logical_array", &
+                                 description="True if all elements are true")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="minloc", return_type="integer_array", &
+                                 arg_types="array", &
+                                 description="Location of minimum value")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="maxloc", return_type="integer_array", &
+                                 arg_types="array", &
+                                 description="Location of maximum value")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="pack", return_type="array", &
+                                 arg_types="array,logical_array", &
+                                 description="Pack array into vector")
     end subroutine register_array_intrinsics
 
     subroutine register_string_intrinsics(i)
@@ -321,6 +381,42 @@ contains
                                  arg_types="allocatable", &
                                  description="Check if allocatable variable is "// &
                                  "allocated")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="huge", return_type="numeric", &
+                                 arg_types="numeric", &
+                                 description="Largest number of the kind")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="epsilon", return_type="real", &
+                                 arg_types="real", &
+                                 description="Machine epsilon")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="kind", return_type="integer", &
+                                 arg_types="any", &
+                                 description="Kind type parameter value")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="selected_int_kind", return_type="integer", &
+                                 arg_types="integer", &
+                                 description="Integer kind for range")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="lbound", return_type="integer_array", &
+                                 arg_types="array", &
+                                 description="Lower bounds of array")
+
+        i = i + 1
+        intrinsic_functions(i) = intrinsic_signature_t( &
+                                 name="ubound", return_type="integer_array", &
+                                 arg_types="array", &
+                                 description="Upper bounds of array")
     end subroutine register_inquiry_intrinsics
 
     ! Helper function to convert string to lowercase


### PR DESCRIPTION
## Summary
Fixes #1856 - Adds 16 missing intrinsic functions to the intrinsic registry that were incorrectly treated as external procedures.

## Changes
**Mathematical intrinsics:**
- `sign` - sign transfer function

**Array/Matrix intrinsics:**
- `dot_product` - dot product of vectors (fixes #1854)
- `matmul` - matrix multiplication (fixes #1853)
- `transpose` - matrix transpose
- `product` - product of array elements
- `any` - test if any element is true
- `all` - test if all elements are true
- `minloc` - location of minimum value
- `maxloc` - location of maximum value
- `pack` - pack array into vector

**Inquiry intrinsics:**
- `huge` - largest number of the kind
- `epsilon` - machine epsilon
- `kind` - kind type parameter value
- `selected_int_kind` - integer kind for range
- `lbound` - lower bounds of array
- `ubound` - upper bounds of array

Registry size increased from 36 to 52 intrinsics.

## Verification

**sign intrinsic (primary test case from issue):**
```bash
$ echo "x=5.0; y=-3.0; result=sign(x,y); print*,result" | ./build/gfortran_*/app/fortfront | gfortran -x f90 - -o /tmp/t && /tmp/t
  -5.00000000
```

**dot_product intrinsic (issue #1854):**
```bash
$ ./build/gfortran_*/app/fortfront examples/lf/intrinsic_dot_product.lf | gfortran -x f90 - -o /tmp/t && /tmp/t
Dot product:   32.0000000
```

**Before fix:** Intrinsics were incorrectly declared as `external`, causing linking errors.
**After fix:** Intrinsics are recognized, no external declarations, compilation and linking succeed.

## Test Results
All existing tests pass:
```bash
$ fpm test
...
SUCCESS: All examples behaved as expected
```

New examples added for regression testing:
- `examples/lf/intrinsic_sign.lf`
- `examples/lf/intrinsic_dot_product.lf`
- `examples/lf/intrinsic_functions.lf` (comprehensive)