### PR TITLE
fix: feature: Parser error with chained comparison operators in lazy  (fixes #2047)

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -2,7 +2,6 @@
 # One filename per line. Lines starting with # are comments.
 # Format: filename  # optional comment with issue reference
 
-chained_comparison.lf   # parser error - needs investigation
 issue_1784_subroutine_wrapping.lf  # transformation regression tracked in #1784
 issue_2013_nested_implied_do_duplicate_var.f90  # duplicate implied-do indices still redeclared; see issue #2013 follow-up
 issue_2017_assumed_shape_duplicate_monomorph.f90  # array type incorrectly changed from real to integer (separate bug from duplicate monomorph fix)
@@ -15,4 +14,3 @@ issue_1827_submodule_with_contents.f90  # submodules unsupported; expect diagnos
 issue_1583_computed_goto_minimal.f90
 issue_1534_multi_dimension_allocatable.lf
 issue_1816_multiple_returns.lf
-issue_216_comparison_chain.lf

--- a/examples/lf/issue_1857_chained_comparison.lf
+++ b/examples/lf/issue_1857_chained_comparison.lf
@@ -1,4 +1,0 @@
-! Issue #1857: chained comparison should be detected and truncated
-x = 5
-result = 1 < x < 10
-print *, 'Result:', result

--- a/examples/skip_all_examples.txt
+++ b/examples/skip_all_examples.txt
@@ -46,5 +46,4 @@ lf/issue_1814_nested_lazy_function.lf
 lf/issue_2012_subroutine_local_not_inferred.lf
 lf/issue_2016_nested_call_type_mismatch.lf
 lf/issue_2019_statements_after_if_dropped.lf
-lf/issue_1857_chained_comparison.lf
 lf/issue_652_multi_var_allocatable.lf

--- a/src/parser/parser_expressions.f90
+++ b/src/parser/parser_expressions.f90
@@ -30,6 +30,7 @@ module parser_expressions_module
                                                operand_stack_clear, &
                                                operand_stack_push, &
                                                operand_stack_pop, &
+                                               operand_stack_peek, &
                                                operand_stack_is_empty, &
                                                token_stack_clear, token_stack_push, &
                                                token_stack_pop
@@ -177,6 +178,43 @@ contains
             end if
         end do
     end function comparison_active
+
+    subroutine prepare_chained_comparison(operators, operands, arena, token, prepared)
+        type(operator_stack_t), intent(inout) :: operators
+        type(operand_stack_t), intent(inout) :: operands
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t), intent(in) :: token
+        logical, intent(out) :: prepared
+        type(operator_entry_t) :: top_entry
+        integer :: shared_operand
+        type(token_t) :: logical_token
+        type(operator_entry_t) :: logical_entry
+
+        prepared = .false.
+
+        if (.not. comparison_active(operators)) return
+        if (operators%size <= 0) return
+        top_entry = operator_stack_peek(operators)
+        if (top_entry%precedence /= PREC_COMPARISON) return
+        if (operands%size < 2) return
+
+        shared_operand = operand_stack_peek(operands)
+        if (shared_operand <= 0) return
+
+        call reduce_single_operator(operators, operands, arena)
+
+        logical_token = token
+        logical_token%text = ".and."
+        logical_token%kind = TK_OPERATOR
+        logical_entry = get_infix_operator_entry(logical_token)
+        logical_entry%token = logical_token
+
+        call reduce_operators_for_incoming(operators, operands, arena, logical_entry)
+        call operator_stack_push(operators, logical_entry)
+        call operand_stack_push(operands, shared_operand)
+
+        prepared = .true.
+    end subroutine prepare_chained_comparison
 
     function create_zero_literal(arena, reference_token) result(zero_index)
         type(ast_arena_t), intent(inout) :: arena
@@ -550,6 +588,7 @@ contains
         logical, intent(inout) :: expect_operand
         logical, intent(out) :: should_exit
         type(operator_entry_t) :: op_entry
+        logical :: chain_prepared
 
         should_exit = .false.
         op_entry = get_infix_operator_entry(token)
@@ -573,8 +612,14 @@ contains
             return
         end if
 
+        chain_prepared = .false.
+        if (op_entry%precedence == PREC_COMPARISON) then
+            call prepare_chained_comparison(operators, operands, arena, token, &
+                                            chain_prepared)
+        end if
+
         if (op_entry%precedence == PREC_COMPARISON .and. &
-            comparison_active(operators)) then
+            .not. chain_prepared .and. comparison_active(operators)) then
             block
                 use, intrinsic :: iso_fortran_env, only: error_unit
                 write (error_unit, '(A)') &

--- a/test/integration/issue_tests/test_issue_214_string_concatenation_precedence.f90
+++ b/test/integration/issue_tests/test_issue_214_string_concatenation_precedence.f90
@@ -9,7 +9,8 @@ program test_issue_214_string_concatenation_precedence
     print *, '=== Comprehensive Operator Precedence and Associativity Tests ==='
     print *, '=== Issues #214, #215, #216 ==='
 
-    if (.not. test_string_concatenation_precedence_with_parentheses()) all_passed = .false.
+    if (.not. test_string_concatenation_precedence_with_parentheses()) &
+        all_passed = .false.
     if (.not. test_unary_operator_precedence()) all_passed = .false.
     if (.not. test_comparison_non_associativity()) all_passed = .false.
     if (.not. test_comprehensive_precedence_hierarchy()) all_passed = .false.
@@ -31,7 +32,8 @@ contains
         character(len=:), allocatable :: source3, output3, error_msg3
 
         test_string_concatenation_precedence_with_parentheses = .true.
-        print *, 'Testing string concatenation precedence using explicit parentheses...'
+        print *, &
+            'Testing string concatenation precedence using explicit parentheses...'
 
         call read_example('examples/lf/issue_214_wrong_precedence.lf', source1)
 
@@ -39,7 +41,8 @@ contains
 
         if (allocated(error_msg1)) then
             if (len_trim(error_msg1) > 0) then
-                print *, '  FAIL: Compilation error (correct version):', trim(error_msg1)
+                print *, '  FAIL: Compilation error (correct version):', &
+                    trim(error_msg1)
                 test_string_concatenation_precedence_with_parentheses = .false.
                 return
             end if
@@ -71,7 +74,8 @@ contains
 
         if (allocated(error_msg3)) then
             if (len_trim(error_msg3) > 0) then
-                print *, '  FAIL: Compilation error (ambiguous version):', trim(error_msg3)
+                print *, '  FAIL: Compilation error (ambiguous version):', &
+                    trim(error_msg3)
                 test_string_concatenation_precedence_with_parentheses = .false.
                 return
             end if
@@ -104,7 +108,8 @@ contains
         if (index(output, 'result = ') > 0) then
             print *, '  OK: Unary operator precedence test generated code successfully'
         else
-            print *, '  FAIL: Could not verify unary operator precedence in generated code'
+            print *, &
+                '  FAIL: Could not verify unary operator precedence in generated code'
             test_unary_operator_precedence = .false.
         end if
 
@@ -128,11 +133,17 @@ contains
             end if
         end if
 
-        if (index(output, 'result = ') > 0) then
-            print *, '  WARNING: Comparison chaining test needs manual verification'
-        else
-            print *, '  FAIL: Could not verify comparison associativity in generated code'
+        if (index(output, '.and.') == 0) then
+            print *, '  FAIL: Chained comparison did not emit logical AND expansion'
             test_comparison_non_associativity = .false.
+            return
+        end if
+
+        if (index(output, 'a < b') == 0 .or. index(output, 'b < c') == 0) then
+            print *, '  FAIL: Missing one side of chained comparison in generated code'
+            test_comparison_non_associativity = .false.
+        else
+            print *, '  OK: Comparison chaining lowered to logical AND sequence'
         end if
 
     end function test_comparison_non_associativity
@@ -158,7 +169,8 @@ contains
         if (index(output, 'result_str = ') > 0) then
             print *, '  OK: Comprehensive precedence test generated code successfully'
         else
-            print *, '  FAIL: Could not verify comprehensive precedence in generated code'
+            print *, &
+                '  FAIL: Could not verify comprehensive precedence in generated code'
             test_comprehensive_precedence_hierarchy = .false.
         end if
 

--- a/test/test_issue_1857_chained_comparison.f90
+++ b/test/test_issue_1857_chained_comparison.f90
@@ -33,7 +33,7 @@ contains
 
         test_chained_comparison_output = .true.
 
-        call read_example('examples/lf/issue_1857_chained_comparison.lf', &
+        call read_example('examples/lf/chained_comparison.lf', &
                           source)
 
         call transform_lazy_fortran_string(source, output, error_msg)
@@ -44,14 +44,17 @@ contains
             return
         end if
 
-        if (index(output, '< 10') /= 0) then
+        if (index(output, '.and.') == 0) then
             write (error_unit, '(A)') &
-                "ERROR: Output contains '< 10', chained comparison not truncated"
+                'ERROR: Output missing .and. expansion for chained comparison'
             write (error_unit, '(A)') trim(output)
             test_chained_comparison_output = .false.
-        else if (index(output, 'result = 1 < x') == 0) then
+            return
+        end if
+
+        if (index(output, '1 < x') == 0 .or. index(output, 'x < 10') == 0) then
             write (error_unit, '(A)') &
-                'ERROR: Output missing expected partial expression'
+                'ERROR: Output missing one of the chained comparison bounds'
             write (error_unit, '(A)') trim(output)
             test_chained_comparison_output = .false.
         end if


### PR DESCRIPTION
### **User description**
## Summary
- allow the Pratt parser to lower chained comparisons into logical `.and.` chains so lazy Fortran inputs such as `1 < x < 10` parse and transform without diagnostics
- drop the duplicated Issue 1857 example while updating the regression tests to assert the new `.and.` output and re-enabling the canonical chained comparison examples
- remove the repaired examples from `examples/expected_failures.txt` so `test_all_examples` no longer reports unexpected passes

## Verification
- `fpm test` (tail: `All AST traversal tests passed!`)
- `fpm test --target test_all_examples` (summary: `SUCCESS: All examples behaved as expected`)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Implement chained comparison lowering to logical `.and.` chains

- Add `operand_stack_peek` function for operator precedence handling

- Update test assertions to verify `.and.` expansion output

- Remove repaired examples from expected failures list


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chained Comparison<br/>1 < x < 10"] -->|prepare_chained_comparison| B["Reduce First<br/>Comparison"]
  B -->|Create .and. Token| C["Insert Logical AND<br/>Operator"]
  C -->|Push Shared Operand| D["Expanded Form<br/>1 < x .and. x < 10"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser_expressions.f90</strong><dd><code>Implement chained comparison lowering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_expressions.f90

<ul><li>Add <code>operand_stack_peek</code> import for accessing top operand without <br>removal<br> <li> Implement <code>prepare_chained_comparison</code> subroutine to transform chained <br>comparisons into logical AND chains<br> <li> Modify <code>handle_infix_operator</code> to call <code>prepare_chained_comparison</code> when <br>encountering comparison operators<br> <li> Update comparison error handling to skip error when chain is <br>successfully prepared</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2058/files#diff-3840ac8e1ba949344a6d9bb928875718aaa4ed437ffbe93f1a8458377286b1aa">+46/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_214_string_concatenation_precedence.f90</strong><dd><code>Update comparison test assertions for AND expansion</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/integration/issue_tests/test_issue_214_string_concatenation_precedence.f90

<ul><li>Reformat long print statements with line continuations for readability<br> <li> Update <code>test_comparison_non_associativity</code> to verify <code>.and.</code> expansion <br>instead of warning<br> <li> Add assertions checking for both <code>a < b</code> and <code>b < c</code> in generated output<br> <li> Change test result from warning to success message for chained <br>comparison lowering</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2058/files#diff-a91c65fd9601ee6164824ab3bd3abcd7e0091d647fc99e8d6ed39ce9f13edbb4">+22/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test_issue_1857_chained_comparison.f90</strong><dd><code>Update chained comparison test expectations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_issue_1857_chained_comparison.f90

<ul><li>Update example file reference from <code>issue_1857_chained_comparison.lf</code> to <br><code>chained_comparison.lf</code><br> <li> Replace output validation checking for <code>< 10</code> with check for <code>.and.</code> token <br>presence<br> <li> Add separate assertions for both <code>1 < x</code> and <code>x < 10</code> bounds in expanded <br>output<br> <li> Improve error messages to clarify expected AND expansion behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2058/files#diff-2ecded9b1cc4bf5adc66bc48333847aa7cd34b5ca5b3bdafe5d600943cb981df">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected_failures.txt</strong><dd><code>Remove repaired examples from failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/expected_failures.txt

<ul><li>Remove <code>chained_comparison.lf</code> from expected failures list<br> <li> Remove <code>issue_216_comparison_chain.lf</code> from expected failures list</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2058/files#diff-f5e7f1a27130e10c3fa158ab22b6d673c4cb6e666a708bb1b9f0b312b4abc497">+0/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>skip_all_examples.txt</strong><dd><code>Remove skipped example reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/skip_all_examples.txt

- Remove `lf/issue_1857_chained_comparison.lf` from skip list


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2058/files#diff-c2baf6bad0f31b48733eaea1d5b99b55b3fcd5e10b5b971893b5484a2e545ad4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Miscellaneous</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue_1857_chained_comparison.lf</strong><dd><code>Remove duplicate chained comparison example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/lf/issue_1857_chained_comparison.lf

<ul><li>Delete deprecated example file (consolidated into <br><code>chained_comparison.lf</code>)</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2058/files#diff-0e4934fafc98966074ff7cc295c722cbce9a1670b20b562156e29eb4e897a2da">+0/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

