### PR TITLE
fix: Code style: Result variable declaration omitted in functions wit (fixes #1891)

### DIFF
--- a/src/ast/nodes/ast_nodes_procedure.f90
+++ b/src/ast/nodes/ast_nodes_procedure.f90
@@ -21,6 +21,7 @@ module ast_nodes_procedure
         character(len=:), allocatable :: name
         integer, allocatable :: param_indices(:)
         character(len=:), allocatable :: return_type
+        logical :: has_return_type_in_header = .false.
         character(len=:), allocatable :: result_variable
         character(len=16), allocatable :: prefix_keywords(:)
         integer, allocatable :: body_indices(:)
@@ -111,6 +112,7 @@ contains
         ! Copy derived class fields
         lhs%name = rhs%name
         lhs%return_type = rhs%return_type
+        lhs%has_return_type_in_header = rhs%has_return_type_in_header
         lhs%is_recursive = rhs%is_recursive
         if (allocated(rhs%result_variable)) lhs%result_variable = rhs%result_variable
         if (allocated(rhs%prefix_keywords)) lhs%prefix_keywords = rhs%prefix_keywords
@@ -232,6 +234,7 @@ contains
             end if
         end if
         node%return_type = return_type
+        node%has_return_type_in_header = len_trim(return_type) > 0
         if (present(result_variable)) then
             node%result_variable = result_variable
         end if

--- a/src/codegen/codegen_declarations_procedures.f90
+++ b/src/codegen/codegen_declarations_procedures.f90
@@ -213,7 +213,8 @@ contains
 
         call filter_implicit_statements(arena, body_indices, filtered_body_indices)
         body = body // generate_grouped_body_with_params(arena, &
-            filtered_body_indices, 1, param_map, node)
+                                                         filtered_body_indices, 1, &
+                                                         param_map, node)
         call reorder_import_lines(body)
     end function build_function_body_section
 
@@ -404,7 +405,8 @@ contains
 
         call filter_implicit_statements(arena, body_indices, filtered_body_indices)
         body = body // generate_grouped_body_with_params(arena, &
-            filtered_body_indices, 1, param_map, node)
+                                                         filtered_body_indices, 1, &
+                                                         param_map, node)
         call reorder_import_lines(body)
     end function build_subroutine_body_section
 
@@ -427,8 +429,8 @@ contains
         character(len=*), intent(in) :: return_type_code
         character(len=:), allocatable :: result_name
         character(len=:), allocatable :: lowered_return
-        integer :: i, decl_index
-        logical :: has_explicit_result_clause
+        integer :: i, decl_index, k
+        logical :: has_header_return_type
 
         omit = .false.
         result_name = ""
@@ -442,16 +444,7 @@ contains
 
         if (.not. allocated(node%name)) return
 
-        has_explicit_result_clause = .false.
-        if (allocated(node%result_variable)) then
-            if (len_trim(node%result_variable) > 0) then
-                if (trim(node%result_variable) /= trim(node%name)) then
-                    has_explicit_result_clause = .true.
-                end if
-            end if
-        end if
-
-        if (has_explicit_result_clause) return
+        has_header_return_type = node%has_return_type_in_header
 
         if (.not. allocated(node%body_indices)) return
 
@@ -464,13 +457,20 @@ contains
             if (.not. allocated(arena%entries(decl_index)%node)) cycle
             select type (decl => arena%entries(decl_index)%node)
             type is (declaration_node)
-                if (trim(decl%var_name) /= trim(result_name)) cycle
-                if (.not. decl%is_array) then
-                    if (.not. allocated(decl%dimension_indices)) cycle
-                    if (size(decl%dimension_indices) == 0) cycle
+                if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
+                    do k = 1, size(decl%var_names)
+                        if (trim(decl%var_names(k)) == trim(result_name)) then
+                            if (has_header_return_type) cycle
+                            omit = .true.
+                            return
+                        end if
+                    end do
+                else
+                    if (trim(decl%var_name) /= trim(result_name)) cycle
+                    if (has_header_return_type) cycle
+                    omit = .true.
+                    return
                 end if
-                omit = .true.
-                return
             end select
         end do
     end function should_omit_return_type
@@ -545,7 +545,8 @@ contains
     end function parameter_has_declaration
 
     ! Collect parameter declarations for undeclared subroutine parameters
-    function collect_subroutine_parameter_decls(arena, sub, param_map) result(decl_code)
+    function collect_subroutine_parameter_decls(arena, sub, param_map) &
+        result(decl_code)
         type(ast_arena_t), intent(in) :: arena
         type(subroutine_def_node), intent(in) :: sub
         type(parameter_info_t), intent(in) :: param_map(:)
@@ -563,7 +564,7 @@ contains
             if (.not. allocated(arena%entries(param_idx)%node)) cycle
 
             has_declaration = subroutine_parameter_has_declaration(arena, sub, &
-                                                                    param_map, i)
+                                                                   param_map, i)
 
             if (.not. has_declaration .and. i <= size(param_map)) then
                 call append_parameter_declaration(arena, param_idx, param_map(i), &
@@ -659,7 +660,8 @@ contains
             integer :: pos_char
             pos_char = index(decl_line, 'character(len=:)')
             if (pos_char > 0) then
-                decl_line = decl_line(1:pos_char+13) // '*)' // decl_line(pos_char+17:)
+                decl_line = decl_line(1:pos_char + 13) // '*)' // &
+                            decl_line(pos_char + 17:)
             end if
         end block
         decl_code = decl_code // decl_line // new_line('A')
@@ -677,7 +679,7 @@ contains
         ! For parameters, convert character(len=:) to character(len=*)
         pos = index(param_type, 'character(len=:)')
         if (pos > 0) then
-            param_type = param_type(1:pos+13) // '*' // param_type(pos+16:)
+            param_type = param_type(1:pos + 13) // '*' // param_type(pos + 16:)
         end if
     end function get_param_type_from_identifier
 
@@ -762,10 +764,11 @@ contains
                 end select
             type is (print_statement_node)
                 call collect_vars_from_print(arena, stmt, param_map, local_vars, &
-                                            n_locals, capacity, result_name, decl_code)
+                                             n_locals, capacity, &
+                                             result_name, decl_code)
             type is (read_statement_node)
                 call collect_vars_from_read(arena, stmt, param_map, local_vars, &
-                                           n_locals, capacity, result_name, decl_code)
+                                            n_locals, capacity, result_name, decl_code)
             end select
         end do
     end function collect_local_variable_decls
@@ -827,7 +830,7 @@ contains
     end subroutine ensure_local_var_capacity
 
     subroutine collect_vars_from_print(arena, stmt, param_map, local_vars, &
-                                      n_locals, capacity, result_name, decl_code)
+                                       n_locals, capacity, result_name, decl_code)
         type(ast_arena_t), intent(in) :: arena
         type(print_statement_node), intent(in) :: stmt
         type(parameter_info_t), intent(in) :: param_map(:)
@@ -866,7 +869,7 @@ contains
     end subroutine collect_vars_from_print
 
     subroutine collect_vars_from_read(arena, stmt, param_map, local_vars, &
-                                     n_locals, capacity, result_name, decl_code)
+                                      n_locals, capacity, result_name, decl_code)
         type(ast_arena_t), intent(in) :: arena
         type(read_statement_node), intent(in) :: stmt
         type(parameter_info_t), intent(in) :: param_map(:)
@@ -933,10 +936,10 @@ contains
             type is (declaration_node)
                 if (allocated(stmt%var_names)) then
                     call add_declared_vars(stmt%var_names, declared_vars, &
-                                          n_declared, decl_capacity)
+                                           n_declared, decl_capacity)
                 else if (allocated(stmt%var_name)) then
                     call add_single_declared_var(stmt%var_name, declared_vars, &
-                                                n_declared, decl_capacity)
+                                                 n_declared, decl_capacity)
                 end if
             end select
         end do
@@ -960,7 +963,8 @@ contains
                     var_name = trim(target%name)
 
                     if (is_parameter_name(var_name, param_map)) cycle
-                    if (is_local_var_collected(var_name, declared_vars, n_declared)) cycle
+                    if (is_local_var_collected(var_name, declared_vars, &
+                                               n_declared)) cycle
 
                     if (.not. is_local_var_collected(var_name, local_vars, n_locals)) &
                         then
@@ -980,19 +984,19 @@ contains
                 end select
             type is (print_statement_node)
                 call collect_vars_from_print_sub(arena, stmt, param_map, local_vars, &
-                                                n_locals, capacity, declared_vars, &
-                                                n_declared, decl_code)
+                                                 n_locals, capacity, declared_vars, &
+                                                 n_declared, decl_code)
             type is (read_statement_node)
                 call collect_vars_from_read_sub(arena, stmt, param_map, local_vars, &
-                                               n_locals, capacity, declared_vars, &
-                                               n_declared, decl_code)
+                                                n_locals, capacity, declared_vars, &
+                                                n_declared, decl_code)
             end select
         end do
     end function collect_subroutine_local_variable_decls
 
     subroutine collect_vars_from_print_sub(arena, stmt, param_map, local_vars, &
-                                          n_locals, capacity, declared_vars, &
-                                          n_declared, decl_code)
+                                           n_locals, capacity, declared_vars, &
+                                           n_declared, decl_code)
         type(ast_arena_t), intent(in) :: arena
         type(print_statement_node), intent(in) :: stmt
         type(parameter_info_t), intent(in) :: param_map(:)
@@ -1032,8 +1036,8 @@ contains
     end subroutine collect_vars_from_print_sub
 
     subroutine collect_vars_from_read_sub(arena, stmt, param_map, local_vars, &
-                                         n_locals, capacity, declared_vars, &
-                                         n_declared, decl_code)
+                                          n_locals, capacity, declared_vars, &
+                                          n_declared, decl_code)
         type(ast_arena_t), intent(in) :: arena
         type(read_statement_node), intent(in) :: stmt
         type(parameter_info_t), intent(in) :: param_map(:)
@@ -1081,7 +1085,7 @@ contains
         do i = 1, size(var_names)
             if (len_trim(var_names(i)) == 0) cycle
             if (.not. is_local_var_collected(trim(var_names(i)), declared_vars, &
-                                            n_declared)) then
+                                             n_declared)) then
                 call ensure_local_var_capacity(declared_vars, capacity, n_declared + 1)
                 n_declared = n_declared + 1
                 declared_vars(n_declared) = trim(var_names(i))

--- a/src/codegen/codegen_utilities.f90
+++ b/src/codegen/codegen_utilities.f90
@@ -495,6 +495,7 @@ contains
         logical :: has_return_type_in_signature
         logical :: keep_result_decl
         logical :: force_keep_result_decl
+        logical :: has_header_return_type
         character(len=:), allocatable :: lowered_return
         logical :: has_dimensions
 
@@ -502,6 +503,7 @@ contains
         indent_str = repeat("    ", indent)
         code = ""
         force_keep_result_decl = .false.
+        has_header_return_type = .false.
         call get_type_standardization(standardize_types_enabled)
 
         ! Determine if we should skip result variable declarations
@@ -509,13 +511,13 @@ contains
         result_var_name = ""
         select type (proc_node)
         type is (function_def_node)
-            if (allocated(proc_node%return_type) .and. &
-                len_trim(proc_node%return_type) > 0) then
-                if (allocated(proc_node%result_variable)) then
-                    result_var_name = trim(proc_node%result_variable)
-                else if (allocated(proc_node%name)) then
-                    result_var_name = trim(proc_node%name)
-                end if
+            if (allocated(proc_node%result_variable)) then
+                result_var_name = trim(proc_node%result_variable)
+            else if (allocated(proc_node%name)) then
+                result_var_name = trim(proc_node%name)
+            end if
+            has_header_return_type = proc_node%has_return_type_in_header
+            if (has_header_return_type) then
                 lowered_return = to_lower(trim(proc_node%return_type))
                 if (index(lowered_return, "len=") > 0) then
                     force_keep_result_decl = .true.
@@ -524,6 +526,10 @@ contains
                                                    has_return_type_in_signature)
             end if
         end select
+
+        if (len_trim(result_var_name) > 0 .and. .not. has_header_return_type) then
+            force_keep_result_decl = .true.
+        end if
 
         ! First pass: collect parameter declarations from the body to capture
         ! types and attributes. Attributes may appear inside the body rather
@@ -570,7 +576,8 @@ contains
                                                 normalize_character_type(node, &
                                                                          type_name)
                                         else if (standardize_types_enabled .and. &
-                                                 to_lower(trim(type_name)) == 'real' .and. &
+                                                 to_lower(trim(type_name)) == &
+                                                 'real' .and. &
                                                  .not. node%has_kind) then
                                             type_name = "real(8)"
                                         end if
@@ -695,7 +702,8 @@ contains
                                         type_name = &
                                             normalize_character_type(node, type_name)
                                     else if (standardize_types_enabled .and. &
-                                             to_lower(trim(type_name)) == 'real' .and. &
+                                             to_lower(trim(type_name)) == &
+                                             'real' .and. &
                                              .not. node%has_kind) then
                                         type_name = "real(8)"
                                     end if

--- a/test/test_issue_1891_result_declaration.f90
+++ b/test/test_issue_1891_result_declaration.f90
@@ -1,0 +1,41 @@
+program test_issue_1891_result_declaration
+    use, intrinsic :: iso_fortran_env, only: dp => real64
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    character(:), allocatable :: input_code
+    character(:), allocatable :: output_code
+    character(:), allocatable :: error_msg
+    logical :: has_result_decl
+
+    print *, "=== Issue #1891: result() declaration preservation ==="
+
+    input_code = &
+        "program sample" // new_line('A') // &
+        "    implicit none" // new_line('A') // &
+        "contains" // new_line('A') // &
+        "    pure function circle_area(radius) result(area)" // new_line('A') // &
+        "        real, intent(in) :: radius" // new_line('A') // &
+        "        real :: area" // new_line('A') // &
+        "        real, parameter :: pi = 3.14159265" // new_line('A') // &
+        "        area = pi * radius**2" // new_line('A') // &
+        "    end function circle_area" // new_line('A') // &
+        "end program sample"
+
+    call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: transformation returned error", trim(error_msg)
+        error stop 1
+    end if
+
+    has_result_decl = index(output_code, "real :: area") > 0
+    if (.not. has_result_decl) then
+        print *, "FAIL: result variable declaration missing in output"
+        print *, "Output:" // new_line('A') // trim(output_code)
+        error stop 1
+    end if
+
+    print *, "PASS: result variable declaration preserved"
+
+end program test_issue_1891_result_declaration


### PR DESCRIPTION
## Summary
- track whether a function header originally specified its return type
- preserve result variable declarations only when the signature omits that type
- add regression coverage for result() declarations staying in the output

## Verification
- make test
