### PR TITLE
fix: Bug: Lazy Fortran fails to infer double-precision from literal f (fixes #1896)

### DIFF
--- a/src/semantic/analyzers/semantic_literal_identifier.f90
+++ b/src/semantic/analyzers/semantic_literal_identifier.f90
@@ -3,13 +3,14 @@ module semantic_literal_identifier
     use type_system_unified, only: type_env_t, type_var_t, mono_type_t, &
                                    poly_type_t, create_mono_type, create_type_var, &
                                    create_poly_type, TVAR, TINT, TREAL, TCHAR, &
-                                   TLOGICAL
+                                   TLOGICAL, TDOUBLE
     use scope_manager, only: scope_stack_t
     use error_handling, only: error_collection_t, result_t, create_error_result, &
                               ERROR_SEMANTIC
     use ast_base, only: LITERAL_INTEGER, LITERAL_REAL, LITERAL_STRING, LITERAL_LOGICAL
     use ast_nodes_core, only: literal_node, identifier_node
     use semantic_function_analysis, only: infer_type_from_usage_context
+    use string_utils_mod, only: to_lower
     implicit none
     private
 
@@ -26,7 +27,7 @@ contains
         case (LITERAL_INTEGER)
             typ = create_mono_type(TINT)
         case (LITERAL_REAL)
-            typ = create_mono_type(TREAL)
+            typ = infer_real_literal_type(lit)
         case (LITERAL_STRING)
             if (allocated(lit%value) .and. len(lit%value) >= 2) then
                 typ = create_mono_type(TCHAR, char_size=len(lit%value) - 2)
@@ -64,12 +65,12 @@ contains
         else
             if (strict_mode) then
                 error_result = create_error_result( &
-                    "Undefined variable '"//ident%name//"' in strict mode", &
-                    ERROR_SEMANTIC, &
-                    component="semantic_literal_identifier", &
-                    context="infer_identifier_type", &
-                    suggestion="Declare 'integer :: "//ident%name// &
-                    "' or drop 'implicit none' for lazy Fortran mode")
+                               "Undefined variable '"//ident%name//"' in strict mode", &
+                               ERROR_SEMANTIC, &
+                               component="semantic_literal_identifier", &
+                               context="infer_identifier_type", &
+                               suggestion="Declare 'integer :: "//ident%name// &
+                               "' or drop 'implicit none' for lazy Fortran mode")
                 call errors%add_result(error_result)
 
                 typ = create_mono_type(TVAR, var=create_type_var(next_var_id, ""))
@@ -79,7 +80,8 @@ contains
 
                 block
                     type(poly_type_t) :: new_scheme
-                    new_scheme = create_poly_type(forall_vars=[type_var_t ::], mono=typ)
+                    new_scheme = create_poly_type(forall_vars=[type_var_t &
+                                                               ::], mono=typ)
                     call scopes%define(ident%name, new_scheme)
                 end block
             end if
@@ -95,5 +97,92 @@ contains
         mutable_scheme = scheme
         typ = mutable_scheme%get_mono()
     end function instantiate_scheme_simple
+
+    function infer_real_literal_type(lit) result(typ)
+        type(literal_node), intent(in) :: lit
+        type(mono_type_t) :: typ
+        character(len=:), allocatable :: literal_value
+        character(len=:), allocatable :: lowered_value
+        character(len=:), allocatable :: kind_token
+        integer :: underscore_pos
+        integer :: read_status
+        integer :: kind_int
+
+        typ = create_mono_type(TREAL)
+        if (.not. allocated(lit%value)) return
+
+        literal_value = trim(lit%value)
+        if (len(literal_value) == 0) return
+
+        lowered_value = to_lower(literal_value)
+        if (contains_double_exponent(lowered_value)) then
+            typ = create_mono_type(TDOUBLE)
+            return
+        end if
+
+        underscore_pos = index(lowered_value, "_")
+        if (underscore_pos <= 0) return
+        if (underscore_pos == len(lowered_value)) return
+
+        kind_token = adjustl(lowered_value(underscore_pos + 1:))
+        kind_token = trim(kind_token)
+        if (len(kind_token) == 0) return
+
+        select case (kind_token)
+        case ("real64", "double", "doubleprecision", "dp")
+            typ = create_mono_type(TDOUBLE)
+            return
+        case ("real32", "sp")
+            typ = create_mono_type(TREAL)
+            return
+        case default
+            read (kind_token, *, iostat=read_status) kind_int
+            if (read_status /= 0) return
+            if (kind_int >= 8) then
+                typ = create_mono_type(TDOUBLE)
+            else
+                typ = create_mono_type(TREAL)
+            end if
+        end select
+    end function infer_real_literal_type
+
+    pure logical function contains_double_exponent(text) result(has_double)
+        character(len=*), intent(in) :: text
+        integer :: i
+        integer :: trimmed_length
+
+        has_double = .false.
+        trimmed_length = len_trim(text)
+
+        do i = 1, trimmed_length
+            if (text(i:i) /= 'd') cycle
+            if (i <= 1) cycle
+            if (.not. is_real_digit_or_dot(text(i - 1:i - 1))) cycle
+            if (i == trimmed_length) then
+                has_double = .true.
+                return
+            end if
+            if (.not. is_digit_or_sign(text(i + 1:i + 1))) cycle
+            has_double = .true.
+            return
+        end do
+    end function contains_double_exponent
+
+    pure logical function is_real_digit_or_dot(ch) result(is_valid)
+        character(len=1), intent(in) :: ch
+        integer :: code
+
+        code = iachar(ch)
+        is_valid = (ch == '.') .or. (code >= iachar('0') .and. code <= iachar('9'))
+    end function is_real_digit_or_dot
+
+    pure logical function is_digit_or_sign(ch) result(is_valid)
+        character(len=1), intent(in) :: ch
+        integer :: code
+
+        code = iachar(ch)
+        is_valid = (code >= iachar('0') .and. code <= iachar('9')) .or. ch == '+' &
+                   .or. ch == '-'
+    end function is_digit_or_sign
 
 end module semantic_literal_identifier

--- a/test/codegen/test_real_literal_kind_inference.f90
+++ b/test/codegen/test_real_literal_kind_inference.f90
@@ -1,0 +1,72 @@
+program test_real_literal_kind_inference
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    logical :: all_passed
+    real(dp), parameter :: zero_dp = 0.0_dp
+
+    if (zero_dp /= 0.0_dp) then
+        stop 1
+    end if
+
+    all_passed = .true.
+
+    if (.not. test_double_exponent_infers_double()) all_passed = .false.
+    if (.not. test_kind_suffix_infers_double()) all_passed = .false.
+
+    if (all_passed) then
+        stop 0
+    else
+        stop 1
+    end if
+
+contains
+
+    function test_double_exponent_infers_double() result(passed)
+        logical :: passed
+        character(len=:), allocatable :: output
+
+        output = compile_lazy_line('c = 1.0d0')
+        passed = check_output(output, 'double precision :: c', 'c = 1.0d0')
+    end function test_double_exponent_infers_double
+
+    function test_kind_suffix_infers_double() result(passed)
+        logical :: passed
+        character(len=:), allocatable :: output
+
+        output = compile_lazy_line('d = 3.14159_8')
+        passed = check_output(output, 'double precision :: d', 'd = 3.14159_8')
+    end function test_kind_suffix_infers_double
+
+    function check_output(output, declaration, assignment) result(passed)
+        character(len=*), intent(in) :: output
+        character(len=*), intent(in) :: declaration
+        character(len=*), intent(in) :: assignment
+        logical :: passed
+
+        passed = index(output, declaration) > 0
+        if (passed) passed = index(output, assignment) > 0
+        if (passed) passed = index(output, '!ERROR:') == 0
+        if (.not. passed) then
+            print *, 'Generated output:'
+            print *, trim(output)
+        end if
+    end function check_output
+
+    function compile_lazy_line(source_line) result(output)
+        character(len=*), intent(in) :: source_line
+        character(len=:), allocatable :: output
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: error_msg
+
+        source = source_line
+        call transform_lazy_fortran_string(source, output, error_msg)
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            print *, 'Unexpected error:'
+            print *, trim(error_msg)
+        end if
+        if (.not. allocated(output)) output = ''
+    end function compile_lazy_line
+
+end program test_real_literal_kind_inference

--- a/test/test_monomorphization.f90
+++ b/test/test_monomorphization.f90
@@ -3,21 +3,21 @@ program test_monomorphization
     implicit none
     character(len=:), allocatable :: input, output, error_msg
     logical :: test_passed
-    
+
     print *, "=== Monomorphization Tests ==="
-    
+
     ! Test 1: Generic function with multiple call signatures
     print *, "Testing generic function monomorphization..."
     input = &
-"function add(a, b)" // new_line('A') // &
-"    add = a + b" // new_line('A') // &
-"end function" // new_line('A') // &
-"" // new_line('A') // &
-"x = add(5, 3)" // new_line('A') // &
-"y = add(2.5d0, 1.5d0)" // new_line('A')
-    
+        "function add(a, b)" // new_line('A') // &
+        "    add = a + b" // new_line('A') // &
+        "end function" // new_line('A') // &
+        "" // new_line('A') // &
+        "x = add(5, 3)" // new_line('A') // &
+        "y = add(2.5d0, 1.5d0)" // new_line('A')
+
     call transform_lazy_fortran_string(input, output, error_msg)
-    
+
     ! Verify output contains monomorphized module
     test_passed = .false.
     if (index(output, "module auto_add") > 0) then
@@ -27,7 +27,7 @@ program test_monomorphization
             end if
         end if
     end if
-    
+
     if (test_passed) then
         print *, "  PASS: Module structure generated"
     else
@@ -35,36 +35,36 @@ program test_monomorphization
         print *, "  Output:", output
         stop 1
     end if
-    
+
     ! Test 2: Verify type-specific variants created
     print *, "Testing type-specific variants..."
     test_passed = .false.
     ! Check for integer variant (k2 = TINT)
     if (index(output, "add__k2_k2") > 0) then
-        ! Check for real variant (k3 = TREAL)  
-        if (index(output, "add__k3_k3") > 0) then
+        ! Check for double precision variant (k9 = TDOUBLE)
+        if (index(output, "add__k9_k9") > 0) then
             test_passed = .true.
         end if
     end if
-    
+
     if (test_passed) then
         print *, "  PASS: Type-specific variants created"
     else
         print *, "  FAIL: Variants missing"
         stop 1
     end if
-    
+
     ! Test 3: Single signature function (should NOT be monomorphized)
     print *, "Testing single-signature function..."
     input = &
-"function square(x)" // new_line('A') // &
-"    square = x * x" // new_line('A') // &
-"end function" // new_line('A') // &
-"" // new_line('A') // &
-"y = square(5)" // new_line('A')
-    
+        "function square(x)" // new_line('A') // &
+        "    square = x * x" // new_line('A') // &
+        "end function" // new_line('A') // &
+        "" // new_line('A') // &
+        "y = square(5)" // new_line('A')
+
     call transform_lazy_fortran_string(input, output, error_msg)
-    
+
     ! Should NOT have auto_square module
     test_passed = .false.
     if (index(output, "module auto_square") == 0) then
@@ -72,15 +72,15 @@ program test_monomorphization
             test_passed = .true.
         end if
     end if
-    
+
     if (test_passed) then
         print *, "  PASS: Single signature not monomorphized"
     else
         print *, "  FAIL: Unnecessary monomorphization"
         stop 1
     end if
-    
+
     print *, ""
     print *, "All monomorphization tests passed!"
-    
+
 end program test_monomorphization


### PR DESCRIPTION
## Summary\n- teach literal inference to treat D exponents and kind suffixes as double precision\n- add regression coverage around double literal inference and update monomorphization expectations\n\n## Verification\n- make test  # PASS\n- printf 'a = 1.0\nc = 1.0d0\nd = 3.14159_8\n' | fpm run --target fortfront  # output shows double precision :: c, d\n