### PR TITLE
fix: emit ENTRY parameter declarations in specification (fixes #2070)

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -20,7 +20,6 @@ issue_2066_array_function_rank_mismatch.lf  # elemental-style array function ran
 issue_2067_implied_do_array_return_rank_mismatch.lf  # implied-do array return rank mismatch #2067
 issue_2068_nested_function_type_inference_mismatch.lf  # nested function type inference mismatch #2068
 issue_2069_allocate_not_inferred_allocatable.lf  # ALLOCATE not inferred as allocatable #2069
-issue_2070_entry_loses_argument_declarations.f90  # ENTRY loses argument declarations #2070
 issue_2071_function_param_string_inferred_as_real.lf  # string parameter inferred as real #2071
 issue_2074_arithmetic_if_not_supported.f90  # arithmetic IF not supported (F77 legacy) #2074
 issue_2075_stop_keyword_collision_in_function_param.lf  # 'stop' keyword collision in function param #2075

--- a/examples/f90/issue_2070_entry_loses_argument_declarations.f90
+++ b/examples/f90/issue_2070_entry_loses_argument_declarations.f90
@@ -7,17 +7,14 @@ program test_entry_statement
 
     result = func2(3, 4)
     print *, "func2(3,4) =", result
-
-contains
-
-    function func1(x) result(res)
-        integer, intent(in) :: x
-        integer :: res
-        res = x * 2
-        return
-        entry func2(a, b) result(res)
-        integer, intent(in) :: a, b
-        res = a + b
-    end function func1
-
 end program test_entry_statement
+
+function func1(x) result(res)
+    integer, intent(in) :: x
+    integer :: res
+    res = x * 2
+    return
+    entry func2(a, b) result(res)
+    integer, intent(in) :: a, b
+    res = a + b
+end function func1

--- a/src/codegen/codegen_function_declarations.f90
+++ b/src/codegen/codegen_function_declarations.f90
@@ -5,6 +5,7 @@ module codegen_function_declarations
     use ast_nodes_data, only: declaration_node, parameter_declaration_node
     use ast_nodes_io, only: print_statement_node, read_statement_node
     use ast_nodes_procedure, only: function_def_node
+    use ast_nodes_transfer, only: entry_node
     use codegen_declarations_core, only: fix_character_len_placeholder
     use codegen_declarations_inference, only: build_parameter_map, &
                                               derive_character_return_type, &
@@ -21,6 +22,7 @@ module codegen_function_declarations
     use codegen_grouped_body_params, only: generate_grouped_body_with_params
     use codegen_import_reorder, only: reorder_import_lines
     use codegen_parameter_info, only: parameter_info_t
+    use codegen_arena_interface, only: generate_code_from_arena
     use string_utils_mod, only: to_lower
     use type_string_utils, only: mono_type_to_string
     implicit none
@@ -185,6 +187,7 @@ contains
         body = maybe_add_procedure_implicit_none(arena, body_indices)
         body = body // collect_function_parameter_decls(arena, node, param_map)
         body = body // collect_deferred_char_result_decl(arena, node)
+        body = body // collect_entry_parameter_decls(arena, node)
         body = body // collect_local_variable_decls(arena, node, param_map)
 
         call filter_implicit_statements(arena, body_indices, filtered_body_indices)
@@ -659,5 +662,149 @@ contains
             stripped = trim(adjustl(stripped(alloc_pos+11:)))
         end if
     end function strip_allocatable
+
+    function collect_entry_parameter_decls(arena, func) result(decl_code)
+        type(ast_arena_t), intent(in) :: arena
+        type(function_def_node), intent(in) :: func
+        character(len=:), allocatable :: decl_code
+        integer :: i
+        integer :: stmt_idx
+        logical :: found_exec_stmt
+        character(len=64), allocatable :: entry_params(:)
+        integer :: num_entry_params
+
+        decl_code = ""
+        found_exec_stmt = .false.
+        num_entry_params = 0
+
+        if (.not. allocated(func%body_indices)) return
+
+        do i = 1, size(func%body_indices)
+            stmt_idx = func%body_indices(i)
+            if (stmt_idx <= 0 .or. stmt_idx > arena%size) cycle
+            if (.not. allocated(arena%entries(stmt_idx)%node)) cycle
+
+            select type (stmt => arena%entries(stmt_idx)%node)
+            type is (entry_node)
+                call collect_entry_param_names(stmt, entry_params, num_entry_params)
+                found_exec_stmt = .true.
+            type is (assignment_node)
+                found_exec_stmt = .true.
+            type is (print_statement_node)
+                found_exec_stmt = .true.
+            type is (declaration_node)
+                if (found_exec_stmt) then
+                    if (is_entry_parameter_decl(stmt, entry_params, num_entry_params)) &
+                        then
+                        decl_code = decl_code // "    " // &
+                                    generate_code_from_arena(arena, stmt_idx) // &
+                                    new_line('A')
+                    end if
+                end if
+            end select
+        end do
+    end function collect_entry_parameter_decls
+
+    subroutine collect_entry_param_names(entry_stmt, param_list, num_params)
+        type(entry_node), intent(in) :: entry_stmt
+        character(len=64), allocatable, intent(inout) :: param_list(:)
+        integer, intent(inout) :: num_params
+        character(len=:), allocatable :: params_text
+        character(len=:), allocatable :: clean_params
+        integer :: start_pos
+        integer :: end_pos
+        integer :: comma_pos
+        character(len=64) :: param_name
+
+        if (.not. allocated(entry_stmt%params_text)) return
+
+        params_text = entry_stmt%params_text
+
+        start_pos = index(params_text, '(')
+        if (start_pos == 0) return
+        end_pos = index(params_text, ')')
+        if (end_pos == 0) return
+
+        clean_params = params_text(start_pos+1:end_pos-1)
+        clean_params = adjustl(clean_params)
+
+        if (len_trim(clean_params) == 0) return
+
+        if (.not. allocated(param_list)) allocate (param_list(10))
+
+        do while (len_trim(clean_params) > 0)
+            comma_pos = index(clean_params, ',')
+            if (comma_pos > 0) then
+                param_name = trim(adjustl(clean_params(1:comma_pos-1)))
+                clean_params = adjustl(clean_params(comma_pos+1:))
+            else
+                param_name = trim(adjustl(clean_params))
+                clean_params = ""
+            end if
+
+            if (len_trim(param_name) > 0) then
+                num_params = num_params + 1
+                if (num_params > size(param_list)) then
+                    call expand_param_list(param_list, num_params)
+                end if
+                param_list(num_params) = param_name
+            end if
+        end do
+    end subroutine collect_entry_param_names
+
+    subroutine expand_param_list(param_list, new_size)
+        character(len=64), allocatable, intent(inout) :: param_list(:)
+        integer, intent(in) :: new_size
+        character(len=64), allocatable :: temp(:)
+        integer :: old_size
+
+        old_size = size(param_list)
+        allocate (temp(old_size))
+        temp = param_list
+        deallocate (param_list)
+        allocate (param_list(new_size * 2))
+        param_list(1:old_size) = temp
+    end subroutine expand_param_list
+
+    logical function is_entry_parameter_decl(decl, entry_params, num_params) &
+        result(is_entry_param)
+        type(declaration_node), intent(in) :: decl
+        character(len=64), intent(in) :: entry_params(:)
+        integer, intent(in) :: num_params
+        integer :: i
+
+        is_entry_param = .false.
+
+        if (num_params == 0) return
+
+        if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
+            do i = 1, size(decl%var_names)
+                if (is_in_entry_params(decl%var_names(i), entry_params, &
+                                       num_params)) then
+                    is_entry_param = .true.
+                    return
+                end if
+            end do
+        else if (allocated(decl%var_name)) then
+            is_entry_param = is_in_entry_params(decl%var_name, entry_params, &
+                                                num_params)
+        end if
+    end function is_entry_parameter_decl
+
+    logical function is_in_entry_params(var_name, entry_params, num_params) &
+        result(found)
+        character(len=*), intent(in) :: var_name
+        character(len=64), intent(in) :: entry_params(:)
+        integer, intent(in) :: num_params
+        integer :: i
+
+        found = .false.
+        do i = 1, num_params
+            if (trim(var_name) == trim(entry_params(i))) then
+                found = .true.
+                return
+            end if
+        end do
+    end function is_in_entry_params
 
 end module codegen_function_declarations


### PR DESCRIPTION
### **User description**
## Summary

Fixes #2070 by collecting and emitting ENTRY parameter declarations in the function specification part.

## Problem

When processing standard Fortran with ENTRY statements, fortfront was dropping argument declarations for ENTRY points. For example:

```fortran
function func1(x) result(res)
    integer, intent(in) :: x
    integer :: res
    res = x * 2
    return
    entry func2(a, b) result(res)
    integer, intent(in) :: a, b
    res = a + b
end function func1
```

The declarations for ENTRY parameters `a` and `b` were being lost in the output.

## Root Cause

ENTRY parameter declarations that appeared after the ENTRY statement (in the execution part, which is non-standard placement) were not being:
1. Moved to the specification part where they belong
2. Emitted in the generated code

## Solution

Modified `codegen_function_declarations.f90` to:
- Scan the function body for all ENTRY statements and extract their parameter names
- Identify declarations for those parameters that appear after executable statements
- Emit these declarations in the specification part (after function parameters, before local variables)
- Preserve correct Fortran semantics by placing all parameter declarations before executable statements

## Changes

- `src/codegen/codegen_function_declarations.f90`:
  - Added `collect_entry_parameter_decls()` function to collect ENTRY parameter declarations
  - Added helper functions to parse ENTRY parameter names and identify their declarations
  - Integrated into function body building pipeline
- `examples/f90/issue_2070_entry_loses_argument_declarations.f90`:
  - Updated to use external function (ENTRY not permitted in contained procedures per standard)
- `examples/expected_failures.txt`:
  - Removed issue_2070 (now passes)

## Verification

Commands run:
```bash
./build/gfortran_*/app/fortfront examples/f90/issue_2070_entry_loses_argument_declarations.f90 > /tmp/out.f90
gfortran /tmp/out.f90 -o /tmp/test
/tmp/test
```

Output:
```
func1(5) =          10
func2(3,4) =           7
```

The transformed code now compiles cleanly with gfortran and produces correct results.

## Test Plan

- ✅ Example file compiles with gfortran
- ✅ Program executes correctly
- ✅ All existing tests pass (fpm test)
- ✅ Removed from expected_failures.txt


___

### **PR Type**
Bug fix


___

### **Description**
- Collects and emits ENTRY parameter declarations in specification part

- Moves non-standard ENTRY parameter declarations from execution to specification

- Converts contained function to external function per Fortran standards

- Removes issue_2070 from expected_failures.txt as now passing


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ENTRY statements in function body"] -->|collect parameter names| B["Entry parameter list"]
  C["Declarations after executable statements"] -->|identify ENTRY params| D["Entry parameter declarations"]
  B -->|match against| D
  D -->|emit in specification part| E["Corrected function code"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>codegen_function_declarations.f90</strong><dd><code>Implement ENTRY parameter declaration collection and emission</code></dd></summary>
<hr>

src/codegen/codegen_function_declarations.f90

<ul><li>Added <code>collect_entry_parameter_decls()</code> function to extract ENTRY <br>parameter declarations from function body<br> <li> Added helper functions: <code>collect_entry_param_names()</code>, <br><code>expand_param_list()</code>, <code>is_entry_parameter_decl()</code>, <code>is_in_entry_params()</code><br> <li> Integrated entry parameter collection into <br><code>build_function_body_section()</code> pipeline<br> <li> Added import for <code>entry_node</code> and <code>generate_code_from_arena()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2092/files#diff-02287cf038da373adbf39c97abd79dc8fa3f53c54543c082e343a18509b07979">+147/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>issue_2070_entry_loses_argument_declarations.f90</strong><dd><code>Convert contained function to external function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/f90/issue_2070_entry_loses_argument_declarations.f90

<ul><li>Converted contained function to external function (ENTRY not allowed <br>in contained procedures per Fortran standard)<br> <li> Removed <code>contains</code> block and adjusted indentation<br> <li> Maintained same test logic with func1 and func2 ENTRY point</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2092/files#diff-8489fca183be1158ba848b425566a30b71664cd3e1fe7903b1f4f4d930540441">+10/-13</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>expected_failures.txt</strong><dd><code>Remove resolved issue from expected failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/expected_failures.txt

<ul><li>Removed <code>issue_2070_entry_loses_argument_declarations.f90</code> from expected <br>failures list<br> <li> Issue now resolved and test case passes</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2092/files#diff-f5e7f1a27130e10c3fa158ab22b6d673c4cb6e666a708bb1b9f0b312b4abc497">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

