### PR TITLE
fix: improve nested function call type inference (partial fix for #2068)

### DIFF
--- a/examples/lf/nested_function_calls_forward_ref.lf
+++ b/examples/lf/nested_function_calls_forward_ref.lf
@@ -1,0 +1,13 @@
+! Test nested function calls with forward references
+! This demonstrates correct type inference when called functions
+! are defined BEFORE the calling function
+function mul(a, b)
+    mul = a * b
+end function
+
+function add(a, b)
+    add = a + b
+end function
+
+result = add(mul(2, 3), mul(4, 5))
+print *, "Result:", result

--- a/src/semantic/analyzers/semantic_expression_context.f90
+++ b/src/semantic/analyzers/semantic_expression_context.f90
@@ -8,6 +8,7 @@ module semantic_expression_context
                               array_literal_node, call_or_subscript_node
     use semantic_type_operations, only: get_common_type
     use semantic_array_type_builders, only: collapse_array_rank
+    use semantic_function_helpers, only: find_return_type
     implicit none
     private
 
@@ -238,6 +239,7 @@ contains
         type(mono_type_t) :: typ
         integer :: i
         integer :: rank
+        logical :: found_type
 
         typ%kind = 0
         if (node%inferred_type%kind > 0) then
@@ -257,6 +259,11 @@ contains
             if (typ%kind == 0) typ = create_mono_type(TREAL)
             return
         end do
+
+        found_type = find_return_type(arena, node%name, typ)
+        if (.not. found_type) then
+            typ = create_mono_type(TVAR, var=create_type_var(0, "unknown_call"))
+        end if
     end function infer_call_expression_type
 
 end module semantic_expression_context


### PR DESCRIPTION
### **User description**
## Summary

Improves type inference for nested function calls by enabling static type lookup during function body analysis. This partially resolves #2068 when called functions are defined before calling functions.

## Changes

- Added `find_return_type` lookup in `infer_call_expression_type`
- Function calls in static analysis now check the arena for function definitions
- Returns TVAR fallback instead of unknown type when function not found
- Added test example: `nested_function_calls_forward_ref.lf`

## Verification

### Test Commands
```bash
# Build and test
fpm build
fpm test

# Test fixed case (forward references)
./build/gfortran_*/app/fortfront examples/lf/nested_function_calls_forward_ref.lf > /tmp/test.f90
gfortran /tmp/test.f90 -o /tmp/test
/tmp/test
# Output: Result: 26 ✓
```

### Test Output

**Forward reference case (NOW WORKS)**:
```fortran
! Input: mul defined before add
function mul(a, b)
    mul = a * b
end function

function add(a, b)
    add = a + b
end function

result = add(mul(2, 3), mul(4, 5))
```

Output: Both `mul` and `add` correctly inferred as `integer`, compiles successfully.

**Backward reference case (STILL FAILS)**:
```fortran
! Input: add defined before mul (issue_2068 file)
function add(a, b)
    add = a + b
end function

function mul(a, b)
    mul = a * b
end function

result = add(mul(2, 3), mul(4, 5))
```

Output: `add` incorrectly inferred as `real`, compilation fails with type mismatch.

### Test Suite
All existing tests pass:
```
fpm test  # 0 new failures, issue_2068 remains XFAIL
```

## Impact

- **Resolves**: Forward reference cases (called functions defined first)
- **Partially resolves #2068**: Helps when function definition order matches call dependency order
- **Does not resolve**: Backward reference cases (would require multi-pass type inference)

## Remaining Work

The original issue #2068 example still fails because `add` is defined before `mul`. A complete fix requires implementing a multi-pass type inference system where:
1. First pass: Collect all function declarations
2. Second pass: Infer types with all functions available

This architectural change is beyond the scope of this PR but has been documented for future work.


___

### **PR Type**
Bug fix


___

### **Description**
- Improves nested function call type inference by enabling static lookup

- Adds `find_return_type` helper to resolve function return types during analysis

- Returns TVAR fallback instead of unknown type for unresolved calls

- Adds test case for forward reference function calls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Call Expression Analysis"] -->|"lookup function"| B["find_return_type"]
  B -->|"found"| C["Return inferred type"]
  B -->|"not found"| D["Return TVAR fallback"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic_expression_context.f90</strong><dd><code>Add static function type lookup to call expressions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_expression_context.f90

<ul><li>Added import of <code>find_return_type</code> from <code>semantic_function_helpers</code><br> <li> Enhanced <code>infer_call_expression_type</code> to perform static function lookup <br>in arena<br> <li> Added <code>found_type</code> logical variable to track lookup success<br> <li> Returns TVAR type variable instead of unknown when function not found</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2093/files#diff-bcd19926fa46b50b0b5527c2f85fcacd4283c7deec01a2c3f8a06159bd3f5c4c">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nested_function_calls_forward_ref.lf</strong><dd><code>Add forward reference nested function calls test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/lf/nested_function_calls_forward_ref.lf

<ul><li>New test file demonstrating nested function calls with forward <br>references<br> <li> Defines <code>mul</code> function before <code>add</code> function<br> <li> Tests type inference for nested calls: <code>add(mul(2, 3), mul(4, 5))</code><br> <li> Verifies correct integer type inference and execution</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2093/files#diff-c26d35bd2dfcaa202a0202bc507bb2eaa408bdd91b2de8ca4350bee53d94df8b">+13/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

