### PR TITLE
fix: Bug: Case insensitivity not respected - duplicate var (fixes #1969)

### DIFF
--- a/src/codegen/codegen_program_variables.f90
+++ b/src/codegen/codegen_program_variables.f90
@@ -284,25 +284,29 @@ contains
     subroutine record_use_associated_name(state, name)
         type(program_decl_state_t), intent(inout) :: state
         character(len=*), intent(in) :: name
+        character(len=64) :: normalized_name
 
-        if (len_trim(name) == 0) return
+        normalized_name = trim(to_lower(name))
+        if (len_trim(normalized_name) == 0) return
         if (state%use_associated_count >= program_decl_max_vars) return
         if (exists_in_list(state%use_associated_names, &
-                           state%use_associated_count, name)) return
+                           state%use_associated_count, normalized_name)) return
         state%use_associated_count = state%use_associated_count + 1
-        state%use_associated_names(state%use_associated_count) = name
+        state%use_associated_names(state%use_associated_count) = normalized_name
     end subroutine record_use_associated_name
 
     subroutine record_use_module_name(state, module_name)
         type(program_decl_state_t), intent(inout) :: state
         character(len=*), intent(in) :: module_name
+        character(len=64) :: normalized_name
 
-        if (len_trim(module_name) == 0) return
+        normalized_name = trim(to_lower(module_name))
+        if (len_trim(normalized_name) == 0) return
         if (state%use_module_count >= program_decl_max_vars) return
         if (exists_in_list(state%use_module_names, &
-                           state%use_module_count, module_name)) return
+                           state%use_module_count, normalized_name)) return
         state%use_module_count = state%use_module_count + 1
-        state%use_module_names(state%use_module_count) = module_name
+        state%use_module_names(state%use_module_count) = normalized_name
     end subroutine record_use_module_name
 
     logical function module_is_used(state, module_name)
@@ -355,22 +359,29 @@ contains
     subroutine record_declared_name(state, name)
         type(program_decl_state_t), intent(inout) :: state
         character(len=*), intent(in) :: name
+        character(len=64) :: normalized_name
 
-        if (len_trim(name) == 0) return
+        normalized_name = trim(to_lower(name))
+        if (len_trim(normalized_name) == 0) return
         if (state%declared_count >= program_decl_max_vars) return
+        if (exists_in_list(state%declared_names, state%declared_count, &
+                           normalized_name)) return
         state%declared_count = state%declared_count + 1
-        state%declared_names(state%declared_count) = name
+        state%declared_names(state%declared_count) = normalized_name
     end subroutine record_declared_name
 
     subroutine try_add_internal_function(state, name)
         type(program_decl_state_t), intent(inout) :: state
         character(len=*), intent(in) :: name
+        character(len=64) :: normalized_name
 
-        if (len_trim(name) == 0) return
+        normalized_name = trim(to_lower(name))
+        if (len_trim(normalized_name) == 0) return
         if (state%internal_count >= program_decl_max_vars) return
-        if (exists_in_list(state%internal_funcs, state%internal_count, name)) return
+        if (exists_in_list(state%internal_funcs, state%internal_count, &
+                           normalized_name)) return
         state%internal_count = state%internal_count + 1
-        state%internal_funcs(state%internal_count) = name
+        state%internal_funcs(state%internal_count) = normalized_name
     end subroutine try_add_internal_function
 
     subroutine collect_entry_points_from_function(arena, func, state)
@@ -631,12 +642,14 @@ contains
         type(program_decl_state_t), intent(inout) :: state
         character(len=*), intent(in) :: name
         character(len=*), intent(in) :: type_name
+        character(len=64) :: normalized_name
 
-        if (len_trim(name) == 0) return
+        normalized_name = trim(to_lower(name))
+        if (len_trim(normalized_name) == 0) return
         if (state%var_count >= program_decl_max_vars) return
-        if (exists_in_list(state%var_names, state%var_count, name)) return
+        if (exists_in_list(state%var_names, state%var_count, normalized_name)) return
         state%var_count = state%var_count + 1
-        state%var_names(state%var_count) = name
+        state%var_names(state%var_count) = normalized_name
         state%var_types(state%var_count) = type_name
     end subroutine try_add_variable
 
@@ -648,15 +661,20 @@ contains
         character(len=:), allocatable :: normalized_type
         character(len=:), allocatable :: current_lower
         character(len=:), allocatable :: new_lower
+        character(len=64) :: normalized_name
+        character(len=64) :: normalized_existing
 
-        if (len_trim(name) == 0) return
+        normalized_name = trim(to_lower(name))
+        if (len_trim(normalized_name) == 0) return
         if (state%func_count >= program_decl_max_vars) return
-        if (exists_in_list(state%declared_names, state%declared_count, name)) return
+        if (exists_in_list(state%declared_names, state%declared_count, &
+                           normalized_name)) return
         normalized_type = canonicalize_type(type_name)
 
         existing_idx = 0
         do i = 1, state%func_count
-            if (trim(state%func_names(i)) == trim(name)) then
+            normalized_existing = trim(to_lower(state%func_names(i)))
+            if (trim(normalized_existing) == trim(normalized_name)) then
                 existing_idx = i
                 exit
             end if
@@ -678,7 +696,7 @@ contains
         end if
 
         state%func_count = state%func_count + 1
-        state%func_names(state%func_count) = name
+        state%func_names(state%func_count) = normalized_name
         state%func_types(state%func_count) = normalized_type
     end subroutine try_add_function_reference
 
@@ -734,10 +752,14 @@ contains
         integer, intent(in) :: count
         character(len=*), intent(in) :: name
         integer :: i
+        character(len=64) :: normalized_target
+        character(len=64) :: normalized_entry
 
         exists_in_list = .false.
+        normalized_target = trim(to_lower(name))
         do i = 1, count
-            if (trim(list(i)) == trim(name)) then
+            normalized_entry = trim(to_lower(list(i)))
+            if (trim(normalized_entry) == trim(normalized_target)) then
                 exists_in_list = .true.
                 return
             end if
@@ -766,7 +788,7 @@ contains
                 if (len_trim(func_name) == 0) cycle
                 if (exists_in_list(func_names, count, func_name)) cycle
                 count = count + 1
-                func_names(count) = func_name
+                func_names(count) = trim(to_lower(func_name))
                 if (allocated(func%return_type)) then
                     if (len_trim(func%return_type) > 0) then
                         func_types(count) = trim(func%return_type)
@@ -775,4 +797,5 @@ contains
             end select
         end do
     end subroutine build_function_return_type_table
+
 end module codegen_program_variables

--- a/src/standardizers/standardizer_declarations_array.f90
+++ b/src/standardizers/standardizer_declarations_array.f90
@@ -4,6 +4,7 @@ module standardizer_declarations_array
     use ast_nodes_core, only: identifier_node, literal_node
     use ast_nodes_data, only: declaration_node
     use ast_base, only: LITERAL_INTEGER
+    use string_utils_mod, only: to_lower
     use type_system_unified, only: mono_type_t, TARRAY
     use uid_generator, only: generate_uid
     implicit none
@@ -288,6 +289,10 @@ contains
         character(len=20) :: size_str
         integer :: ndims
         integer, allocatable :: dim_sizes(:)
+        character(len=64) :: target_name
+        character(len=64) :: candidate_name
+
+        target_name = to_lower(trim(var_name))
 
         if (decl_node%is_parameter) return
 
@@ -295,7 +300,8 @@ contains
             if (allocated(arena%entries(j)%node)) then
                 select type (node => arena%entries(j)%node)
                 type is (identifier_node)
-                    if (trim(node%name) == trim(var_name)) then
+                    candidate_name = to_lower(trim(node%name))
+                    if (trim(candidate_name) == trim(target_name)) then
                         if (node%inferred_type%kind == TARRAY) then
                             decl_node%is_array = .true.
 

--- a/src/standardizers/standardizer_declarations_collection.f90
+++ b/src/standardizers/standardizer_declarations_collection.f90
@@ -130,6 +130,10 @@ contains
             type(declaration_node), intent(in) :: decl
             character(len=:), allocatable :: type_str
             integer :: idx, k
+            character(len=64) :: normalized_name
+            character(len=64) :: normalized_existing
+
+            normalized_name = to_lower(trim(name))
 
             if (len_trim(name) == 0) return
             type_str = declaration_type_string(decl)
@@ -139,7 +143,8 @@ contains
 
             idx = 0
             do k = 1, var_count
-                if (trim(var_names(k)) == trim(name)) then
+                normalized_existing = to_lower(trim(var_names(k)))
+                if (trim(normalized_existing) == trim(normalized_name)) then
                     idx = k
                     exit
                 end if
@@ -300,12 +305,19 @@ contains
                     type is (identifier_node)
                         var_type = ""
                         existing_idx = 0
-                        do i = 1, var_count
-                            if (trim(var_names(i)) == trim(target%name)) then
-                                existing_idx = i
-                                exit
-                            end if
-                        end do
+                        block
+                            character(len=64) :: normalized_target
+                            character(len=64) :: normalized_existing
+                            normalized_target = to_lower(trim(target%name))
+                            do i = 1, var_count
+                                normalized_existing = to_lower(trim(var_names(i)))
+                                if (trim(normalized_existing) == &
+                                    trim(normalized_target)) then
+                                    existing_idx = i
+                                    exit
+                                end if
+                            end do
+                        end block
 
                         if (assign%value_index > 0 .and. &
                             assign%value_index <= arena%size) then
@@ -401,7 +413,7 @@ contains
                                 character(len=96) :: decl_type
                                 integer :: rank, idx
 
-                                base_name = trim(target%name)
+                                base_name = to_lower(trim(target%name))
                                 decl_type = ''
 
                                 if (assign%type_was_inferred .and. &

--- a/src/standardizers/standardizer_declarations_insertion.f90
+++ b/src/standardizers/standardizer_declarations_insertion.f90
@@ -334,7 +334,10 @@ contains
         allocate (var_types(100))
         allocate (var_declared(100))
         allocate (function_names(100))
+        var_names = ''
+        var_types = ''
         var_declared = .false.
+        function_names = ''
         var_count = 0
         func_count = 0
 
@@ -347,7 +350,7 @@ contains
                         type is (function_def_node)
                             if (func_count < size(function_names)) then
                                 func_count = func_count + 1
-                                function_names(func_count) = stmt%name
+                                function_names(func_count) = to_lower(trim(stmt%name))
                             end if
                         end select
                     end if
@@ -464,6 +467,10 @@ contains
         type(program_node), intent(in) :: prog
         character(len=*), intent(in) :: var_name
         integer :: i, j
+        character(len=64) :: target_name
+        character(len=64) :: candidate_name
+
+        target_name = to_lower(trim(var_name))
 
         has_explicit_declaration = .false.
 
@@ -474,14 +481,16 @@ contains
                     if (allocated(arena%entries(prog%body_indices(i))%node)) then
                         select type (stmt => arena%entries(prog%body_indices(i))%node)
                         type is (declaration_node)
-                            if (trim(stmt%var_name) == trim(var_name)) then
+                            candidate_name = to_lower(trim(stmt%var_name))
+                            if (trim(candidate_name) == trim(target_name)) then
                                 has_explicit_declaration = .true.
                                 return
                             end if
                             if (stmt%is_multi_declaration .and. &
                                 allocated(stmt%var_names)) then
                                 do j = 1, size(stmt%var_names)
-                                    if (trim(stmt%var_names(j)) == trim(var_name)) then
+                                    candidate_name = to_lower(trim(stmt%var_names(j)))
+                                    if (trim(candidate_name) == trim(target_name)) then
                                         has_explicit_declaration = .true.
                                         return
                                     end if

--- a/src/standardizers/standardizer_declarations_parsing.f90
+++ b/src/standardizers/standardizer_declarations_parsing.f90
@@ -191,6 +191,10 @@ contains
         character(len=*), intent(in) :: var_name, var_type
         type(program_node) :: prog
         integer :: i, j, node_idx
+        character(len=64) :: target_name
+        character(len=64) :: candidate_name
+
+        target_name = to_lower(trim(var_name))
 
         if (prog_index <= 0 .or. prog_index > arena%size) return
         if (.not. allocated(arena%entries(prog_index)%node)) return
@@ -205,7 +209,8 @@ contains
                 select type (decl => arena%entries(node_idx)%node)
                 type is (declaration_node)
                     if (.not. decl%is_multi_declaration) then
-                        if (trim(decl%var_name) == trim(var_name)) then
+                        candidate_name = to_lower(trim(decl%var_name))
+                        if (trim(candidate_name) == trim(target_name)) then
                             call apply_type_string_to_decl(arena, prog_index, &
                                                            var_name, var_type, &
                                                            decl)
@@ -214,7 +219,8 @@ contains
                         end if
                     else if (allocated(decl%var_names)) then
                         do j = 1, size(decl%var_names)
-                            if (trim(decl%var_names(j)) == trim(var_name)) then
+                            candidate_name = to_lower(trim(decl%var_names(j)))
+                            if (trim(candidate_name) == trim(target_name)) then
                                 if (index(to_lower(var_type), 'dimension(') == 0) then
                                     call apply_type_string_to_decl(arena, &
                                                                    prog_index, &

--- a/src/standardizers/standardizer_declarations_variables.f90
+++ b/src/standardizers/standardizer_declarations_variables.f90
@@ -1,6 +1,7 @@
 module standardizer_declarations_variables
     use ast_nodes_core, only: identifier_node
     use standardizer_declarations_state, only: get_standardizer_type_standardization
+    use string_utils_mod, only: to_lower
     use type_string_utils, only: mono_type_to_string
     implicit none
     private
@@ -24,10 +25,16 @@ contains
         integer, intent(in) :: func_count
         integer :: i
         logical :: found, is_function
+        character(len=64) :: normalized_input
+        character(len=64) :: normalized_existing
+        character(len=64) :: normalized_function
+
+        normalized_input = to_lower(trim(var_name))
 
         is_function = .false.
         do i = 1, func_count
-            if (trim(function_names(i)) == trim(var_name)) then
+            normalized_function = to_lower(trim(function_names(i)))
+            if (trim(normalized_function) == trim(normalized_input)) then
                 is_function = .true.
                 exit
             end if
@@ -37,7 +44,8 @@ contains
 
         found = .false.
         do i = 1, var_count
-            if (trim(var_names(i)) == trim(var_name)) then
+            normalized_existing = to_lower(trim(var_names(i)))
+            if (trim(normalized_existing) == trim(normalized_input)) then
                 found = .true.
                 exit
             end if
@@ -46,7 +54,7 @@ contains
         if (.not. found) then
             var_count = var_count + 1
             if (var_count <= size(var_names)) then
-                var_names(var_count) = var_name
+                var_names(var_count) = normalized_input
                 var_types(var_count) = var_type
                 var_declared(var_count) = .true.
             end if
@@ -59,9 +67,14 @@ contains
         logical, intent(inout) :: var_declared(:)
         integer, intent(in) :: var_count
         integer :: i
+        character(len=64) :: normalized_input
+        character(len=64) :: normalized_existing
+
+        normalized_input = to_lower(trim(var_name))
 
         do i = 1, var_count
-            if (trim(var_names(i)) == trim(var_name)) then
+            normalized_existing = to_lower(trim(var_names(i)))
+            if (trim(normalized_existing) == trim(normalized_input)) then
                 var_declared(i) = .false.
                 return
             end if
@@ -122,4 +135,3 @@ contains
     end subroutine collect_identifier_var
 
 end module standardizer_declarations_variables
-

--- a/test/integration/issue_tests/test_issue_1703_lazy_matrices.f90
+++ b/test/integration/issue_tests/test_issue_1703_lazy_matrices.f90
@@ -1,5 +1,6 @@
 program test_issue_1703_lazy_matrices
     use, intrinsic :: iso_fortran_env, only: dp => real64
+    use string_utils_mod, only: to_lower
     use transformation_api, only: transform_lazy_fortran_string
 
     call test_reshape_integer_matrices()
@@ -10,6 +11,7 @@ contains
 
     subroutine test_reshape_integer_matrices()
         character(len=:), allocatable :: input, output, error_msg
+        character(len=:), allocatable :: lowered
 
         input = 'A = reshape([1, 2, 3, 4], [2, 2])' // new_line('A') // &
                 'B = reshape([5, 6, 7, 8], [2, 2])' // new_line('A') // &
@@ -24,26 +26,28 @@ contains
             error stop 1
         end if
 
-        if (index(output, 'integer') == 0 .and. index(output, 'real') == 0) then
+        lowered = to_lower(output)
+
+        if (index(lowered, 'integer') == 0 .and. index(lowered, 'real') == 0) then
             print *, 'FAIL: No type declaration found for matrices'
             print *, output
             error stop 1
         end if
 
-        if (index(output, '(:,:)') == 0 .and. index(output, '(2,2)') == 0 .and. &
-            index(output, '(2, 2)') == 0) then
+        if (index(lowered, '(:,:)') == 0 .and. index(lowered, '(2,2)') == 0 .and. &
+            index(lowered, '(2, 2)') == 0) then
             print *, 'FAIL: Matrices not declared as 2D arrays'
             print *, output
             error stop 1
         end if
 
-        if (index(output, ':: A') == 0) then
-            print *, 'FAIL: Variable A not declared'
+        if (index(lowered, ':: a') == 0) then
+            print *, 'FAIL: Variable a not declared'
             print *, output
             error stop 1
         end if
 
-        if (index(output, 'A = reshape') == 0) then
+        if (index(lowered, 'a = reshape') == 0) then
             print *, 'FAIL: reshape assignment not preserved'
             print *, output
             error stop 1
@@ -54,6 +58,7 @@ contains
 
     subroutine test_reshape_real_matrices()
         character(len=:), allocatable :: input, output, error_msg
+        character(len=:), allocatable :: lowered
 
         input = 'X = reshape([1.0, 2.0, 3.0, 4.0], [2, 2])' // new_line('A') // &
                 'print *, X(1,1)'
@@ -65,14 +70,16 @@ contains
             error stop 1
         end if
 
-        if (index(output, 'real') == 0) then
+        lowered = to_lower(output)
+
+        if (index(lowered, 'real') == 0) then
             print *, 'FAIL: Real matrices not inferred as real type'
             print *, output
             error stop 1
         end if
 
-        if (index(output, '(:,:)') == 0 .and. index(output, '(2,2)') == 0 .and. &
-            index(output, '(2, 2)') == 0) then
+        if (index(lowered, '(:,:)') == 0 .and. index(lowered, '(2,2)') == 0 .and. &
+            index(lowered, '(2, 2)') == 0) then
             print *, 'FAIL: Real matrices not declared as 2D arrays'
             print *, output
             error stop 1
@@ -83,6 +90,7 @@ contains
 
     subroutine test_reshape_mixed_operations()
         character(len=:), allocatable :: input, output, error_msg
+        character(len=:), allocatable :: lowered
 
         input = 'M = reshape([1, 2, 3, 4, 5, 6], [2, 3])' // new_line('A') // &
                 'N = M * 2' // new_line('A') // &
@@ -95,8 +103,10 @@ contains
             error stop 1
         end if
 
-        if (index(output, '(:,:)') == 0 .and. index(output, '(2,3)') == 0 .and. &
-            index(output, '(2, 3)') == 0) then
+        lowered = to_lower(output)
+
+        if (index(lowered, '(:,:)') == 0 .and. index(lowered, '(2,3)') == 0 .and. &
+            index(lowered, '(2, 3)') == 0) then
             print *, 'FAIL: 2x3 matrices not declared correctly'
             print *, output
             error stop 1

--- a/test/integration/issue_tests/test_issue_1813_matrix_ops.f90
+++ b/test/integration/issue_tests/test_issue_1813_matrix_ops.f90
@@ -1,5 +1,6 @@
 program test_issue_1813_matrix_ops
     use, intrinsic :: iso_fortran_env, only: dp => real64
+    use string_utils_mod, only: to_lower
     use transformation_api, only: transform_lazy_fortran_string
     implicit none
 
@@ -9,6 +10,7 @@ contains
 
     subroutine test_matrix_literal_addition()
         character(len=:), allocatable :: input, output, error_msg
+        character(len=:), allocatable :: lowered
 
         input = 'A = [[1, 2], [3, 4]]' // new_line('A') // &
                 'B = [[5, 6], [7, 8]]' // new_line('A') // &
@@ -22,25 +24,27 @@ contains
             error stop 1
         end if
 
-        if (index(output, 'integer :: A(2,2)') == 0) then
-            print *, 'FAIL: A not declared as (2,2)'
+        lowered = to_lower(output)
+
+        if (index(lowered, 'integer :: a(2,2)') == 0) then
+            print *, 'FAIL: a not declared as (2,2)'
             print *, output
             error stop 1
         end if
 
-        if (index(output, 'integer :: B(2,2)') == 0) then
-            print *, 'FAIL: B not declared as (2,2)'
+        if (index(lowered, 'integer :: b(2,2)') == 0) then
+            print *, 'FAIL: b not declared as (2,2)'
             print *, output
             error stop 1
         end if
 
-        if (index(output, 'integer :: C(2,2)') == 0) then
-            print *, 'FAIL: C not declared as (2,2), issue #1813 not fixed'
+        if (index(lowered, 'integer :: c(2,2)') == 0) then
+            print *, 'FAIL: c not declared as (2,2), issue #1813 not fixed'
             print *, output
             error stop 1
         end if
 
-        if (index(output, 'C = A + B') == 0) then
+        if (index(lowered, 'c = a + b') == 0) then
             print *, 'FAIL: Matrix addition not preserved'
             print *, output
             error stop 1

--- a/test/test_issue_1969_case_insensitive_variables.f90
+++ b/test/test_issue_1969_case_insensitive_variables.f90
@@ -1,0 +1,95 @@
+program test_issue_1969_case_insensitive_variables
+    use transformation_api, only: transform_lazy_fortran_string
+    use string_utils_mod, only: to_lower
+    implicit none
+
+    character(:), allocatable :: input_code
+    character(:), allocatable :: output_code
+    character(:), allocatable :: error_msg
+    character(:), allocatable :: lowered
+    integer :: result_decls
+    integer :: x_decls
+    integer :: y_decls
+
+    print *, '=== Issue #1969: Case insensitive variable handling ==='
+
+    input_code = 'X = 5' // new_line('a') // &
+                 'y = 10' // new_line('a') // &
+                 'Result = x + Y' // new_line('a') // &
+                 'print *, ''Result:'', result'
+
+    call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+    if (len_trim(error_msg) > 0) then
+        print *, 'FAIL: transformation reported an error'
+        print *, trim(error_msg)
+        error stop 1
+    end if
+
+    lowered = to_lower(output_code)
+
+    result_decls = count_occurrences(lowered, ':: result')
+    if (result_decls /= 1) then
+        print *, 'FAIL: result declared incorrect number of times'
+        print *, trim(output_code)
+        error stop 1
+    end if
+
+    x_decls = count_occurrences(lowered, ':: x')
+    if (x_decls /= 1) then
+        print *, 'FAIL: x declared incorrect number of times'
+        print *, trim(output_code)
+        error stop 1
+    end if
+
+    y_decls = count_occurrences(lowered, ':: y')
+    if (y_decls == 0) then
+        if (index(lowered, ', y') == 0) then
+            print *, 'FAIL: y declaration missing'
+            print *, trim(output_code)
+            error stop 1
+        end if
+    else if (y_decls > 1) then
+        print *, 'FAIL: y declared more than once'
+        print *, trim(output_code)
+        error stop 1
+    end if
+
+    if (index(lowered, ':: result, result') > 0) then
+        print *, 'FAIL: duplicate mixed case declaration detected'
+        print *, trim(output_code)
+        error stop 1
+    end if
+
+    if (index(lowered, 'result = x + y') == 0) then
+        print *, 'FAIL: assignment not canonicalized'
+        print *, trim(output_code)
+        error stop 1
+    end if
+
+    print *, 'PASS: mixed case identifiers handled correctly'
+
+contains
+
+    integer function count_occurrences(buffer, pattern) result(total)
+        character(len=*), intent(in) :: buffer
+        character(len=*), intent(in) :: pattern
+        integer :: start_pos
+        integer :: found_pos
+        integer :: pattern_len
+
+        total = 0
+        pattern_len = len(pattern)
+        if (pattern_len <= 0) return
+
+        start_pos = 1
+        do
+            if (start_pos > len(buffer)) exit
+            found_pos = index(buffer(start_pos:), pattern)
+            if (found_pos == 0) exit
+            total = total + 1
+            start_pos = start_pos + found_pos + pattern_len - 1
+        end do
+    end function count_occurrences
+
+end program test_issue_1969_case_insensitive_variables


### PR DESCRIPTION
## Summary
- canonicalize identifier tracking in the standardizer and code generator so mixed-case names resolve to a single symbol
- ensure array property inference, implicit declarations, and call-site analysis use lower-case comparisons
- add mixed-case regression coverage and align existing matrix tests with case-insensitive declarations

## Verification
- fpm test --target test_issue_1969_case_insensitive_variables
- make test
