### PR TITLE
fix: Bug: intent attrs dropped from proc args (fixes #1883)

### DIFF
--- a/src/codegen/codegen_declarations_inference.f90
+++ b/src/codegen/codegen_declarations_inference.f90
@@ -93,6 +93,7 @@ contains
         integer, intent(in) :: body_indices(:)
         type(parameter_info_t), intent(inout) :: param_map(:)
         integer :: j, idx
+        integer :: name_idx
         character(len=:), allocatable :: intent_str
 
         do j = 1, size(body_indices)
@@ -107,9 +108,24 @@ contains
                                             .true., body_node%is_optional, &
                                             body_node%is_target)
             type is (declaration_node)
-                call update_parameter_entry(param_map, body_node%var_name, &
-                                            body_node%intent, body_node%has_intent, &
-                                            body_node%is_optional, body_node%is_target)
+                if (body_node%is_multi_declaration .and. &
+                    allocated(body_node%var_names)) then
+                    do name_idx = 1, size(body_node%var_names)
+                        if (len_trim(body_node%var_names(name_idx)) == 0) cycle
+                        call update_parameter_entry(param_map, &
+                                                    body_node%var_names(name_idx), &
+                                                    body_node%intent, &
+                                                    body_node%has_intent, &
+                                                    body_node%is_optional, &
+                                                    body_node%is_target)
+                    end do
+                else
+                    call update_parameter_entry(param_map, body_node%var_name, &
+                                                body_node%intent, &
+                                                body_node%has_intent, &
+                                                body_node%is_optional, &
+                                                body_node%is_target)
+                end if
             end select
         end do
     end subroutine merge_parameter_details_from_body
@@ -625,9 +641,9 @@ contains
                                                     state%defined_func_count, rhs%name)
         type is (array_literal_node)
             type_name = mono_type_to_string(rhs%inferred_type, &
-                include_shape=.true., &
-                standardize_real=standardize_types_enabled, &
-                fallback='')
+                                            include_shape=.true., &
+                                           standardize_real=standardize_types_enabled, &
+                                            fallback='')
         end select
     end function infer_function_return_type_from_rhs
 
@@ -706,7 +722,7 @@ contains
     end subroutine process_allocate_variables
 
     subroutine add_allocate_variable(state, stmt, name, inferred_type, rank, &
-                                      standardize_types_enabled)
+                                     standardize_types_enabled)
         type(program_decl_state_t), intent(inout) :: state
         type(allocate_statement_node), intent(in) :: stmt
         character(len=*), intent(in) :: name
@@ -734,9 +750,9 @@ contains
 
         if (.not. allocated(base_type)) then
             base_type = mono_type_to_string(inferred_type, &
-                include_shape=.false., &
-                standardize_real=standardize_types_enabled, &
-                fallback='integer')
+                                            include_shape=.false., &
+                                           standardize_real=standardize_types_enabled, &
+                                            fallback='integer')
         end if
 
         if (len_trim(base_type) == 0) base_type = 'integer'
@@ -756,7 +772,7 @@ contains
             lowered = to_lower(type_buf)
             if (index(lowered, 'dimension(') == 0) then
                 type_buf = trim(type_buf) // ', dimension(' // &
-                          trim(dimension_spec) // ')'
+                    trim(dimension_spec) // ')'
             end if
         end if
 

--- a/test/test_issue_1883_intent_result.f90
+++ b/test/test_issue_1883_intent_result.f90
@@ -1,0 +1,41 @@
+program test_issue_1883_intent_result
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    character(:), allocatable :: input_code
+    character(:), allocatable :: output_code
+    character(:), allocatable :: error_msg
+    logical :: has_intent
+
+    print *, "=== Issue #1883: intent attributes with result clause ==="
+
+    input_code = &
+        "program test_intent" // new_line('A') // &
+        "    implicit none" // new_line('A') // &
+        "contains" // new_line('A') // &
+        "    function add(a, b) result(c)" // new_line('A') // &
+        "        real, intent(in) :: a, b" // new_line('A') // &
+        "        real :: c" // new_line('A') // &
+        "        c = a + b" // new_line('A') // &
+        "    end function add" // new_line('A') // &
+        "end program test_intent"
+
+    call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: transformation returned error:", trim(error_msg)
+        error stop 1
+    end if
+
+    has_intent = index(output_code, "real, intent(in) :: a, b") > 0
+    if (.not. has_intent) then
+        print *, "FAIL: intent attributes dropped from parameters"
+        print *, "Output:"
+        print *, trim(output_code)
+        error stop 1
+    end if
+
+    print *, "PASS: intent attributes preserved in functions with result clause"
+
+end program test_issue_1883_intent_result


### PR DESCRIPTION
## Summary
- ensure multi-variable parameter declarations propagate intent metadata from the body when building parameter maps
- cover the regression with a transformation test exercising functions using result variables

## Verification
- make test
  - PASS: intent attributes preserved in functions with result clause
