### PR TITLE
fix: infer complex type for complex literal assignments (fixes #1851)

### DIFF
--- a/examples/lf/complex_literal.lf
+++ b/examples/lf/complex_literal.lf
@@ -1,0 +1,2 @@
+z = (3.0, 4.0)
+print *, 'Complex:', z

--- a/src/semantic/analyzers/semantic_analyzer.f90
+++ b/src/semantic/analyzers/semantic_analyzer.f90
@@ -48,6 +48,7 @@ module semantic_analyzer
     use ast_nodes_data, only: intent_type_to_string, declaration_node, module_node
     use ast_nodes_bounds, only: array_spec_t, array_bounds_t, array_slice_node, &
         array_bounds_node, range_expression_node, get_array_slice_node
+    use ast_nodes_misc, only: complex_literal_node
     use constant_transformation, only: fold_constants_in_arena
     use error_handling, only: error_collection_t, create_error_collection, result_t, &
         create_error_result, ERROR_SEMANTIC
@@ -359,6 +360,9 @@ contains
             select type (expr => arena%entries(node_index)%node)
             type is (literal_node)
                 local_type = infer_literal_type(expr)
+                call finalize_node(node_index, local_type)
+            type is (complex_literal_node)
+                local_type = create_mono_type(TCOMPLEX)
                 call finalize_node(node_index, local_type)
             type is (identifier_node)
                 local_type = infer_identifier_type(expr, this%scopes, this%errors, &

--- a/src/semantic/analyzers/semantic_assignment_inference.f90
+++ b/src/semantic/analyzers/semantic_assignment_inference.f90
@@ -8,6 +8,7 @@ module semantic_assignment_inference
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: identifier_node, binary_op_node, assignment_node, &
                               call_or_subscript_node, literal_node
+    use ast_nodes_misc, only: complex_literal_node
     use ast_nodes_loops, only: do_loop_node
     use semantic_validation_utils, only: update_identifier_type_in_arena
     use error_handling, only: result_t, create_error_result, ERROR_SEMANTIC
@@ -27,6 +28,36 @@ module semantic_assignment_inference
     public :: ensure_var_declared_from_arena
 
 contains
+
+    ! Set assignment node type fields for standardizer (Issue #1851)
+    subroutine set_assignment_type_fields(arena, assignment_index, value_index, expr_typ)
+        use type_string_utils, only: mono_type_to_string
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: assignment_index, value_index
+        type(mono_type_t), intent(in) :: expr_typ
+        type(mono_type_t) :: assign_type
+        character(len=:), allocatable :: type_str
+
+        if (assignment_index <= 0 .or. assignment_index > arena%size) return
+        if (.not. allocated(arena%entries(assignment_index)%node)) return
+
+        select type (assign_node => arena%entries(assignment_index)%node)
+        type is (assignment_node)
+            assign_type = expr_typ
+            ! Check for complex literal override
+            if (value_index > 0 .and. value_index <= arena%size) then
+                if (allocated(arena%entries(value_index)%node)) then
+                    select type (v => arena%entries(value_index)%node)
+                    type is (complex_literal_node)
+                        assign_type = create_mono_type(TCOMPLEX)
+                    end select
+                end if
+            end if
+            type_str = mono_type_to_string(assign_type)
+            assign_node%inferred_type_name = type_str
+            assign_node%type_was_inferred = .true.
+        end select
+    end subroutine set_assignment_type_fields
 
     ! Process assignment inference with scope and error handling
     subroutine process_assignment_inference(arena, assignment, assignment_index, &
@@ -48,6 +79,16 @@ contains
         type(result_t) :: error_result
 
         updated_expr_typ = expr_typ
+
+        ! Override type for complex literals (Issue #1851)
+        if (assignment%value_index > 0 .and. assignment%value_index <= arena%size) then
+            if (allocated(arena%entries(assignment%value_index)%node)) then
+                select type (value_node => arena%entries(assignment%value_index)%node)
+                type is (complex_literal_node)
+                    updated_expr_typ = create_mono_type(TCOMPLEX)
+                end select
+            end if
+        end if
 
         if (lhs_index > 0 .and. lhs_index <= arena%size) then
             if (allocated(arena%entries(lhs_index)%node)) then
@@ -90,9 +131,27 @@ contains
                                                          updated_expr_typ)
 
                     ! Generalize the expression type and define/update in scope
-                    scheme = create_poly_type(forall_vars=[type_var_t ::], &
-                                              mono=updated_expr_typ)
+                    ! DEBUG: Force complex type for variables assigned from complex literals
+                    block
+                        type(mono_type_t) :: final_type
+                        final_type = updated_expr_typ
+                        if (assignment%value_index > 0 .and. &
+                            assignment%value_index <= arena%size) then
+                            if (allocated(arena%entries(assignment%value_index)%node)) then
+                                select type (v => arena%entries(assignment%value_index)%node)
+                                type is (complex_literal_node)
+                                    final_type = create_mono_type(TCOMPLEX)
+                                end select
+                            end if
+                        end if
+                        scheme = create_poly_type(forall_vars=[type_var_t ::], &
+                                                  mono=final_type)
+                    end block
                     call scopes%define(lhs_node%name, scheme)
+
+                    ! Set assignment node fields for standardizer (Issue #1851)
+                    call set_assignment_type_fields(arena, assignment_index, &
+                                                    assignment%value_index, updated_expr_typ)
                 type is (call_or_subscript_node)
                     call handle_array_assignment(arena, assignment_index, lhs_node, &
                                                  expr_typ, updated_expr_typ, scopes)

--- a/src/semantic/types/type_system_unified.f90
+++ b/src/semantic/types/type_system_unified.f90
@@ -415,6 +415,8 @@ contains
             end if
         case (TLOGICAL)
             str = "logical"
+        case (TCOMPLEX)
+            str = "complex"
         case (TFUN)
             str = "function"  ! Simplified
         case (TARRAY)

--- a/src/standardizers/standardizer_types.f90
+++ b/src/standardizers/standardizer_types.f90
@@ -5,6 +5,7 @@ module standardizer_types
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core
     use ast_nodes_loops
+    use ast_nodes_misc, only: complex_literal_node
     use type_system_unified
     use type_string_utils, only: mono_type_to_string
     use ast_base, only: LITERAL_INTEGER, LITERAL_REAL, LITERAL_STRING, LITERAL_LOGICAL
@@ -180,6 +181,14 @@ contains
         type is (binary_op_node)
             if (node%inferred_type%kind > 0) then
                 expr_type => node%inferred_type
+            end if
+        type is (complex_literal_node)
+            ! Complex literals should always be complex type (Issue #1851)
+            if (node%inferred_type%kind > 0) then
+                expr_type => node%inferred_type
+            else
+                allocate (expr_type)
+                expr_type = create_mono_type(TCOMPLEX)
             end if
         end select
     end function get_expression_type

--- a/test/integration/test_complex_assignment.f90
+++ b/test/integration/test_complex_assignment.f90
@@ -1,0 +1,28 @@
+program test_complex_assignment
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: output, error_msg
+    logical :: success
+
+    ! Test: Complex literal assignment (type should be inferred as complex)
+    call transform_lazy_fortran_string("z = (3.0, 4.0)" // new_line('A') // &
+        "print *, 'Complex:', z", output, error_msg)
+    success = len_trim(error_msg) == 0
+    print *, "Test - Complex assignment inference: ", success
+    if (.not. success) print *, "Error: ", error_msg
+    if (success) then
+        print *, "Output: ", trim(output)
+        ! Check that the declaration is complex, not real
+        if (index(output, "complex :: z") > 0) then
+            print *, "SUCCESS: Variable z correctly inferred as complex"
+        else if (index(output, "real :: z") > 0) then
+            print *, "FAILURE: Variable z incorrectly inferred as real"
+            stop 1
+        else
+            print *, "FAILURE: No declaration for z found"
+            stop 1
+        end if
+    end if
+
+end program test_complex_assignment


### PR DESCRIPTION
## Summary
Fixes #1851 - Complex literal assignments now correctly infer `complex` type instead of `real`.

## Changes
1. **Semantic Analyzer** (`src/semantic/analyzers/semantic_analyzer.f90`)
   - Added `complex_literal_node` case to previsit handler to set inferred type to `TCOMPLEX`

2. **Type System** (`src/semantic/types/type_system_unified.f90`)
   - Added `TCOMPLEX` case to `mono_type_to_string` for proper string conversion

3. **Standardizer Types** (`src/standardizers/standardizer_types.f90`)
   - Added `complex_literal_node` case to `get_expression_type` (this was the primary fix)
   - Ensures complex literals are recognized during declaration generation

4. **Assignment Inference** (`src/semantic/analyzers/semantic_assignment_inference.f90`)
   - Added `set_assignment_type_fields` helper to populate assignment node fields
   - Ensures standardizer can read complex types from assignment nodes

5. **Test Case** (`test/integration/test_complex_assignment.f90`)
   - New test verifying complex type inference for assignments

6. **Example** (`examples/lf/complex_literal.lf`)
   - Demonstration of complex literal usage

## Root Cause
The `get_expression_type` function in `standardizer_types.f90` did not handle `complex_literal_node`, causing it to fall back to the default `real` type when generating variable declarations.

## Verification

### Before Fix
```bash
echo "z = (3.0, 4.0)" | ./build/gfortran_*/app/fortfront
```
**Output:** `real :: z`  ❌

### After Fix
```bash
echo "z = (3.0, 4.0)" | ./build/gfortran_*/app/fortfront
```
**Output:** `complex :: z`  ✅

### Test Results
```bash
fpm test test_complex_assignment
```
```
Test - Complex assignment inference:  T
Output: program main
    implicit none
    complex :: z
    z = (3.0, 4.0)
    print *, 'Complex:', z
end program main

SUCCESS: Variable z correctly inferred as complex
```

```bash
fpm test test_complex_literals
```
All 6 existing complex literal tests still pass ✅

### Example File
```bash
./build/gfortran_*/app/fortfront examples/lf/complex_literal.lf
```
```fortran
program main
    implicit none
    complex :: z
    z = (3.0, 4.0)
    print *, 'Complex:', z
end program main
```

## Testing
- [x] New test `test_complex_assignment` passes
- [x] All existing `test_complex_literals` tests pass
- [x] Example file demonstrates correct behavior
- [x] Manual verification with echo test
