### PR TITLE
fix: infer CHARACTER type for function parameters from string literals and comparisons (fixes #2071)

### DIFF
--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -4,6 +4,7 @@ submodule(semantic_analyzer) semantic_analyzer_infer_impl
                                    create_fun_type, create_poly_type, &
                                    create_type_var, TREAL, TVAR, TCOMPLEX, &
                                    TFUN, TARRAY, TLOGICAL, TINT, TCHAR
+    use semantic_type_operations, only: get_common_type
     implicit none
 
     type :: infer_frame_t
@@ -743,13 +744,34 @@ contains
             type(mono_type_t) :: left_t
             type(mono_type_t) :: right_t
             type(mono_type_t) :: node_type
+            type(mono_type_t) :: common_t
 
             left_t = get_node_type(expr%left_index)
             right_t = get_node_type(expr%right_index)
             node_type = infer_binary_operation(arena, node_index, expr, &
                                                left_t, right_t)
-            call this%unify(left_t, create_mono_type(TCHAR))
-            call this%unify(right_t, create_mono_type(TCHAR))
+
+            ! Unify operand types based on operator kind
+            if (expr%operator == "//") then
+                ! String concatenation: both operands must be CHARACTER
+                call this%unify(left_t, create_mono_type(TCHAR))
+                call this%unify(right_t, create_mono_type(TCHAR))
+            else if (expr%operator == "==" .or. expr%operator == "/=" .or. &
+                     expr%operator == "<" .or. expr%operator == "<=" .or. &
+                     expr%operator == ">" .or. expr%operator == ">=") then
+                ! Comparison operators: operands must have compatible types
+                ! For string comparisons, if either operand is TCHAR, both must be
+                if (left_t%kind == TCHAR .or. right_t%kind == TCHAR) then
+                    call this%unify(left_t, create_mono_type(TCHAR))
+                    call this%unify(right_t, create_mono_type(TCHAR))
+                else
+                    ! For numeric comparisons, use common type promotion
+                    common_t = get_common_type(left_t, right_t)
+                    call this%unify(left_t, common_t)
+                    call this%unify(right_t, common_t)
+                end if
+            end if
+
             call finalize_node(node_index, node_type)
         end subroutine finalize_binary_operation
 

--- a/src/semantic/analyzers/semantic_parameter_analysis.f90
+++ b/src/semantic/analyzers/semantic_parameter_analysis.f90
@@ -1,7 +1,8 @@
 module semantic_parameter_analysis
     use type_system_unified, only: type_var_t, mono_type_t, poly_type_t, &
                                    create_mono_type, create_type_var, &
-                                   create_poly_type, TVAR, TREAL, TDOUBLE, TINT
+                                   create_poly_type, TVAR, TREAL, TDOUBLE, &
+                                   TINT, TCHAR
     use semantic_type_operations, only: get_common_type
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: identifier_node, call_or_subscript_node, &
@@ -17,6 +18,7 @@ module semantic_parameter_analysis
                                      infer_expression_type_static
     use semantic_procedure_utils, only: declaration_type_to_mono
     use semantic_function_helpers, only: find_return_type
+    use ast_base, only: LITERAL_STRING
     implicit none
     private
 
@@ -170,7 +172,11 @@ contains
                     if (.not. allocated(arena%entries(arg_idx)%node)) cycle
                     select type (arg_node => arena%entries(arg_idx)%node)
                     type is (literal_node)
-                        literal_type = literal_numeric_type(arg_node)
+                        if (arg_node%literal_kind == LITERAL_STRING) then
+                            literal_type = create_mono_type(TCHAR)
+                        else
+                            literal_type = literal_numeric_type(arg_node)
+                        end if
                         call merge_parameter_type(param_types(i), literal_type)
                     type is (identifier_node)
                         call merge_parameter_type(param_types(i), &
@@ -373,7 +379,11 @@ contains
 
                             select type (arg_node => arena%entries(arg_idx)%node)
                             type is (literal_node)
-                                literal_type = literal_numeric_type(arg_node)
+                                if (arg_node%literal_kind == LITERAL_STRING) then
+                                    literal_type = create_mono_type(TCHAR)
+                                else
+                                    literal_type = literal_numeric_type(arg_node)
+                                end if
                                 if (literal_type%kind > 0) then
                                     inferred_type = literal_type
                                     if (allocated(outer_param_types)) &


### PR DESCRIPTION
### **User description**
## Summary

Fixes #2071 - Function parameters with string usage now correctly inferred as CHARACTER instead of REAL.

## Root Cause

Two issues prevented correct CHARACTER type inference for function parameters:

1. **Call site inference ignored string literals** - Only numeric literals were considered when inferring parameter types from call sites
2. **Comparison operations didn't unify types** - Binary operations like `==` didn't enforce type compatibility between operands

## Changes

### `semantic_parameter_analysis.f90`
- Added detection of `LITERAL_STRING` when inferring parameter types from call site arguments
- Both `infer_parameter_types_from_calls` and `infer_type_from_enclosing_function_param` now handle string literals

### `semantic_analyzer_infer_impl.f90`  
- Modified `finalize_binary_operation` to conditionally unify operand types:
  - String concatenation (`//`): both operands → CHARACTER
  - Comparisons (`==`, `!=`, `<`, `<=`, `>`, `>=`): if either operand is CHARACTER, both must be CHARACTER
  - Other operations: use existing numeric type promotion

## Verification

**Test case:**
```bash
echo 'subroutine process(msg)
    if (msg == "hello") then
        print *, "greeting"
    end if
end subroutine

call process("world")' | ./build/gfortran_*/app/fortfront > /tmp/test.f90
gfortran /tmp/test.f90 -o /tmp/test
./tmp/test
```

**Before:** `msg` inferred as `real`, compilation fails with type mismatch error

**After:** `msg` inferred as `character(len=*)`, compiles and runs successfully

**Test suite:** All tests pass (2 pre-existing failures unrelated to this change)

**Example output:**
```fortran
subroutine process(msg)
    implicit none
    character(len=*):: msg  ✓ Correctly inferred
    if (msg == "hello") then
        print *, "greeting"
    end if
end subroutine
```

## Note

The original example file (`issue_2071_function_param_string_inferred_as_real.lf`) uses a function with string return type, which exposes a separate codegen issue with `allocatable` attribute placement. The core type inference fix is verified with the simpler subroutine test case above.


___

### **PR Type**
Bug fix


___

### **Description**
- Infer CHARACTER type for function parameters from string literals at call sites

- Unify operand types in comparison operations when CHARACTER is involved

- Handle string concatenation operator to enforce CHARACTER type on both operands

- Support type inference from enclosing function parameters with string arguments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["String Literal Arguments"] -->|"Detected in call sites"| B["Parameter Type Inference"]
  B -->|"Infer CHARACTER type"| C["Function Parameter"]
  D["Comparison Operations"] -->|"Check operand types"| E["Type Unification"]
  E -->|"If either is CHARACTER"| F["Both become CHARACTER"]
  E -->|"Otherwise numeric"| G["Common Type Promotion"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic_analyzer_infer_impl.f90</strong><dd><code>Conditional type unification for binary operations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_analyzer_infer_impl.f90

<ul><li>Added <code>get_common_type</code> import from <code>semantic_type_operations</code><br> <li> Modified <code>finalize_binary_operation</code> to conditionally unify operand <br>types based on operator kind<br> <li> String concatenation (<code>//</code>) enforces CHARACTER type on both operands<br> <li> Comparison operators (<code>==</code>, <code>/=</code>, <code><</code>, <code><=</code>, <code>></code>, <code>>=</code>) unify to CHARACTER if either <br>operand is CHARACTER, otherwise apply numeric type promotion<br> <li> Introduced <code>common_t</code> variable for numeric type promotion handling</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2088/files#diff-c6ab1fd366e457e6eb128eb0d7c360f60f12c0364136ebd9d8a7c9fd9f8735dd">+24/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>semantic_parameter_analysis.f90</strong><dd><code>Detect string literals for CHARACTER parameter inference</code>&nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_parameter_analysis.f90

<ul><li>Added <code>TCHAR</code> import to type system constants<br> <li> Added <code>LITERAL_STRING</code> import from <code>ast_base</code> module<br> <li> Modified <code>infer_parameter_types_from_calls</code> to detect string literal <br>arguments and infer CHARACTER type<br> <li> Applied same string literal detection to <br><code>infer_type_from_enclosing_function_param</code> function<br> <li> Both functions now check <code>arg_node%literal_kind == LITERAL_STRING</code> <br>before calling <code>literal_numeric_type</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2088/files#diff-ec33eeeb2027387965530d39ae5c8410330d637e48dfcf102edf45f4f4e098f7">+13/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

