### PR TITLE
fix: refactor: semantic analyzer modules exceed 1000-line hard limit (fixes #1923)

### DIFF
--- a/src/semantic/analyzers/semantic_analyzer.f90
+++ b/src/semantic/analyzers/semantic_analyzer.f90
@@ -1,20 +1,8 @@
 module semantic_analyzer
-    ! Core semantic analysis - split to comply with 1000-line limit (Issue #1593)
     use type_system_unified, only: type_env_t, type_var_t, mono_type_t, poly_type_t, &
-                                   substitution_t, allocation_info_t, &
-                                   create_mono_type, &
-                                   create_type_var, &
-                                   create_poly_type, create_fun_type, free_type_vars, &
-                                   compose_substitutions, &
-                                   occurs_check, TVAR, TINT, TREAL, TCHAR, TLOGICAL, &
-                                   TFUN, TARRAY, &
-                                   TCOMPLEX, &
-                                   TDOUBLE, TDERIVED, type_args_allocated, &
-                                   type_args_size, &
-                                   type_args_element
-    use scope_manager
+                                   substitution_t, allocation_info_t
+    use scope_manager, only: scope_stack_t, create_scope_stack
     use ast_arena_modern, only: ast_arena_t
-    use semantic_inference_helpers, only: check_implicit_none
     use semantic_validation_utils, only: validate_array_bounds, &
                                          check_shape_conformance, &
                                          update_identifier_type_in_arena, int_to_str
@@ -33,7 +21,8 @@ module semantic_analyzer
     use semantic_binary_operations, only: infer_string_concatenation, &
                                           infer_comparison_operation, &
                                           infer_logical_operation
-    use semantic_inference_helpers, only: process_if_node_branches, &
+    use semantic_inference_helpers, only: check_implicit_none, &
+                                          process_if_node_branches, &
                                           process_do_while_node_body, &
                                           process_where_node_clauses, &
                                           process_where_stmt_node, &
@@ -55,20 +44,15 @@ module semantic_analyzer
     use ast_base, only: LITERAL_INTEGER, LITERAL_REAL, LITERAL_STRING, LITERAL_LOGICAL
     use ast_nodes_core, only: literal_node, identifier_node, binary_op_node, &
                               assignment_node, call_or_subscript_node, &
-                              array_literal_node, &
-                              program_node
+                              array_literal_node, program_node
     use ast_nodes_procedure, only: subroutine_call_node, function_def_node, &
                                    subroutine_def_node
     use ast_nodes_control, only: do_loop_node, if_node, do_while_node, where_node, &
                                  where_stmt_node, forall_node, select_case_node, &
-                                 case_block_node, &
-                                 associate_node, association_t, cycle_node, &
-                                 exit_node, &
-                                 stop_node, &
-                                 return_node, entry_node, continue_node, &
-                                 elsewhere_clause_t, &
-                                 pause_node, &
-                                 nullify_node
+                                 case_block_node, associate_node, association_t, &
+                                 cycle_node, exit_node, stop_node, return_node, &
+                                 entry_node, continue_node, elsewhere_clause_t, &
+                                 pause_node, nullify_node
     use ast_nodes_data, only: intent_type_to_string, declaration_node, module_node
     use ast_nodes_bounds, only: array_spec_t, array_bounds_t, array_slice_node, &
                                 array_bounds_node, range_expression_node, &
@@ -86,8 +70,10 @@ module semantic_analyzer
     implicit none
     private
 
-    public :: semantic_context_t, create_semantic_context, analyze_program, &
-              has_semantic_errors
+    public :: semantic_context_t
+    public :: create_semantic_context
+    public :: analyze_program
+    public :: has_semantic_errors
 
     type, extends(semantic_context_base_t) :: semantic_context_t
         type(scope_stack_t) :: scopes
@@ -119,1241 +105,167 @@ module semantic_analyzer
         generic :: assignment(=) => assign
     end type semantic_context_t
 
-    type :: infer_frame_t
-        integer :: node_index = 0
-        integer :: state = 0
-        integer :: aux_index = 0
-        logical :: leave_scope = .false.
-        logical :: has_cached_type = .false.
-        type(mono_type_t) :: cached_type
-        type(mono_type_t), allocatable :: param_types(:)
-    end type infer_frame_t
+    interface
+        module subroutine create_semantic_context(ctx)
+            type(semantic_context_t), intent(out) :: ctx
+        end subroutine create_semantic_context
 
-contains
+        module subroutine analyze_program(ctx, arena, root_index)
+            type(semantic_context_t), intent(inout) :: ctx
+            type(ast_arena_t), intent(inout) :: arena
+            integer, intent(in) :: root_index
+        end subroutine analyze_program
 
-    subroutine create_semantic_context(ctx)
-        type(semantic_context_t), intent(out) :: ctx
-        type(poly_type_t) :: builtin_scheme
-        type(mono_type_t) :: real_to_real, real_type
+        module subroutine analyze_program_node_arena(ctx, arena, prog, prog_index)
+            type(semantic_context_t), intent(inout) :: ctx
+            type(ast_arena_t), intent(inout) :: arena
+            type(program_node), intent(inout) :: prog
+            integer, intent(in) :: prog_index
+        end subroutine analyze_program_node_arena
 
-        ! Initialize base class components
-        ctx%context_id = 1
-        ctx%context_name = "semantic_context"
-
-        ! Initialize basic components
-        call create_scope_stack(ctx%scopes)
-        ctx%subst%count = 0
-        ctx%subst%capacity = 64
-        if (allocated(ctx%subst%vars)) deallocate (ctx%subst%vars)
-        if (allocated(ctx%subst%types)) deallocate (ctx%subst%types)
-        allocate (ctx%subst%vars(ctx%subst%capacity))
-        allocate (ctx%subst%types(ctx%subst%capacity))
-        ! No parameter/temporary tracking in lean build
-        ctx%errors = create_error_collection()
-        ctx%next_var_id = 1  ! Start from 1 (main branch compatibility)
-        ctx%respect_implicit_none = .true.
-        ctx%type_hierarchy = create_type_hierarchy()
-        ctx%signatures = create_signatures_map()
-
-        ! Create real -> real type for math functions
-        real_type = create_mono_type(TREAL)
-        real_to_real = create_fun_type(real_type, real_type)
-
-        ! Create polymorphic type scheme (no type variables to generalize)
-        builtin_scheme = create_poly_type(forall_vars=[type_var_t ::], &
-                                          mono=real_to_real)
-
-        call ctx%scopes%define("exp", builtin_scheme)
-
-        if (has_type_annotations()) then
-            call consume_type_annotations(ctx%parser_type_hints)
-        else
-            allocate (ctx%parser_type_hints(0))
-        end if
-        call ctx%scopes%define("log", builtin_scheme)
-        call ctx%scopes%define("abs", builtin_scheme)
-    end subroutine create_semantic_context
-
-    subroutine analyze_program(ctx, arena, root_index)
-        type(semantic_context_t), intent(inout) :: ctx
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: root_index
-
-        if (root_index <= 0 .or. root_index > arena%size) return
-        if (.not. allocated(arena%entries(root_index)%node)) return
-
-        select type (ast => arena%entries(root_index)%node)
-        type is (program_node)
-            ! Only enable strict mode when implicit none is present
-            if (ctx%respect_implicit_none .and. .not. ctx%strict_mode) then
-                ctx%strict_mode = check_implicit_none(arena, ast)
-            end if
-            call analyze_program_node_arena(ctx, arena, ast, root_index)
-        type is (module_node)
-            return  ! Skip module analysis
-        class default
-            call infer_and_store_type(ctx, arena, root_index)
-        end select
-
-        call fold_constants_in_arena(arena)
-    end subroutine analyze_program
-
-    subroutine analyze_program_node_arena(ctx, arena, prog, prog_index)
-        type(semantic_context_t), intent(inout) :: ctx
-        type(ast_arena_t), intent(inout) :: arena
-        type(program_node), intent(inout) :: prog
-        integer, intent(in) :: prog_index
-        integer :: i
-
-        ! Prepass: define all declared variables in scope before inference
-        if (allocated(prog%body_indices)) then
-            do i = 1, size(prog%body_indices)
-                if (prog%body_indices(i) > 0 .and. &
-                    prog%body_indices(i) <= arena%size) then
-                    if (allocated(arena%entries(prog%body_indices(i))%node)) then
-                        select type (node => arena%entries(prog%body_indices(i))%node)
-                        type is (declaration_node)
-                            block
-                                type(mono_type_t) :: decl_type
-                                type(poly_type_t) :: scheme
-                                type(type_annotation_t) :: hint
-                                integer :: j
-
-                                if (ctx%get_type_hint(prog%body_indices(i), hint)) then
-                                    call type_from_annotation(hint, decl_type)
-                                else
-                                    call process_declaration_variables(node, decl_type)
-                                end if
-
-                                scheme = ctx%generalize(decl_type)
-                                if (node%is_multi_declaration .and. &
-                                    allocated(node%var_names)) then
-                                    do j = 1, size(node%var_names)
-                                        call &
-                                            ctx%scopes%define(node%var_names(j), &
-                                                              scheme)
-                                    end do
-                                else if (allocated(node%var_name)) then
-                                    call ctx%scopes%define(node%var_name, scheme)
-                                end if
-                            end block
-                        class default
-                            continue
-                        end select
-                    end if
-                end if
-            end do
-        end if
-
-        ! Main inference over statements
-        if (allocated(prog%body_indices)) then
-            do i = 1, size(prog%body_indices)
-                if (prog%body_indices(i) > 0 .and. &
-                    prog%body_indices(i) <= arena%size) then
-                    call infer_and_store_type(ctx, arena, prog%body_indices(i))
-                end if
-            end do
-        end if
-        call check_undefined_variables_generic(ctx%scopes, ctx%errors, &
-                                               ctx%strict_mode, &
-                                               arena, prog_index)
-    end subroutine analyze_program_node_arena
-
-    subroutine infer_and_store_type(ctx, arena, node_index)
-        type(semantic_context_t), intent(inout) :: ctx
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: node_index
-        type(mono_type_t) :: inferred
-
-        if (node_index <= 0 .or. node_index > arena%size) return
-        if (.not. allocated(arena%entries(node_index)%node)) return
-
-        inferred = ctx%infer_stmt(arena, node_index)
-
-        ! Direct assignment without allocation since inferred_type is not allocatable
-    end subroutine infer_and_store_type
-
-    function infer_statement_type(this, arena, stmt_index) result(typ)
-        class(semantic_context_t), intent(inout) :: this
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: stmt_index
-        type(mono_type_t) :: typ
-
-        typ = this%infer(arena, stmt_index)
-    end function infer_statement_type
-
-    function infer_type(this, arena, expr_index) result(typ)
-        class(semantic_context_t), intent(inout) :: this
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: expr_index
-        type(mono_type_t) :: typ
-        type(infer_frame_t), allocatable :: stack(:)
-        type(infer_frame_t) :: frame
-        integer :: stack_size
-        integer :: stack_capacity
-        integer, parameter :: STATE_PRE = 0
-        integer, parameter :: STATE_POST = 1
-        integer, parameter :: STATE_ASSOC_DEFINE = 2
-
-        typ = create_mono_type(TREAL)
-        if (expr_index <= 0 .or. expr_index > arena%size) return
-        if (.not. allocated(arena%entries(expr_index)%node)) return
-
-        stack_capacity = max(16, arena%size / 4 + 1)
-        allocate (stack(stack_capacity))
-        stack_size = 0
-
-        call push_pre(expr_index)
-
-        do while (stack_size > 0)
-            frame = stack(stack_size)
-            stack_size = stack_size - 1
-
-            select case (frame%state)
-            case (STATE_PRE)
-                call handle_previsit(frame)
-            case (STATE_POST)
-                call handle_postvisit(frame)
-            case (STATE_ASSOC_DEFINE)
-                call handle_association(frame)
-            end select
-        end do
-
-        typ = get_node_type(expr_index)
-
-    contains
-
-        subroutine ensure_capacity(required)
-            integer, intent(in) :: required
-            type(infer_frame_t), allocatable :: new_stack(:)
-            integer :: new_capacity
-
-            if (required <= stack_capacity) return
-
-            new_capacity = max(required, stack_capacity * 2)
-            allocate (new_stack(new_capacity))
-            if (stack_size > 0) new_stack(1:stack_size) = stack(1:stack_size)
-            call move_alloc(new_stack, stack)
-            stack_capacity = new_capacity
-        end subroutine ensure_capacity
-
-        subroutine push_frame_local(f)
-            type(infer_frame_t), intent(in) :: f
-
-            call ensure_capacity(stack_size + 1)
-            stack_size = stack_size + 1
-            stack(stack_size) = f
-        end subroutine push_frame_local
-
-        subroutine push_pre(index)
-            integer, intent(in) :: index
-            type(infer_frame_t) :: new_frame
-
-            new_frame%node_index = index
-            new_frame%state = STATE_PRE
-            new_frame%aux_index = 0
-            new_frame%leave_scope = .false.
-            new_frame%has_cached_type = .false.
-            if (allocated(new_frame%param_types)) deallocate (new_frame%param_types)
-            call push_frame_local(new_frame)
-        end subroutine push_pre
-
-        subroutine push_child(index)
-            integer, intent(in) :: index
-
-            if (index <= 0) return
-            call push_pre(index)
-        end subroutine push_child
-
-        subroutine handle_previsit(current)
-            type(infer_frame_t), intent(in) :: current
-            type(infer_frame_t) :: post_frame
-            integer :: node_index
-            integer :: i, j
-            type(mono_type_t) :: local_type
-            type(poly_type_t) :: int_scheme
-            type(mono_type_t), allocatable :: param_types(:)
-            character(len=64), allocatable :: param_names(:)
-            type(mono_type_t) :: return_type
-            type(mono_type_t) :: control_type
-
-            node_index = current%node_index
-            if (node_index <= 0 .or. node_index > arena%size) then
-                call finalize_node(node_index, create_mono_type(TREAL))
-                return
-            end if
-            if (.not. allocated(arena%entries(node_index)%node)) then
-                call finalize_node(node_index, create_mono_type(TREAL))
-                return
-            end if
-
-            select type (expr => arena%entries(node_index)%node)
-            type is (literal_node)
-                local_type = infer_literal_type(expr)
-                call finalize_node(node_index, local_type)
-            type is (complex_literal_node)
-                local_type = create_mono_type(TCOMPLEX)
-                call finalize_node(node_index, local_type)
-            type is (identifier_node)
-                local_type = infer_identifier_type(expr, this%scopes, this%errors, &
-                                                   this%strict_mode, this%next_var_id)
-                call finalize_node(node_index, local_type)
-            type is (binary_op_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                call push_child(expr%right_index)
-                call push_child(expr%left_index)
-            type is (call_or_subscript_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%arg_indices)) then
-                    do i = size(expr%arg_indices), 1, -1
-                        call push_child(expr%arg_indices(i))
-                    end do
-                end if
-            type is (program_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%body_indices)) then
-                    do i = size(expr%body_indices), 1, -1
-                        call push_child(expr%body_indices(i))
-                    end do
-                end if
-            type is (array_slice_node)
-                local_type = infer_array_slice_type(arena, expr, &
-                                                    get_node_type_with_arena)
-                call finalize_node(node_index, local_type)
-            type is (subroutine_call_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%arg_indices)) then
-                    do i = size(expr%arg_indices), 1, -1
-                        call push_child(expr%arg_indices(i))
-                    end do
-                end if
-            type is (function_def_node)
-                call analyze_function_parameters( &
-                    arena, expr, param_types, param_names, this%scopes, &
-                    this%next_var_id)
-                return_type = determine_function_return_type( &
-                              arena, expr, param_names, param_types, this%next_var_id)
-                call create_function_scope( &
-                    arena, expr, node_index, return_type, this%scopes)
-                post_frame = current
-                post_frame%state = STATE_POST
-                post_frame%leave_scope = .true.
-                post_frame%has_cached_type = .true.
-                post_frame%cached_type = return_type
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                if (allocated(param_types)) then
-                    post_frame%param_types = param_types
-                else
-                    allocate (post_frame%param_types(0))
-                end if
-                call push_frame_local(post_frame)
-                if (allocated(param_types)) deallocate (param_types)
-                if (allocated(param_names)) deallocate (param_names)
-                if (allocated(expr%body_indices)) then
-                    do i = size(expr%body_indices), 1, -1
-                        call push_child(expr%body_indices(i))
-                    end do
-                end if
-            type is (subroutine_def_node)
-                call analyze_subroutine_parameters( &
-                    arena, expr, param_types, param_names, this%scopes, &
-                    this%next_var_id)
-                call create_subroutine_scope( &
-                    arena, expr, node_index, this%scopes)
-                post_frame = current
-                post_frame%state = STATE_POST
-                post_frame%leave_scope = .true.
-                post_frame%has_cached_type = .false.
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                if (allocated(param_types)) then
-                    post_frame%param_types = param_types
-                else
-                    allocate (post_frame%param_types(0))
-                end if
-                call push_frame_local(post_frame)
-                if (allocated(param_types)) deallocate (param_types)
-                if (allocated(param_names)) deallocate (param_names)
-                if (allocated(expr%body_indices)) then
-                    do i = size(expr%body_indices), 1, -1
-                        call push_child(expr%body_indices(i))
-                    end do
-                end if
-            type is (assignment_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                call push_child(expr%target_index)
-                call push_child(expr%value_index)
-            type is (array_literal_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%element_indices)) then
-                    do i = size(expr%element_indices), 1, -1
-                        call push_child(expr%element_indices(i))
-                    end do
-                end if
-            type is (do_loop_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (expr%step_expr_index > 0) call push_child(expr%step_expr_index)
-                if (expr%end_expr_index > 0) call push_child(expr%end_expr_index)
-                if (expr%start_expr_index > 0) call push_child(expr%start_expr_index)
-                if (allocated(expr%body_indices)) then
-                    do i = size(expr%body_indices), 1, -1
-                        call push_child(expr%body_indices(i))
-                    end do
-                end if
-            type is (declaration_node)
-                call handle_declaration(expr, node_index)
-            type is (if_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%then_body_indices)) then
-                    do i = size(expr%then_body_indices), 1, -1
-                        call push_child(expr%then_body_indices(i))
-                    end do
-                end if
-                call push_child(expr%condition_index)
-            type is (do_while_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%body_indices)) then
-                    do i = size(expr%body_indices), 1, -1
-                        call push_child(expr%body_indices(i))
-                    end do
-                end if
-                call push_child(expr%condition_index)
-            type is (where_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%elsewhere_clauses)) then
-                    do i = size(expr%elsewhere_clauses), 1, -1
-                        if (allocated(expr%elsewhere_clauses(i)%body_indices)) then
-                            do j = size(expr%elsewhere_clauses(i)%body_indices), 1, -1
-                                call push_child( &
-                                    expr%elsewhere_clauses(i)%body_indices(j))
-                            end do
-                        end if
-                        if (expr%elsewhere_clauses(i)%mask_index > 0) then
-                            call push_child(expr%elsewhere_clauses(i)%mask_index)
-                        end if
-                    end do
-                end if
-                if (allocated(expr%where_body_indices)) then
-                    do i = size(expr%where_body_indices), 1, -1
-                        call push_child(expr%where_body_indices(i))
-                    end do
-                end if
-                call push_child(expr%mask_expr_index)
-            type is (where_stmt_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                call push_child(expr%assignment_index)
-                call push_child(expr%mask_expr_index)
-            type is (forall_node)
-                call process_forall_node_body(expr, int_scheme, control_type)
-                call this%scopes%enter_block()
-                if (allocated(expr%index_names)) then
-                    do i = 1, size(expr%index_names)
-                        call this%scopes%define(expr%index_names(i), int_scheme)
-                    end do
-                end if
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                post_frame%leave_scope = .true.
-                post_frame%has_cached_type = .true.
-                post_frame%cached_type = control_type
-                call push_frame_local(post_frame)
-                if (allocated(expr%body_indices)) then
-                    do i = size(expr%body_indices), 1, -1
-                        call push_child(expr%body_indices(i))
-                    end do
-                end if
-            type is (select_case_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%case_indices)) then
-                    do i = size(expr%case_indices), 1, -1
-                        call push_child(expr%case_indices(i))
-                    end do
-                end if
-                call push_child(expr%selector_index)
-            type is (associate_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                post_frame%leave_scope = .true.
-                call push_frame_local(post_frame)
-                call this%scopes%enter_block()
-                if (allocated(expr%body_indices)) then
-                    do i = size(expr%body_indices), 1, -1
-                        call push_child(expr%body_indices(i))
-                    end do
-                end if
-                if (allocated(expr%associations)) then
-                    do i = size(expr%associations), 1, -1
-                        if (expr%associations(i)%expr_index > 0) then
-                            post_frame = current
-                            if (allocated(post_frame%param_types)) then
-                                deallocate (post_frame%param_types)
-                            end if
-                            post_frame%node_index = current%node_index
-                            post_frame%state = STATE_ASSOC_DEFINE
-                            post_frame%aux_index = i
-                            post_frame%leave_scope = .false.
-                            post_frame%has_cached_type = .false.
-                            call push_frame_local(post_frame)
-                            call push_child(expr%associations(i)%expr_index)
-                        end if
-                    end do
-                end if
-            type is (stop_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                call push_child(expr%stop_code_index)
-            type is (pause_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                call push_child(expr%pause_code_index)
-            type is (nullify_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%pointer_indices)) then
-                    do i = size(expr%pointer_indices), 1, -1
-                        if (expr%pointer_indices(i) > 0) then
-                            call push_child(expr%pointer_indices(i))
-                        end if
-                    end do
-                end if
-            type is (cycle_node)
-                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
-                call finalize_node(node_index, local_type)
-            type is (exit_node)
-                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
-                call finalize_node(node_index, local_type)
-            type is (return_node)
-                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
-                call finalize_node(node_index, local_type)
-            type is (entry_node)
-                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
-                call finalize_node(node_index, local_type)
-            type is (continue_node)
-                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
-                call finalize_node(node_index, local_type)
-            type is (read_statement_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%var_indices)) then
-                    do i = size(expr%var_indices), 1, -1
-                        call push_child(expr%var_indices(i))
-                    end do
-                end if
-            type is (allocate_statement_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%var_indices)) then
-                    do i = size(expr%var_indices), 1, -1
-                        call push_child(expr%var_indices(i))
-                    end do
-                end if
-            type is (print_statement_node)
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-                if (allocated(expr%expression_indices)) then
-                    do i = size(expr%expression_indices), 1, -1
-                        call push_child(expr%expression_indices(i))
-                    end do
-                end if
-            class default
-                post_frame = current
-                if (allocated(post_frame%param_types)) deallocate &
-                    (post_frame%param_types)
-                post_frame%state = STATE_POST
-                call push_frame_local(post_frame)
-            end select
-        end subroutine handle_previsit
-
-        subroutine handle_postvisit(current)
-            type(infer_frame_t), intent(inout) :: current
-            integer :: node_index
-            type(mono_type_t) :: node_type
-            type(poly_type_t) :: dummy_scheme
-
-            node_index = current%node_index
-            if (current%leave_scope) call this%scopes%leave_scope()
-            if (node_index <= 0 .or. node_index > arena%size) return
-            if (.not. allocated(arena%entries(node_index)%node)) return
-
-            select type (expr => arena%entries(node_index)%node)
-            type is (binary_op_node)
-                block
-                    type(mono_type_t) :: left_t, right_t
-                    left_t = get_node_type(expr%left_index)
-                    right_t = get_node_type(expr%right_index)
-                    node_type = infer_binary_operation(arena, node_index, expr, &
-                                                       left_t, right_t)
-                    call this%unify(left_t, create_mono_type(TCHAR))
-                    call this%unify(right_t, create_mono_type(TCHAR))
-                end block
-                call finalize_node(node_index, node_type)
-            type is (call_or_subscript_node)
-                node_type = infer_function_call_type(arena, expr, this%scopes, &
-                                                     get_node_type_with_arena)
-                call collect_call_signature(this%signatures, arena, expr, &
-                                            node_type, node_index)
-                call finalize_node(node_index, node_type)
-            type is (subroutine_call_node)
-                node_type = create_mono_type(TVAR, var=create_type_var(0, "error"))
-                call finalize_node(node_index, node_type)
-            type is (do_loop_node)
-                block
-                    type(mono_type_t), allocatable :: args(:)
-                    allocate (args(1))
-                    args(1) = create_mono_type(TINT)
-                    node_type = create_mono_type(TARRAY, args=args)
-                end block
-                call finalize_node(node_index, node_type)
-            type is (function_def_node)
-                node_type = build_function_type(current)
-                call finalize_node(node_index, node_type)
-                if (allocated(expr%name)) then
-                    block
-                        type(poly_type_t) :: func_scheme
-                        func_scheme = this%generalize(node_type)
-                        call this%scopes%define(trim(expr%name), func_scheme)
-                    end block
-                end if
-            type is (assignment_node)
-                node_type = infer_assignment(this, arena, expr, node_index)
-                call finalize_node(node_index, node_type)
-            type is (array_literal_node)
-                node_type = infer_array_literal_type(arena, expr, &
-                                                     get_node_type_with_arena)
-                call finalize_node(node_index, node_type)
-            type is (if_node)
-                call process_if_node_branches(expr, node_type)
-                call finalize_node(node_index, node_type)
-            type is (do_while_node)
-                call process_do_while_node_body(expr, node_type)
-                call finalize_node(node_index, node_type)
-            type is (where_node)
-                call process_where_node_clauses(expr, node_type)
-                call finalize_node(node_index, node_type)
-            type is (where_stmt_node)
-                call process_where_stmt_node(expr, node_type)
-                call finalize_node(node_index, node_type)
-            type is (forall_node)
-                if (current%has_cached_type) then
-                    node_type = current%cached_type
-                else
-                    call process_forall_node_body(expr, dummy_scheme, node_type)
-                end if
-                call finalize_node(node_index, node_type)
-            type is (select_case_node)
-                call process_select_case_blocks(expr, node_type)
-                call finalize_node(node_index, node_type)
-            type is (associate_node)
-                call process_associate_node_body(expr, node_type)
-                call finalize_node(node_index, node_type)
-            type is (stop_node)
-                call process_stop_node_code(expr, node_type)
-                call finalize_node(node_index, node_type)
-            type is (pause_node)
-                call process_pause_node_code(expr, node_type)
-                call finalize_node(node_index, node_type)
-            type is (nullify_node)
-                call process_nullify_node_code(expr, node_type)
-                call finalize_node(node_index, node_type)
-            type is (read_statement_node)
-                call infer_read_statement(this, arena, expr, node_index, node_type)
-                call finalize_node(node_index, node_type)
-            type is (allocate_statement_node)
-                call infer_allocate_statement(this, arena, expr, node_index, node_type)
-                call finalize_node(node_index, node_type)
-            type is (print_statement_node)
-                node_type = create_mono_type(TVAR, var=create_type_var(0, "io"))
-                call finalize_node(node_index, node_type)
-            class default
-                node_type = get_node_type(node_index)
-                call finalize_node(node_index, node_type)
-            end select
-
-            if (allocated(current%param_types)) deallocate (current%param_types)
-        end subroutine handle_postvisit
-
-        subroutine handle_association(current)
-            type(infer_frame_t), intent(in) :: current
-            integer :: parent_index
-            integer :: assoc_index
-            type(mono_type_t) :: assoc_type
-            type(poly_type_t) :: assoc_scheme
-
-            parent_index = current%node_index
-            assoc_index = current%aux_index
-            if (parent_index <= 0 .or. parent_index > arena%size) return
-            if (.not. allocated(arena%entries(parent_index)%node)) return
-
-            select type (assoc_node => arena%entries(parent_index)%node)
-            type is (associate_node)
-                if (.not. allocated(assoc_node%associations)) return
-                if (assoc_index < 1 .or. assoc_index > &
-                    & size(assoc_node%associations)) return
-                if (assoc_node%associations(assoc_index)%expr_index <= 0) return
-                assoc_type = &
-                    & get_node_type(assoc_node%associations(assoc_index)%expr_index)
-                assoc_scheme = create_poly_type(forall_vars=[type_var_t ::], &
-                    & mono=assoc_type)
-                if (allocated(assoc_node%associations(assoc_index)%name)) then
-                    call this%scopes%define(assoc_node%associations(assoc_index)%name, &
-                                            assoc_scheme)
-                end if
-            end select
-        end subroutine handle_association
-
-        subroutine finalize_node(node_idx, raw_type)
-            integer, intent(in) :: node_idx
-            type(mono_type_t), intent(in) :: raw_type
-            type(mono_type_t) :: final_type
-
-            final_type = this%apply_subst_to_type(raw_type)
-            if (final_type%kind == TVAR) then
-                if (len_trim(final_type%var%name) == 0) then
-                    final_type%var%name = "v" // int_to_str(final_type%var%id)
-                end if
-            end if
-            call set_node_inferred_type(arena, node_idx, final_type)
-        end subroutine finalize_node
-
-        function get_node_type(idx) result(res_type)
-            integer, intent(in) :: idx
-            type(mono_type_t) :: res_type
-
-            res_type = get_inferred_type_from_arena(this, arena, idx)
-        end function get_node_type
-
-        function get_node_type_with_arena(a, idx) result(res_type)
-            type(ast_arena_t), intent(inout) :: a
-            integer, intent(in) :: idx
-            type(mono_type_t) :: res_type
-
-            res_type = get_inferred_type_from_arena(this, a, idx)
-        end function get_node_type_with_arena
-
-        subroutine handle_declaration(node, node_index)
-            type(declaration_node), intent(in) :: node
+        module subroutine infer_and_store_type(ctx, arena, node_index)
+            type(semantic_context_t), intent(inout) :: ctx
+            type(ast_arena_t), intent(inout) :: arena
             integer, intent(in) :: node_index
-            type(mono_type_t) :: decl_type
+        end subroutine infer_and_store_type
+
+        module function infer_statement_type(this, arena, stmt_index) result(typ)
+            class(semantic_context_t), intent(inout) :: this
+            type(ast_arena_t), intent(inout) :: arena
+            integer, intent(in) :: stmt_index
+            type(mono_type_t) :: typ
+        end function infer_statement_type
+
+        module function infer_type(this, arena, expr_index) result(typ)
+            class(semantic_context_t), intent(inout) :: this
+            type(ast_arena_t), intent(inout) :: arena
+            integer, intent(in) :: expr_index
+            type(mono_type_t) :: typ
+        end function infer_type
+
+        module subroutine set_node_inferred_type(arena, index, typ)
+            type(ast_arena_t), intent(inout) :: arena
+            integer, intent(in) :: index
+            type(mono_type_t), intent(in) :: typ
+        end subroutine set_node_inferred_type
+
+        module function get_inferred_type_from_arena(ctx, arena, index) result(typ)
+            class(semantic_context_t), intent(inout) :: ctx
+            type(ast_arena_t), intent(inout) :: arena
+            integer, intent(in) :: index
+            type(mono_type_t) :: typ
+        end function get_inferred_type_from_arena
+
+        module subroutine unify_types(this, t1, t2)
+            class(semantic_context_t), intent(inout) :: this
+            type(mono_type_t), intent(in) :: t1
+            type(mono_type_t), intent(in) :: t2
+        end subroutine unify_types
+
+        module function instantiate_type_scheme(this, scheme) result(typ)
+            class(semantic_context_t), intent(inout) :: this
+            type(poly_type_t), intent(in) :: scheme
+            type(mono_type_t) :: typ
+        end function instantiate_type_scheme
+
+        module function generalize_type(this, typ) result(scheme)
+            class(semantic_context_t), intent(in) :: this
+            type(mono_type_t), intent(in) :: typ
             type(poly_type_t) :: scheme
-            integer :: j
-
-            call process_declaration_variables(node, decl_type)
-            scheme = this%generalize(decl_type)
-            if (node%is_multi_declaration .and. allocated(node%var_names)) then
-                do j = 1, size(node%var_names)
-                    call this%scopes%define(node%var_names(j), scheme)
-                end do
-            else if (allocated(node%var_name)) then
-                call this%scopes%define(node%var_name, scheme)
-            end if
-            call finalize_node(node_index, decl_type)
-        end subroutine handle_declaration
-
-        function build_function_type(frame) result(fun_type)
-            type(infer_frame_t), intent(in) :: frame
-            type(mono_type_t) :: fun_type
-            type(mono_type_t) :: return_type
-            type(mono_type_t), allocatable :: params(:)
-
-            if (frame%has_cached_type) then
-                return_type = frame%cached_type
-            else
-                return_type = create_mono_type(TREAL)
-            end if
-
-            if (allocated(frame%param_types)) then
-                allocate (params(size(frame%param_types)))
-                params = frame%param_types
-            else
-                allocate (params(0))
-            end if
-
-            if (size(params) == 0) then
-                fun_type = create_fun_type(create_mono_type(TCHAR), return_type)
-            else if (size(params) == 1) then
-                fun_type = create_fun_type(params(1), return_type)
-            else
-                fun_type = create_fun_type(params(1), return_type)
-            end if
-
-            if (allocated(params)) deallocate (params)
-        end function build_function_type
-
-    end function infer_type
-
-    subroutine set_node_inferred_type(arena, index, typ)
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: index
-        type(mono_type_t), intent(in) :: typ
-
-        if (index <= 0 .or. index > arena%size) return
-        if (.not. allocated(arena%entries(index)%node)) return
-        arena%entries(index)%node%inferred_type = typ
-    end subroutine set_node_inferred_type
-
-    function get_inferred_type_from_arena(ctx, arena, index) result(typ)
-        class(semantic_context_t), intent(inout) :: ctx
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: index
-        type(mono_type_t) :: typ
-
-        typ = create_mono_type(TREAL)
-        if (index <= 0 .or. index > arena%size) return
-        if (.not. allocated(arena%entries(index)%node)) return
-
-        typ = ctx%apply_subst_to_type(arena%entries(index)%node%inferred_type)
-        if (typ%kind == TVAR) then
-            if (len_trim(typ%var%name) == 0) typ%var%name = "v" // &
-                                                            int_to_str(typ%var%id)
-        end if
-        arena%entries(index)%node%inferred_type = typ
-    end function get_inferred_type_from_arena
-
-    subroutine unify_types(this, t1, t2)
-        class(semantic_context_t), intent(inout) :: this
-        type(mono_type_t), intent(in) :: t1, t2
-
-        ! Simplified unification
-    end subroutine unify_types
-
-    function instantiate_type_scheme(this, scheme) result(typ)
-        class(semantic_context_t), intent(inout) :: this
-        type(poly_type_t), intent(in) :: scheme
-        type(mono_type_t) :: typ
-
-        typ = instantiate_type_scheme_op(scheme, this%next_var_id)
-    end function instantiate_type_scheme
-
-    function generalize_type(this, typ) result(scheme)
-        class(semantic_context_t), intent(in) :: this
-        type(mono_type_t), intent(in) :: typ
-        type(poly_type_t) :: scheme
-
-        scheme = generalize_type_op(typ)
-    end function generalize_type
-
-    function generate_fresh_type_var(this) result(tv)
-        class(semantic_context_t), intent(inout) :: this
-        type(type_var_t) :: tv
-
-        tv = generate_fresh_type_var_op(this%next_var_id)
-    end function generate_fresh_type_var
-
-    function apply_current_substitution(this, typ) result(result_type)
-        class(semantic_context_t), intent(in) :: this
-        type(mono_type_t), intent(in) :: typ
-        type(mono_type_t) :: result_type
-
-        result_type = apply_substitution_to_type(typ, this%subst)
-    end function apply_current_substitution
-
-    function get_builtin_function_type(this, name) result(typ)
-        class(semantic_context_t), intent(inout) :: this
-        character(len=*), intent(in) :: name
-        type(mono_type_t) :: typ
-        type(poly_type_t), allocatable :: scheme
-
-        call this%scopes%lookup(name, scheme)
-        if (allocated(scheme)) then
-            typ = this%instantiate(scheme)
-        else
-            ! Default to real -> real
-            typ = create_fun_type(create_mono_type(TREAL), create_mono_type(TREAL))
-        end if
-    end function get_builtin_function_type
-
-    subroutine compose_with_subst(this, new_subst)
-        class(semantic_context_t), intent(inout) :: this
-        type(substitution_t), intent(in) :: new_subst
-
-        this%subst = compose_substitutions(new_subst, this%subst)
-    end subroutine compose_with_subst
-
-    subroutine semantic_context_deep_copy(this, copy)
-        class(semantic_context_t), intent(in) :: this
-        type(semantic_context_t), intent(out) :: copy
-
-        copy%scopes = this%scopes
-        copy%next_var_id = this%next_var_id
-        copy%subst = this%subst
-        ! Tracking fields removed in lean build
-        copy%errors = this%errors
-        copy%strict_mode = this%strict_mode
-        copy%respect_implicit_none = this%respect_implicit_none
-        copy%signatures = this%signatures
-    end subroutine semantic_context_deep_copy
-
-    subroutine semantic_context_assign(lhs, rhs)
-        class(semantic_context_t), intent(inout) :: lhs
-        type(semantic_context_t), intent(in) :: rhs
-
-        lhs%scopes = rhs%scopes
-        lhs%next_var_id = rhs%next_var_id
-        lhs%subst = rhs%subst
-        ! Tracking fields removed in lean build
-        lhs%errors = rhs%errors
-        lhs%strict_mode = rhs%strict_mode
-        lhs%respect_implicit_none = rhs%respect_implicit_none
-        lhs%signatures = rhs%signatures
-    end subroutine semantic_context_assign
-
-    function semantic_context_has_errors(this) result(has_errors)
-        class(semantic_context_t), intent(in) :: this
-        logical :: has_errors
-        has_errors = this%errors%has_errors()
-    end function semantic_context_has_errors
-
-    logical function semantic_get_type_hint(this, decl_index, annotation)
-        class(semantic_context_t), intent(in) :: this
-        integer, intent(in) :: decl_index
-        type(type_annotation_t), intent(out) :: annotation
-        integer :: i
-
-        semantic_get_type_hint = .false.
-        if (.not. allocated(this%parser_type_hints)) return
-        if (size(this%parser_type_hints) == 0) return
-
-        do i = 1, size(this%parser_type_hints)
-            if (this%parser_type_hints(i)%decl_index == decl_index) then
-                annotation = this%parser_type_hints(i)
-                semantic_get_type_hint = .true.
-                return
-            end if
-        end do
-    end function semantic_get_type_hint
-
-    function infer_assignment(ctx, arena, assignment, assignment_index) result(typ)
-        type(semantic_context_t), intent(inout) :: ctx
-        type(ast_arena_t), intent(inout) :: arena
-        type(assignment_node), intent(in) :: assignment
-        integer, intent(in) :: assignment_index
-        type(mono_type_t) :: typ
-        type(mono_type_t) :: expr_typ, updated_expr_typ
-        integer :: lhs_index
-        lhs_index = assignment%target_index
-        expr_typ = get_inferred_type_from_arena(ctx, arena, assignment%value_index)
-        call ensure_string_literal_type(arena, assignment%value_index, expr_typ)
-        updated_expr_typ = expr_typ
-
-        ! Use extracted assignment processing
-        call process_assignment_inference( &
-            arena, assignment, assignment_index, lhs_index, expr_typ, &
-                updated_expr_typ, &
-            ctx%scopes, ctx%errors, ctx%strict_mode, ctx%next_var_id, &
-                & ctx%parser_type_hints)
-
-        typ = updated_expr_typ
-
-        ! Store the actual assignment type
-        call set_node_inferred_type(arena, assignment_index, typ)
-    end function infer_assignment
-
-    subroutine infer_read_statement(ctx, arena, read_stmt, stmt_index, typ)
-        type(semantic_context_t), intent(inout) :: ctx
-        type(ast_arena_t), intent(inout) :: arena
-        type(read_statement_node), intent(in) :: read_stmt
-        integer, intent(in) :: stmt_index
-        type(mono_type_t), intent(out) :: typ
-        integer :: i, var_index
-        type(mono_type_t) :: var_type
-        type(poly_type_t) :: var_scheme
-        type(poly_type_t), allocatable :: existing_scheme
-
-        typ = create_mono_type(TVAR, var=create_type_var(0, "io"))
-
-        if (.not. allocated(read_stmt%var_indices)) return
-
-        do i = 1, size(read_stmt%var_indices)
-            var_index = read_stmt%var_indices(i)
-            if (var_index <= 0) cycle
-            if (.not. allocated(arena%entries(var_index)%node)) cycle
-
-            select type (node => arena%entries(var_index)%node)
-            type is (identifier_node)
-                call ctx%scopes%lookup(node%name, existing_scheme)
-
-                if (.not. allocated(existing_scheme)) then
-                    var_type = get_inferred_type_from_arena(ctx, arena, var_index)
-
-                    if (var_type%kind == TVAR .and. var_type%var%id == 0) then
-                        var_type = create_mono_type(TREAL)
-                    end if
-
-                    call update_identifier_type_in_arena(arena, node%name, var_type)
-
-                    var_scheme = create_poly_type(forall_vars=[type_var_t ::], &
-                                                  mono=var_type)
-                    call ctx%scopes%define(node%name, var_scheme)
-
-                    call set_node_inferred_type(arena, var_index, var_type)
-                end if
-            end select
-        end do
-    end subroutine infer_read_statement
-
-    subroutine infer_allocate_statement(ctx, arena, alloc_stmt, stmt_index, typ)
-        type(semantic_context_t), intent(inout) :: ctx
-        type(ast_arena_t), intent(inout) :: arena
-        type(allocate_statement_node), intent(in) :: alloc_stmt
-        integer, intent(in) :: stmt_index
-        type(mono_type_t), intent(out) :: typ
-        integer :: i, var_index, rank, j
-        type(mono_type_t) :: var_type, element_type
-        type(mono_type_t), allocatable :: args(:)
-        type(poly_type_t) :: var_scheme
-        type(poly_type_t), allocatable :: existing_scheme
-        character(len=:), allocatable :: var_name
-        character(len=:), allocatable :: type_spec_buf
-
-        typ = create_mono_type(TVAR, var=create_type_var(0, "mem"))
-
-        if (.not. allocated(alloc_stmt%var_indices)) return
-
-        do i = 1, size(alloc_stmt%var_indices)
-            var_index = alloc_stmt%var_indices(i)
-            if (var_index <= 0) cycle
-            if (.not. allocated(arena%entries(var_index)%node)) cycle
-
-            var_name = ""
-            rank = 0
-            select type (node => arena%entries(var_index)%node)
-            type is (identifier_node)
-                var_name = node%name
-                if (allocated(alloc_stmt%shape_indices)) then
-                    rank = size(alloc_stmt%shape_indices)
-                end if
-            type is (call_or_subscript_node)
-                var_name = node%name
-                if (allocated(node%arg_indices)) then
-                    rank = size(node%arg_indices)
-                else if (allocated(alloc_stmt%shape_indices)) then
-                    rank = size(alloc_stmt%shape_indices)
-                end if
-            end select
-
-            if (len_trim(var_name) > 0) then
-                call ctx%scopes%lookup(var_name, existing_scheme)
-
-                if (.not. allocated(existing_scheme)) then
-                    element_type = get_inferred_type_from_arena(ctx, arena, var_index)
-
-                    if (allocated(alloc_stmt%type_spec)) then
-                        if (len_trim(alloc_stmt%type_spec) > 0) then
-                            type_spec_buf = to_lower(trim(alloc_stmt%type_spec))
-                            select case (trim(type_spec_buf))
-                            case ('integer')
-                                element_type = create_mono_type(TINT)
-                            case ('real')
-                                element_type = create_mono_type(TREAL)
-                            case ('logical')
-                                element_type = create_mono_type(TLOGICAL)
-                            case ('character')
-                                element_type = create_mono_type(TCHAR)
-                            case ('complex')
-                                element_type = create_mono_type(TCOMPLEX)
-                            end select
-                        end if
-                    else if (element_type%kind == TVAR .and. &
-                             element_type%var%id == 0) then
-                        element_type = create_mono_type(TINT)
-                    else if (element_type%kind == TREAL) then
-                        element_type = create_mono_type(TINT)
-                    end if
-
-                    if (rank > 0) then
-                        var_type = element_type
-                        do j = 1, rank
-                            allocate (args(1))
-                            args(1) = var_type
-                            var_type = create_mono_type(TARRAY, args=args)
-                            var_type%alloc_info%is_allocatable = .true.
-                            deallocate (args)
-                        end do
-                    else
-                        var_type = element_type
-                        var_type%alloc_info%is_allocatable = .true.
-                    end if
-
-                    var_type%alloc_info%needs_allocatable_string = .true.
-
-                    call update_identifier_type_in_arena(arena, var_name, var_type)
-
-                    var_scheme = create_poly_type(forall_vars=[type_var_t ::], &
-                                                  mono=var_type)
-                    call ctx%scopes%define(var_name, var_scheme)
-
-                    call set_node_inferred_type(arena, var_index, var_type)
-                end if
-            end if
-        end do
-    end subroutine infer_allocate_statement
-
-    subroutine ensure_string_literal_type(arena, value_index, expr_typ)
-        type(ast_arena_t), intent(inout) :: arena
-        integer, intent(in) :: value_index
-        type(mono_type_t), intent(inout) :: expr_typ
-        integer :: literal_length
-
-        if (value_index <= 0) return
-        if (value_index > arena%size) return
-        if (.not. allocated(arena%entries(value_index)%node)) return
-
-        select type (value_node => arena%entries(value_index)%node)
-        type is (literal_node)
-            if (value_node%literal_kind == LITERAL_STRING) then
-                literal_length = compute_string_literal_length(value_node)
-                expr_typ = create_mono_type(TCHAR, char_size=literal_length)
-                call set_node_inferred_type(arena, value_index, expr_typ)
-            end if
-        end select
-    end subroutine ensure_string_literal_type
-
-    pure integer function compute_string_literal_length(literal) result(len_value)
-        type(literal_node), intent(in) :: literal
-        character(len=:), allocatable :: trimmed_value
-        character(len=:), allocatable :: inner_value
-        character(len=1) :: quote_char
-        integer :: trimmed_length
-        integer :: i
-
-        len_value = 0
-        if (.not. allocated(literal%value)) return
-
-        trimmed_value = adjustl(trim(literal%value))
-        trimmed_length = len_trim(trimmed_value)
-        if (trimmed_length < 2) then
-            len_value = trimmed_length
-            return
-        end if
-
-        quote_char = trimmed_value(1:1)
-        if (quote_char /= '"' .and. quote_char /= "'") then
-            len_value = trimmed_length
-            return
-        end if
-
-        if (trimmed_value(trimmed_length:trimmed_length) /= quote_char) then
-            len_value = trimmed_length
-            return
-        end if
-
-        if (trimmed_length == 2) then
-            len_value = 0
-            return
-        end if
-
-        inner_value = trimmed_value(2:trimmed_length - 1)
-        len_value = len(inner_value)
-
-        i = 1
-        do while (i <= len(inner_value) - 1)
-            if (inner_value(i:i) == quote_char .and. &
-                inner_value(i + 1:i + 1) == quote_char) then
-                len_value = len_value - 1
-                i = i + 2
-            else
-                i = i + 1
-            end if
-        end do
-    end function compute_string_literal_length
-
-    function has_semantic_errors(ctx) result(has_errors)
-        type(semantic_context_t), intent(in) :: ctx
-        logical :: has_errors
-        has_errors = ctx%errors%has_errors()
-    end function has_semantic_errors
-
-    function semantic_get_context_name(this) result(name)
-        class(semantic_context_t), intent(in) :: this
-        character(:), allocatable :: name
-        name = "semantic_context"
-    end function semantic_get_context_name
-
-    function semantic_clone_context(this) result(cloned)
-        class(semantic_context_t), intent(in) :: this
-        class(semantic_context_base_t), allocatable :: cloned
-        type(semantic_context_t) :: temp_context
-        temp_context%context_id = this%context_id
-        temp_context%context_name = this%context_name
-        temp_context%scopes = this%scopes
-        temp_context%next_var_id = this%next_var_id
-        temp_context%subst = this%subst
-        ! Tracking fields removed in lean build
-        temp_context%errors = this%errors
-        temp_context%strict_mode = this%strict_mode
-
-        allocate (cloned, source=temp_context)
-    end function semantic_clone_context
+        end function generalize_type
+
+        module function generate_fresh_type_var(this) result(tv)
+            class(semantic_context_t), intent(inout) :: this
+            type(type_var_t) :: tv
+        end function generate_fresh_type_var
+
+        module function apply_current_substitution(this, typ) result(result_type)
+            class(semantic_context_t), intent(in) :: this
+            type(mono_type_t), intent(in) :: typ
+            type(mono_type_t) :: result_type
+        end function apply_current_substitution
+
+        module function get_builtin_function_type(this, name) result(typ)
+            class(semantic_context_t), intent(inout) :: this
+            character(len=*), intent(in) :: name
+            type(mono_type_t) :: typ
+        end function get_builtin_function_type
+
+        module subroutine compose_with_subst(this, new_subst)
+            class(semantic_context_t), intent(inout) :: this
+            type(substitution_t), intent(in) :: new_subst
+        end subroutine compose_with_subst
+
+        module subroutine semantic_context_deep_copy(this, copy)
+            class(semantic_context_t), intent(in) :: this
+            type(semantic_context_t), intent(out) :: copy
+        end subroutine semantic_context_deep_copy
+
+        module subroutine semantic_context_assign(lhs, rhs)
+            class(semantic_context_t), intent(inout) :: lhs
+            type(semantic_context_t), intent(in) :: rhs
+        end subroutine semantic_context_assign
+
+        module function semantic_context_has_errors(this) result(has_errors)
+            class(semantic_context_t), intent(in) :: this
+            logical :: has_errors
+        end function semantic_context_has_errors
+
+        module function infer_assignment(ctx, arena, assignment, assignment_index) &
+            result(typ)
+            type(semantic_context_t), intent(inout) :: ctx
+            type(ast_arena_t), intent(inout) :: arena
+            type(assignment_node), intent(in) :: assignment
+            integer, intent(in) :: assignment_index
+            type(mono_type_t) :: typ
+        end function infer_assignment
+
+        module subroutine infer_read_statement(ctx, arena, read_stmt, stmt_index, typ)
+            type(semantic_context_t), intent(inout) :: ctx
+            type(ast_arena_t), intent(inout) :: arena
+            type(read_statement_node), intent(in) :: read_stmt
+            integer, intent(in) :: stmt_index
+            type(mono_type_t), intent(out) :: typ
+        end subroutine infer_read_statement
+
+        module subroutine infer_allocate_statement(ctx, arena, alloc_stmt, &
+                                                   stmt_index, &
+                                                   typ)
+            type(semantic_context_t), intent(inout) :: ctx
+            type(ast_arena_t), intent(inout) :: arena
+            type(allocate_statement_node), intent(in) :: alloc_stmt
+            integer, intent(in) :: stmt_index
+            type(mono_type_t), intent(out) :: typ
+        end subroutine infer_allocate_statement
+
+        module subroutine ensure_string_literal_type(arena, value_index, expr_typ)
+            type(ast_arena_t), intent(inout) :: arena
+            integer, intent(in) :: value_index
+            type(mono_type_t), intent(inout) :: expr_typ
+        end subroutine ensure_string_literal_type
+
+        module function has_semantic_errors(ctx) result(has_errors)
+            type(semantic_context_t), intent(in) :: ctx
+            logical :: has_errors
+        end function has_semantic_errors
+
+        module function semantic_get_context_name(this) result(name)
+            class(semantic_context_t), intent(in) :: this
+            character(:), allocatable :: name
+        end function semantic_get_context_name
+
+        module function semantic_clone_context(this) result(cloned)
+            class(semantic_context_t), intent(in) :: this
+            class(semantic_context_base_t), allocatable :: cloned
+        end function semantic_clone_context
+
+        module function semantic_get_type_hint(this, decl_index, annotation) &
+            result(found)
+            class(semantic_context_t), intent(in) :: this
+            integer, intent(in) :: decl_index
+            type(type_annotation_t), intent(out) :: annotation
+            logical :: found
+        end function semantic_get_type_hint
+    end interface
 
 end module semantic_analyzer

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -1,0 +1,232 @@
+submodule(semantic_analyzer) semantic_analyzer_context_impl
+    use type_system_unified, only: type_var_t, mono_type_t, poly_type_t, &
+                                   create_mono_type, create_fun_type, &
+                                   create_poly_type, &
+                                   TVAR, TREAL
+    use scope_manager, only: create_scope_stack
+    use parser_type_hooks_module, only: consume_type_annotations, &
+                                        has_type_annotations
+    use semantic_annotation_utils, only: type_from_annotation
+    use semantic_inference_helpers, only: check_implicit_none, &
+                                          process_declaration_variables
+    use semantic_undefined_variable_checker, only: check_undefined_variables_generic
+    use constant_transformation, only: fold_constants_in_arena
+    use error_handling, only: create_error_collection
+    use type_hierarchy, only: create_type_hierarchy
+    use call_graph_signatures_mod, only: create_signatures_map
+    use semantic_validation_utils, only: int_to_str
+    use ast_nodes_data, only: declaration_node
+    use semantic_context_types, only: semantic_context_base_t
+    implicit none
+contains
+
+    module subroutine create_semantic_context(ctx)
+        type(semantic_context_t), intent(out) :: ctx
+        type(poly_type_t) :: builtin_scheme
+        type(mono_type_t) :: real_to_real, real_type
+
+        ctx%context_id = 1
+        ctx%context_name = "semantic_context"
+
+        call create_scope_stack(ctx%scopes)
+        ctx%subst%count = 0
+        ctx%subst%capacity = 64
+        if (allocated(ctx%subst%vars)) deallocate (ctx%subst%vars)
+        if (allocated(ctx%subst%types)) deallocate (ctx%subst%types)
+        allocate (ctx%subst%vars(ctx%subst%capacity))
+        allocate (ctx%subst%types(ctx%subst%capacity))
+        ctx%errors = create_error_collection()
+        ctx%next_var_id = 1
+        ctx%respect_implicit_none = .true.
+        ctx%type_hierarchy = create_type_hierarchy()
+        ctx%signatures = create_signatures_map()
+
+        real_type = create_mono_type(TREAL)
+        real_to_real = create_fun_type(real_type, real_type)
+
+        builtin_scheme = create_poly_type(forall_vars=[type_var_t ::], &
+                                          mono=real_to_real)
+
+        call ctx%scopes%define("exp", builtin_scheme)
+
+        if (has_type_annotations()) then
+            call consume_type_annotations(ctx%parser_type_hints)
+        else
+            allocate (ctx%parser_type_hints(0))
+        end if
+        call ctx%scopes%define("log", builtin_scheme)
+        call ctx%scopes%define("abs", builtin_scheme)
+    end subroutine create_semantic_context
+
+    module subroutine analyze_program(ctx, arena, root_index)
+        type(semantic_context_t), intent(inout) :: ctx
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: root_index
+
+        if (root_index <= 0 .or. root_index > arena%size) return
+        if (.not. allocated(arena%entries(root_index)%node)) return
+
+        select type (ast => arena%entries(root_index)%node)
+        type is (program_node)
+            if (ctx%respect_implicit_none .and. .not. ctx%strict_mode) then
+                ctx%strict_mode = check_implicit_none(arena, ast)
+            end if
+            call analyze_program_node_arena(ctx, arena, ast, root_index)
+        type is (module_node)
+            return
+        class default
+            call infer_and_store_type(ctx, arena, root_index)
+        end select
+
+        call fold_constants_in_arena(arena)
+    end subroutine analyze_program
+
+    module subroutine analyze_program_node_arena(ctx, arena, prog, prog_index)
+        type(semantic_context_t), intent(inout) :: ctx
+        type(ast_arena_t), intent(inout) :: arena
+        type(program_node), intent(inout) :: prog
+        integer, intent(in) :: prog_index
+        integer :: i
+
+        if (allocated(prog%body_indices)) then
+            do i = 1, size(prog%body_indices)
+                if (prog%body_indices(i) > 0 .and. &
+                    prog%body_indices(i) <= arena%size) then
+                    if (allocated(arena%entries(prog%body_indices(i))%node)) then
+                        select type (node => arena%entries(prog%body_indices(i))%node)
+                        type is (declaration_node)
+                            block
+                                type(mono_type_t) :: decl_type
+                                type(poly_type_t) :: scheme
+                                type(type_annotation_t) :: hint
+                                integer :: j
+
+                                if (ctx%get_type_hint(prog%body_indices(i), hint)) then
+                                    call type_from_annotation(hint, decl_type)
+                                else
+                                    call process_declaration_variables(node, decl_type)
+                                end if
+
+                                scheme = ctx%generalize(decl_type)
+                                if (node%is_multi_declaration .and. &
+                                    allocated(node%var_names)) then
+                                    do j = 1, size(node%var_names)
+                                        call ctx%scopes%define(node%var_names(j), &
+                                                               scheme)
+                                    end do
+                                else if (allocated(node%var_name)) then
+                                    call ctx%scopes%define(node%var_name, scheme)
+                                end if
+                            end block
+                        class default
+                            continue
+                        end select
+                    end if
+                end if
+            end do
+        end if
+
+        if (allocated(prog%body_indices)) then
+            do i = 1, size(prog%body_indices)
+                if (prog%body_indices(i) > 0 .and. &
+                    prog%body_indices(i) <= arena%size) then
+                    call infer_and_store_type(ctx, arena, prog%body_indices(i))
+                end if
+            end do
+        end if
+        call check_undefined_variables_generic(ctx%scopes, ctx%errors, &
+                                               ctx%strict_mode, arena, prog_index)
+    end subroutine analyze_program_node_arena
+
+    module subroutine infer_and_store_type(ctx, arena, node_index)
+        type(semantic_context_t), intent(inout) :: ctx
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: node_index
+        type(mono_type_t) :: inferred
+
+        if (node_index <= 0 .or. node_index > arena%size) return
+        if (.not. allocated(arena%entries(node_index)%node)) return
+
+        inferred = ctx%infer_stmt(arena, node_index)
+    end subroutine infer_and_store_type
+
+    module subroutine set_node_inferred_type(arena, index, typ)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: index
+        type(mono_type_t), intent(in) :: typ
+
+        if (index <= 0 .or. index > arena%size) return
+        if (.not. allocated(arena%entries(index)%node)) return
+        arena%entries(index)%node%inferred_type = typ
+    end subroutine set_node_inferred_type
+
+    module function get_inferred_type_from_arena(ctx, arena, index) result(typ)
+        class(semantic_context_t), intent(inout) :: ctx
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: index
+        type(mono_type_t) :: typ
+
+        typ = create_mono_type(TREAL)
+        if (index <= 0 .or. index > arena%size) return
+        if (.not. allocated(arena%entries(index)%node)) return
+
+        typ = ctx%apply_subst_to_type(arena%entries(index)%node%inferred_type)
+        if (typ%kind == TVAR) then
+            if (len_trim(typ%var%name) == 0) typ%var%name = "v" // &
+                                                            int_to_str(typ%var%id)
+        end if
+        arena%entries(index)%node%inferred_type = typ
+    end function get_inferred_type_from_arena
+
+    module function has_semantic_errors(ctx) result(has_errors)
+        type(semantic_context_t), intent(in) :: ctx
+        logical :: has_errors
+        has_errors = ctx%errors%has_errors()
+    end function has_semantic_errors
+
+    module function semantic_get_context_name(this) result(name)
+        class(semantic_context_t), intent(in) :: this
+        character(:), allocatable :: name
+        name = "semantic_context"
+    end function semantic_get_context_name
+
+    module function semantic_clone_context(this) result(cloned)
+        class(semantic_context_t), intent(in) :: this
+        class(semantic_context_base_t), allocatable :: cloned
+        type(semantic_context_t) :: temp_context
+
+        temp_context%context_id = this%context_id
+        temp_context%context_name = this%context_name
+        temp_context%scopes = this%scopes
+        temp_context%next_var_id = this%next_var_id
+        temp_context%subst = this%subst
+        temp_context%errors = this%errors
+        temp_context%strict_mode = this%strict_mode
+        temp_context%respect_implicit_none = this%respect_implicit_none
+        temp_context%signatures = this%signatures
+
+        allocate (cloned, source=temp_context)
+    end function semantic_clone_context
+
+    module function semantic_get_type_hint(this, decl_index, annotation) &
+        result(found)
+        class(semantic_context_t), intent(in) :: this
+        integer, intent(in) :: decl_index
+        type(type_annotation_t), intent(out) :: annotation
+        integer :: i
+        logical :: found
+
+        found = .false.
+        if (.not. allocated(this%parser_type_hints)) return
+        if (size(this%parser_type_hints) == 0) return
+
+        do i = 1, size(this%parser_type_hints)
+            if (this%parser_type_hints(i)%decl_index == decl_index) then
+                annotation = this%parser_type_hints(i)
+                found = .true.
+                return
+            end if
+        end do
+    end function semantic_get_type_hint
+
+end submodule semantic_analyzer_context_impl

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -1,0 +1,936 @@
+submodule(semantic_analyzer) semantic_analyzer_infer_impl
+    use type_system_unified, only: type_var_t, mono_type_t, poly_type_t, &
+                                   allocation_info_t, create_mono_type, &
+                                   create_fun_type, create_poly_type, &
+                                   create_type_var, TREAL, TVAR, TCOMPLEX, &
+                                   TFUN, TARRAY, TLOGICAL, TINT, TCHAR
+    implicit none
+
+    type :: infer_frame_t
+        integer :: node_index = 0
+        integer :: state = 0
+        integer :: aux_index = 0
+        logical :: leave_scope = .false.
+        logical :: has_cached_type = .false.
+        type(mono_type_t) :: cached_type
+        type(mono_type_t), allocatable :: param_types(:)
+    end type infer_frame_t
+
+contains
+
+    module function infer_statement_type(this, arena, stmt_index) result(typ)
+        class(semantic_context_t), intent(inout) :: this
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: stmt_index
+        type(mono_type_t) :: typ
+
+        typ = this%infer(arena, stmt_index)
+    end function infer_statement_type
+
+    module function infer_type(this, arena, expr_index) result(typ)
+        class(semantic_context_t), intent(inout) :: this
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: expr_index
+        type(mono_type_t) :: typ
+        type(infer_frame_t), allocatable :: stack(:)
+        type(infer_frame_t) :: frame
+        integer :: stack_size
+        integer :: stack_capacity
+        integer, parameter :: STATE_PRE = 0
+        integer, parameter :: STATE_POST = 1
+        integer, parameter :: STATE_ASSOC_DEFINE = 2
+
+        typ = create_mono_type(TREAL)
+        if (expr_index <= 0 .or. expr_index > arena%size) return
+        if (.not. allocated(arena%entries(expr_index)%node)) return
+
+        stack_capacity = max(16, arena%size / 4 + 1)
+        allocate (stack(stack_capacity))
+        stack_size = 0
+
+        call push_pre(expr_index)
+
+        do while (stack_size > 0)
+            frame = stack(stack_size)
+            stack_size = stack_size - 1
+
+            select case (frame%state)
+            case (STATE_PRE)
+                call handle_previsit(frame)
+            case (STATE_POST)
+                call handle_postvisit(frame)
+            case (STATE_ASSOC_DEFINE)
+                call handle_association(frame)
+            end select
+        end do
+
+        typ = get_node_type(expr_index)
+
+    contains
+
+        subroutine ensure_capacity(required)
+            integer, intent(in) :: required
+            type(infer_frame_t), allocatable :: new_stack(:)
+            integer :: new_capacity
+
+            if (required <= stack_capacity) return
+
+            new_capacity = max(required, stack_capacity * 2)
+            allocate (new_stack(new_capacity))
+            if (stack_size > 0) new_stack(1:stack_size) = stack(1:stack_size)
+            call move_alloc(new_stack, stack)
+            stack_capacity = new_capacity
+        end subroutine ensure_capacity
+
+        subroutine push_frame_local(f)
+            type(infer_frame_t), intent(in) :: f
+
+            call ensure_capacity(stack_size + 1)
+            stack_size = stack_size + 1
+            stack(stack_size) = f
+        end subroutine push_frame_local
+
+        subroutine push_pre(index)
+            integer, intent(in) :: index
+            type(infer_frame_t) :: new_frame
+
+            new_frame%node_index = index
+            new_frame%state = STATE_PRE
+            new_frame%aux_index = 0
+            new_frame%leave_scope = .false.
+            new_frame%has_cached_type = .false.
+            if (allocated(new_frame%param_types)) deallocate (new_frame%param_types)
+            call push_frame_local(new_frame)
+        end subroutine push_pre
+
+        subroutine push_child(index)
+            integer, intent(in) :: index
+
+            if (index <= 0) return
+            call push_pre(index)
+        end subroutine push_child
+
+        subroutine handle_previsit(current)
+            type(infer_frame_t), intent(in) :: current
+            type(infer_frame_t) :: post_frame
+            integer :: node_index
+            integer :: i, j
+            type(mono_type_t) :: local_type
+            type(poly_type_t) :: int_scheme
+            type(mono_type_t), allocatable :: param_types(:)
+            character(len=64), allocatable :: param_names(:)
+            type(mono_type_t) :: return_type
+            type(mono_type_t) :: control_type
+
+            node_index = current%node_index
+            if (node_index <= 0 .or. node_index > arena%size) then
+                call finalize_node(node_index, create_mono_type(TREAL))
+                return
+            end if
+            if (.not. allocated(arena%entries(node_index)%node)) then
+                call finalize_node(node_index, create_mono_type(TREAL))
+                return
+            end if
+
+            select type (expr => arena%entries(node_index)%node)
+            type is (literal_node)
+                local_type = infer_literal_type(expr)
+                call finalize_node(node_index, local_type)
+            type is (complex_literal_node)
+                local_type = create_mono_type(TCOMPLEX)
+                call finalize_node(node_index, local_type)
+            type is (identifier_node)
+                local_type = infer_identifier_type(expr, this%scopes, this%errors, &
+                                                   this%strict_mode, this%next_var_id)
+                call finalize_node(node_index, local_type)
+            type is (binary_op_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                call push_child(expr%right_index)
+                call push_child(expr%left_index)
+            type is (call_or_subscript_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%arg_indices)) then
+                    do i = size(expr%arg_indices), 1, -1
+                        call push_child(expr%arg_indices(i))
+                    end do
+                end if
+            type is (program_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%body_indices)) then
+                    do i = size(expr%body_indices), 1, -1
+                        call push_child(expr%body_indices(i))
+                    end do
+                end if
+            type is (array_slice_node)
+                local_type = infer_array_slice_type(arena, expr, &
+                                                    get_node_type_with_arena)
+                call finalize_node(node_index, local_type)
+            type is (subroutine_call_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%arg_indices)) then
+                    do i = size(expr%arg_indices), 1, -1
+                        call push_child(expr%arg_indices(i))
+                    end do
+                end if
+            type is (function_def_node)
+                call analyze_function_parameters( &
+                    arena, expr, param_types, param_names, this%scopes, &
+                    this%next_var_id)
+                return_type = determine_function_return_type( &
+                              arena, expr, param_names, param_types, this%next_var_id)
+                call create_function_scope( &
+                    arena, expr, node_index, return_type, this%scopes)
+                post_frame = current
+                post_frame%state = STATE_POST
+                post_frame%leave_scope = .true.
+                post_frame%has_cached_type = .true.
+                post_frame%cached_type = return_type
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                if (allocated(param_types)) then
+                    post_frame%param_types = param_types
+                else
+                    allocate (post_frame%param_types(0))
+                end if
+                call push_frame_local(post_frame)
+                if (allocated(param_types)) deallocate (param_types)
+                if (allocated(param_names)) deallocate (param_names)
+                if (allocated(expr%body_indices)) then
+                    do i = size(expr%body_indices), 1, -1
+                        call push_child(expr%body_indices(i))
+                    end do
+                end if
+            type is (subroutine_def_node)
+                call analyze_subroutine_parameters( &
+                    arena, expr, param_types, param_names, this%scopes, &
+                    this%next_var_id)
+                call create_subroutine_scope( &
+                    arena, expr, node_index, this%scopes)
+                post_frame = current
+                post_frame%state = STATE_POST
+                post_frame%leave_scope = .true.
+                post_frame%has_cached_type = .false.
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                if (allocated(param_types)) then
+                    post_frame%param_types = param_types
+                else
+                    allocate (post_frame%param_types(0))
+                end if
+                call push_frame_local(post_frame)
+                if (allocated(param_types)) deallocate (param_types)
+                if (allocated(param_names)) deallocate (param_names)
+                if (allocated(expr%body_indices)) then
+                    do i = size(expr%body_indices), 1, -1
+                        call push_child(expr%body_indices(i))
+                    end do
+                end if
+            type is (assignment_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                call push_child(expr%target_index)
+                call push_child(expr%value_index)
+            type is (array_literal_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%element_indices)) then
+                    do i = size(expr%element_indices), 1, -1
+                        call push_child(expr%element_indices(i))
+                    end do
+                end if
+            type is (do_loop_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (expr%step_expr_index > 0) call push_child(expr%step_expr_index)
+                if (expr%end_expr_index > 0) call push_child(expr%end_expr_index)
+                if (expr%start_expr_index > 0) call push_child(expr%start_expr_index)
+                if (allocated(expr%body_indices)) then
+                    do i = size(expr%body_indices), 1, -1
+                        call push_child(expr%body_indices(i))
+                    end do
+                end if
+            type is (declaration_node)
+                call handle_declaration(expr, node_index)
+            type is (if_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%then_body_indices)) then
+                    do i = size(expr%then_body_indices), 1, -1
+                        call push_child(expr%then_body_indices(i))
+                    end do
+                end if
+                call push_child(expr%condition_index)
+            type is (do_while_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%body_indices)) then
+                    do i = size(expr%body_indices), 1, -1
+                        call push_child(expr%body_indices(i))
+                    end do
+                end if
+                call push_child(expr%condition_index)
+            type is (where_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%elsewhere_clauses)) then
+                    do i = size(expr%elsewhere_clauses), 1, -1
+                        if (allocated(expr%elsewhere_clauses(i)%body_indices)) then
+                            do j = size(expr%elsewhere_clauses(i)%body_indices), 1, -1
+                                call push_child( &
+                                    expr%elsewhere_clauses(i)%body_indices(j))
+                            end do
+                        end if
+                        if (expr%elsewhere_clauses(i)%mask_index > 0) then
+                            call push_child(expr%elsewhere_clauses(i)%mask_index)
+                        end if
+                    end do
+                end if
+                if (allocated(expr%where_body_indices)) then
+                    do i = size(expr%where_body_indices), 1, -1
+                        call push_child(expr%where_body_indices(i))
+                    end do
+                end if
+                call push_child(expr%mask_expr_index)
+            type is (where_stmt_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                call push_child(expr%assignment_index)
+                call push_child(expr%mask_expr_index)
+            type is (forall_node)
+                call process_forall_node_body(expr, int_scheme, control_type)
+                call this%scopes%enter_block()
+                if (allocated(expr%index_names)) then
+                    do i = 1, size(expr%index_names)
+                        call this%scopes%define(expr%index_names(i), int_scheme)
+                    end do
+                end if
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                post_frame%leave_scope = .true.
+                post_frame%has_cached_type = .true.
+                post_frame%cached_type = control_type
+                call push_frame_local(post_frame)
+                if (allocated(expr%body_indices)) then
+                    do i = size(expr%body_indices), 1, -1
+                        call push_child(expr%body_indices(i))
+                    end do
+                end if
+            type is (select_case_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%case_indices)) then
+                    do i = size(expr%case_indices), 1, -1
+                        call push_child(expr%case_indices(i))
+                    end do
+                end if
+                call push_child(expr%selector_index)
+            type is (associate_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                post_frame%leave_scope = .true.
+                call push_frame_local(post_frame)
+                call this%scopes%enter_block()
+                if (allocated(expr%body_indices)) then
+                    do i = size(expr%body_indices), 1, -1
+                        call push_child(expr%body_indices(i))
+                    end do
+                end if
+                if (allocated(expr%associations)) then
+                    do i = size(expr%associations), 1, -1
+                        if (expr%associations(i)%expr_index > 0) then
+                            post_frame = current
+                            if (allocated(post_frame%param_types)) then
+                                deallocate (post_frame%param_types)
+                            end if
+                            post_frame%node_index = current%node_index
+                            post_frame%state = STATE_ASSOC_DEFINE
+                            post_frame%aux_index = i
+                            post_frame%leave_scope = .false.
+                            post_frame%has_cached_type = .false.
+                            call push_frame_local(post_frame)
+                            call push_child(expr%associations(i)%expr_index)
+                        end if
+                    end do
+                end if
+            type is (stop_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                call push_child(expr%stop_code_index)
+            type is (pause_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                call push_child(expr%pause_code_index)
+            type is (nullify_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%pointer_indices)) then
+                    do i = size(expr%pointer_indices), 1, -1
+                        if (expr%pointer_indices(i) > 0) then
+                            call push_child(expr%pointer_indices(i))
+                        end if
+                    end do
+                end if
+            type is (cycle_node)
+                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
+                call finalize_node(node_index, local_type)
+            type is (exit_node)
+                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
+                call finalize_node(node_index, local_type)
+            type is (return_node)
+                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
+                call finalize_node(node_index, local_type)
+            type is (entry_node)
+                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
+                call finalize_node(node_index, local_type)
+            type is (continue_node)
+                local_type = create_mono_type(TVAR, var=create_type_var(0, "control"))
+                call finalize_node(node_index, local_type)
+            type is (read_statement_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%var_indices)) then
+                    do i = size(expr%var_indices), 1, -1
+                        call push_child(expr%var_indices(i))
+                    end do
+                end if
+            type is (allocate_statement_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%var_indices)) then
+                    do i = size(expr%var_indices), 1, -1
+                        call push_child(expr%var_indices(i))
+                    end do
+                end if
+            type is (print_statement_node)
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+                if (allocated(expr%expression_indices)) then
+                    do i = size(expr%expression_indices), 1, -1
+                        call push_child(expr%expression_indices(i))
+                    end do
+                end if
+            class default
+                post_frame = current
+                if (allocated(post_frame%param_types)) deallocate &
+                    (post_frame%param_types)
+                post_frame%state = STATE_POST
+                call push_frame_local(post_frame)
+            end select
+        end subroutine handle_previsit
+
+        subroutine handle_postvisit(current)
+            type(infer_frame_t), intent(inout) :: current
+            integer :: node_index
+            type(mono_type_t) :: node_type
+            type(poly_type_t) :: dummy_scheme
+
+            node_index = current%node_index
+            if (current%leave_scope) call this%scopes%leave_scope()
+            if (node_index <= 0 .or. node_index > arena%size) return
+            if (.not. allocated(arena%entries(node_index)%node)) return
+
+            select type (expr => arena%entries(node_index)%node)
+            type is (binary_op_node)
+                block
+                    type(mono_type_t) :: left_t, right_t
+                    left_t = get_node_type(expr%left_index)
+                    right_t = get_node_type(expr%right_index)
+                    node_type = infer_binary_operation(arena, node_index, expr, &
+                                                       left_t, right_t)
+                    call this%unify(left_t, create_mono_type(TCHAR))
+                    call this%unify(right_t, create_mono_type(TCHAR))
+                end block
+                call finalize_node(node_index, node_type)
+            type is (call_or_subscript_node)
+                node_type = infer_function_call_type(arena, expr, this%scopes, &
+                                                     get_node_type_with_arena)
+                call collect_call_signature(this%signatures, arena, expr, &
+                                            node_type, node_index)
+                call finalize_node(node_index, node_type)
+            type is (subroutine_call_node)
+                node_type = create_mono_type(TVAR, var=create_type_var(0, "error"))
+                call finalize_node(node_index, node_type)
+            type is (do_loop_node)
+                block
+                    type(mono_type_t), allocatable :: args(:)
+                    allocate (args(1))
+                    args(1) = create_mono_type(TINT)
+                    node_type = create_mono_type(TARRAY, args=args)
+                end block
+                call finalize_node(node_index, node_type)
+            type is (function_def_node)
+                node_type = build_function_type(current)
+                call finalize_node(node_index, node_type)
+                if (allocated(expr%name)) then
+                    block
+                        type(poly_type_t) :: func_scheme
+                        func_scheme = this%generalize(node_type)
+                        call this%scopes%define(trim(expr%name), func_scheme)
+                    end block
+                end if
+            type is (assignment_node)
+                node_type = infer_assignment(this, arena, expr, node_index)
+                call finalize_node(node_index, node_type)
+            type is (array_literal_node)
+                node_type = infer_array_literal_type(arena, expr, &
+                                                     get_node_type_with_arena)
+                call finalize_node(node_index, node_type)
+            type is (if_node)
+                call process_if_node_branches(expr, node_type)
+                call finalize_node(node_index, node_type)
+            type is (do_while_node)
+                call process_do_while_node_body(expr, node_type)
+                call finalize_node(node_index, node_type)
+            type is (where_node)
+                call process_where_node_clauses(expr, node_type)
+                call finalize_node(node_index, node_type)
+            type is (where_stmt_node)
+                call process_where_stmt_node(expr, node_type)
+                call finalize_node(node_index, node_type)
+            type is (forall_node)
+                if (current%has_cached_type) then
+                    node_type = current%cached_type
+                else
+                    call process_forall_node_body(expr, dummy_scheme, node_type)
+                end if
+                call finalize_node(node_index, node_type)
+            type is (select_case_node)
+                call process_select_case_blocks(expr, node_type)
+                call finalize_node(node_index, node_type)
+            type is (associate_node)
+                call process_associate_node_body(expr, node_type)
+                call finalize_node(node_index, node_type)
+            type is (stop_node)
+                call process_stop_node_code(expr, node_type)
+                call finalize_node(node_index, node_type)
+            type is (pause_node)
+                call process_pause_node_code(expr, node_type)
+                call finalize_node(node_index, node_type)
+            type is (nullify_node)
+                call process_nullify_node_code(expr, node_type)
+                call finalize_node(node_index, node_type)
+            type is (read_statement_node)
+                call infer_read_statement(this, arena, expr, node_index, node_type)
+                call finalize_node(node_index, node_type)
+            type is (allocate_statement_node)
+                call infer_allocate_statement(this, arena, expr, node_index, node_type)
+                call finalize_node(node_index, node_type)
+            type is (print_statement_node)
+                node_type = create_mono_type(TVAR, var=create_type_var(0, "io"))
+                call finalize_node(node_index, node_type)
+            class default
+                node_type = get_node_type(node_index)
+                call finalize_node(node_index, node_type)
+            end select
+
+            if (allocated(current%param_types)) deallocate (current%param_types)
+        end subroutine handle_postvisit
+
+        subroutine handle_association(current)
+            type(infer_frame_t), intent(in) :: current
+            integer :: parent_index
+            integer :: assoc_index
+            type(mono_type_t) :: assoc_type
+            type(poly_type_t) :: assoc_scheme
+
+            parent_index = current%node_index
+            assoc_index = current%aux_index
+            if (parent_index <= 0 .or. parent_index > arena%size) return
+            if (.not. allocated(arena%entries(parent_index)%node)) return
+
+            select type (assoc_node => arena%entries(parent_index)%node)
+            type is (associate_node)
+                if (.not. allocated(assoc_node%associations)) return
+                if (assoc_index < 1 .or. assoc_index > &
+                    & size(assoc_node%associations)) return
+                if (assoc_node%associations(assoc_index)%expr_index <= 0) return
+                assoc_type = &
+                    & get_node_type(assoc_node%associations(assoc_index)%expr_index)
+                assoc_scheme = create_poly_type(forall_vars=[type_var_t ::], &
+                    & mono=assoc_type)
+                if (allocated(assoc_node%associations(assoc_index)%name)) then
+                    call this%scopes%define(assoc_node%associations(assoc_index)%name, &
+                                            assoc_scheme)
+                end if
+            end select
+        end subroutine handle_association
+
+        subroutine finalize_node(node_idx, raw_type)
+            integer, intent(in) :: node_idx
+            type(mono_type_t), intent(in) :: raw_type
+            type(mono_type_t) :: final_type
+
+            final_type = this%apply_subst_to_type(raw_type)
+            if (final_type%kind == TVAR) then
+                if (len_trim(final_type%var%name) == 0) then
+                    final_type%var%name = "v" // int_to_str(final_type%var%id)
+                end if
+            end if
+            call set_node_inferred_type(arena, node_idx, final_type)
+        end subroutine finalize_node
+
+        function get_node_type(idx) result(res_type)
+            integer, intent(in) :: idx
+            type(mono_type_t) :: res_type
+
+            res_type = get_inferred_type_from_arena(this, arena, idx)
+        end function get_node_type
+
+        function get_node_type_with_arena(a, idx) result(res_type)
+            type(ast_arena_t), intent(inout) :: a
+            integer, intent(in) :: idx
+            type(mono_type_t) :: res_type
+
+            res_type = get_inferred_type_from_arena(this, a, idx)
+        end function get_node_type_with_arena
+
+        subroutine handle_declaration(node, node_index)
+            type(declaration_node), intent(in) :: node
+            integer, intent(in) :: node_index
+            type(mono_type_t) :: decl_type
+            type(poly_type_t) :: scheme
+            integer :: j
+
+            call process_declaration_variables(node, decl_type)
+            scheme = this%generalize(decl_type)
+            if (node%is_multi_declaration .and. allocated(node%var_names)) then
+                do j = 1, size(node%var_names)
+                    call this%scopes%define(node%var_names(j), scheme)
+                end do
+            else if (allocated(node%var_name)) then
+                call this%scopes%define(node%var_name, scheme)
+            end if
+            call finalize_node(node_index, decl_type)
+        end subroutine handle_declaration
+
+        function build_function_type(frame) result(fun_type)
+            type(infer_frame_t), intent(in) :: frame
+            type(mono_type_t) :: fun_type
+            type(mono_type_t) :: return_type
+            type(mono_type_t), allocatable :: params(:)
+
+            if (frame%has_cached_type) then
+                return_type = frame%cached_type
+            else
+                return_type = create_mono_type(TREAL)
+            end if
+
+            if (allocated(frame%param_types)) then
+                allocate (params(size(frame%param_types)))
+                params = frame%param_types
+            else
+                allocate (params(0))
+            end if
+
+            if (size(params) == 0) then
+                fun_type = create_fun_type(create_mono_type(TCHAR), return_type)
+            else if (size(params) == 1) then
+                fun_type = create_fun_type(params(1), return_type)
+            else
+                fun_type = create_fun_type(params(1), return_type)
+            end if
+
+            if (allocated(params)) deallocate (params)
+        end function build_function_type
+
+    end function infer_type
+    module function infer_assignment(ctx, arena, assignment, assignment_index) &
+        result(typ)
+        type(semantic_context_t), intent(inout) :: ctx
+        type(ast_arena_t), intent(inout) :: arena
+        type(assignment_node), intent(in) :: assignment
+        integer, intent(in) :: assignment_index
+        type(mono_type_t) :: typ
+        type(mono_type_t) :: expr_typ, updated_expr_typ
+        integer :: lhs_index
+        lhs_index = assignment%target_index
+        expr_typ = get_inferred_type_from_arena(ctx, arena, assignment%value_index)
+        call ensure_string_literal_type(arena, assignment%value_index, expr_typ)
+        updated_expr_typ = expr_typ
+
+        ! Use extracted assignment processing
+        call process_assignment_inference( &
+            arena, assignment, assignment_index, lhs_index, expr_typ, &
+                updated_expr_typ, &
+            ctx%scopes, ctx%errors, ctx%strict_mode, ctx%next_var_id, &
+                & ctx%parser_type_hints)
+
+        typ = updated_expr_typ
+
+        ! Store the actual assignment type
+        call set_node_inferred_type(arena, assignment_index, typ)
+    end function infer_assignment
+
+    module subroutine infer_read_statement(ctx, arena, read_stmt, stmt_index, typ)
+        type(semantic_context_t), intent(inout) :: ctx
+        type(ast_arena_t), intent(inout) :: arena
+        type(read_statement_node), intent(in) :: read_stmt
+        integer, intent(in) :: stmt_index
+        type(mono_type_t), intent(out) :: typ
+        integer :: i, var_index
+        type(mono_type_t) :: var_type
+        type(poly_type_t) :: var_scheme
+        type(poly_type_t), allocatable :: existing_scheme
+
+        typ = create_mono_type(TVAR, var=create_type_var(0, "io"))
+
+        if (.not. allocated(read_stmt%var_indices)) return
+
+        do i = 1, size(read_stmt%var_indices)
+            var_index = read_stmt%var_indices(i)
+            if (var_index <= 0) cycle
+            if (.not. allocated(arena%entries(var_index)%node)) cycle
+
+            select type (node => arena%entries(var_index)%node)
+            type is (identifier_node)
+                call ctx%scopes%lookup(node%name, existing_scheme)
+
+                if (.not. allocated(existing_scheme)) then
+                    var_type = get_inferred_type_from_arena(ctx, arena, var_index)
+
+                    if (var_type%kind == TVAR .and. var_type%var%id == 0) then
+                        var_type = create_mono_type(TREAL)
+                    end if
+
+                    call update_identifier_type_in_arena(arena, node%name, var_type)
+
+                    var_scheme = create_poly_type(forall_vars=[type_var_t ::], &
+                                                  mono=var_type)
+                    call ctx%scopes%define(node%name, var_scheme)
+
+                    call set_node_inferred_type(arena, var_index, var_type)
+                end if
+            end select
+        end do
+    end subroutine infer_read_statement
+
+    module subroutine infer_allocate_statement(ctx, arena, alloc_stmt, stmt_index, typ)
+        type(semantic_context_t), intent(inout) :: ctx
+        type(ast_arena_t), intent(inout) :: arena
+        type(allocate_statement_node), intent(in) :: alloc_stmt
+        integer, intent(in) :: stmt_index
+        type(mono_type_t), intent(out) :: typ
+        integer :: i, var_index, rank, j
+        type(mono_type_t) :: var_type, element_type
+        type(mono_type_t), allocatable :: args(:)
+        type(poly_type_t) :: var_scheme
+        type(poly_type_t), allocatable :: existing_scheme
+        character(len=:), allocatable :: var_name
+        character(len=:), allocatable :: type_spec_buf
+
+        typ = create_mono_type(TVAR, var=create_type_var(0, "mem"))
+
+        if (.not. allocated(alloc_stmt%var_indices)) return
+
+        do i = 1, size(alloc_stmt%var_indices)
+            var_index = alloc_stmt%var_indices(i)
+            if (var_index <= 0) cycle
+            if (.not. allocated(arena%entries(var_index)%node)) cycle
+
+            var_name = ""
+            rank = 0
+            select type (node => arena%entries(var_index)%node)
+            type is (identifier_node)
+                var_name = node%name
+                if (allocated(alloc_stmt%shape_indices)) then
+                    rank = size(alloc_stmt%shape_indices)
+                end if
+            type is (call_or_subscript_node)
+                var_name = node%name
+                if (allocated(node%arg_indices)) then
+                    rank = size(node%arg_indices)
+                else if (allocated(alloc_stmt%shape_indices)) then
+                    rank = size(alloc_stmt%shape_indices)
+                end if
+            end select
+
+            if (len_trim(var_name) > 0) then
+                call ctx%scopes%lookup(var_name, existing_scheme)
+
+                if (.not. allocated(existing_scheme)) then
+                    element_type = get_inferred_type_from_arena(ctx, arena, var_index)
+
+                    if (allocated(alloc_stmt%type_spec)) then
+                        if (len_trim(alloc_stmt%type_spec) > 0) then
+                            type_spec_buf = to_lower(trim(alloc_stmt%type_spec))
+                            select case (trim(type_spec_buf))
+                            case ('integer')
+                                element_type = create_mono_type(TINT)
+                            case ('real')
+                                element_type = create_mono_type(TREAL)
+                            case ('logical')
+                                element_type = create_mono_type(TLOGICAL)
+                            case ('character')
+                                element_type = create_mono_type(TCHAR)
+                            case ('complex')
+                                element_type = create_mono_type(TCOMPLEX)
+                            end select
+                        end if
+                    else if (element_type%kind == TVAR .and. &
+                             element_type%var%id == 0) then
+                        element_type = create_mono_type(TINT)
+                    else if (element_type%kind == TREAL) then
+                        element_type = create_mono_type(TINT)
+                    end if
+
+                    if (rank > 0) then
+                        var_type = element_type
+                        do j = 1, rank
+                            allocate (args(1))
+                            args(1) = var_type
+                            var_type = create_mono_type(TARRAY, args=args)
+                            var_type%alloc_info%is_allocatable = .true.
+                            deallocate (args)
+                        end do
+                    else
+                        var_type = element_type
+                        var_type%alloc_info%is_allocatable = .true.
+                    end if
+
+                    var_type%alloc_info%needs_allocatable_string = .true.
+
+                    call update_identifier_type_in_arena(arena, var_name, var_type)
+
+                    var_scheme = create_poly_type(forall_vars=[type_var_t ::], &
+                                                  mono=var_type)
+                    call ctx%scopes%define(var_name, var_scheme)
+
+                    call set_node_inferred_type(arena, var_index, var_type)
+                end if
+            end if
+        end do
+    end subroutine infer_allocate_statement
+
+    module subroutine ensure_string_literal_type(arena, value_index, expr_typ)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: value_index
+        type(mono_type_t), intent(inout) :: expr_typ
+        integer :: literal_length
+
+        if (value_index <= 0) return
+        if (value_index > arena%size) return
+        if (.not. allocated(arena%entries(value_index)%node)) return
+
+        select type (value_node => arena%entries(value_index)%node)
+        type is (literal_node)
+            if (value_node%literal_kind == LITERAL_STRING) then
+                literal_length = compute_string_literal_length(value_node)
+                expr_typ = create_mono_type(TCHAR, char_size=literal_length)
+                call set_node_inferred_type(arena, value_index, expr_typ)
+            end if
+        end select
+    end subroutine ensure_string_literal_type
+
+    pure module integer function compute_string_literal_length(literal) &
+        result(len_value)
+        type(literal_node), intent(in) :: literal
+        character(len=:), allocatable :: trimmed_value
+        character(len=:), allocatable :: inner_value
+        character(len=1) :: quote_char
+        integer :: trimmed_length
+        integer :: i
+
+        len_value = 0
+        if (.not. allocated(literal%value)) return
+
+        trimmed_value = adjustl(trim(literal%value))
+        trimmed_length = len_trim(trimmed_value)
+        if (trimmed_length < 2) then
+            len_value = trimmed_length
+            return
+        end if
+
+        quote_char = trimmed_value(1:1)
+        if (quote_char /= '"' .and. quote_char /= "'") then
+            len_value = trimmed_length
+            return
+        end if
+
+        if (trimmed_value(trimmed_length:trimmed_length) /= quote_char) then
+            len_value = trimmed_length
+            return
+        end if
+
+        if (trimmed_length == 2) then
+            len_value = 0
+            return
+        end if
+
+        inner_value = trimmed_value(2:trimmed_length - 1)
+        len_value = len(inner_value)
+
+        i = 1
+        do while (i <= len(inner_value) - 1)
+            if (inner_value(i:i) == quote_char .and. &
+                inner_value(i + 1:i + 1) == quote_char) then
+                len_value = len_value - 1
+                i = i + 2
+            else
+                i = i + 1
+            end if
+        end do
+    end function compute_string_literal_length
+
+end submodule semantic_analyzer_infer_impl

--- a/src/semantic/analyzers/semantic_analyzer_type_ops_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_type_ops_impl.f90
@@ -1,0 +1,104 @@
+submodule(semantic_analyzer) semantic_analyzer_type_ops_impl
+    use semantic_type_operations, only: instantiate_type_scheme_op, &
+                                        generalize_type_op, &
+                                        generate_fresh_type_var_op, &
+                                        apply_substitution_to_type
+    use type_system_unified, only: mono_type_t, poly_type_t, type_var_t, &
+                                   substitution_t, create_fun_type, create_mono_type, &
+                                   compose_substitutions, TREAL
+    implicit none
+contains
+
+    module subroutine unify_types(this, t1, t2)
+        class(semantic_context_t), intent(inout) :: this
+        type(mono_type_t), intent(in) :: t1
+        type(mono_type_t), intent(in) :: t2
+
+        ! Simplified unification retained for lean build
+    end subroutine unify_types
+
+    module function instantiate_type_scheme(this, scheme) result(typ)
+        class(semantic_context_t), intent(inout) :: this
+        type(poly_type_t), intent(in) :: scheme
+        type(mono_type_t) :: typ
+
+        typ = instantiate_type_scheme_op(scheme, this%next_var_id)
+    end function instantiate_type_scheme
+
+    module function generalize_type(this, typ) result(scheme)
+        class(semantic_context_t), intent(in) :: this
+        type(mono_type_t), intent(in) :: typ
+        type(poly_type_t) :: scheme
+
+        scheme = generalize_type_op(typ)
+    end function generalize_type
+
+    module function generate_fresh_type_var(this) result(tv)
+        class(semantic_context_t), intent(inout) :: this
+        type(type_var_t) :: tv
+
+        tv = generate_fresh_type_var_op(this%next_var_id)
+    end function generate_fresh_type_var
+
+    module function apply_current_substitution(this, typ) result(result_type)
+        class(semantic_context_t), intent(in) :: this
+        type(mono_type_t), intent(in) :: typ
+        type(mono_type_t) :: result_type
+
+        result_type = apply_substitution_to_type(typ, this%subst)
+    end function apply_current_substitution
+
+    module function get_builtin_function_type(this, name) result(typ)
+        class(semantic_context_t), intent(inout) :: this
+        character(len=*), intent(in) :: name
+        type(mono_type_t) :: typ
+        type(poly_type_t), allocatable :: scheme
+
+        call this%scopes%lookup(name, scheme)
+        if (allocated(scheme)) then
+            typ = this%instantiate(scheme)
+        else
+            typ = create_fun_type(create_mono_type(TREAL), create_mono_type(TREAL))
+        end if
+    end function get_builtin_function_type
+
+    module subroutine compose_with_subst(this, new_subst)
+        class(semantic_context_t), intent(inout) :: this
+        type(substitution_t), intent(in) :: new_subst
+
+        this%subst = compose_substitutions(new_subst, this%subst)
+    end subroutine compose_with_subst
+
+    module subroutine semantic_context_deep_copy(this, copy)
+        class(semantic_context_t), intent(in) :: this
+        type(semantic_context_t), intent(out) :: copy
+
+        copy%scopes = this%scopes
+        copy%next_var_id = this%next_var_id
+        copy%subst = this%subst
+        copy%errors = this%errors
+        copy%strict_mode = this%strict_mode
+        copy%respect_implicit_none = this%respect_implicit_none
+        copy%signatures = this%signatures
+    end subroutine semantic_context_deep_copy
+
+    module subroutine semantic_context_assign(lhs, rhs)
+        class(semantic_context_t), intent(inout) :: lhs
+        type(semantic_context_t), intent(in) :: rhs
+
+        lhs%scopes = rhs%scopes
+        lhs%next_var_id = rhs%next_var_id
+        lhs%subst = rhs%subst
+        lhs%errors = rhs%errors
+        lhs%strict_mode = rhs%strict_mode
+        lhs%respect_implicit_none = rhs%respect_implicit_none
+        lhs%signatures = rhs%signatures
+    end subroutine semantic_context_assign
+
+    module function semantic_context_has_errors(this) result(has_errors)
+        class(semantic_context_t), intent(in) :: this
+        logical :: has_errors
+        has_errors = this%errors%has_errors()
+    end function semantic_context_has_errors
+
+end submodule semantic_analyzer_type_ops_impl


### PR DESCRIPTION
## Summary
- split `semantic_analyzer` external procedures into context, inference, and type-op submodules to keep the module under the 1000-line limit
- reused existing semantic function analysis entry points without behaviour changes
- formatted new sources with `fprettify` to satisfy Fortran style constraints

## Verification
- make test
  - fpm test
