### PR TITLE
fix: Code style: INTRINSIC statements silently removed from output (fixes #1902)

### DIFF
--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -56,11 +56,12 @@ module ast_factory
 
     ! Statement nodes
     use ast_factory_statements, only: &
-        push_use_statement, push_visibility_statement, push_namelist_statement, &
-        push_implicit_statement, push_include_statement, push_import_statement, &
-        push_end_statement, push_stop, push_return, push_entry, push_continue, &
-        push_goto, push_error_stop, push_cycle, push_exit, push_allocate, &
-        push_deallocate, push_io_implied_do, push_pause, push_nullify
+        push_use_statement, push_intrinsic_statement, push_visibility_statement, &
+        push_namelist_statement, push_implicit_statement, push_include_statement, &
+        push_import_statement, push_end_statement, push_stop, push_return, &
+        push_entry, push_continue, push_goto, push_error_stop, push_cycle, &
+        push_exit, push_allocate, push_deallocate, push_io_implied_do, &
+        push_pause, push_nullify
 
     ! Error nodes
     use ast_factory_errors, only: push_error_node
@@ -96,7 +97,8 @@ module ast_factory
     public :: push_print_statement, push_write_statement, push_read_statement
     public :: push_read_statement_with_err, push_read_statement_with_end
     public :: push_read_statement_with_all_specifiers, push_write_statement_with_iostat
-    public :: push_write_statement_with_format, push_write_statement_with_runtime_format
+    public :: push_write_statement_with_format, &
+              push_write_statement_with_runtime_format
     public :: push_format_statement, push_open_statement, push_close_statement
     public :: push_inquire_statement, push_backspace_statement, push_rewind_statement
     public :: push_endfile_statement
@@ -111,7 +113,8 @@ module ast_factory
     public :: push_range_expression, push_assumed_size_bounds
 
     ! Statement nodes
-    public :: push_use_statement, push_visibility_statement, push_namelist_statement, &
+    public :: push_use_statement, push_intrinsic_statement, &
+              push_visibility_statement, push_namelist_statement, &
               push_implicit_statement, push_include_statement, push_import_statement
     public :: push_end_statement, push_stop, push_return, push_entry, push_continue, &
               push_goto, push_error_stop, push_pause, push_nullify

--- a/src/ast/factory/ast_factory_statements.f90
+++ b/src/ast/factory/ast_factory_statements.f90
@@ -3,10 +3,11 @@ module ast_factory_statements
     use ast_base, only: string_t
     use uid_generator, only: generate_uid
     use ast_nodes_misc, only: use_statement_node, implicit_statement_node, &
-                              visibility_statement_node, namelist_statement_node, &
-                              include_statement_node, import_statement_node, &
-                              end_statement_node, allocate_statement_node, &
-                              deallocate_statement_node, create_implicit_statement
+                              intrinsic_statement_node, visibility_statement_node, &
+                              namelist_statement_node, include_statement_node, &
+                              import_statement_node, end_statement_node, &
+                              allocate_statement_node, deallocate_statement_node, &
+                              create_implicit_statement
     use ast_nodes_control, only: stop_node, return_node, entry_node, goto_node, &
                                  error_stop_node, cycle_node, exit_node, &
                                  continue_node, pause_node, nullify_node
@@ -15,7 +16,8 @@ module ast_factory_statements
     private
 
     ! Public statement node creation functions
-    public :: push_use_statement, push_visibility_statement, push_namelist_statement, &
+    public :: push_use_statement, push_intrinsic_statement, &
+              push_visibility_statement, push_namelist_statement, &
               push_implicit_statement, push_include_statement, push_import_statement
     public :: push_end_statement
     public :: push_stop, push_return, push_entry, push_continue, push_goto, &
@@ -71,6 +73,34 @@ contains
         call arena%push(use_stmt, "use_statement", parent_index)
         use_index = arena%size
     end function push_use_statement
+
+    function push_intrinsic_statement(arena, procedure_names, line, column, &
+                                      parent_index, has_double_colon) &
+        result(stmt_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: procedure_names(:)
+        integer, intent(in), optional :: line, column, parent_index
+        logical, intent(in), optional :: has_double_colon
+        integer :: stmt_index
+        type(intrinsic_statement_node) :: node
+        integer :: i
+
+        node%uid = generate_uid()
+        if (present(has_double_colon)) node%has_double_colon = has_double_colon
+
+        if (size(procedure_names) > 0) then
+            allocate (node%procedure_names(size(procedure_names)))
+            do i = 1, size(procedure_names)
+                node%procedure_names(i) = string_t(trim(procedure_names(i)))
+            end do
+        end if
+
+        if (present(line)) node%line = line
+        if (present(column)) node%column = column
+
+        call arena%push(node, "intrinsic_statement", parent_index)
+        stmt_index = arena%size
+    end function push_intrinsic_statement
 
     function push_visibility_statement(arena, is_private, names, line, column, &
                                        parent_index, has_double_colon) &

--- a/src/ast/nodes/ast_nodes_misc.f90
+++ b/src/ast/nodes/ast_nodes_misc.f90
@@ -88,6 +88,17 @@ module ast_nodes_misc
         generic :: assignment(=) => assign
     end type use_statement_node
 
+    ! Intrinsic statement node
+    type, extends(ast_node), public :: intrinsic_statement_node
+        type(string_t), allocatable :: procedure_names(:)
+        logical :: has_double_colon = .false.
+    contains
+        procedure :: accept => intrinsic_statement_accept
+        procedure :: to_json => intrinsic_statement_to_json
+        procedure :: assign => intrinsic_statement_assign
+        generic :: assignment(=) => assign
+    end type intrinsic_statement_node
+
     type, extends(ast_node), public :: visibility_statement_node
         type(string_t), allocatable :: names(:)
         logical :: is_private = .false.
@@ -208,9 +219,11 @@ module ast_nodes_misc
 
     ! Constructors migrated from ast_core
     public :: create_comment, create_blank_line, create_end_statement
-    public :: create_use_statement, create_visibility_statement, create_include_statement
+    public :: create_use_statement, create_visibility_statement, &
+              create_include_statement
     public :: create_import_statement
-    public :: create_implicit_statement, create_interface_block, create_module_procedure
+    public :: create_implicit_statement, create_interface_block, &
+              create_module_procedure
 
 contains
 
@@ -286,7 +299,8 @@ contains
         character(len=*), intent(in), optional :: url_spec
         logical, intent(in), optional :: has_only
         integer, intent(in), optional :: line, column
-        logical, intent(in), optional :: has_double_colon, is_intrinsic, is_non_intrinsic
+        logical, intent(in), optional :: has_double_colon, is_intrinsic, &
+                                         is_non_intrinsic
         type(use_statement_node) :: node
         integer :: i
 
@@ -696,6 +710,63 @@ contains
         lhs%is_intrinsic = rhs%is_intrinsic
         lhs%is_non_intrinsic = rhs%is_non_intrinsic
     end subroutine use_statement_assign
+
+    ! Intrinsic statement implementations
+    subroutine intrinsic_statement_accept(this, visitor)
+        class(intrinsic_statement_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+    end subroutine intrinsic_statement_accept
+
+    subroutine intrinsic_statement_to_json(this, json, parent)
+        class(intrinsic_statement_node), intent(in) :: this
+        type(json_core), intent(inout) :: json
+        type(json_value), pointer, intent(in) :: parent
+        type(json_value), pointer :: obj
+        integer :: i
+
+        call json%create_object(obj, '')
+        call json%add(obj, 'type', 'intrinsic_statement')
+        call json%add(obj, 'line', this%line)
+        call json%add(obj, 'column', this%column)
+        call json%add(obj, 'has_double_colon', this%has_double_colon)
+        if (allocated(this%procedure_names)) then
+            do i = 1, size(this%procedure_names)
+                if (allocated(this%procedure_names(i)%s)) then
+                    call json%add(obj, 'procedure_'//trim(adjustl(int_to_string(i))), &
+                                  this%procedure_names(i)%s)
+                end if
+            end do
+        end if
+        call json%add(parent, obj)
+    end subroutine intrinsic_statement_to_json
+
+    subroutine intrinsic_statement_assign(lhs, rhs)
+        class(intrinsic_statement_node), intent(inout) :: lhs
+        class(intrinsic_statement_node), intent(in) :: rhs
+        integer :: i
+
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+
+        lhs%has_double_colon = rhs%has_double_colon
+
+        if (allocated(lhs%procedure_names)) then
+            deallocate (lhs%procedure_names)
+        end if
+        if (allocated(rhs%procedure_names)) then
+            allocate (lhs%procedure_names(size(rhs%procedure_names)))
+            do i = 1, size(rhs%procedure_names)
+                lhs%procedure_names(i) = rhs%procedure_names(i)
+            end do
+        end if
+    end subroutine intrinsic_statement_assign
 
     subroutine visibility_statement_accept(this, visitor)
         class(visibility_statement_node), intent(in) :: this
@@ -1245,7 +1316,8 @@ contains
         if (allocated(rhs%type_spec%type_name)) then
             lhs%type_spec%type_name = rhs%type_spec%type_name
         else
-            if (allocated(lhs%type_spec%type_name)) deallocate (lhs%type_spec%type_name)
+            if (allocated(lhs%type_spec%type_name)) deallocate &
+                (lhs%type_spec%type_name)
         end if
         lhs%type_spec%has_kind = rhs%type_spec%has_kind
         lhs%type_spec%kind_value = rhs%type_spec%kind_value

--- a/src/codegen/codegen_core.f90
+++ b/src/codegen/codegen_core.f90
@@ -25,9 +25,10 @@ module codegen_core
     use ast_nodes_misc, only: complex_literal_node, comment_node, blank_line_node, &
                               implicit_statement_node, allocate_statement_node, &
                               deallocate_statement_node, use_statement_node, &
-                              import_statement_node, &
+                              intrinsic_statement_node, import_statement_node, &
                               visibility_statement_node, namelist_statement_node, &
-                              contains_node, end_statement_node, interface_block_node, &
+                              contains_node, end_statement_node, &
+                              interface_block_node, &
                               module_procedure_node
     use ast_error_nodes, only: error_node_t
     use ast_nodes_control
@@ -138,6 +139,8 @@ contains
             code = generate_code_namelist_statement(node)
         type is (use_statement_node)
             code = generate_code_use_statement(node)
+        type is (intrinsic_statement_node)
+            code = generate_code_intrinsic_statement(node)
         type is (import_statement_node)
             code = generate_code_import_statement(node)
         type is (implicit_statement_node)

--- a/src/codegen/codegen_declarations_programs.f90
+++ b/src/codegen/codegen_declarations_programs.f90
@@ -5,7 +5,8 @@ module codegen_declarations_programs
                               call_or_subscript_node
     use ast_nodes_misc, only: blank_line_node, comment_node, contains_node, &
                               implicit_statement_node, use_statement_node, &
-                              interface_block_node, module_procedure_node
+                              intrinsic_statement_node, interface_block_node, &
+                              module_procedure_node
     use ast_nodes_procedure, only: function_def_node, subroutine_def_node
     use ast_nodes_data, only: declaration_node, module_node, block_data_node, &
                               derived_type_node
@@ -246,12 +247,14 @@ contains
         logical :: has_implicit
         character(len=:), allocatable :: use_statements_code
         character(len=:), allocatable :: implicit_statements_code
+        character(len=:), allocatable :: intrinsic_statements_code
         character(len=:), allocatable :: interface_blocks_code
         character(len=:), allocatable :: declaration_statements_code
         character(len=:), allocatable :: extra_decls
 
         call gather_program_header_entries(arena, node, has_implicit, &
                                            use_statements_code, &
+                                           intrinsic_statements_code, &
                                            implicit_statements_code, &
                                            declaration_statements_code, &
                                            interface_blocks_code, non_use_indices, &
@@ -263,6 +266,10 @@ contains
             code = code // implicit_statements_code
         else if (.not. has_implicit) then
             code = code // "    implicit none" // new_line('A')
+        end if
+
+        if (len(intrinsic_statements_code) > 0) then
+            code = code // intrinsic_statements_code
         end if
 
         if (len(declaration_statements_code) > 0) then
@@ -280,6 +287,7 @@ contains
 
     subroutine gather_program_header_entries(arena, node, has_implicit, &
                                              use_statements_code, &
+                                             intrinsic_statements_code, &
                                              implicit_statements_code, &
                                              declaration_statements_code, &
                                              interface_blocks_code, non_use_indices, &
@@ -288,6 +296,7 @@ contains
         type(program_node), intent(in) :: node
         logical, intent(out) :: has_implicit
         character(len=:), allocatable, intent(out) :: use_statements_code
+        character(len=:), allocatable, intent(out) :: intrinsic_statements_code
         character(len=:), allocatable, intent(out) :: implicit_statements_code
         character(len=:), allocatable, intent(out) :: declaration_statements_code
         character(len=:), allocatable, intent(out) :: interface_blocks_code
@@ -299,6 +308,7 @@ contains
 
         has_implicit = .false.
         use_statements_code = ""
+        intrinsic_statements_code = ""
         implicit_statements_code = ""
         declaration_statements_code = ""
         interface_blocks_code = ""
@@ -316,6 +326,7 @@ contains
         do i = 1, size(node%body_indices)
             call categorize_header_entry(arena, node, node%body_indices(i), &
                                          has_implicit, use_statements_code, &
+                                         intrinsic_statements_code, &
                                          implicit_statements_code, &
                                          interface_blocks_code, non_use_indices, &
                                          non_use_count, header_decl_indices, &
@@ -335,8 +346,9 @@ contains
     end subroutine gather_program_header_entries
 
     subroutine categorize_header_entry(arena, prog_node, body_index, has_implicit, &
-                                       use_statements_code, implicit_statements_code, &
-                                       interface_blocks_code, non_use_indices, &
+                                       use_statements_code, intrinsic_statements_code, &
+                                       implicit_statements_code, interface_blocks_code, &
+                                       non_use_indices, &
                                        non_use_count, header_decl_indices, &
                                        header_decl_count)
         type(ast_arena_t), intent(in) :: arena
@@ -344,6 +356,7 @@ contains
         integer, intent(in) :: body_index
         logical, intent(inout) :: has_implicit
         character(len=:), allocatable, intent(inout) :: use_statements_code
+        character(len=:), allocatable, intent(inout) :: intrinsic_statements_code
         character(len=:), allocatable, intent(inout) :: implicit_statements_code
         character(len=:), allocatable, intent(inout) :: interface_blocks_code
         integer, intent(inout) :: non_use_indices(:)
@@ -358,6 +371,7 @@ contains
         is_header_stmt = classify_and_process_header_node(arena, body_index, &
                                                           has_implicit, &
                                                           use_statements_code, &
+                                                          intrinsic_statements_code, &
                                                           implicit_statements_code, &
                                                           interface_blocks_code, &
                                                           non_use_count, &
@@ -375,15 +389,18 @@ contains
     logical function classify_and_process_header_node(arena, body_index, &
                                                       has_implicit, &
                                                       use_statements_code, &
+                                                      intrinsic_statements_code, &
                                                       implicit_statements_code, &
                                                       interface_blocks_code, &
                                                       non_use_count, &
                                                       header_decl_count, &
-                                                      header_decl_indices) result(is_header)
+                                                      header_decl_indices) &
+        result(is_header)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: body_index
         logical, intent(inout) :: has_implicit
         character(len=:), allocatable, intent(inout) :: use_statements_code
+        character(len=:), allocatable, intent(inout) :: intrinsic_statements_code
         character(len=:), allocatable, intent(inout) :: implicit_statements_code
         character(len=:), allocatable, intent(inout) :: interface_blocks_code
         integer, intent(in) :: non_use_count
@@ -397,33 +414,38 @@ contains
         type is (use_statement_node)
             call process_use_statement(arena, body_index, use_statements_code)
             is_header = .true.
+        type is (intrinsic_statement_node)
+            call process_intrinsic_statement(arena, body_index, intrinsic_statements_code)
+            is_header = .true.
         type is (comment_node)
             is_header = process_comment_node(arena, body_index, ib, non_use_count, &
-                                            header_decl_count, use_statements_code, &
-                                            implicit_statements_code, &
-                                            interface_blocks_code)
+                                             header_decl_count, use_statements_code, &
+                                             intrinsic_statements_code, &
+                                             implicit_statements_code, &
+                                             interface_blocks_code)
         type is (blank_line_node)
             is_header = process_blank_line(arena, body_index, non_use_count, &
-                                          header_decl_count, use_statements_code, &
-                                          implicit_statements_code, &
-                                          interface_blocks_code)
+                                           header_decl_count, use_statements_code, &
+                                           intrinsic_statements_code, &
+                                           implicit_statements_code, &
+                                           interface_blocks_code)
         type is (implicit_statement_node)
             call process_implicit_statement(arena, body_index, ib, has_implicit, &
-                                           implicit_statements_code)
+                                            implicit_statements_code)
             is_header = .true.
         type is (derived_type_node)
             call process_derived_type(arena, body_index, implicit_statements_code)
             is_header = .true.
         type is (declaration_node)
             call process_declaration(body_index, header_decl_count, &
-                                    header_decl_indices)
+                                     header_decl_indices)
             is_header = .true.
         type is (interface_block_node)
             call process_interface_block(arena, body_index, interface_blocks_code)
             is_header = .true.
         type is (literal_node)
             is_header = process_literal_node(ib, has_implicit, &
-                                            implicit_statements_code)
+                                             implicit_statements_code)
         end select
     end function classify_and_process_header_node
 
@@ -438,16 +460,29 @@ contains
                               new_line('A')
     end subroutine process_use_statement
 
+    subroutine process_intrinsic_statement(arena, body_index, intrinsic_statements_code)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_index
+        character(len=:), allocatable, intent(inout) :: intrinsic_statements_code
+        character(len=:), allocatable :: stmt_code
+
+        stmt_code = generate_code_from_arena(arena, body_index)
+        intrinsic_statements_code = intrinsic_statements_code // "    " // &
+                                    stmt_code // new_line('A')
+    end subroutine process_intrinsic_statement
+
     logical function process_comment_node(arena, body_index, ib, non_use_count, &
-                                         header_decl_count, use_statements_code, &
-                                         implicit_statements_code, &
-                                         interface_blocks_code) result(is_header)
+                                          header_decl_count, use_statements_code, &
+                                          intrinsic_statements_code, &
+                                          implicit_statements_code, &
+                                          interface_blocks_code) result(is_header)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: body_index
         type(comment_node), intent(in) :: ib
         integer, intent(in) :: non_use_count
         integer, intent(in) :: header_decl_count
         character(len=:), allocatable, intent(inout) :: use_statements_code
+        character(len=:), allocatable, intent(inout) :: intrinsic_statements_code
         character(len=:), allocatable, intent(inout) :: implicit_statements_code
         character(len=:), allocatable, intent(inout) :: interface_blocks_code
         character(len=:), allocatable :: stmt_code
@@ -462,6 +497,7 @@ contains
                                            stmt_code // new_line('A')
             else
                 call append_header_trivia(stmt_code, use_statements_code, &
+                                          intrinsic_statements_code, &
                                           implicit_statements_code, &
                                           interface_blocks_code)
             end if
@@ -469,14 +505,16 @@ contains
     end function process_comment_node
 
     logical function process_blank_line(arena, body_index, non_use_count, &
-                                       header_decl_count, use_statements_code, &
-                                       implicit_statements_code, &
-                                       interface_blocks_code) result(is_header)
+                                        header_decl_count, use_statements_code, &
+                                        intrinsic_statements_code, &
+                                        implicit_statements_code, &
+                                        interface_blocks_code) result(is_header)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: body_index
         integer, intent(in) :: non_use_count
         integer, intent(in) :: header_decl_count
         character(len=:), allocatable, intent(inout) :: use_statements_code
+        character(len=:), allocatable, intent(inout) :: intrinsic_statements_code
         character(len=:), allocatable, intent(inout) :: implicit_statements_code
         character(len=:), allocatable, intent(inout) :: interface_blocks_code
         character(len=:), allocatable :: stmt_code
@@ -486,13 +524,14 @@ contains
             is_header = .true.
             stmt_code = generate_code_from_arena(arena, body_index)
             call append_header_trivia(stmt_code, use_statements_code, &
+                                      intrinsic_statements_code, &
                                       implicit_statements_code, &
                                       interface_blocks_code)
         end if
     end function process_blank_line
 
     subroutine process_implicit_statement(arena, body_index, ib, has_implicit, &
-                                         implicit_statements_code)
+                                          implicit_statements_code)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: body_index
         type(implicit_statement_node), intent(in) :: ib
@@ -550,7 +589,7 @@ contains
     end subroutine process_interface_block
 
     logical function process_literal_node(ib, has_implicit, &
-                                         implicit_statements_code) result(is_header)
+                                          implicit_statements_code) result(is_header)
         type(literal_node), intent(in) :: ib
         logical, intent(inout) :: has_implicit
         character(len=:), allocatable, intent(inout) :: implicit_statements_code
@@ -571,9 +610,10 @@ contains
         end if
     end function process_literal_node
 
-    subroutine append_header_trivia(fragment, use_code, implicit_code, interface_code)
+    subroutine append_header_trivia(fragment, use_code, intrinsic_code, implicit_code, interface_code)
         character(len=*), intent(in) :: fragment
         character(len=:), allocatable, intent(inout) :: use_code
+        character(len=:), allocatable, intent(inout) :: intrinsic_code
         character(len=:), allocatable, intent(inout) :: implicit_code
         character(len=:), allocatable, intent(inout) :: interface_code
         character(len=:), allocatable :: trimmed_fragment
@@ -589,6 +629,14 @@ contains
                 interface_code = interface_code // trimmed_fragment
             else
                 interface_code = interface_code // "    " // &
+                                 trim(trimmed_fragment) // &
+                                 new_line('A')
+            end if
+        else if (len(intrinsic_code) > 0) then
+            if (is_blank) then
+                intrinsic_code = intrinsic_code // trimmed_fragment
+            else
+                intrinsic_code = intrinsic_code // "    " // &
                                  trim(trimmed_fragment) // &
                                  new_line('A')
             end if

--- a/src/codegen/codegen_statements.f90
+++ b/src/codegen/codegen_statements.f90
@@ -30,6 +30,7 @@ module codegen_statements
     public :: generate_code_cycle
     public :: generate_code_exit
     public :: generate_code_use_statement
+    public :: generate_code_intrinsic_statement
     public :: generate_code_import_statement
     public :: generate_code_visibility_statement
     public :: generate_code_namelist_statement
@@ -141,7 +142,7 @@ contains
                 if (node%arg_indices(i) > 0 .and. &
                     node%arg_indices(i) <= arena%size) then
                     args_code = args_code // &
-                        generate_code_from_arena(arena, node%arg_indices(i))
+                                generate_code_from_arena(arena, node%arg_indices(i))
                 end if
             end do
             code = code // "(" // args_code // ")"
@@ -176,7 +177,8 @@ contains
                 if (node%expression_indices(i) > 0 .and. &
                     node%expression_indices(i) <= arena%size) then
                     args_code = args_code // &
-                        generate_code_from_arena(arena, node%expression_indices(i))
+                                generate_code_from_arena(arena, &
+                                                         node%expression_indices(i))
                 end if
             end do
         end if
@@ -224,7 +226,7 @@ contains
                     node%arg_indices(i) <= arena%size) then
                     ! Use recursive code generation for proper expression handling
                     args_code = args_code // &
-                        generate_code_from_arena(arena, node%arg_indices(i))
+                                generate_code_from_arena(arena, node%arg_indices(i))
                 end if
             end do
         end if
@@ -269,7 +271,7 @@ contains
                 if (node%var_indices(i) > 0 .and. &
                     node%var_indices(i) <= arena%size) then
                     vars_code = vars_code // &
-                        generate_code_from_arena(arena, node%var_indices(i))
+                                generate_code_from_arena(arena, node%var_indices(i))
                 end if
             end do
         end if
@@ -512,6 +514,31 @@ contains
         call prepend_stmt_label(code, node%stmt_label)
     end function generate_code_use_statement
 
+    function generate_code_intrinsic_statement(node) result(code)
+        type(intrinsic_statement_node), intent(in) :: node
+        character(len=:), allocatable :: code
+        integer :: i
+
+        code = "intrinsic"
+        if (node%has_double_colon) then
+            code = code // " ::"
+        end if
+
+        if (allocated(node%procedure_names)) then
+            do i = 1, size(node%procedure_names)
+                if (allocated(node%procedure_names(i)%s)) then
+                    if (i == 1) then
+                        code = code // " " // trim(node%procedure_names(i)%s)
+                    else
+                        code = code // ", " // trim(node%procedure_names(i)%s)
+                    end if
+                end if
+            end do
+        end if
+
+        call prepend_stmt_label(code, node%stmt_label)
+    end function generate_code_intrinsic_statement
+
     function generate_code_import_statement(node) result(code)
         type(import_statement_node), intent(in) :: node
         character(len=:), allocatable :: code
@@ -625,8 +652,9 @@ contains
                         node%letter_specs(i)%end_letter) then
                         letter_part = letter_part // node%letter_specs(i)%start_letter
                     else
-                        letter_part = letter_part // node%letter_specs(i)%start_letter &
-                            // "-" // node%letter_specs(i)%end_letter
+                        letter_part = letter_part // &
+                                      node%letter_specs(i)%start_letter &
+                                      // "-" // node%letter_specs(i)%end_letter
                     end if
                 end do
             end if
@@ -747,22 +775,22 @@ contains
         if (node%stat_var_index > 0 .and. &
             node%stat_var_index <= arena%size) then
             args = args // ", stat=" // &
-                generate_code_from_arena(arena, node%stat_var_index)
+                   generate_code_from_arena(arena, node%stat_var_index)
         end if
         if (node%errmsg_var_index > 0 .and. &
             node%errmsg_var_index <= arena%size) then
             args = args // ", errmsg=" // &
-                generate_code_from_arena(arena, node%errmsg_var_index)
+                   generate_code_from_arena(arena, node%errmsg_var_index)
         end if
         if (node%source_expr_index > 0 .and. &
             node%source_expr_index <= arena%size) then
             args = args // ", source=" // &
-                generate_code_from_arena(arena, node%source_expr_index)
+                   generate_code_from_arena(arena, node%source_expr_index)
         end if
         if (node%mold_expr_index > 0 .and. &
             node%mold_expr_index <= arena%size) then
             args = args // ", mold=" // &
-                generate_code_from_arena(arena, node%mold_expr_index)
+                   generate_code_from_arena(arena, node%mold_expr_index)
         end if
 
         code = "allocate(" // args // ")"
@@ -784,22 +812,22 @@ contains
         if (allocated(node%var_indices)) then
             do i = 1, size(node%var_indices)
                 if (i > 1) args = args // ", "
-        if (node%var_indices(i) > 0 .and. &
-            node%var_indices(i) <= arena%size) then
-            args = args // generate_code_from_arena(arena, node%var_indices(i))
-        end if
+                if (node%var_indices(i) > 0 .and. &
+                    node%var_indices(i) <= arena%size) then
+                    args = args // generate_code_from_arena(arena, node%var_indices(i))
+                end if
             end do
         end if
 
         if (node%stat_var_index > 0 .and. &
             node%stat_var_index <= arena%size) then
             args = args // ", stat=" // &
-                generate_code_from_arena(arena, node%stat_var_index)
+                   generate_code_from_arena(arena, node%stat_var_index)
         end if
         if (node%errmsg_var_index > 0 .and. &
             node%errmsg_var_index <= arena%size) then
             args = args // ", errmsg=" // &
-                generate_code_from_arena(arena, node%errmsg_var_index)
+                   generate_code_from_arena(arena, node%errmsg_var_index)
         end if
 
         code = "deallocate(" // args // ")"

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -490,7 +490,7 @@ contains
               'endfunction', 'endinterface', 'endmodule', 'endprogram', &
               'endselect', 'endsubmodule', 'endsubroutine', 'endtype', &
               'elemental', 'pure', 'impure', 'recursive', 'nonrecursive', &
-              'non_recursive')
+              'non_recursive', 'intrinsic', 'non_intrinsic')
             keyword = .true.
         case default
             keyword = .false.

--- a/src/parser/parser_dispatcher.f90
+++ b/src/parser/parser_dispatcher.f90
@@ -12,6 +12,7 @@ module parser_dispatcher_module
     use parser_utils, only: analyze_declaration_structure
     use parser_import_statements_module, only: parse_use_statement, &
                                                parse_include_statement, parse_module
+    use parser_intrinsic_statements_module, only: parse_intrinsic_statement
     use parser_block_data_module, only: parse_block_data
     use parser_io_statements_module, only: parse_print_statement, &
                                            parse_write_statement, parse_read_statement
@@ -75,6 +76,8 @@ contains
             select case (lowered_keyword)
             case ("use")
                 stmt_index = parse_use_statement(parser, arena)
+            case ("intrinsic")
+                stmt_index = parse_intrinsic_statement(parser, arena)
             case ("include")
                 stmt_index = parse_include_statement(parser, arena)
             case ("print")

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -44,6 +44,7 @@ module parser_execution_statements_module
                                             get_data_additional_indices
     use parser_call_module, only: parse_call_statement
     use parser_import_statements_module, only: parse_use_statement
+    use parser_intrinsic_statements_module, only: parse_intrinsic_statement
     use parser_type_specifications_module, only: parse_implicit_statement, &
                                                  take_implicit_additional_indices
     use parser_dimension_statements_module, only: parse_dimension_statement
@@ -352,6 +353,8 @@ contains
                 end block
             case ("use")
                 stmt_index = parse_use_statement(parser_ref, arena_ref)
+            case ("intrinsic")
+                stmt_index = parse_intrinsic_statement(parser_ref, arena_ref)
             case ("write")
                 stmt_index = parse_write_statement(parser_ref, arena_ref)
             case ("read")

--- a/src/parser/parser_intrinsic_statements.f90
+++ b/src/parser/parser_intrinsic_statements.f90
@@ -1,0 +1,92 @@
+module parser_intrinsic_statements_module
+    use lexer_core, only: token_t, TK_IDENTIFIER, TK_KEYWORD, TK_OPERATOR
+    use parser_state_module, only: parser_state_t
+    use ast_arena_modern, only: ast_arena_t
+    use ast_factory, only: push_intrinsic_statement
+    implicit none
+    private
+
+    public :: parse_intrinsic_statement
+
+contains
+
+    function parse_intrinsic_statement(parser, arena) result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer :: stmt_index
+        type(token_t) :: token
+        integer :: line, column
+        logical :: has_double_colon
+        character(len=64), allocatable :: names(:)
+        integer :: count
+
+        stmt_index = 0
+        has_double_colon = .false.
+        count = 0
+
+        token = parser%consume()
+        line = token%line
+        column = token%column
+
+        if (.not. allocated(names)) then
+            allocate (names(8))
+            names = ""
+        end if
+
+        if (parser%is_at_end()) then
+            return
+        end if
+
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. token%text == "::") then
+            token = parser%consume()
+            has_double_colon = .true.
+        end if
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%kind /= TK_IDENTIFIER .and. token%kind /= TK_KEYWORD) then
+                exit
+            end if
+
+            token = parser%consume()
+            if (len_trim(token%text) == 0) cycle
+
+            count = count + 1
+            if (count > size(names)) then
+                call grow_name_buffer(names)
+            end if
+            names(count) = trim(token%text)
+
+            if (parser%is_at_end()) exit
+
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                token = parser%consume()
+                cycle
+            end if
+            exit
+        end do
+
+        if (count <= 0) then
+            return
+        end if
+
+        stmt_index = push_intrinsic_statement(arena, names(1:count), line, column, &
+                                              has_double_colon=has_double_colon)
+
+    contains
+        subroutine grow_name_buffer(buffer)
+            character(len=64), allocatable, intent(inout) :: buffer(:)
+            character(len=64), allocatable :: temp(:)
+            integer :: old_size
+
+            old_size = size(buffer)
+            allocate (temp(old_size * 2))
+            temp = ""
+            temp(1:old_size) = buffer
+            call move_alloc(temp, buffer)
+        end subroutine grow_name_buffer
+    end function parse_intrinsic_statement
+
+end module parser_intrinsic_statements_module

--- a/src/standardizers/standardizer_declarations_core.f90
+++ b/src/standardizers/standardizer_declarations_core.f90
@@ -300,6 +300,8 @@ contains
                     select type (stmt => arena%entries(prog%body_indices(i))%node)
                     type is (use_statement_node)
                         keep_scanning = .true.
+                    type is (intrinsic_statement_node)
+                        keep_scanning = .true.
                     type is (comment_node)
                         ! Legacy statement comments (COMMON/EQUIVALENCE) are treated as declarations
                         if (is_legacy_statement_comment(stmt)) then

--- a/test/codegen/test_issue_1902_intrinsic_statement.f90
+++ b/test/codegen/test_issue_1902_intrinsic_statement.f90
@@ -1,0 +1,51 @@
+program test_issue_1902_intrinsic_statement
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+    logical :: success
+
+    print *, "=== Codegen: preserve INTRINSIC statements ==="
+
+    source = 'program sample' // new_line('a') // &
+             '    implicit none' // new_line('a') // &
+             '    intrinsic :: sin, cos' // new_line('a') // &
+             '    real :: x' // new_line('a') // &
+             '    x = sin(0.0)' // new_line('a') // &
+             '    print *, cos(x)' // new_line('a') // &
+             'end program sample' // new_line('a')
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    success = .true.
+    if (.not. allocated(output)) success = .false.
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) success = .false.
+    end if
+
+    if (success) then
+        if (index(output, 'intrinsic :: sin, cos') == 0) success = .false.
+        if (index(output, 'sin(0.0)') == 0) success = .false.
+        if (index(output, 'cos(x)') == 0) success = .false.
+    end if
+
+    if (success) then
+        print *, 'PASSED'
+    else
+        print *, 'FAILED: intrinsic statement was not preserved'
+        if (allocated(output)) then
+            print *, 'OUTPUT:'
+            print *, trim(output)
+        end if
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'ERRORS:'
+                print *, trim(error_msg)
+            end if
+        end if
+        stop 1
+    end if
+
+end program test_issue_1902_intrinsic_statement


### PR DESCRIPTION
## Summary
- mark intrinsic/non_intrinsic as keywords so the parser builds intrinsic statement nodes
- keep intrinsic statements in the generated program header after implicit none for the original ordering

## Verification
- make test