### PR TITLE
fix: Bug: Monomorphization generates wrong return types for polymorph (fixes #1885)

### DIFF
--- a/src/codegen/codegen_declarations_inference.f90
+++ b/src/codegen/codegen_declarations_inference.f90
@@ -637,14 +637,32 @@ contains
             type_buf = mono_type_to_string(id%inferred_type, &
                                            include_shape=.true., &
                                            standardize_real=standardize_types_enabled, &
-                                           fallback='real')
-            if (len_trim(type_buf) == 0 .or. trim(type_buf) == 'real') then
-                func_return_type = infer_function_return_type_from_rhs(arena, &
-                                                                       stmt, state)
-                if (len_trim(func_return_type) > 0) type_buf = trim(func_return_type)
-            end if
-            if (len_trim(type_buf) == 0) type_buf = 'real'
+                                           fallback='')
+            type_buf = canonicalize_type(type_buf)
+            func_return_type = infer_function_return_type_from_rhs(arena, stmt, &
+                                                                   state)
+            func_return_type = canonicalize_type(func_return_type)
 
+            if (len_trim(func_return_type) > 0) then
+                block
+                    character(len=:), allocatable :: curr_lower
+                    character(len=:), allocatable :: func_lower
+
+                    curr_lower = to_lower(trim(type_buf))
+                    func_lower = to_lower(trim(func_return_type))
+
+                    if (len_trim(type_buf) == 0) then
+                        type_buf = func_return_type
+                    else if (curr_lower == 'integer' .and. func_lower /= &
+                             'integer') then
+                        type_buf = func_return_type
+                    else if (curr_lower == 'real' .and. func_lower /= 'real') then
+                        type_buf = func_return_type
+                    end if
+                end block
+            end if
+
+            if (len_trim(type_buf) == 0) type_buf = 'real'
             call try_add_variable(state, name_buf, trim(type_buf))
         end select
     end subroutine process_assignment_target
@@ -669,12 +687,36 @@ contains
             if (len_trim(rhs%name) == 0) return
             type_name = lookup_function_return_type(state%defined_func_names, &
                                                     state%defined_func_types, &
-                                                    state%defined_func_count, rhs%name)
+                                                    state%defined_func_count, &
+                                                    rhs%name)
+            type_name = canonicalize_type(type_name)
+            if (len_trim(type_name) == 0) then
+                type_name = deduce_type_from_arguments(arena, rhs, &
+                                                       standardize_types_enabled)
+            else
+                block
+                    character(len=:), allocatable :: inferred_type
+                    character(len=:), allocatable :: current_lower
+                    character(len=:), allocatable :: inferred_lower
+
+                    current_lower = to_lower(trim(type_name))
+                    if (current_lower == 'integer') then
+                        inferred_type = deduce_type_from_arguments( &
+                                        arena, rhs, standardize_types_enabled)
+                        inferred_lower = to_lower(trim(inferred_type))
+                        if (len_trim(inferred_lower) > 0 .and. &
+                            inferred_lower /= 'integer') then
+                            type_name = inferred_type
+                        end if
+                    end if
+                end block
+            end if
         type is (array_literal_node)
-            type_name = mono_type_to_string(rhs%inferred_type, &
-                                            include_shape=.true., &
-                                           standardize_real=standardize_types_enabled, &
-                                            fallback='')
+            type_name = mono_type_to_string( &
+                rhs%inferred_type, &
+                include_shape=.true., &
+                standardize_real=standardize_types_enabled, &
+                fallback='')
         end select
     end function infer_function_return_type_from_rhs
 
@@ -698,18 +740,35 @@ contains
         type is (call_or_subscript_node)
             name_buf = trim(val%name)
             if (len_trim(name_buf) == 0) return
-            type_buf = mono_type_to_string(val%inferred_type, &
-                                           include_shape=.true., &
-                                           standardize_real=standardize_types_enabled, &
-                                           fallback='real')
-            if (len_trim(type_buf) == 0 .or. trim(type_buf) == 'real') then
-                func_return_type = &
-                    lookup_function_return_type(state%defined_func_names, &
-                                                state%defined_func_types, &
-                                                state%defined_func_count, &
-                                                name_buf)
-                if (len_trim(func_return_type) > 0) type_buf = trim(func_return_type)
+            type_buf = mono_type_to_string( &
+                val%inferred_type, &
+                include_shape=.true., &
+                standardize_real=standardize_types_enabled, &
+                fallback='')
+            type_buf = canonicalize_type(type_buf)
+            func_return_type = infer_function_return_type_from_rhs(arena, stmt, &
+                                                                   state)
+            func_return_type = canonicalize_type(func_return_type)
+
+            if (len_trim(func_return_type) > 0) then
+                block
+                    character(len=:), allocatable :: curr_lower
+                    character(len=:), allocatable :: func_lower
+
+                    curr_lower = to_lower(trim(type_buf))
+                    func_lower = to_lower(trim(func_return_type))
+
+                    if (len_trim(type_buf) == 0) then
+                        type_buf = func_return_type
+                    else if (curr_lower == 'integer' .and. func_lower /= &
+                             'integer') then
+                        type_buf = func_return_type
+                    else if (curr_lower == 'real' .and. func_lower /= 'real') then
+                        type_buf = func_return_type
+                    end if
+                end block
             end if
+
             if (len_trim(type_buf) == 0) type_buf = 'real'
             call try_add_function_reference(state, name_buf, trim(type_buf))
         end select
@@ -780,10 +839,11 @@ contains
         end if
 
         if (.not. allocated(base_type)) then
-            base_type = mono_type_to_string(inferred_type, &
-                                            include_shape=.false., &
-                                           standardize_real=standardize_types_enabled, &
-                                            fallback='integer')
+            base_type = mono_type_to_string( &
+                        inferred_type, &
+                        include_shape=.false., &
+                        standardize_real=standardize_types_enabled, &
+                        fallback='integer')
         end if
 
         if (len_trim(base_type) == 0) base_type = 'integer'
@@ -832,14 +892,42 @@ contains
         type(program_decl_state_t), intent(inout) :: state
         character(len=*), intent(in) :: name
         character(len=*), intent(in) :: type_name
+        integer :: i, existing_idx
+        character(len=:), allocatable :: normalized_type
+        character(len=:), allocatable :: current_lower
+        character(len=:), allocatable :: new_lower
 
         if (len_trim(name) == 0) return
         if (state%func_count >= program_decl_max_vars) return
         if (exists_in_list(state%declared_names, state%declared_count, name)) return
-        if (exists_in_list(state%func_names, state%func_count, name)) return
+        normalized_type = canonicalize_type(type_name)
+
+        existing_idx = 0
+        do i = 1, state%func_count
+            if (trim(state%func_names(i)) == trim(name)) then
+                existing_idx = i
+                exit
+            end if
+        end do
+
+        if (existing_idx > 0) then
+            current_lower = to_lower(trim(state%func_types(existing_idx)))
+            new_lower = to_lower(trim(normalized_type))
+            if (len_trim(new_lower) == 0) return
+            if (current_lower == 'integer' .and. new_lower /= 'integer') then
+                state%func_types(existing_idx) = normalized_type
+            else if (current_lower == 'real' .and. new_lower /= 'real') then
+                state%func_types(existing_idx) = normalized_type
+            else if (current_lower /= new_lower .and. new_lower == 'real(8)' &
+                     .and. current_lower == 'real') then
+                state%func_types(existing_idx) = normalized_type
+            end if
+            return
+        end if
+
         state%func_count = state%func_count + 1
         state%func_names(state%func_count) = name
-        state%func_types(state%func_count) = type_name
+        state%func_types(state%func_count) = normalized_type
     end subroutine try_add_function_reference
 
     function emit_program_declarations(state) result(code)
@@ -887,6 +975,99 @@ contains
                    ", external :: " // trim(state%func_names(i)) // new_line('A')
         end do
     end function emit_program_declarations
+
+    pure function canonicalize_type(type_str) result(canon)
+        character(len=*), intent(in) :: type_str
+        character(len=:), allocatable :: canon
+        character(len=:), allocatable :: lowered
+
+        lowered = to_lower(trim(type_str))
+        if (len_trim(lowered) == 0) then
+            canon = ""
+            return
+        end if
+
+        select case (lowered)
+        case ('double precision')
+            canon = 'real(8)'
+        case default
+            canon = trim(type_str)
+        end select
+    end function canonicalize_type
+
+    function deduce_type_from_arguments(arena, call_node, standardize_real) &
+        result(type_str)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: call_node
+        logical, intent(in) :: standardize_real
+        character(len=:), allocatable :: type_str
+        integer :: i, arg_idx
+        logical :: has_character
+        logical :: has_complex
+        logical :: has_double
+        logical :: has_real
+        logical :: has_logical
+        logical :: has_integer
+        character(len=:), allocatable :: arg_type
+        character(len=:), allocatable :: lowered
+
+        type_str = ""
+        has_character = .false.
+        has_complex = .false.
+        has_double = .false.
+        has_real = .false.
+        has_logical = .false.
+        has_integer = .false.
+
+        if (.not. allocated(call_node%arg_indices)) return
+
+        do i = 1, size(call_node%arg_indices)
+            arg_idx = call_node%arg_indices(i)
+            if (arg_idx <= 0 .or. arg_idx > arena%size) cycle
+            if (.not. allocated(arena%entries(arg_idx)%node)) cycle
+
+            select type (arg_node => arena%entries(arg_idx)%node)
+            class default
+                arg_type = canonicalize_type(mono_type_to_string( &
+                                             arg_node%inferred_type, &
+                                             include_shape=.false., &
+                                             standardize_real=standardize_real, &
+                                             fallback=''))
+            end select
+
+            lowered = to_lower(trim(arg_type))
+            if (len_trim(lowered) == 0) cycle
+            if (index(lowered, 'character') == 1) then
+                has_character = .true.
+            else if (lowered == 'complex') then
+                has_complex = .true.
+            else if (lowered == 'logical') then
+                has_logical = .true.
+            else if (lowered == 'real(8)') then
+                has_double = .true.
+            else if (index(lowered, 'real(') == 1) then
+                has_double = .true.
+            else if (lowered == 'real') then
+                has_real = .true.
+            else
+                has_integer = .true.
+            end if
+        end do
+
+        if (has_character) then
+            type_str = 'character'
+        else if (has_complex) then
+            type_str = 'complex'
+        else if (has_double) then
+            type_str = 'real(8)'
+        else if (has_real) then
+            type_str = 'real'
+        else if (has_logical) then
+            type_str = 'logical'
+        else if (has_integer) then
+            type_str = 'integer'
+        end if
+    end function deduce_type_from_arguments
 
     ! Helper function to check if a name exists in a list
     logical function exists_in_list(list, count, name)

--- a/src/semantic/analyzers/semantic_function_array.f90
+++ b/src/semantic/analyzers/semantic_function_array.f90
@@ -44,13 +44,19 @@ contains
         character(len=:), allocatable :: intrinsic_sig
         integer :: i
         logical :: is_intrinsic_func
+        type(mono_type_t), allocatable :: arg_types(:)
+        integer :: deduced_kind
 
         typ = create_mono_type(TREAL)
 
         if (allocated(call_node%arg_indices)) then
+            allocate (arg_types(size(call_node%arg_indices)))
             do i = 1, size(call_node%arg_indices)
                 arg_type = get_type_fn(arena, call_node%arg_indices(i))
+                arg_types(i) = arg_type
             end do
+        else
+            allocate (arg_types(0))
         end if
 
         if (allocated(call_node%name)) then
@@ -94,7 +100,61 @@ contains
                 typ = create_mono_type(TREAL)
             end if
         end if
+
+        if (allocated(arg_types)) then
+            deduced_kind = deduce_return_kind_from_args(arg_types)
+            if (deduced_kind > 0) then
+                select case (typ%kind)
+                case (TVAR)
+                    typ = create_mono_type(deduced_kind)
+                case (TREAL)
+                    if (deduced_kind /= TREAL) typ = create_mono_type(deduced_kind)
+                case (TINT)
+                    if (deduced_kind /= TINT) typ = create_mono_type(deduced_kind)
+                case default
+                    if (typ%kind <= 0) typ = create_mono_type(deduced_kind)
+                end select
+            end if
+        end if
     end function infer_function_call_type
+
+    integer function deduce_return_kind_from_args(arg_types) result(kind_value)
+        type(mono_type_t), intent(in) :: arg_types(:)
+        integer :: i
+        integer :: best_kind
+        integer :: current_kind
+
+        best_kind = 0
+        do i = 1, size(arg_types)
+            block
+                type(mono_type_t) :: type_copy
+                type_copy = arg_types(i)
+                call type_copy%sync_from_arena()
+                current_kind = type_copy%kind
+            end block
+            if (current_kind <= 0) cycle
+            select case (current_kind)
+            case (TDOUBLE)
+                kind_value = TDOUBLE
+                return
+            case (TCOMPLEX)
+                if (best_kind /= TDOUBLE) best_kind = TCOMPLEX
+            case (TREAL)
+                if (best_kind /= TDOUBLE .and. best_kind /= TCOMPLEX) &
+                    best_kind = TREAL
+            case (TCHAR)
+                if (best_kind == 0) best_kind = TCHAR
+            case (TLOGICAL)
+                if (best_kind == 0) best_kind = TLOGICAL
+            case (TINT)
+                if (best_kind == 0) best_kind = TINT
+            case default
+                if (best_kind == 0) best_kind = current_kind
+            end select
+        end do
+
+        kind_value = best_kind
+    end function deduce_return_kind_from_args
 
     logical function find_return_type(arena, func_name, return_type) result(found)
         type(ast_arena_t), intent(in) :: arena

--- a/src/standardizers/ast_monomorphization.f90
+++ b/src/standardizers/ast_monomorphization.f90
@@ -1,6 +1,6 @@
 module ast_monomorphization
     use ast_arena_modern, only: ast_arena_t
-    use ast_nodes_core, only: program_node
+    use ast_nodes_core, only: program_node, call_or_subscript_node
     use ast_nodes_procedure, only: function_def_node, &
                                    get_procedure_name, get_procedure_params, &
                                    get_procedure_body, get_procedure_return_type, &
@@ -13,6 +13,8 @@ module ast_monomorphization
     use ast_base, only: string_t
     use call_graph_signatures_mod, only: signatures_map_t, type_signature_t
     use codegen_name_mangling, only: mangle_procedure_name
+    use type_string_utils, only: mono_type_to_string
+    use type_system_unified, only: mono_type_t
     use uid_generator, only: generate_uid
     implicit none
     private
@@ -107,6 +109,7 @@ contains
         type(function_def_node) :: new_func
         integer, allocatable :: new_param_indices(:)
         character(len=:), allocatable :: mangled_name, return_type
+        character(len=:), allocatable :: result_name
         integer :: i
 
         call get_function_node(arena, func_idx, orig_func)
@@ -116,16 +119,36 @@ contains
         end if
 
         mangled_name = mangle_procedure_name(orig_func%name, signature%param_kinds)
-        return_type = get_kind_type_string(signature%return_kind)
+        return_type = determine_return_type_string(arena, signature, orig_func)
 
         if (allocated(orig_func%param_indices)) then
             allocate (new_param_indices(size(orig_func%param_indices)))
             do i = 1, size(orig_func%param_indices)
                 new_param_indices(i) = clone_parameter_with_kind(arena, &
-                    orig_func%param_indices(i), signature%param_kinds(i))
+                                   orig_func%param_indices(i), signature%param_kinds(i))
             end do
         else
             allocate (new_param_indices(0))
+        end if
+
+        if (allocated(orig_func%result_variable)) then
+            if (len_trim(orig_func%result_variable) > 0) then
+                result_name = trim(orig_func%result_variable)
+            end if
+        end if
+
+        if (.not. allocated(result_name)) then
+            if (allocated(orig_func%name)) then
+                if (len_trim(orig_func%name) > 0) then
+                    result_name = trim(orig_func%name)
+                end if
+            end if
+        end if
+
+        if (.not. allocated(result_name)) then
+            result_name = mangled_name
+        else if (len_trim(result_name) == 0) then
+            result_name = mangled_name
         end if
 
         new_func = create_function_def( &
@@ -135,7 +158,7 @@ contains
                    body_indices=orig_func%body_indices, &
                    line=orig_func%line, &
                    column=orig_func%column, &
-                   result_variable=mangled_name)
+                   result_variable=result_name)
 
         call arena%push(new_func)
         new_idx = arena%size
@@ -157,6 +180,14 @@ contains
         end if
 
         type_name = get_kind_type_string(kind_value)
+        if (len_trim(type_name) == 0) then
+            if (allocated(orig_param%type_name)) then
+                if (len_trim(orig_param%type_name) > 0) then
+                    type_name = trim(orig_param%type_name)
+                end if
+            end if
+        end if
+        if (len_trim(type_name) == 0) type_name = "real"
 
         new_param%uid = generate_uid()
         new_param%name = orig_param%name
@@ -245,6 +276,113 @@ contains
         idx = arena%size
     end function create_use_statement_node
 
+    function determine_return_type_string(arena, signature, orig_func) &
+        result(type_str)
+        type(ast_arena_t), intent(inout) :: arena
+        type(type_signature_t), intent(in) :: signature
+        type(function_def_node), pointer, intent(in) :: orig_func
+        character(len=:), allocatable :: type_str
+        type(call_or_subscript_node), pointer :: call_node
+        type(mono_type_t) :: inferred_type
+        logical :: has_value
+
+        type_str = ""
+
+        if (signature%call_site_node > 0) then
+            call get_call_node(arena, signature%call_site_node, call_node)
+            if (associated(call_node)) then
+                inferred_type = call_node%inferred_type
+                call inferred_type%sync_from_arena()
+                type_str = trim(mono_type_to_string(inferred_type, &
+                                                    include_shape=.false., fallback=''))
+                if (len_trim(type_str) == 0) then
+                    type_str = get_kind_type_string(inferred_type%kind)
+                end if
+            end if
+        end if
+
+        if (len_trim(type_str) == 0) then
+            has_value = associated(orig_func)
+            if (has_value) has_value = allocated(orig_func%return_type)
+            if (has_value) then
+                if (len_trim(orig_func%return_type) > 0) then
+                    type_str = trim(orig_func%return_type)
+                end if
+            end if
+        end if
+
+        if (len_trim(type_str) == 0) then
+            type_str = get_kind_type_string(signature%return_kind)
+        end if
+
+        if (allocated(signature%param_kinds)) then
+            if (size(signature%param_kinds) > 0) then
+                if (len_trim(type_str) == 0) then
+                    type_str = fallback_return_type_from_params( &
+                        signature%param_kinds)
+                else if (trim(type_str) == "integer") then
+                    if (any(signature%param_kinds /= 2)) then
+                        type_str = fallback_return_type_from_params( &
+                            signature%param_kinds)
+                    end if
+                end if
+            end if
+        end if
+
+        if (len_trim(type_str) == 0) type_str = "real"
+    end function determine_return_type_string
+
+    function fallback_return_type_from_params(param_kinds) result(type_str)
+        integer, intent(in) :: param_kinds(:)
+        character(len=:), allocatable :: type_str
+        integer :: i
+        integer :: best_rank
+
+        type_str = ""
+        best_rank = -1
+
+        do i = 1, size(param_kinds)
+            select case (param_kinds(i))
+            case (9)  ! TDOUBLE
+                if (best_rank < 4) then
+                    type_str = "real(8)"
+                    best_rank = 4
+                end if
+            case (8)  ! TCOMPLEX
+                if (best_rank < 3) then
+                    type_str = "complex"
+                    best_rank = 3
+                end if
+            case (3)  ! TREAL
+                if (best_rank < 2) then
+                    type_str = "real"
+                    best_rank = 2
+                end if
+            case (4)  ! TCHAR
+                if (best_rank < 2) then
+                    type_str = "character"
+                    best_rank = 2
+                end if
+            case (5)  ! TLOGICAL
+                if (best_rank < 1) then
+                    type_str = "logical"
+                    best_rank = 1
+                end if
+            case (2)  ! TINT
+                if (best_rank < 0) then
+                    type_str = "integer"
+                    best_rank = 0
+                end if
+            case default
+                if (best_rank < 0) then
+                    type_str = get_kind_type_string(param_kinds(i))
+                    if (len_trim(type_str) > 0) best_rank = 0
+                end if
+            end select
+            if (best_rank == 4) exit
+        end do
+    end function fallback_return_type_from_params
+
     function get_kind_type_string(kind_value) result(type_str)
         integer, intent(in) :: kind_value
         character(len=:), allocatable :: type_str
@@ -259,8 +397,12 @@ contains
             type_str = "character"
         case (5)  ! TLOGICAL
             type_str = "logical"
+        case (8)  ! TCOMPLEX
+            type_str = "complex"
+        case (9)  ! TDOUBLE
+            type_str = "real(8)"
         case default
-            type_str = "integer"  ! Default fallback
+            type_str = ""
         end select
     end function get_kind_type_string
 
@@ -294,7 +436,7 @@ contains
 
         ! If no signatures found, allocate empty array
         if (num_sigs == 0 .and. .not. allocated(sigs)) then
-            allocate(sigs(0))
+            allocate (sigs(0))
         end if
     end function get_function_signatures
 
@@ -327,6 +469,21 @@ contains
             node_ptr => n
         end select
     end subroutine get_function_node
+
+    subroutine get_call_node(arena, idx, node_ptr)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: idx
+        type(call_or_subscript_node), pointer, intent(out) :: node_ptr
+
+        nullify (node_ptr)
+        if (idx < 1 .or. idx > arena%size) return
+        if (.not. allocated(arena%entries(idx)%node)) return
+
+        select type (n => arena%entries(idx)%node)
+        type is (call_or_subscript_node)
+            node_ptr => n
+        end select
+    end subroutine get_call_node
 
     subroutine get_parameter_node(arena, idx, node_ptr)
         type(ast_arena_t), intent(inout) :: arena

--- a/test/test_monomorphization.f90
+++ b/test/test_monomorphization.f90
@@ -80,6 +80,50 @@ program test_monomorphization
         stop 1
     end if
 
+    ! Test 4: Return type specialization propagates correctly
+    print *, "Testing return type specialization..."
+    input = &
+        "function square(x)" // new_line('A') // &
+        "    square = x * x" // new_line('A') // &
+        "end function" // new_line('A') // &
+        "" // new_line('A') // &
+        "y = square(5)" // new_line('A') // &
+        "z = square(3.0)" // new_line('A')
+
+    call transform_lazy_fortran_string(input, output, error_msg)
+
+    test_passed = .false.
+    if (index(output, "real function square__k3") > 0 .or. &
+        index(output, "real(8) function square__k3") > 0) then
+        if (index(output, "integer function square__k3") == 0) then
+            test_passed = .true.
+        end if
+    end if
+
+    if (test_passed) then
+        print *, "  PASS: Real specialization has correct return type"
+    else
+        print *, "  FAIL: Real specialization return type incorrect"
+        print *, "  Output:", output
+        stop 1
+    end if
+
+    test_passed = .false.
+    if (index(output, "real :: z") > 0 .or. &
+        index(output, "real(8) :: z") > 0) then
+        if (index(output, "integer :: z") == 0) then
+            test_passed = .true.
+        end if
+    end if
+
+    if (test_passed) then
+        print *, "  PASS: Assignment result typed correctly"
+    else
+        print *, "  FAIL: Assignment result type incorrect"
+        print *, "  Output:", output
+        stop 1
+    end if
+
     print *, ""
     print *, "All monomorphization tests passed!"
 


### PR DESCRIPTION
## Summary
- derive specialized function result types from call-site inference and signature metadata
- tighten declaration inference to reuse specialized return types for assignments and references
- add regression coverage proving mixed integer/real monomorphization stays correctly typed

## Verification
- make test
  - PASS: Real specialization has correct return type
  - PASS: Assignment result typed correctly
