### PR TITLE
fix: Bug: Array type incorrectly inferred from implied-do array const (fixes #1970)

### DIFF
--- a/examples/f90/issue_1970_implied_do_array_constructor.f90
+++ b/examples/f90/issue_1970_implied_do_array_constructor.f90
@@ -1,0 +1,9 @@
+program issue_1970_implied_do_array_constructor
+    implicit none
+
+    integer :: i
+    real :: halves(5)
+
+    halves = [(real(i) / 2.0, i=1, 5)]
+    print *, 'Halves:', halves
+end program issue_1970_implied_do_array_constructor

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -759,7 +759,7 @@ contains
                     select type (call_expr => arena%entries(node_index)%node)
                     type is (subroutine_call_node)
                         call collect_subroutine_signature(this%signatures, arena, &
-                            call_expr, node_index)
+                                                          call_expr, node_index)
                     end select
                 end if
             end if
@@ -772,9 +772,52 @@ contains
             integer, intent(in) :: node_index
             type(mono_type_t), allocatable :: args(:)
             type(mono_type_t) :: node_type
+            type(mono_type_t) :: element_type
+            type(mono_type_t) :: child_type
+            integer :: parent_index
+            integer :: i
+            logical :: is_implied_do
+
+            element_type = create_mono_type(TINT)
+            is_implied_do = .false.
+
+            if (node_index > 0 .and. node_index <= arena%size) then
+                parent_index = arena%entries(node_index)%parent_index
+                if (parent_index > 0 .and. parent_index <= arena%size) then
+                    if (allocated(arena%entries(parent_index)%node)) then
+                        select type (parent_node => arena%entries(parent_index)%node)
+                        type is (array_literal_node)
+                            is_implied_do = .true.
+                        end select
+                    end if
+                end if
+            end if
+
+            if (is_implied_do) then
+                element_type%kind = 0
+                element_type%size = 0
+                if (allocated(arena%entries(node_index)%node)) then
+                    select type (loop_node => arena%entries(node_index)%node)
+                    type is (do_loop_node)
+                        if (allocated(loop_node%body_indices)) then
+                            do i = 1, size(loop_node%body_indices)
+                                child_type = get_node_type(loop_node%body_indices(i))
+                                if (child_type%kind == 0) cycle
+                                if (element_type%kind == 0) then
+                                    element_type = child_type
+                                else
+                                    element_type = &
+                                        get_common_type(element_type, child_type)
+                                end if
+                            end do
+                        end if
+                    end select
+                end if
+                if (element_type%kind == 0) element_type = create_mono_type(TINT)
+            end if
 
             allocate (args(1))
-            args(1) = create_mono_type(TINT)
+            args(1) = element_type
             node_type = create_mono_type(TARRAY, args=args)
             call finalize_node(node_index, node_type)
             if (allocated(args)) deallocate (args)

--- a/src/semantic/analyzers/semantic_function_array.f90
+++ b/src/semantic/analyzers/semantic_function_array.f90
@@ -9,6 +9,7 @@ module semantic_function_array
     use scope_manager, only: scope_stack_t
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: call_or_subscript_node, array_literal_node
+    use ast_nodes_loops, only: do_loop_node
     use ast_nodes_procedure, only: function_def_node
     use ast_nodes_data, only: declaration_node
     use ast_nodes_bounds, only: array_slice_node, range_expression_node, &
@@ -17,6 +18,7 @@ module semantic_function_array
     use semantic_validation_utils, only: int_to_str
     use string_utils_mod, only: to_lower
     use semantic_array_type_builders, only: collapse_array_rank
+    use semantic_type_operations, only: get_common_type
     implicit none
     private
 
@@ -413,7 +415,8 @@ contains
             end if
         end if
 
-        first_type = get_type_fn(arena, array_lit%element_indices(1))
+        first_type = resolve_constructor_element_type( &
+                     arena, array_lit%element_indices(1), get_type_fn)
         promoted_type = first_type
         has_real = (first_type%kind == TREAL)
         all_arrays = (first_type%kind == TARRAY)
@@ -429,7 +432,8 @@ contains
         end if
 
         do i = 2, size(array_lit%element_indices)
-            element_type = get_type_fn(arena, array_lit%element_indices(i))
+            element_type = resolve_constructor_element_type( &
+                           arena, array_lit%element_indices(i), get_type_fn)
 
             if (all_arrays .and. element_type%kind /= TARRAY) then
                 all_arrays = .false.
@@ -492,6 +496,77 @@ contains
                                    array_size=size(array_lit%element_indices))
         end if
     end function infer_array_literal_type
+
+    recursive function resolve_constructor_element_type(arena, element_index, &
+                                                        get_type_fn) &
+        result(resolved_type)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: element_index
+        interface
+            function get_type_fn(a, idx) result(t)
+                import :: mono_type_t, ast_arena_t
+                type(ast_arena_t), intent(inout) :: a
+                integer, intent(in) :: idx
+                type(mono_type_t) :: t
+            end function get_type_fn
+        end interface
+        type(mono_type_t) :: resolved_type
+
+        resolved_type%kind = 0
+        resolved_type%size = 0
+        if (element_index <= 0) return
+        if (element_index > arena%size) return
+        if (.not. allocated(arena%entries(element_index)%node)) return
+
+        select type (element_node => arena%entries(element_index)%node)
+        type is (do_loop_node)
+            resolved_type = resolve_implied_do_type(arena, element_index, &
+                                                    get_type_fn)
+        class default
+            resolved_type = get_type_fn(arena, element_index)
+        end select
+    end function resolve_constructor_element_type
+
+    recursive function resolve_implied_do_type(arena, loop_index, get_type_fn) &
+        result(resolved_type)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: loop_index
+        interface
+            function get_type_fn(a, idx) result(t)
+                import :: mono_type_t, ast_arena_t
+                type(ast_arena_t), intent(inout) :: a
+                integer, intent(in) :: idx
+                type(mono_type_t) :: t
+            end function get_type_fn
+        end interface
+        type(mono_type_t) :: resolved_type
+        type(mono_type_t) :: element_type
+        integer :: i
+
+        resolved_type%kind = 0
+        resolved_type%size = 0
+        if (loop_index <= 0) return
+        if (loop_index > arena%size) return
+        if (.not. allocated(arena%entries(loop_index)%node)) return
+
+        select type (loop_node => arena%entries(loop_index)%node)
+        type is (do_loop_node)
+            if (.not. allocated(loop_node%body_indices)) return
+            do i = 1, size(loop_node%body_indices)
+                element_type = resolve_constructor_element_type( &
+                               arena, loop_node%body_indices(i), get_type_fn)
+                if (element_type%kind == 0) cycle
+                if (resolved_type%kind == 0) then
+                    resolved_type = element_type
+                else
+                    resolved_type = get_common_type(resolved_type, element_type)
+                end if
+            end do
+            if (resolved_type%kind == 0) resolved_type = create_mono_type(TINT)
+        class default
+            resolved_type = get_type_fn(arena, loop_index)
+        end select
+    end function resolve_implied_do_type
 
     function infer_array_intrinsic_type(arena, call_node, get_type_fn) &
         result(typ)

--- a/test/integration/issue_tests/test_issue_1970_implied_do_array_constructor.f90
+++ b/test/integration/issue_tests/test_issue_1970_implied_do_array_constructor.f90
@@ -1,0 +1,60 @@
+program test_issue_1970_implied_do_array_constructor
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use, intrinsic :: iso_fortran_env, only: input_unit, iostat_end, iostat_eor
+    use transformation_api, only: transform_with_context, transform_context_t, &
+                                  INPUT_MODE_STANDARD
+    implicit none
+
+    type(transform_context_t) :: context
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: transformed
+    character(len=:), allocatable :: error_msg
+    logical :: has_real_decl
+
+    call read_example( &
+        'examples/f90/issue_1970_implied_do_array_constructor.f90', source)
+
+    context%input_mode = INPUT_MODE_STANDARD
+    call transform_with_context(source, transformed, error_msg, context)
+
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) then
+            write (error_unit, '(a)') 'FAIL: unexpected error: ' // &
+                trim(error_msg)
+            stop 1
+        end if
+    end if
+
+    has_real_decl = index(transformed, 'real :: halves(5)') > 0
+    if (.not. has_real_decl) then
+        write (error_unit, '(a)') 'FAIL: real declaration missing'
+        write (error_unit, '(a)') transformed
+        stop 1
+    end if
+
+    if (index(transformed, 'integer :: halves(5)') > 0) then
+        write (error_unit, '(a)') 'FAIL: integer declaration still present'
+        write (error_unit, '(a)') transformed
+        stop 1
+    end if
+
+    write (error_unit, '(a)') &
+        'PASS: implied-do array constructor infers real element type'
+
+contains
+
+    include '../../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(a)') 'FAIL: failed to load example'
+            stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_1970_implied_do_array_constructor


### PR DESCRIPTION
## Summary
- derive implied-do element types from loop bodies during semantic inference
- reuse the resolved element type when inferring array literal constructors
- add regression example and integration test for #1970

## Verification
- make test  # includes PASS: implied-do array constructor infers real element type
