### PR TITLE
fix: Bug: Type inference incorrect for nested function calls (fixes #1964)

### DIFF
--- a/examples/lf/issue_1964_nested_function_calls.lf
+++ b/examples/lf/issue_1964_nested_function_calls.lf
@@ -1,0 +1,10 @@
+function add(a, b)
+    add = a + b
+end function
+
+function multiply(x, y)
+    multiply = x * y
+end function
+
+result = multiply(add(2, 3), 4)
+print *, 'Result:', result

--- a/src/semantic/analyzers/semantic_function_array.f90
+++ b/src/semantic/analyzers/semantic_function_array.f90
@@ -23,6 +23,7 @@ module semantic_function_array
     public :: infer_function_call_type
     public :: infer_array_slice_type
     public :: infer_array_literal_type
+    public :: find_return_type
 
 contains
 

--- a/src/semantic/analyzers/semantic_parameter_analysis.f90
+++ b/src/semantic/analyzers/semantic_parameter_analysis.f90
@@ -13,8 +13,10 @@ module semantic_parameter_analysis
     use semantic_validation_utils, only: update_identifier_type_in_arena, &
                                          int_to_str
     use semantic_type_context, only: infer_type_from_usage_context, &
-                                     infer_identifier_type_from_context
+                                     infer_identifier_type_from_context, &
+                                     infer_expression_type_static
     use semantic_procedure_utils, only: declaration_type_to_mono
+    use semantic_function_array, only: find_return_type
     implicit none
     private
 
@@ -149,15 +151,18 @@ contains
         integer :: arg_idx
         type(mono_type_t) :: inferred_arg_type
         type(mono_type_t) :: literal_type
+        character(len=:), allocatable :: func_name
 
         if (.not. allocated(func_node%name)) return
+        func_name = trim(func_node%name)
+        if (len_trim(func_name) == 0) return
 
         do idx = 1, arena%size
             if (.not. allocated(arena%entries(idx)%node)) cycle
             select type (call_node => arena%entries(idx)%node)
             type is (call_or_subscript_node)
                 if (.not. allocated(call_node%name)) cycle
-                if (trim(call_node%name) /= trim(func_node%name)) cycle
+                if (trim(call_node%name) /= func_name) cycle
                 if (.not. allocated(call_node%arg_indices)) cycle
                 do i = 1, min(size(call_node%arg_indices), size(param_types))
                     arg_idx = call_node%arg_indices(i)
@@ -175,11 +180,56 @@ contains
                             arena, arg_node%name, param_names, param_types, &
                             scopes, arg_idx, next_var_id)
                         call merge_parameter_type(param_types(i), inferred_arg_type)
+                    type is (call_or_subscript_node)
+                        if (allocated(arg_node%name)) then
+                            if (trim(arg_node%name) == func_name) cycle
+                        end if
+                        inferred_arg_type = infer_expression_type_static( &
+                                            arena, arg_idx, param_names, &
+                                            param_types)
+                        if (inferred_arg_type%kind == 0 .or. &
+                            inferred_arg_type%kind == TVAR) then
+                            inferred_arg_type = resolve_call_argument_type( &
+                                                arena, arg_node, func_name, &
+                                                next_var_id)
+                        end if
+                        call merge_parameter_type(param_types(i), inferred_arg_type)
                     end select
                 end do
             end select
         end do
     end subroutine infer_parameter_types_from_calls
+
+    function resolve_call_argument_type(arena, call_node, current_name, &
+                                        next_var_id) &
+        result(arg_type)
+        type(ast_arena_t), intent(inout) :: arena
+        type(call_or_subscript_node), intent(in) :: call_node
+        character(len=*), intent(in) :: current_name
+        integer, intent(inout) :: next_var_id
+        type(mono_type_t) :: arg_type
+        character(len=:), allocatable :: call_name
+        logical :: found_return
+
+        arg_type%kind = 0
+        if (call_node%inferred_type%kind > 0) then
+            arg_type = call_node%inferred_type
+            return
+        end if
+        if (.not. allocated(call_node%name)) return
+        if (call_node%is_array_access) return
+
+        call_name = trim(call_node%name)
+        if (len_trim(call_name) == 0) return
+        if (len_trim(current_name) > 0) then
+            if (call_name == trim(current_name)) return
+        end if
+
+        found_return = find_return_type(arena, call_name, arg_type)
+        if (found_return) return
+
+        arg_type = infer_type_from_usage_context(call_name, next_var_id)
+    end function resolve_call_argument_type
 
     subroutine update_parameter_nodes(arena, func_node, param_types)
         type(ast_arena_t), intent(inout) :: arena

--- a/test/integration/issue_tests/test_issue_1964_nested_function_calls.f90
+++ b/test/integration/issue_tests/test_issue_1964_nested_function_calls.f90
@@ -1,0 +1,98 @@
+program test_issue_1964_nested_function_calls
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit
+    use, intrinsic :: iso_fortran_env, only: iostat_end, iostat_eor
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+    print *, '=== Issue #1964: Nested function call parameter inference ==='
+
+    if (.not. check_nested_call_parameters()) all_passed = .false.
+
+    print *
+    if (all_passed) then
+        print *, 'Issue #1964 fixed!'
+    else
+        print *, 'Issue #1964 regression detected!'
+        stop 1
+    end if
+
+contains
+
+    include '../../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            print *, 'FAIL: failed to read ', trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    logical function check_nested_call_parameters()
+        implicit none
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: output
+        character(len=:), allocatable :: error_msg
+        integer :: pos_header
+        logical :: has_integer_decl
+        logical :: has_real_decl
+
+        check_nested_call_parameters = .true.
+        print *, 'Checking nested call argument inference...'
+
+        call read_example('examples/lf/issue_1964_nested_function_calls.lf', &
+                          source)
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, '  FAIL: unexpected error -', trim(error_msg)
+                check_nested_call_parameters = .false.
+                return
+            end if
+        end if
+
+        if (.not. allocated(output)) then
+            print *, '  FAIL: transformation produced no output'
+            check_nested_call_parameters = .false.
+            return
+        end if
+
+        pos_header = index(output, 'integer function multiply')
+        if (pos_header <= 0) then
+            print *, '  FAIL: multiply function not inferred as integer'
+            print *, trim(output)
+            check_nested_call_parameters = .false.
+            return
+        end if
+
+        has_integer_decl = index(output, 'integer :: x') > 0
+        if (.not. has_integer_decl) then
+            has_integer_decl = index(output, 'integer, intent(in) :: x') > 0
+        end if
+        if (.not. has_integer_decl) then
+            print *, '  FAIL: parameter x not declared as integer'
+            print *, trim(output)
+            check_nested_call_parameters = .false.
+        end if
+
+        has_real_decl = index(output, 'real :: x') > 0
+        if (has_real_decl) then
+            print *, '  FAIL: parameter x still declared as real'
+            print *, trim(output)
+            check_nested_call_parameters = .false.
+        end if
+
+        if (check_nested_call_parameters) then
+            print *, '  PASS: nested call arguments retain integer type'
+        end if
+    end function check_nested_call_parameters
+
+end program test_issue_1964_nested_function_calls


### PR DESCRIPTION
## Summary
- ensure nested call arguments contribute to parameter inference while skipping recursive self-calls
- expose function return lookup and add regression coverage for issue 1964

## Verification
- make test
