### PR TITLE
fix: preserve elemental keyword in typed function definitions (fixes #2014)

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -5,6 +5,5 @@
 intrinsic_functions.lf  # parser error - needs investigation
 chained_comparison.lf   # parser error - needs investigation
 issue_1784_subroutine_wrapping.lf  # transformation regression tracked in #1784
-issue_2020_pure_function_mangled.f90  # internal procedure body leaked to parent scope; tracked in #2020
 issue_2025_multi_internal_proc_structure_collapse.f90  # internal procedures not emitted yet; tracked in #2025
 issue_2013_nested_implied_do_duplicate_var.f90  # duplicate implied-do indices still redeclared; see issue #2013 follow-up

--- a/examples/f90/issue_2014_elemental_function_lost.f90
+++ b/examples/f90/issue_2014_elemental_function_lost.f90
@@ -1,0 +1,17 @@
+program test_elemental_function
+    implicit none
+    integer, dimension(5) :: arr
+    integer :: i
+
+    arr = [(i, i = 1, 5)]
+    print *, 'Input:', arr
+    print *, 'Doubled:', double(arr)
+
+contains
+
+    elemental integer function double(x)
+        integer, intent(in) :: x
+        double = x * 2
+    end function double
+
+end program test_elemental_function

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -310,26 +310,42 @@ contains
             type(parser_state_t), intent(inout) :: parser_ref
             type(ast_arena_t), intent(inout) :: arena_ref
 
-            call flush_pending_prefixes()
             select case (lowered)
-            case ("implicit")
-                stmt_index = parse_implicit_statement(parser_ref, arena_ref)
-                block
-                    integer, allocatable :: extra_indices(:)
-                    if (allocated(additional_execution_indices)) then
-                        block
-                            integer, allocatable :: temp(:)
-                            call move_alloc(additional_execution_indices, temp)
-                        end block
-                    end if
-                    extra_indices = take_implicit_additional_indices()
-                    if (size(extra_indices) > 0) then
-                        call move_alloc(extra_indices, additional_execution_indices)
-                    end if
-                end block
             case ("real", "integer", "logical", "character", "complex", "double", &
                   "class", "procedure")
-                call handle_variable_declaration(parser_ref, arena_ref, stmt_index)
+                ! Check if function or subroutine follows this type keyword
+                if (is_function_or_subroutine_ahead(parser_ref)) then
+                    ! This is a return type prefix, not a variable declaration
+                    call append_prefix_token(pending_prefixes, lowered)
+                    block
+                        type(token_t) :: ignored_token
+                        ignored_token = parser_ref%consume()
+                    end block
+                    stmt_index = 0
+                else
+                    ! This is a variable declaration
+                    call flush_pending_prefixes()
+                    call handle_variable_declaration(parser_ref, arena_ref, stmt_index)
+                end if
+            case default
+                ! For all other keywords, flush prefixes and process normally
+                call flush_pending_prefixes()
+                select case (lowered)
+                case ("implicit")
+                    stmt_index = parse_implicit_statement(parser_ref, arena_ref)
+                    block
+                        integer, allocatable :: extra_indices(:)
+                        if (allocated(additional_execution_indices)) then
+                            block
+                                integer, allocatable :: temp(:)
+                                call move_alloc(additional_execution_indices, temp)
+                            end block
+                        end if
+                        extra_indices = take_implicit_additional_indices()
+                        if (size(extra_indices) > 0) then
+                            call move_alloc(extra_indices, additional_execution_indices)
+                        end if
+                    end block
             case ("type")
                 call handle_type_declaration(parser_ref, arena_ref, stmt_index)
             case ("print")
@@ -456,8 +472,41 @@ contains
                     ignored_token = parser_ref%consume()
                 end block
                 stmt_index = 0
+                end select
             end select
         end function parse_general_keyword
+
+        logical function is_function_or_subroutine_ahead(parser) result(is_proc)
+            type(parser_state_t), intent(in) :: parser
+            type(token_t) :: lookahead
+            integer :: offset
+
+            is_proc = .false.
+            offset = 1
+
+            ! Skip past type specifiers like (8), (kind=8), (len=*), etc.
+            if (parser%current_token + offset <= size(parser%tokens)) then
+                lookahead = parser%tokens(parser%current_token + offset)
+                if (lookahead%text == "(") then
+                    ! Skip to matching closing paren
+                    offset = offset + 1
+                    do while (parser%current_token + offset <= size(parser%tokens))
+                        lookahead = parser%tokens(parser%current_token + offset)
+                        offset = offset + 1
+                        if (lookahead%text == ")") exit
+                    end do
+                end if
+            end if
+
+            ! Now check if function or subroutine follows
+            if (parser%current_token + offset <= size(parser%tokens)) then
+                lookahead = parser%tokens(parser%current_token + offset)
+                if (to_lower(trim(lookahead%text)) == "function" .or. &
+                    to_lower(trim(lookahead%text)) == "subroutine") then
+                    is_proc = .true.
+                end if
+            end if
+        end function is_function_or_subroutine_ahead
 
         integer function parse_unsupported_stmt(keyword, parser_ref, arena_ref) &
             result(stmt_index)

--- a/test/codegen/test_issue_2014_elemental_only.f90
+++ b/test/codegen/test_issue_2014_elemental_only.f90
@@ -1,0 +1,61 @@
+program test_issue_2014_elemental_only
+    use transformation_api, only: compile_source, compilation_options_t
+    implicit none
+
+    character(len=:), allocatable :: input_file, output_file
+    character(len=256) :: error_msg
+    type(compilation_options_t) :: options
+    integer :: unit, io_status
+    logical :: found_elemental_integer
+    character(len=256) :: line
+
+    found_elemental_integer = .false.
+
+    input_file = 'test_issue_2014_elemental_only_input.f90'
+    output_file = 'test_issue_2014_elemental_only_output.f90'
+
+    open (newunit=unit, file=input_file, status='replace')
+    write (unit, '(a)') 'program test_elemental_function'
+    write (unit, '(a)') '    implicit none'
+    write (unit, '(a)') '    integer, dimension(5) :: arr'
+    write (unit, '(a)') '    integer :: i'
+    write (unit, '(a)') '    arr = [(i, i = 1, 5)]'
+    write (unit, '(a)') 'contains'
+    write (unit, '(a)') '    elemental integer function double(x)'
+    write (unit, '(a)') '        integer, intent(in) :: x'
+    write (unit, '(a)') '        double = x * 2'
+    write (unit, '(a)') '    end function double'
+    write (unit, '(a)') 'end program test_elemental_function'
+    close (unit)
+
+    options%output_file = output_file
+
+    call compile_source(input_file, options, error_msg)
+    if (len_trim(error_msg) /= 0) then
+        print *, 'Compiler reported error: ', trim(error_msg)
+        stop 1
+    end if
+
+    open (newunit=unit, file=output_file, status='old', action='read')
+    do
+        read (unit, '(a)', iostat=io_status) line
+        if (io_status /= 0) exit
+        if (.not. found_elemental_integer) then
+            if (index(line, 'function double') > 0 .and. &
+                index(line, 'elemental') > 0 .and. &
+                index(line, 'integer') > 0) then
+                found_elemental_integer = .true.
+            end if
+        end if
+        if (found_elemental_integer) exit
+    end do
+    close (unit)
+
+    if (.not. found_elemental_integer) then
+        print *, 'FAIL: elemental integer function keywords missing in output'
+        stop 1
+    end if
+
+    print *, 'PASS: ELEMENTAL-only function prefix preserved'
+    stop 0
+end program test_issue_2014_elemental_only


### PR DESCRIPTION
### **User description**
## Summary
- Fixes parser regression where `elemental` keyword was lost when combined with typed function signatures (e.g., `elemental integer function f(x)`)
- Also fixes #2020 (pure functions with typed signatures) as a side effect

## Root Cause
When parsing `elemental integer function f(x)`:
1. Parser added `elemental` to `pending_prefixes`
2. Then saw `integer` keyword
3. Called `parse_general_keyword()` which **flushed `pending_prefixes`** before checking if this was a function definition
4. By the time `function` was encountered, the `elemental` prefix was already lost

## Changes
- Modified `parse_general_keyword()` in `src/parser/parser_execution_statements.f90`:
  - Added lookahead for type keywords (`integer`, `real`, `character`, etc.)
  - If `function` or `subroutine` follows, treat type as a prefix instead of variable declaration
  - Added helper `is_function_or_subroutine_ahead()` with proper handling of type specifiers like `(8)`, `(kind=8)`

## Verification

### Test Results
```
Testing issue_2014_elemental_function_lost.f90 ...  PASS
Testing issue_2020_pure_function_mangled.f90 ...  PASS (was XFail, now fixed!)
```

### Input
```fortran
program test_elemental_function
    implicit none
    integer, dimension(5) :: arr
    integer :: i

    arr = [(i, i = 1, 5)]
    print *, 'Input:', arr
    print *, 'Doubled:', double(arr)

contains

    elemental integer function double(x)
        integer, intent(in) :: x
        double = x * 2
    end function double

end program test_elemental_function
```

### Output (Before Fix)
```fortran
real function double()
    implicit none
    integer :: i
end function double
```
❌ Lost: `elemental` keyword, `integer` return type, parameter `x`, function body

### Output (After Fix)
```fortran
elemental integer function double(x)
    implicit none
    integer, intent(in) :: x
    double = x*2
end function double
```
✅ All elements preserved correctly

## Test Coverage
- Added example: `examples/f90/issue_2014_elemental_function_lost.f90`
- Added regression test: `test/codegen/test_issue_2014_elemental_only.f90`
- Updated `examples/expected_failures.txt` (removed issue_2020)
- All existing tests pass (116/116)


___

### **PR Type**
Bug fix


___

### **Description**
- Preserve `elemental` keyword in typed function definitions

- Add lookahead logic to distinguish type prefixes from variable declarations

- Fix parser regression where `elemental` lost with typed signatures

- Also resolves issue #2020 (pure functions with typed signatures)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["parse_general_keyword<br/>encounters type keyword"] --> B{"is_function_or_subroutine<br/>_ahead?"}
  B -->|Yes| C["Add to pending_prefixes<br/>treat as return type"]
  B -->|No| D["Flush pending_prefixes<br/>handle variable declaration"]
  C --> E["elemental integer function<br/>preserved correctly"]
  D --> F["Variable declaration<br/>processed normally"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser_execution_statements.f90</strong><dd><code>Add lookahead logic for typed function definitions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_execution_statements.f90

<ul><li>Restructured <code>parse_general_keyword()</code> to check for function/subroutine <br>ahead before flushing prefixes<br> <li> Added <code>is_function_or_subroutine_ahead()</code> helper function with lookahead <br>logic<br> <li> Handles type specifiers like <code>(8)</code>, <code>(kind=8)</code> when skipping to find <br>function/subroutine keyword<br> <li> Type keywords now added to <code>pending_prefixes</code> when followed by <br>function/subroutine</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2038/files#diff-9ccd5393b9a82f76b4345c7b1141a995279e28b89526ec3c6a4d9b39e1ecaf62">+66/-17</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue_2014_elemental_function_lost.f90</strong><dd><code>Example of elemental typed function definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/f90/issue_2014_elemental_function_lost.f90

<ul><li>New example demonstrating <code>elemental integer function</code> with parameter<br> <li> Shows correct preservation of elemental keyword and return type<br> <li> Includes function body and proper parameter handling</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2038/files#diff-9203e4a6efe1563f4c0ac1cfc1eaebb0f4848c9d22f1906757e14d86cca83fa2">+17/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_2014_elemental_only.f90</strong><dd><code>Regression test for elemental function preservation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/codegen/test_issue_2014_elemental_only.f90

<ul><li>New regression test for issue #2014<br> <li> Verifies that <code>elemental integer function</code> keywords are preserved in <br>output<br> <li> Dynamically creates test input and validates compiled output<br> <li> Checks for presence of both <code>elemental</code> and <code>integer</code> keywords in function <br>definition</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2038/files#diff-392017f4fcdde648d8b41bc06e75aa031f4c93af8d360d17ce753d71ea1554f1">+61/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected_failures.txt</strong><dd><code>Remove fixed issue from expected failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/expected_failures.txt

<ul><li>Removed <code>issue_2020_pure_function_mangled.f90</code> from expected failures <br>list<br> <li> Issue #2020 now fixed as side effect of issue #2014 fix</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2038/files#diff-f5e7f1a27130e10c3fa158ab22b6d673c4cb6e666a708bb1b9f0b312b4abc497">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

