### PR TITLE
fix: add recursive nested DO loop variable declaration (partial fix for #2062)

### DIFF
--- a/src/codegen/codegen_function_declarations.f90
+++ b/src/codegen/codegen_function_declarations.f90
@@ -467,9 +467,9 @@ contains
         end do
     end subroutine collect_vars_from_read
 
-    subroutine collect_loop_var(arena, func, stmt_position, loop_node, param_map, &
-                                local_vars, n_locals, capacity, result_name, &
-                                decl_code)
+    recursive subroutine collect_loop_var(arena, func, stmt_position, loop_node, &
+                                          param_map, local_vars, n_locals, capacity, &
+                                          result_name, decl_code)
         type(ast_arena_t), intent(in) :: arena
         type(function_def_node), intent(in) :: func
         integer, intent(in) :: stmt_position
@@ -481,6 +481,7 @@ contains
         character(len=*), intent(in) :: result_name
         character(len=:), allocatable, intent(inout) :: decl_code
         character(len=64) :: var_name
+        integer :: body_idx, nested_idx
 
         if (.not. allocated(loop_node%var_name)) return
 
@@ -498,6 +499,21 @@ contains
             local_vars(n_locals) = var_name
             decl_code = decl_code // "    integer :: " // trim(var_name) // &
                         new_line('A')
+        end if
+
+        if (allocated(loop_node%body_indices)) then
+            do body_idx = 1, size(loop_node%body_indices)
+                nested_idx = loop_node%body_indices(body_idx)
+                if (nested_idx <= 0 .or. nested_idx > arena%size) cycle
+                if (.not. allocated(arena%entries(nested_idx)%node)) cycle
+
+                select type (nested_stmt => arena%entries(nested_idx)%node)
+                type is (do_loop_node)
+                    call collect_loop_var(arena, func, stmt_position, nested_stmt, &
+                                          param_map, local_vars, n_locals, capacity, &
+                                          result_name, decl_code)
+                end select
+            end do
         end if
     end subroutine collect_loop_var
 

--- a/src/codegen/codegen_subroutine_declarations.f90
+++ b/src/codegen/codegen_subroutine_declarations.f90
@@ -234,7 +234,7 @@ contains
                                                 n_locals, capacity, declared_vars, &
                                                 n_declared, decl_code)
             type is (do_loop_node)
-                call collect_loop_var_sub(stmt, param_map, local_vars, n_locals, &
+                call collect_loop_var_sub(arena, stmt, param_map, local_vars, n_locals, &
                                           capacity, declared_vars, n_declared, decl_code)
             end select
         end do
@@ -326,8 +326,10 @@ contains
         end do
     end subroutine collect_vars_from_read_sub
 
-    subroutine collect_loop_var_sub(loop_node, param_map, local_vars, n_locals, &
-                                    capacity, declared_vars, n_declared, decl_code)
+    recursive subroutine collect_loop_var_sub(arena, loop_node, param_map, &
+                                              local_vars, n_locals, capacity, &
+                                              declared_vars, n_declared, decl_code)
+        type(ast_arena_t), intent(in) :: arena
         type(do_loop_node), intent(in) :: loop_node
         type(parameter_info_t), intent(in) :: param_map(:)
         character(len=64), allocatable, intent(inout) :: local_vars(:)
@@ -337,6 +339,7 @@ contains
         integer, intent(in) :: n_declared
         character(len=:), allocatable, intent(inout) :: decl_code
         character(len=64) :: var_name
+        integer :: body_idx, nested_idx
 
         if (.not. allocated(loop_node%var_name)) return
 
@@ -351,6 +354,21 @@ contains
             n_locals = n_locals + 1
             local_vars(n_locals) = var_name
             decl_code = decl_code // "    integer :: " // trim(var_name) // new_line('A')
+        end if
+
+        if (allocated(loop_node%body_indices)) then
+            do body_idx = 1, size(loop_node%body_indices)
+                nested_idx = loop_node%body_indices(body_idx)
+                if (nested_idx <= 0 .or. nested_idx > arena%size) cycle
+                if (.not. allocated(arena%entries(nested_idx)%node)) cycle
+
+                select type (nested_stmt => arena%entries(nested_idx)%node)
+                type is (do_loop_node)
+                    call collect_loop_var_sub(arena, nested_stmt, param_map, local_vars, &
+                                              n_locals, capacity, declared_vars, n_declared, &
+                                              decl_code)
+                end select
+            end do
         end if
     end subroutine collect_loop_var_sub
 


### PR DESCRIPTION
### **User description**
## Summary

Fixes the nested DO loop variable declaration issue by recursively traversing loop bodies to collect all loop variables.

## Changes

- Made `collect_loop_var` and `collect_loop_var_sub` recursive
- Added traversal of `loop_node%body_indices` to find nested DO loops
- Both function and subroutine codegen now properly handle nested loops

## Verification

**Before:**
```fortran
real function matrix_sum(mat) result(total)
    implicit none
    integer, dimension(:,:), allocatable :: mat
    integer :: i
    ! ERROR: j not declared
    total = 0.0
    do i = 1, size(mat, 1)
        do j = 1, size(mat, 2)  ! j has no IMPLICIT type
            total = total + mat(i, j)
        end do
    end do
end function matrix_sum
```

**After:**
```fortran
real function matrix_sum(mat) result(total)
    implicit none
    integer, dimension(:,:), allocatable :: mat
    integer :: i
    integer :: j  ! Now declared
    total = 0.0
    do i = 1, size(mat, 1)
        do j = 1, size(mat, 2)
            total = total + mat(i, j)
        end do
    end do
end function matrix_sum
```

**Commands:**
```bash
./build/gfortran_*/app/fortfront examples/lf/issue_2062_nested_do_missing_var_type_mismatch.lf
fpm test  # All tests pass
```

## Remaining Issue

Type inference issue remains (separate concern):
- Function parameter `mat` still inferred as `integer` instead of `real`
- This is a deeper type inference limitation requiring array element type propagation
- Will be addressed in follow-up work

## Testing

- Verified nested loop variable `j` is now declared
- All existing tests pass (no regressions)
- Example: `examples/lf/issue_2062_nested_do_missing_var_type_mismatch.lf`

Fixes #2062 (partial - nested loop variable declaration)


___

### **PR Type**
Bug fix


___

### **Description**
- Add recursive traversal of nested DO loops to collect all loop variables

- Declare missing variables in nested loop structures automatically

- Apply fix to both function and subroutine code generation paths

- Prevent "implicit type" errors for inner loop variables


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DO loop variable collection"] --> B["Traverse loop body indices"]
  B --> C["Find nested DO loops"]
  C --> D["Recursively collect nested variables"]
  D --> E["Generate declarations for all loop vars"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen_function_declarations.f90</strong><dd><code>Recursive nested loop variable collection for functions</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/codegen/codegen_function_declarations.f90

<ul><li>Made <code>collect_loop_var</code> subroutine recursive to handle nested loops<br> <li> Added traversal of <code>loop_node%body_indices</code> to discover nested DO loops<br> <li> Recursively call <code>collect_loop_var</code> for each nested loop found<br> <li> Declare all nested loop variables with proper integer type <br>declarations</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2090/files#diff-02287cf038da373adbf39c97abd79dc8fa3f53c54543c082e343a18509b07979">+19/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>codegen_subroutine_declarations.f90</strong><dd><code>Recursive nested loop variable collection for subroutines</code></dd></summary>
<hr>

src/codegen/codegen_subroutine_declarations.f90

<ul><li>Made <code>collect_loop_var_sub</code> subroutine recursive for nested loop <br>handling<br> <li> Added <code>arena</code> parameter to enable nested loop traversal<br> <li> Added traversal of <code>loop_node%body_indices</code> to find nested DO loops<br> <li> Recursively call <code>collect_loop_var_sub</code> for each nested loop discovered</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2090/files#diff-ef6b72a8b1f804dd80a6f356a02431f2205f417e88614ff0db5522963a2a1629">+21/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

