### PR TITLE
fix: CRITICAL: TARGET attribute stripped, breaking pointer assignm (fixes #1959)

### DIFF
--- a/src/frontend_transformation.f90
+++ b/src/frontend_transformation.f90
@@ -13,7 +13,8 @@ module frontend_transformation
     use semantic_analyzer, only: semantic_context_t, create_semantic_context, &
                                  analyze_program, has_semantic_errors
     use standardizer, only: standardize_ast, set_standardizer_type_standardization, &
-                            get_standardizer_type_standardization
+                            get_standardizer_type_standardization, &
+                            mark_pointer_targets
     use codegen_arena_interface, only: generate_code_from_arena
     use ast_monomorphization, only: transform_monomorphization
     use call_graph_signatures_mod, only: signatures_map_t, type_signature_t, &
@@ -314,7 +315,7 @@ contains
 
         ! Run semantic analysis and standardization (but not code generation yet)
         call run_semantic_analysis_phase(shared_arena, prog_index, error_msg, &
-            signatures)
+                                         signatures)
         if (allocated(error_msg) .and. len(error_msg) > 0) then
             call run_code_generation_phase(shared_arena, prog_index, output)
             call trace_leave('transform_lazy_with_ast_wrapping')
@@ -666,7 +667,7 @@ contains
 
         ! Phase 3: Semantic Analysis
         call run_semantic_analysis_phase(compiler_arena, prog_index, error_msg, &
-            signatures)
+                                         signatures)
         if (allocated(error_msg) .and. len(error_msg) > 0) then
             ! CRITICAL FIX for Issue #1120: Generate output even with semantic errors
             ! Continue to code generation to provide useful output to user
@@ -690,7 +691,7 @@ contains
 
     ! Run semantic analysis phase
     subroutine run_semantic_analysis_phase(compiler_arena, prog_index, error_msg, &
-        signatures)
+                                           signatures)
         type(compiler_arena_t), intent(inout) :: compiler_arena
         integer, intent(in) :: prog_index
         character(len=:), allocatable, intent(out) :: error_msg
@@ -710,7 +711,8 @@ contains
 
             if (prog_index > 0 .and. prog_index <= compiler_arena%ast%size) then
                 if (allocated(compiler_arena%ast%entries(prog_index)%node)) then
-                    select type (root_node => compiler_arena%ast%entries(prog_index)%node)
+                    select type (root_node => &
+                                 compiler_arena%ast%entries(prog_index)%node)
                     type is (mixed_construct_container_node)
                         call analyze_container_semantics(compiler_arena%ast, &
                                                          root_node, signatures, &
@@ -820,8 +822,8 @@ contains
             if (source%proc_sigs(i)%sig_count <= 0) cycle
             do j = 1, source%proc_sigs(i)%sig_count
                 call add_signature_from_entry(target, &
-                    trim(source%proc_sigs(i)%procedure_name), &
-                    source%proc_sigs(i)%signatures(j))
+                                             trim(source%proc_sigs(i)%procedure_name), &
+                                              source%proc_sigs(i)%signatures(j))
             end do
         end do
     end subroutine merge_signature_maps
@@ -915,10 +917,12 @@ contains
         call normalize_multi_unit_container(compiler_arena%ast, prog_index)
         ! Skip standardization for multi-unit containers
         if (should_skip_standardization(compiler_arena, prog_index)) then
+            call mark_pointer_targets(compiler_arena%ast)
             return
         end if
 
         call standardize_ast(compiler_arena%ast, prog_index)
+        call mark_pointer_targets(compiler_arena%ast)
     end subroutine run_standardization_phase
 
     ! Check if should skip standardization
@@ -1766,19 +1770,25 @@ contains
                     write (error_unit, '(A)') 'DEBUG run_mono node_type <not set>'
                 end if
                 if (allocated(compiler_arena%ast%entries(prog_index)%node)) then
-                    select type (root_node => compiler_arena%ast%entries(prog_index)%node)
+                    select type (root_node => &
+                                 compiler_arena%ast%entries(prog_index)%node)
                     type is (program_node)
-                        write (error_unit, '(A,1X,A)') 'DEBUG run_mono root=program', trim(root_node%name)
+                        write (error_unit, '(A,1X,A)') 'DEBUG run_mono root=program', &
+                            trim(root_node%name)
                     type is (module_node)
-                        write (error_unit, '(A,1X,A)') 'DEBUG run_mono root=module', trim(root_node%name)
+                        write (error_unit, '(A,1X,A)') 'DEBUG run_mono root=module', &
+                            trim(root_node%name)
                     class default
-                        write (error_unit, '(A,1X,I0)') 'DEBUG run_mono root=other index', prog_index
+                        write (error_unit, '(A,1X,I0)') &
+                            'DEBUG run_mono root=other index', prog_index
                     end select
                 else
-                    write (error_unit, '(A,1X,I0)') 'DEBUG run_mono root node not allocated', prog_index
+                    write (error_unit, '(A,1X,I0)') &
+                        'DEBUG run_mono root node not allocated', prog_index
                 end if
             else
-                write (error_unit, '(A,1X,I0)') 'DEBUG run_mono invalid prog_index', prog_index
+                write (error_unit, '(A,1X,I0)') &
+                    'DEBUG run_mono invalid prog_index', prog_index
             end if
         end if
 

--- a/src/standardizers/standardizer.f90
+++ b/src/standardizers/standardizer.f90
@@ -82,6 +82,8 @@ module standardizer
         is_procedure_parameter, &
         is_type_component, &
         collect_string_vars_needing_allocatable
+    use standardizer_pointer_targets, only: &
+        mark_pointer_targets
 
     implicit none
 
@@ -147,6 +149,8 @@ module standardizer
         is_array_assignment, &
         is_procedure_parameter, &
         is_type_component, &
-        collect_string_vars_needing_allocatable
+        collect_string_vars_needing_allocatable, &
+        ! Pointer attribute helpers
+        mark_pointer_targets
 
 end module standardizer

--- a/src/standardizers/standardizer_pointer_targets.f90
+++ b/src/standardizers/standardizer_pointer_targets.f90
@@ -1,0 +1,198 @@
+module standardizer_pointer_targets
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: pointer_assignment_node, call_or_subscript_node, &
+                              component_access_node, range_subscript_node, &
+                              identifier_node
+    use ast_nodes_data, only: declaration_node, parameter_declaration_node
+    use string_utils_mod, only: to_lower
+    implicit none
+    private
+
+    public :: mark_pointer_targets
+
+contains
+
+    subroutine mark_pointer_targets(arena)
+        type(ast_arena_t), intent(inout) :: arena
+        integer :: i
+
+        if (arena%size <= 0) return
+
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+
+            select type (node => arena%entries(i)%node)
+            type is (pointer_assignment_node)
+                call handle_pointer_target(arena, node%target_index)
+            class default
+            end select
+        end do
+    end subroutine mark_pointer_targets
+
+    subroutine handle_pointer_target(arena, target_index)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: target_index
+        character(len=64), allocatable :: names(:)
+        integer :: count
+        integer :: i
+
+        call init_name_buffer(names, count)
+        call collect_target_names(arena, target_index, names, count)
+        if (count == 0) then
+            call finalize_name_buffer(names)
+            return
+        end if
+
+        do i = 1, count
+            call mark_name_as_target(arena, names(i))
+        end do
+
+        call finalize_name_buffer(names)
+    end subroutine handle_pointer_target
+
+    recursive subroutine collect_target_names(arena, expr_index, names, count)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: expr_index
+        character(len=64), allocatable, intent(inout) :: names(:)
+        integer, intent(inout) :: count
+
+        if (expr_index <= 0) return
+        if (expr_index > arena%size) return
+        if (.not. allocated(arena%entries(expr_index)%node)) return
+
+        select type (expr => arena%entries(expr_index)%node)
+        type is (identifier_node)
+            call append_name(names, count, expr%name)
+        type is (call_or_subscript_node)
+            if (allocated(expr%name)) then
+                call append_name(names, count, expr%name)
+            end if
+            if (expr%base_expr_index > 0) then
+                call collect_target_names(arena, expr%base_expr_index, names, count)
+            end if
+        type is (range_subscript_node)
+            call collect_target_names(arena, expr%base_expr_index, names, count)
+        type is (component_access_node)
+            if (allocated(expr%component_name)) then
+                call append_name(names, count, expr%component_name)
+            end if
+            if (expr%base_expr_index > 0) then
+                call collect_target_names(arena, expr%base_expr_index, names, count)
+            end if
+        class default
+            ! No additional handling required for other node types
+        end select
+    end subroutine collect_target_names
+
+    subroutine mark_name_as_target(arena, lowered_name)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: lowered_name
+        integer :: i, j
+        logical :: updated
+        character(len=:), allocatable :: candidate
+
+        if (len_trim(lowered_name) == 0) return
+
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            updated = .false.
+
+            select type (decl => arena%entries(i)%node)
+            type is (declaration_node)
+                if (allocated(decl%var_name)) then
+                    candidate = to_lower(trim(decl%var_name))
+                    if (candidate == lowered_name) then
+                        if (.not. decl%is_target) then
+                            decl%is_target = .true.
+                            updated = .true.
+                        end if
+                    end if
+                end if
+
+                if (.not. updated) then
+                    if (decl%is_multi_declaration .and. &
+                        allocated(decl%var_names)) then
+                        do j = 1, size(decl%var_names)
+                            candidate = to_lower(trim(decl%var_names(j)))
+                            if (candidate == lowered_name) then
+                                if (.not. decl%is_target) then
+                                    decl%is_target = .true.
+                                    updated = .true.
+                                end if
+                                exit
+                            end if
+                        end do
+                    end if
+                end if
+
+                if (updated) arena%entries(i)%node = decl
+            type is (parameter_declaration_node)
+                if (allocated(decl%name)) then
+                    candidate = to_lower(trim(decl%name))
+                    if (candidate == lowered_name) then
+                        if (.not. decl%is_target) then
+                            decl%is_target = .true.
+                            arena%entries(i)%node = decl
+                        end if
+                    end if
+                end if
+            class default
+            end select
+        end do
+    end subroutine mark_name_as_target
+
+    subroutine init_name_buffer(names, count)
+        character(len=64), allocatable, intent(inout) :: names(:)
+        integer, intent(out) :: count
+
+        allocate (names(4))
+        names = ""
+        count = 0
+    end subroutine init_name_buffer
+
+    subroutine finalize_name_buffer(names)
+        character(len=64), allocatable, intent(inout) :: names(:)
+
+        if (allocated(names)) then
+            block
+                character(len=64), allocatable :: temp(:)
+                call move_alloc(names, temp)
+            end block
+        end if
+    end subroutine finalize_name_buffer
+
+    subroutine append_name(names, count, raw_name)
+        character(len=64), allocatable, intent(inout) :: names(:)
+        integer, intent(inout) :: count
+        character(len=*), intent(in) :: raw_name
+        character(len=:), allocatable :: lowered
+        character(len=64), allocatable :: temp(:)
+        integer :: i, new_capacity
+
+        lowered = to_lower(trim(adjustl(raw_name)))
+        if (len_trim(lowered) == 0) return
+
+        do i = 1, count
+            if (trim(names(i)) == trimmed(lowered)) return
+        end do
+
+        if (count >= size(names)) then
+            new_capacity = max(4, size(names) * 2)
+            allocate (temp(new_capacity))
+            temp = ""
+            temp(1:size(names)) = names
+            call move_alloc(temp, names)
+        end if
+
+        count = count + 1
+        names(count) = trimmed(lowered)
+    contains
+        pure function trimmed(text) result(value)
+            character(len=*), intent(in) :: text
+            character(len=64) :: value
+            value = ""
+            value(1:len_trim(text)) = text
+        end function trimmed
+    end subroutine append_name
+
+end module standardizer_pointer_targets

--- a/test/test_issue_1959_target_attribute.f90
+++ b/test/test_issue_1959_target_attribute.f90
@@ -1,0 +1,55 @@
+program test_issue_1959_target_attribute
+    use transformation_api, only: transform_with_context, transform_context_t
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=:), allocatable :: input_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: context
+    logical :: has_target_attr
+    logical :: test_passed
+
+    print *, "=== Issue #1959: preserve target attribute for pointer targets ==="
+
+    input_code = &
+        "program test_pointer" // new_line('A') // &
+        "    implicit none" // new_line('A') // &
+        "    integer, target :: x, y" // new_line('A') // &
+        "    integer, pointer :: p" // new_line('A') // &
+        new_line('A') // &
+        "    x = 10" // new_line('A') // &
+        "    y = 20" // new_line('A') // &
+        "    p => x" // new_line('A') // &
+        "end program test_pointer"
+
+    context%input_mode = INPUT_MODE_STANDARD
+    context%has_filename = .true.
+    context%source_name = "test_issue_1959_input"
+
+    call transform_with_context(input_code, output_code, error_msg, context)
+
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: transform_with_context returned error:", trim(error_msg)
+        error stop 1
+    end if
+
+    has_target_attr = index(output_code, ", target :: x") > 0 .or. &
+                      index(output_code, ", target :: y") > 0
+
+    test_passed = has_target_attr
+
+    if (.not. has_target_attr) then
+        print *, "FAIL: target attribute missing from transformed declaration"
+        print *, "Transformed output:"
+        print *, trim(output_code)
+        error stop 1
+    end if
+
+    if (test_passed) then
+        print *, "PASS: target attribute preserved for pointer associations"
+    else
+        error stop 1
+    end if
+
+end program test_issue_1959_target_attribute


### PR DESCRIPTION
## Summary
- add a standardizer pass that marks pointer targets so declarations keep the TARGET attribute
- wire the pass into the overall pipeline (including skip paths) so codegen sees the flag
- add a regression exercising pointer assignments to guard the behaviour

## Verification
- make test
