### PR TITLE
fix: infer and declare subroutine local variables (fixes #2012)

### DIFF
--- a/examples/lf/issue_2012_subroutine_local_not_inferred.lf
+++ b/examples/lf/issue_2012_subroutine_local_not_inferred.lf
@@ -1,0 +1,11 @@
+subroutine swap(a, b)
+    temp = a
+    a = b
+    b = temp
+end subroutine
+
+x = 10
+y = 20
+print *, 'Before:', x, y
+call swap(x, y)
+print *, 'After:', x, y

--- a/src/codegen/codegen_subroutine_declarations.f90
+++ b/src/codegen/codegen_subroutine_declarations.f90
@@ -1,6 +1,6 @@
 module codegen_subroutine_declarations
     use ast_arena_modern, only: ast_arena_t
-    use ast_nodes_core, only: identifier_node
+    use ast_nodes_core, only: identifier_node, assignment_node
     use ast_nodes_data, only: declaration_node, parameter_declaration_node
     use ast_nodes_io, only: print_statement_node, read_statement_node
     use ast_nodes_loops, only: do_loop_node
@@ -17,6 +17,7 @@ module codegen_subroutine_declarations
     use codegen_grouped_body_params, only: generate_grouped_body_with_params
     use codegen_import_reorder, only: reorder_import_lines
     use codegen_parameter_info, only: parameter_info_t
+    use type_string_utils, only: mono_type_to_string
     implicit none
     private
     public :: generate_code_subroutine_def
@@ -220,6 +221,10 @@ contains
             type is (parameter_declaration_node)
                 call add_single_declared_var(stmt%name, declared_vars, n_declared, &
                                              declared_capacity)
+            type is (assignment_node)
+                call collect_vars_from_assignment_sub(arena, stmt, param_map, &
+                                                      local_vars, n_locals, capacity, &
+                                                      declared_vars, n_declared, decl_code)
             type is (print_statement_node)
                 call collect_vars_from_print_sub(arena, stmt, param_map, local_vars, &
                                                  n_locals, capacity, declared_vars, &
@@ -348,5 +353,49 @@ contains
             decl_code = decl_code // "    integer :: " // trim(var_name) // new_line('A')
         end if
     end subroutine collect_loop_var_sub
+
+    subroutine collect_vars_from_assignment_sub(arena, stmt, param_map, &
+                                                local_vars, n_locals, capacity, &
+                                                declared_vars, n_declared, decl_code)
+        type(ast_arena_t), intent(in) :: arena
+        type(assignment_node), intent(in) :: stmt
+        type(parameter_info_t), intent(in) :: param_map(:)
+        character(len=64), allocatable, intent(inout) :: local_vars(:)
+        integer, intent(inout) :: n_locals
+        integer, intent(inout) :: capacity
+        character(len=64), allocatable, intent(in) :: declared_vars(:)
+        integer, intent(in) :: n_declared
+        character(len=:), allocatable, intent(inout) :: decl_code
+        character(len=64) :: var_name
+        integer :: j
+
+        if (stmt%target_index <= 0 .or. stmt%target_index > arena%size) return
+        if (.not. allocated(arena%entries(stmt%target_index)%node)) return
+
+        select type (target => arena%entries(stmt%target_index)%node)
+        type is (identifier_node)
+            if (.not. allocated(target%name)) return
+            if (target%inferred_type%kind == 0) return
+
+            var_name = trim(target%name)
+
+            if (is_parameter_name(var_name, param_map)) return
+
+            do j = 1, n_declared
+                if (trim(declared_vars(j)) == var_name) return
+            end do
+
+            if (.not. is_local_var_collected(var_name, local_vars, n_locals)) then
+                call ensure_local_var_capacity(local_vars, capacity, n_locals + 1)
+                n_locals = n_locals + 1
+                local_vars(n_locals) = var_name
+                decl_code = decl_code // "    " // &
+                            mono_type_to_string(target%inferred_type, &
+                                                include_shape=.true., &
+                                                fallback='integer') // &
+                            " :: " // trim(var_name) // new_line('A')
+            end if
+        end select
+    end subroutine collect_vars_from_assignment_sub
 
 end module codegen_subroutine_declarations

--- a/test/test_issue_2012_subroutine_local_inference.f90
+++ b/test/test_issue_2012_subroutine_local_inference.f90
@@ -1,0 +1,70 @@
+program test_issue_2012_subroutine_local_inference
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    call test_subroutine_local_variable()
+    print *, "Issue 2012 subroutine local variable inference test completed."
+
+contains
+
+    subroutine test_subroutine_local_variable()
+        character(:), allocatable :: source, output, error_msg
+
+        call read_example('examples/lf/issue_2012_subroutine_local_not_inferred.lf', &
+                          source)
+
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            print *, "FAIL: Transformation failed:", trim(error_msg)
+            error stop 1
+        end if
+
+        if (index(output, 'integer :: temp') == 0) then
+            print *, "FAIL: Local variable 'temp' not declared"
+            print *, "Output:", output
+            error stop 1
+        end if
+
+        if (index(output, 'subroutine swap') == 0) then
+            print *, "FAIL: Subroutine not found in output"
+            error stop 1
+        end if
+
+        if (index(output, 'implicit none') == 0) then
+            print *, "FAIL: implicit none not found"
+            error stop 1
+        end if
+
+        print *, "[PASS] Subroutine local variable correctly inferred and declared"
+    end subroutine test_subroutine_local_variable
+
+    subroutine read_example(filepath, content)
+        character(len=*), intent(in) :: filepath
+        character(len=:), allocatable, intent(out) :: content
+        integer :: unit, ios, file_size
+        character(len=1), allocatable :: buffer(:)
+
+        open (newunit=unit, file=filepath, status='old', action='read', &
+              form='unformatted', access='stream', iostat=ios)
+        if (ios /= 0) then
+            print *, "Error opening file:", filepath
+            error stop 1
+        end if
+
+        inquire (unit=unit, size=file_size)
+        allocate (buffer(file_size))
+        read (unit, iostat=ios) buffer
+        close (unit)
+
+        if (ios /= 0) then
+            print *, "Error reading file:", filepath
+            error stop 1
+        end if
+
+        allocate (character(len=file_size) :: content)
+        content = transfer(buffer, content)
+        deallocate (buffer)
+    end subroutine read_example
+
+end program test_issue_2012_subroutine_local_inference


### PR DESCRIPTION
### **User description**
## Summary

Fixes issue #2012 where subroutine local variables were not being type-inferred or declared, causing compilation failures.

The fix adds assignment node processing to subroutine local variable collection, matching the pattern already implemented for function declarations.

## Changes

- Added `assignment_node` case to `collect_subroutine_local_variable_decls()`
- Implemented `collect_vars_from_assignment_sub()` helper subroutine
- Added required imports for `assignment_node` and `mono_type_to_string`

## Verification

**Input:** `examples/lf/issue_2012_subroutine_local_not_inferred.lf`
```fortran
subroutine swap(a, b)
    temp = a
    a = b
    b = temp
end subroutine
```

**Before fix:** `temp` had no declaration - GCC error: "Symbol 'temp' has no IMPLICIT type"

**After fix:** Output correctly includes `integer :: temp` declaration

**Test results:**
```
fpm test test_issue_2012_subroutine_local_inference
[PASS] Subroutine local variable correctly inferred and declared
```

**All tests pass:** `fpm test` completes successfully with no warnings or errors.


___

### **PR Type**
Bug fix


___

### **Description**
- Added assignment node processing to infer and declare subroutine local variables

- Implemented `collect_vars_from_assignment_sub()` helper to extract variable types

- Added imports for `assignment_node` and `mono_type_to_string` utilities

- Created test and example demonstrating the fix for issue #2012


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Assignment Node"] -->|"collect_vars_from_assignment_sub"| B["Extract Target Variable"]
  B -->|"Get Inferred Type"| C["Generate Declaration"]
  C -->|"Add to Local Vars"| D["Subroutine Declaration Code"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen_subroutine_declarations.f90</strong><dd><code>Add assignment node processing for local variable inference</code></dd></summary>
<hr>

src/codegen/codegen_subroutine_declarations.f90

<ul><li>Added <code>assignment_node</code> import to handle assignment statements<br> <li> Added <code>mono_type_to_string</code> import for type conversion<br> <li> Implemented new <code>collect_vars_from_assignment_sub()</code> subroutine to <br>process assignments<br> <li> Integrated assignment node case into <br><code>collect_subroutine_local_variable_decls()</code> function<br> <li> Extracts variable names and inferred types from assignment targets</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2033/files#diff-ef6b72a8b1f804dd80a6f356a02431f2205f417e88614ff0db5522963a2a1629">+50/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_2012_subroutine_local_inference.f90</strong><dd><code>Add test for subroutine local variable inference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_issue_2012_subroutine_local_inference.f90

<ul><li>Created comprehensive test program for subroutine local variable <br>inference<br> <li> Tests that <code>temp</code> variable is properly declared with correct type<br> <li> Validates presence of <code>implicit none</code> and subroutine structure<br> <li> Includes file reading utility for loading example Fortran code<br> <li> Verifies transformation succeeds without errors</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2033/files#diff-78b42409bd24f1128459e49ca5fd2be67223a34b622ace2028e1570f71e7edd0">+70/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue_2012_subroutine_local_not_inferred.lf</strong><dd><code>Add example for subroutine local variable issue</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/lf/issue_2012_subroutine_local_not_inferred.lf

<ul><li>Created example demonstrating the issue with untyped local variables<br> <li> Shows <code>swap</code> subroutine with implicit <code>temp</code> variable assignment<br> <li> Includes test code calling the subroutine with print statements<br> <li> Serves as input for test validation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2033/files#diff-1b05c63ef19a9ede89a484a4086f6bff2164ae4d726407eb9672b914af166f81">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

