### PR TITLE
fix: wire PAUSE statement through parser dispatchers (fixes #2076)

### DIFF
--- a/src/parser/parser_dispatcher.f90
+++ b/src/parser/parser_dispatcher.f90
@@ -24,7 +24,8 @@ module parser_dispatcher_module
     use parser_control_statements_module, only: &
         parse_stop_statement, parse_return_statement, parse_entry_statement, &
         parse_goto_statement, parse_error_stop_statement, parse_cycle_statement, &
-        parse_exit_statement, parse_end_statement, parse_nullify_statement
+        parse_exit_statement, parse_end_statement, parse_nullify_statement, &
+        parse_pause_statement
     use parser_memory_statements_module, only: parse_allocate_statement, &
                                                parse_deallocate_statement
     use parser_execution_statements_module, only: parse_call_statement, &
@@ -188,6 +189,8 @@ contains
                 stmt_index = parse_call_statement(parser, arena)
             case ("stop")
                 stmt_index = parse_stop_statement(parser, arena)
+            case ("pause")
+                stmt_index = parse_pause_statement(parser, arena)
             case ("return")
                 stmt_index = parse_return_statement(parser, arena)
             case ("entry")

--- a/src/parser/parser_execution_statements.f90
+++ b/src/parser/parser_execution_statements.f90
@@ -35,7 +35,8 @@ module parser_execution_statements_module
                                                 parse_continue_statement, &
                                                 parse_cycle_statement, &
                                                 parse_exit_statement, &
-                                                parse_nullify_statement
+                                                parse_nullify_statement, &
+                                                parse_pause_statement
     use parser_control_flow_router_module, only: route_control_flow, &
                                                  is_control_flow_keyword
     use parser_do_constructs_module, only: parse_do_loop
@@ -396,6 +397,8 @@ contains
                     stmt_index = parse_deallocate_statement(parser_ref, arena_ref)
                 case ("stop")
                     stmt_index = parse_stop_statement(parser_ref, arena_ref)
+                case ("pause")
+                    stmt_index = parse_pause_statement(parser_ref, arena_ref)
                 case ("go", "goto")
                     stmt_index = parse_goto_statement(parser_ref, arena_ref)
                 case ("error")

--- a/src/parser/parser_statement_utilities.f90
+++ b/src/parser/parser_statement_utilities.f90
@@ -19,7 +19,8 @@ module parser_statement_utilities_module
                                                 parse_cycle_statement, &
                                                 parse_exit_statement, &
                                                 parse_nullify_statement, &
-                                                parse_continue_statement
+                                                parse_continue_statement, &
+                                                parse_pause_statement
     use parser_memory_statements_module, only: parse_allocate_statement, &
                                                parse_deallocate_statement
     use parser_assignment_module, only: parse_assignment_statement
@@ -104,6 +105,8 @@ contains
                 stmt_index = parse_if_from_definition(parser, arena)
             case ("stop")
                 stmt_index = parse_stop_statement(parser, arena)
+            case ("pause")
+                stmt_index = parse_pause_statement(parser, arena)
             case ("return")
                 stmt_index = parse_return_statement(parser, arena)
             case ("entry")


### PR DESCRIPTION
### **User description**
## Summary

Fixes #2076 - PAUSE statements were being silently dropped during round-trip transformation.

**Root cause**: The `parse_pause_statement` function and codegen existed but were unreachable because parser dispatchers did not route "pause" keywords to the parser.

**Changes**:
- Added `parse_pause_statement` imports to 3 dispatcher modules
- Added `case ("pause")` handlers to route to the parser
- No changes to AST, codegen, or core parsing logic needed

## Verification

Round-trip test with example file:
```bash
$ ./build/gfortran_*/app/fortfront examples/f90/issue_2076_pause_statement_silently_dropped.f90
program test_pause_statement
    implicit none
    integer :: x
    x = 42 
    print *, "Before pause:", x 
    pause "Press Enter to continue..."  # ← Now preserved!
    x = 99 
    print *, "After pause:", x 
end program test_pause_statement
```

Output compiles successfully:
```bash
$ gfortran /tmp/pause_test.f90 -o /tmp/pause_test
# Warning expected (PAUSE is deleted feature in F2018)
```

All tests pass:
```bash
$ fpm test test_pause_statement
 PASS: test_pause_with_string
 PASS: test_pause_without_message
 PASS: test_pause_in_if_block
```


___

### **PR Type**
Bug fix


___

### **Description**
- Wire PAUSE statement through parser dispatchers to fix silent dropping

- Add `parse_pause_statement` imports to three dispatcher modules

- Add case handlers routing "pause" keywords to parser functions

- Enable round-trip preservation of PAUSE statements in Fortran code


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parser Dispatchers"] -->|missing route| B["parse_pause_statement"]
  C["PAUSE keyword"] -->|dropped| D["Lost in transformation"]
  A -->|added case handler| B
  C -->|routed correctly| E["Preserved in output"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser_dispatcher.f90</strong><dd><code>Add PAUSE statement routing to main dispatcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_dispatcher.f90

<ul><li>Added <code>parse_pause_statement</code> import from <br><code>parser_control_statements_module</code><br> <li> Added <code>case ("pause")</code> handler in <code>parse_statement_dispatcher</code> function<br> <li> Routes "pause" keywords to <code>parse_pause_statement</code> parser function</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2082/files#diff-8f45b8ae4a5fdd312228210a9b220ebd19a6d9c906860c829822b6b97de7123b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_execution_statements.f90</strong><dd><code>Add PAUSE statement routing to execution dispatcher</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_execution_statements.f90

<ul><li>Added <code>parse_pause_statement</code> import from <br><code>parser_control_statements_module</code><br> <li> Added <code>case ("pause")</code> handler in <code>parse_general_keyword</code> function<br> <li> Routes "pause" keywords to <code>parse_pause_statement</code> parser function</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2082/files#diff-9ccd5393b9a82f76b4345c7b1141a995279e28b89526ec3c6a4d9b39e1ecaf62">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>parser_statement_utilities.f90</strong><dd><code>Add PAUSE statement routing to statement utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser/parser_statement_utilities.f90

<ul><li>Added <code>parse_pause_statement</code> import from <br><code>parser_control_statements_module</code><br> <li> Added <code>case ("pause")</code> handler in <code>parse_statement_in_if_block</code> function<br> <li> Routes "pause" keywords to <code>parse_pause_statement</code> parser function</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2082/files#diff-0132b6bdc035b4276690bac222a7fb77723d2a75f849825c217c2420c9f4216f">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

