### PR TITLE
fix: Bug: Lazy Fortran incorrectly infers function return type as int (fixes #1890)

### DIFF
--- a/src/semantic/analyzers/semantic_function_analysis.f90
+++ b/src/semantic/analyzers/semantic_function_analysis.f90
@@ -5,7 +5,7 @@ module semantic_function_analysis
                                    create_mono_type, create_type_var, &
                                    create_poly_type, create_fun_type, &
                                    TVAR, TINT, TREAL, TCHAR, TLOGICAL, TFUN, &
-                                   TARRAY
+                                   TARRAY, TDOUBLE
     use ast_base, only: LITERAL_INTEGER, LITERAL_REAL
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: identifier_node, assignment_node, &
@@ -15,6 +15,7 @@ module semantic_function_analysis
     use ast_nodes_data, only: declaration_node, parameter_declaration_node
     use scope_manager, only: scope_stack_t
     use semantic_validation_utils, only: update_identifier_type_in_arena, int_to_str
+    use semantic_literal_type_helpers, only: literal_numeric_type
     use semantic_type_operations, only: get_common_type, &
                                         instantiate_type_scheme_op
     use string_utils_mod, only: int_to_string
@@ -58,7 +59,8 @@ contains
                 index(var_name, 'msg') > 0 .or. index(var_name, 'text') > 0) then
                 ! String-like variable names
                 typ = create_mono_type(TCHAR)
-            else if (index(var_name, 'num') > 0 .or. index(var_name, 'count') > 0 .or. &
+            else if (index(var_name, 'num') > 0 .or. index(var_name, &
+                                                           'count') > 0 .or. &
                      index(var_name, 'idx') > 0) then
                 ! Number-like variable names
                 typ = create_mono_type(TINT)
@@ -71,7 +73,8 @@ contains
     end function infer_type_from_usage_context
 
     ! Analyze function parameters and extract their types
-    subroutine analyze_function_parameters(arena, func_node, param_types, param_names, &
+    subroutine analyze_function_parameters(arena, func_node, param_types, &
+                                           param_names, &
                                            scopes, next_var_id)
         type(ast_arena_t), intent(inout) :: arena
         type(function_def_node), intent(in) :: func_node
@@ -83,6 +86,7 @@ contains
         integer :: i, idx, arg_idx
         type(mono_type_t) :: temp_type
         type(mono_type_t) :: inferred_arg_type
+        type(mono_type_t) :: literal_type
         type(poly_type_t) :: scheme
         character(len=64), allocatable :: stored_names(:)
         character(len=64) :: param_name
@@ -139,7 +143,8 @@ contains
             if (temp_type%kind == TVAR) then
                 if (temp_type%var%id == 0) then
                     temp_type = create_mono_type(TVAR, &
-                                                 var=create_type_var(next_var_id, "arg"))
+                                                 var=create_type_var(next_var_id, &
+                                                                     "arg"))
                     next_var_id = next_var_id + 1
                 end if
                 if (len_trim(trimmed_name) > 0) then
@@ -171,8 +176,15 @@ contains
                     end if
                     select type (arg_node => arena%entries(arg_idx)%node)
                     type is (literal_node)
-                        if (arg_node%literal_kind == LITERAL_INTEGER) then
-                            param_types(i) = create_mono_type(TINT)
+                        literal_type = literal_numeric_type(arg_node)
+                        if (literal_type%kind == 0) cycle
+                        if (param_types(i)%kind == 0 .or. &
+                            param_types(i)%kind == TVAR) then
+                            param_types(i) = literal_type
+                        else if (param_types(i)%kind == TREAL) then
+                            if (literal_type%kind == TDOUBLE) then
+                                param_types(i) = literal_type
+                            end if
                         end if
                     type is (identifier_node)
                         if (arg_node%inferred_type%kind == TINT) then
@@ -464,7 +476,8 @@ contains
 
         if (search_start >= 1) then
             call search_identifier_type_range(arena, lowered_name, param_names, &
-                                              param_types, scope_index, program_index, &
+                                              param_types, scope_index, &
+                                              program_index, &
                                               search_start, 1, -1, typ)
             if (typ%kind /= 0) return
         end if
@@ -477,7 +490,8 @@ contains
 
         if (forward_start <= arena%size) then
             call search_identifier_type_range(arena, lowered_name, param_names, &
-                                              param_types, scope_index, program_index, &
+                                              param_types, scope_index, &
+                                              program_index, &
                                               forward_start, arena%size, 1, typ)
         end if
     end function infer_identifier_type_from_context
@@ -846,11 +860,12 @@ contains
                 if (len_trim(param_name) > 0) then
                     trimmed_name = trim(param_name)
                     inferred_arg_type = infer_type_from_usage_context(trimmed_name, &
-                                                                       next_var_id)
+                                                                      next_var_id)
                     param_types(i) = inferred_arg_type
                 else
                     param_types(i) = create_mono_type(TVAR, &
-                                                      var=create_type_var(next_var_id, "p"))
+                                                      var=create_type_var(next_var_id, &
+                                                                          "p"))
                     next_var_id = next_var_id + 1
                 end if
             else

--- a/src/semantic/analyzers/semantic_literal_identifier.f90
+++ b/src/semantic/analyzers/semantic_literal_identifier.f90
@@ -3,14 +3,14 @@ module semantic_literal_identifier
     use type_system_unified, only: type_env_t, type_var_t, mono_type_t, &
                                    poly_type_t, create_mono_type, create_type_var, &
                                    create_poly_type, TVAR, TINT, TREAL, TCHAR, &
-                                   TLOGICAL, TDOUBLE
+                                   TLOGICAL
     use scope_manager, only: scope_stack_t
     use error_handling, only: error_collection_t, result_t, create_error_result, &
                               ERROR_SEMANTIC
     use ast_base, only: LITERAL_INTEGER, LITERAL_REAL, LITERAL_STRING, LITERAL_LOGICAL
     use ast_nodes_core, only: literal_node, identifier_node
     use semantic_function_analysis, only: infer_type_from_usage_context
-    use string_utils_mod, only: to_lower
+    use semantic_literal_type_helpers, only: infer_real_literal_kind
     implicit none
     private
 
@@ -27,7 +27,7 @@ contains
         case (LITERAL_INTEGER)
             typ = create_mono_type(TINT)
         case (LITERAL_REAL)
-            typ = infer_real_literal_type(lit)
+            typ = infer_real_literal_kind(lit)
         case (LITERAL_STRING)
             if (allocated(lit%value) .and. len(lit%value) >= 2) then
                 typ = create_mono_type(TCHAR, char_size=len(lit%value) - 2)
@@ -97,92 +97,4 @@ contains
         mutable_scheme = scheme
         typ = mutable_scheme%get_mono()
     end function instantiate_scheme_simple
-
-    function infer_real_literal_type(lit) result(typ)
-        type(literal_node), intent(in) :: lit
-        type(mono_type_t) :: typ
-        character(len=:), allocatable :: literal_value
-        character(len=:), allocatable :: lowered_value
-        character(len=:), allocatable :: kind_token
-        integer :: underscore_pos
-        integer :: read_status
-        integer :: kind_int
-
-        typ = create_mono_type(TREAL)
-        if (.not. allocated(lit%value)) return
-
-        literal_value = trim(lit%value)
-        if (len(literal_value) == 0) return
-
-        lowered_value = to_lower(literal_value)
-        if (contains_double_exponent(lowered_value)) then
-            typ = create_mono_type(TDOUBLE)
-            return
-        end if
-
-        underscore_pos = index(lowered_value, "_")
-        if (underscore_pos <= 0) return
-        if (underscore_pos == len(lowered_value)) return
-
-        kind_token = adjustl(lowered_value(underscore_pos + 1:))
-        kind_token = trim(kind_token)
-        if (len(kind_token) == 0) return
-
-        select case (kind_token)
-        case ("real64", "double", "doubleprecision", "dp")
-            typ = create_mono_type(TDOUBLE)
-            return
-        case ("real32", "sp")
-            typ = create_mono_type(TREAL)
-            return
-        case default
-            read (kind_token, *, iostat=read_status) kind_int
-            if (read_status /= 0) return
-            if (kind_int >= 8) then
-                typ = create_mono_type(TDOUBLE)
-            else
-                typ = create_mono_type(TREAL)
-            end if
-        end select
-    end function infer_real_literal_type
-
-    pure logical function contains_double_exponent(text) result(has_double)
-        character(len=*), intent(in) :: text
-        integer :: i
-        integer :: trimmed_length
-
-        has_double = .false.
-        trimmed_length = len_trim(text)
-
-        do i = 1, trimmed_length
-            if (text(i:i) /= 'd') cycle
-            if (i <= 1) cycle
-            if (.not. is_real_digit_or_dot(text(i - 1:i - 1))) cycle
-            if (i == trimmed_length) then
-                has_double = .true.
-                return
-            end if
-            if (.not. is_digit_or_sign(text(i + 1:i + 1))) cycle
-            has_double = .true.
-            return
-        end do
-    end function contains_double_exponent
-
-    pure logical function is_real_digit_or_dot(ch) result(is_valid)
-        character(len=1), intent(in) :: ch
-        integer :: code
-
-        code = iachar(ch)
-        is_valid = (ch == '.') .or. (code >= iachar('0') .and. code <= iachar('9'))
-    end function is_real_digit_or_dot
-
-    pure logical function is_digit_or_sign(ch) result(is_valid)
-        character(len=1), intent(in) :: ch
-        integer :: code
-
-        code = iachar(ch)
-        is_valid = (code >= iachar('0') .and. code <= iachar('9')) .or. ch == '+' &
-                   .or. ch == '-'
-    end function is_digit_or_sign
-
 end module semantic_literal_identifier

--- a/src/semantic/analyzers/semantic_literal_type_helpers.f90
+++ b/src/semantic/analyzers/semantic_literal_type_helpers.f90
@@ -1,0 +1,116 @@
+module semantic_literal_type_helpers
+    use type_system_unified, only: mono_type_t, create_mono_type, TINT, TREAL, &
+                                   TDOUBLE
+    use ast_base, only: LITERAL_INTEGER, LITERAL_REAL
+    use ast_nodes_core, only: literal_node
+    use string_utils_mod, only: to_lower
+    implicit none
+    private
+
+    public :: literal_numeric_type
+    public :: infer_real_literal_kind
+
+contains
+
+    function literal_numeric_type(lit) result(typ)
+        type(literal_node), intent(in) :: lit
+        type(mono_type_t) :: typ
+
+        select case (lit%literal_kind)
+        case (LITERAL_INTEGER)
+            typ = create_mono_type(TINT)
+        case (LITERAL_REAL)
+            typ = infer_real_literal_kind(lit)
+        case default
+            typ%kind = 0
+        end select
+    end function literal_numeric_type
+
+    function infer_real_literal_kind(lit) result(typ)
+        type(literal_node), intent(in) :: lit
+        type(mono_type_t) :: typ
+        character(len=:), allocatable :: literal_value
+        character(len=:), allocatable :: lowered_value
+        character(len=:), allocatable :: kind_token
+        integer :: underscore_pos
+        integer :: read_status
+        integer :: kind_int
+
+        typ = create_mono_type(TREAL)
+        if (.not. allocated(lit%value)) return
+
+        literal_value = trim(lit%value)
+        if (len(literal_value) == 0) return
+
+        lowered_value = to_lower(literal_value)
+        if (contains_double_exponent(lowered_value)) then
+            typ = create_mono_type(TDOUBLE)
+            return
+        end if
+
+        underscore_pos = index(lowered_value, "_")
+        if (underscore_pos <= 0) return
+        if (underscore_pos == len(lowered_value)) return
+
+        kind_token = adjustl(lowered_value(underscore_pos + 1:))
+        kind_token = trim(kind_token)
+        if (len(kind_token) == 0) return
+
+        select case (kind_token)
+        case ("real64", "double", "doubleprecision", "dp")
+            typ = create_mono_type(TDOUBLE)
+            return
+        case ("real32", "sp")
+            typ = create_mono_type(TREAL)
+            return
+        case default
+            read (kind_token, *, iostat=read_status) kind_int
+            if (read_status /= 0) return
+            if (kind_int >= 8) then
+                typ = create_mono_type(TDOUBLE)
+            else
+                typ = create_mono_type(TREAL)
+            end if
+        end select
+    end function infer_real_literal_kind
+
+    pure logical function contains_double_exponent(text) result(has_double)
+        character(len=*), intent(in) :: text
+        integer :: i
+        integer :: trimmed_length
+
+        has_double = .false.
+        trimmed_length = len_trim(text)
+
+        do i = 1, trimmed_length
+            if (text(i:i) /= 'd') cycle
+            if (i <= 1) cycle
+            if (.not. is_real_digit_or_dot(text(i - 1:i - 1))) cycle
+            if (i == trimmed_length) then
+                has_double = .true.
+                return
+            end if
+            if (.not. is_digit_or_sign(text(i + 1:i + 1))) cycle
+            has_double = .true.
+            return
+        end do
+    end function contains_double_exponent
+
+    pure logical function is_real_digit_or_dot(ch) result(is_valid)
+        character(len=1), intent(in) :: ch
+        integer :: code
+
+        code = iachar(ch)
+        is_valid = (ch == '.') .or. (code >= iachar('0') .and. code <= iachar('9'))
+    end function is_real_digit_or_dot
+
+    pure logical function is_digit_or_sign(ch) result(is_valid)
+        character(len=1), intent(in) :: ch
+        integer :: code
+
+        code = iachar(ch)
+        is_valid = (ch == '+') .or. (ch == '-') .or. &
+                   (code >= iachar('0') .and. code <= iachar('9'))
+    end function is_digit_or_sign
+
+end module semantic_literal_type_helpers

--- a/test/integration/issue_tests/test_issue_1890_lazy_function_return.f90
+++ b/test/integration/issue_tests/test_issue_1890_lazy_function_return.f90
@@ -1,0 +1,51 @@
+program test_issue_1890_lazy_function_return
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: transformed
+    character(len=:), allocatable :: error_msg
+
+    source = 'function quadratic(a, b, c, x)' // new_line('a') // &
+             '    quadratic = a*x**2 + b*x + c' // new_line('a') // &
+             'end function' // new_line('a') // &
+             ' ' // new_line('a') // &
+             'result = quadratic(2.0, -3.0, 1.0, 5.0)' // new_line('a') // &
+             'print *, ''Result:'', result'
+
+    call transform_lazy_fortran_string(source, transformed, error_msg)
+
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) then
+            print *, 'FAIL: unexpected error:', trim(error_msg)
+            stop 1
+        end if
+    end if
+
+    if (index(transformed, 'integer function quadratic') /= 0) then
+        print *, 'FAIL: quadratic inferred as integer function'
+        print *, trim(transformed)
+        stop 1
+    end if
+
+    if (index(transformed, 'real function quadratic') == 0) then
+        print *, 'FAIL: quadratic not declared as real function'
+        print *, trim(transformed)
+        stop 1
+    end if
+
+    if (index(transformed, 'real :: result') == 0) then
+        print *, 'FAIL: result variable not inferred as real'
+        print *, trim(transformed)
+        stop 1
+    end if
+
+    if (index(transformed, 'real, intent(in) :: a') == 0 .and. &
+        index(transformed, 'real :: a') == 0) then
+        print *, 'FAIL: parameter a not inferred as real'
+        print *, trim(transformed)
+        stop 1
+    end if
+
+    print *, 'PASS: lazy Fortran infers real return type for quadratic'
+end program test_issue_1890_lazy_function_return

--- a/test/test_monomorphization.f90
+++ b/test/test_monomorphization.f90
@@ -110,7 +110,11 @@ program test_monomorphization
 
     test_passed = .false.
     if (index(output, "real :: z") > 0 .or. &
-        index(output, "real(8) :: z") > 0) then
+        index(output, "real(8) :: z") > 0 .or. &
+        index(output, "real :: y, z") > 0 .or. &
+        index(output, "real :: y,z") > 0 .or. &
+        index(output, "real(8) :: y, z") > 0 .or. &
+        index(output, "real(8) :: y,z") > 0) then
         if (index(output, "integer :: z") == 0) then
             test_passed = .true.
         end if


### PR DESCRIPTION
## Summary
- share literal numeric inference and reuse it in literal/parameter analyzers
- use literal kinds when seeding parameter heuristics without reintroducing circular deps
- add regression coverage for issue 1890 and accept combined real declarations in monomorph tests

## Verification
- make test
