### PR TITLE
fix: parse assignments to keyword-named variables (fixes #1850)

### DIFF
--- a/src/parser/parser_dispatcher.f90
+++ b/src/parser/parser_dispatcher.f90
@@ -60,7 +60,7 @@ contains
         integer :: stmt_index
         character(len=:), allocatable :: lowered_keyword
         type(parser_state_t) :: parser
-        type(token_t) :: first_token, second_token
+        type(token_t) :: first_token, second_token, next_token
         integer :: target_index, value_index
 
         call init_interface_procedure_parser()
@@ -170,7 +170,14 @@ contains
                 stmt_index = parse_type_or_declaration(parser, arena, prefix_buffer)
             case ("real", "integer", "logical", "character", "complex", "double", &
                   "class", "procedure")
-                stmt_index = parse_type_or_declaration(parser, arena, prefix_buffer)
+                ! Check if this is actually an assignment like "double = 5"
+                next_token = parser%get_token_at_index(parser%current_token + 1)
+                if (next_token%kind == TK_OPERATOR .and. &
+                    (next_token%text == "=" .or. next_token%text == "=>")) then
+                    stmt_index = parse_assignment_or_expression(parser, arena)
+                else
+                    stmt_index = parse_type_or_declaration(parser, arena, prefix_buffer)
+                end if
             case ("call")
                 stmt_index = parse_call_statement(parser, arena)
             case ("stop")

--- a/src/parser/parser_procedure_shared.f90
+++ b/src/parser/parser_procedure_shared.f90
@@ -37,9 +37,6 @@ contains
                     return_type_str = trim(token%text)//" "//trim(lookahead%text)
                     token = parser%consume()
                     token = parser%consume()
-                else
-                    return_type_str = token%text
-                    token = parser%consume()
                 end if
             end select
         end if

--- a/src/parser/parser_statement_utilities.f90
+++ b/src/parser/parser_statement_utilities.f90
@@ -87,7 +87,14 @@ contains
                 stmt_index = parse_call_statement(parser, arena)
             case ("integer", "real", "logical", "character", "complex", &
                   "double", "type", "class", "procedure")
-                stmt_index = parse_declaration(parser, arena)
+                ! Check if this is actually an assignment like "double = 5"
+                next_token = parser%get_token_at_index(parser%current_token + 1)
+                if (next_token%kind == TK_OPERATOR .and. &
+                    (next_token%text == "=" .or. next_token%text == "=>")) then
+                    stmt_index = parse_assignment_simple(parser, arena)
+                else
+                    stmt_index = parse_declaration(parser, arena)
+                end if
             case ("allocate")
                 stmt_index = parse_allocate_statement(parser, arena)
             case ("deallocate")
@@ -121,7 +128,15 @@ contains
                 stmt_index = parse_legacy_statement(trim(to_lower(token%text)), &
                                                     parser, arena)
             case default
-                stmt_index = skip_unknown_statement(parser)
+                ! Check if this might be an assignment with a keyword as target
+                ! (e.g., "double = 5" where "double" is both a keyword and a variable)
+                next_token = parser%get_token_at_index(parser%current_token + 1)
+                if (next_token%kind == TK_OPERATOR .and. &
+                    (next_token%text == "=" .or. next_token%text == "=>")) then
+                    stmt_index = parse_assignment_simple(parser, arena)
+                else
+                    stmt_index = skip_unknown_statement(parser)
+                end if
             end select
         case default
             stmt_index = parse_assignment_simple(parser, arena)


### PR DESCRIPTION
## Summary
Fixes function bodies being lost when function names or result variables match Fortran type keywords (e.g., `double`, `precision`).

## Root Cause
Three parser locations incorrectly treated type keywords followed by `=` as declarations rather than assignments:
1. `consume_optional_return_type` consumed "double" as a return type even when it was the function name
2. `parse_statement_dispatcher` treated keywords like "double" followed by `=` as type declarations at program level
3. `parse_statement_in_if_block` did the same within function bodies

## Changes
- `src/parser/parser_procedure_shared.f90`: Remove else branch that incorrectly consumed "double" as return type
- `src/parser/parser_dispatcher.f90`: Check for `=` operator after type keywords; parse as assignment if present
- `src/parser/parser_statement_utilities.f90`: Apply same check in two locations (type keyword case + unknown keyword default)

## Verification

### Test Input
```fortran
function double(x)
    double = x * 2
end function

result = double(21)
print *, 'Result:', result
```

### Before Fix
```fortran
program main
    implicit none
    real :: result
    result = double(21)
    print *, 'Result:', result
contains
    function double(x)
    implicit none
    integer :: x
end function double  ! Body missing!
end program main
```
Compilation fails: "Contained function 'double' at (1) has no IMPLICIT type"

### After Fix
```fortran
program main
    implicit none
    integer :: result
    result = double(21)
    print *, 'Result:', result
contains
    integer function double(x)
    implicit none
    integer :: x
    double = x*2  ! Body present!
end function double
end program main
```
Compiles and runs successfully, outputs: `42`

## Test Plan
- [x] `fpm test` - All tests pass
- [x] Manual verification with issue example - Body now emitted correctly
- [x] Compile and execute generated code - Produces correct output (42)
- [x] Test other keywords (precision, real, integer) - All work correctly
