### PR TITLE
fix: preserve fixed-size arrays instead of converting to allocatable (fixes #2022)

### DIFF
--- a/examples/f90/issue_2022_fixed_array_to_unallocated.f90
+++ b/examples/f90/issue_2022_fixed_array_to_unallocated.f90
@@ -1,0 +1,15 @@
+program test_array_scalar_assign
+    implicit none
+    integer, dimension(5) :: arr
+    integer :: i
+
+    ! Assign scalar to entire array
+    arr = 7
+
+    print *, 'Array after scalar assignment:', arr
+
+    ! Multiply entire array by scalar
+    arr = arr * 3
+
+    print *, 'Array after multiplication:', arr
+end program test_array_scalar_assign

--- a/src/standardizers/standardizer_allocatable.f90
+++ b/src/standardizers/standardizer_allocatable.f90
@@ -919,9 +919,10 @@ contains
     end function has_explicit_character_length
 
     pure logical function has_explicit_array_bounds(decl) result(has_bounds)
-        ! Check if a declaration has explicit array bounds (e.g., arr(0:9), arr(-5:5))
-        ! rather than just a size (e.g., arr(10)) or deferred shape (e.g., arr(:))
-        ! Arrays with explicit bounds should NOT be converted to allocatable.
+        ! Check if a declaration has explicit array bounds or size
+        ! (e.g., arr(5), arr(0:9), arr(-5:5)) vs deferred shape (e.g., arr(:))
+        ! Arrays with explicit bounds/size should NOT be converted to allocatable
+        ! to preserve the original declaration (fixes #2022).
         type(declaration_node), intent(in) :: decl
         integer :: i
 
@@ -931,11 +932,12 @@ contains
         if (.not. allocated(decl%dimension_indices)) return
         if (size(decl%dimension_indices) == 0) return
 
-        ! Check if any dimension index is > 1000000
-        ! Heuristic: Parser stores range expressions (like 0:9) as large indices
-        ! while simple sizes (like 10) are stored as small indices
+        ! Check each dimension:
+        ! - dimension_indices(i) = 0 means deferred shape (:)
+        ! - dimension_indices(i) > 0 means explicit size or range expression
+        ! Only deferred shape should be converted to allocatable
         do i = 1, size(decl%dimension_indices)
-            if (decl%dimension_indices(i) > 1000000) then
+            if (decl%dimension_indices(i) > 0) then
                 has_bounds = .true.
                 return
             end if

--- a/test/test_issue_2022_fixed_array_preservation.f90
+++ b/test/test_issue_2022_fixed_array_preservation.f90
@@ -1,0 +1,67 @@
+program test_issue_2022_fixed_array_preservation
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit
+    use, intrinsic :: iso_fortran_env, only: iostat_end, iostat_eor
+    use transformation_api, only: transform_with_context, transform_context_t
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use string_utils_mod, only: to_lower
+    implicit none
+
+    character(:), allocatable :: input_code
+    character(:), allocatable :: output_code
+    character(:), allocatable :: error_msg
+    character(:), allocatable :: lowered_output
+    type(transform_context_t) :: context
+
+    print *, '=== Issue #2022: fixed-size array preservation ==='
+
+    call read_example('examples/f90/issue_2022_fixed_array_to_unallocated.f90', &
+                      input_code)
+
+    context%input_mode = INPUT_MODE_STANDARD
+    context%has_filename = .true.
+    context%source_name = "test_issue_2022_input"
+
+    call transform_with_context(input_code, output_code, error_msg, context)
+
+    if (len_trim(error_msg) > 0) then
+        print *, 'FAIL: transformation reported an error'
+        print *, trim(error_msg)
+        error stop 1
+    end if
+
+    lowered_output = to_lower(output_code)
+
+    ! Verify fixed-size array is preserved
+    if (index(lowered_output, 'integer :: arr(5)') == 0) then
+        print *, 'FAIL: fixed-size array arr(5) not preserved'
+        print *, 'Output:' // new_line('A') // trim(output_code)
+        error stop 1
+    end if
+
+    ! Verify it's NOT converted to allocatable
+    if (index(lowered_output, 'allocatable :: arr') > 0 .or. &
+        index(lowered_output, 'arr(:)') > 0) then
+        print *, 'FAIL: array incorrectly converted to allocatable'
+        print *, 'Output:' // new_line('A') // trim(output_code)
+        error stop 1
+    end if
+
+    print *, 'PASS: fixed-size array preserved correctly'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            print *, 'FAIL: failed to read ', trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2022_fixed_array_preservation


### PR DESCRIPTION
### **User description**
## Summary
Fixes #2022 - Fixed-size arrays like `integer :: arr(5)` are now correctly preserved instead of being converted to unallocated allocatable arrays.

## Problem
When fortfront processed standard Fortran with fixed-size array declarations, it incorrectly converted them to allocatable arrays without allocation:

**Input:**
```fortran
integer, dimension(5) :: arr
arr = 7
```

**Previous (buggy) output:**
```fortran
integer, allocatable :: arr(:)
arr = 7  ! Assignment to unallocated array!
```

**Runtime behavior:** Silent data corruption - arrays printed empty because they were never allocated.

## Root Cause
The `has_explicit_array_bounds()` function in `src/standardizers/standardizer_allocatable.f90` only detected explicit bounds like `arr(0:9)` using a heuristic (dimension index > 1000000), but **missed simple fixed-size arrays** like `arr(5)` which have smaller dimension indices.

This caused the standardizer to treat fixed-size arrays as needing allocatable conversion when they had multiple assignments.

## Solution
Updated `has_explicit_array_bounds()` to return `true` for **any** array with explicit dimensions (`dimension_indices > 0`), not just range expressions. Only deferred shape arrays (`dimension_indices = 0`) are now converted to allocatable.

## Verification

### Build and Test
```bash
fpm build
fpm test test_issue_2022_fixed_array_preservation
```

**Test output:**
```
=== Issue #2022: fixed-size array preservation ===
 PASS: fixed-size array preserved correctly
```

### Transformation Verification
```bash
./build/gfortran_*/app/fortfront examples/f90/issue_2022_fixed_array_to_unallocated.f90
```

**Correct output:**
```fortran
integer :: arr(5)  ✓ Preserved fixed-size
```

### Runtime Verification
Compiled and executed the transformed output:
```
 Array after scalar assignment:           7           7           7           7           7
 Array after multiplication:          21          21          21          21          21
```
✓ Array correctly allocated and populated (was empty before fix)

## Files Changed
- `src/standardizers/standardizer_allocatable.f90` - Fixed dimension detection logic
- `examples/f90/issue_2022_fixed_array_to_unallocated.f90` - Example demonstrating the issue
- `test/test_issue_2022_fixed_array_preservation.f90` - Test verifying the fix

## Testing
- ✅ New test passes
- ✅ All existing tests pass
- ✅ Example compiles and runs correctly
- ✅ Output matches expected standard Fortran


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed-size arrays now preserved instead of converted to allocatable

- Updated dimension detection logic to recognize explicit array bounds

- Only deferred shape arrays (`:`) converted to allocatable now

- Added test and example demonstrating the fix


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Fixed-size array<br/>arr(5)"] -->|Previously| B["Allocatable<br/>arr(:)<br/>unallocated"]
  A -->|Now| C["Preserved<br/>arr(5)"]
  D["Deferred shape<br/>arr(:)"] -->|Still converts| E["Allocatable<br/>arr(:)"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>standardizer_allocatable.f90</strong><dd><code>Fix dimension detection for fixed-size arrays</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/standardizers/standardizer_allocatable.f90

<ul><li>Updated <code>has_explicit_array_bounds()</code> function logic to detect any <br>explicit dimension<br> <li> Changed condition from checking <code>dimension_indices(i) > 1000000</code> to <br><code>dimension_indices(i) > 0</code><br> <li> Now correctly distinguishes between deferred shape arrays (0) and <br>explicit bounds/sizes (>0)<br> <li> Updated comments to clarify the distinction between array types</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2026/files#diff-eb6db709c95eff701c3b9ae39e966f855890fccb6b4bb4c3036ca8da51fe4fc5">+9/-7</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue_2022_fixed_array_to_unallocated.f90</strong><dd><code>Add example for fixed-size array preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/f90/issue_2022_fixed_array_to_unallocated.f90

<ul><li>New example demonstrating fixed-size array handling<br> <li> Shows scalar assignment to entire array and array multiplication<br> <li> Demonstrates correct runtime behavior with array values</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2026/files#diff-56f8369f35521f42d423c3379ee22981c011e752a4256273a0fa75f5055a0a43">+15/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_2022_fixed_array_preservation.f90</strong><dd><code>Add test for fixed-size array preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_issue_2022_fixed_array_preservation.f90

<ul><li>New test program verifying fixed-size arrays are preserved<br> <li> Validates that <code>arr(5)</code> is not converted to allocatable<br> <li> Checks transformation output contains correct array declaration<br> <li> Includes file reading utility for example code</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2026/files#diff-f626eff43d1579a0663d34ab8585ee749c5f68c2a9076584ba9078720b0e1333">+67/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

