### PR TITLE
fix: improve array parameter type inference (partial fix for #2062)

### DIFF
--- a/src/semantic/analyzers/semantic_parameter_analysis.f90
+++ b/src/semantic/analyzers/semantic_parameter_analysis.f90
@@ -28,6 +28,7 @@ module semantic_parameter_analysis
 contains
 
     subroutine merge_parameter_type(current_type, candidate_type)
+        use type_system_unified, only: TARRAY
         type(mono_type_t), intent(inout) :: current_type
         type(mono_type_t), intent(in) :: candidate_type
         type(mono_type_t) :: merged_type
@@ -45,6 +46,12 @@ contains
         end if
 
         if (candidate_type%kind == TVAR) return
+
+        ! Prefer array types over scalar types (fixes #2062)
+        if (candidate_type%kind == TARRAY .and. current_type%kind /= TARRAY) then
+            current_type = candidate_type
+            return
+        end if
 
         if (current_type%kind == candidate_type%kind) return
 

--- a/src/standardizers/standardizer_function_param_scanner.f90
+++ b/src/standardizers/standardizer_function_param_scanner.f90
@@ -133,8 +133,52 @@ contains
         call scan_node(arena, child_index, metadata)
     end subroutine scan_optional_child
 
+    logical function is_array_intrinsic(name) result(is_array_fn)
+        use lexer_core, only: to_lower
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: lowered
+
+        lowered = to_lower(trim(name))
+        select case (lowered)
+        case ("size", "lbound", "ubound", "shape", "allocated", &
+              "maxloc", "minloc", "sum", "product", "maxval", "minval", &
+              "any", "all", "count", "matmul", "transpose", "pack", &
+              "unpack", "reshape", "spread", "merge", "cshift", "eoshift")
+            is_array_fn = .true.
+        case default
+            is_array_fn = .false.
+        end select
+    end function is_array_intrinsic
+
+    subroutine mark_intrinsic_array_args(arena, node, metadata)
+        use ast_nodes_core, only: call_or_subscript_node, identifier_node
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        type(param_metadata_t), intent(inout) :: metadata
+        integer :: first_arg_idx, param_idx
+        character(len=:), allocatable :: arg_name
+
+        if (.not. allocated(node%arg_indices)) return
+        if (size(node%arg_indices) < 1) return
+
+        first_arg_idx = node%arg_indices(1)
+        if (.not. node_exists(arena, first_arg_idx)) return
+
+        select type (arg => arena%entries(first_arg_idx)%node)
+        type is (identifier_node)
+            if (.not. allocated(arg%name)) return
+            arg_name = trim(arg%name)
+            param_idx = metadata_find_param(metadata, arg_name)
+            if (param_idx > 0) then
+                metadata%is_array(param_idx) = .true.
+                if (metadata%rank(param_idx) < 1) metadata%rank(param_idx) = 1
+            end if
+        end select
+    end subroutine mark_intrinsic_array_args
+
     subroutine handle_call_or_subscript(arena, node, metadata)
         use ast_nodes_core, only: call_or_subscript_node
+        use lexer_core, only: to_lower
         type(ast_arena_t), intent(in) :: arena
         type(call_or_subscript_node), intent(in) :: node
         type(param_metadata_t), intent(inout) :: metadata
@@ -150,6 +194,13 @@ contains
             end if
         end if
         if (len_trim(target_name) == 0) return
+
+        ! Check if this is an array intrinsic call (fixes #2062)
+        if (is_array_intrinsic(target_name)) then
+            call mark_intrinsic_array_args(arena, node, metadata)
+            return
+        end if
+
         idx = metadata_find_param(metadata, target_name)
         if (idx <= 0) return
 


### PR DESCRIPTION
### **User description**
## Summary

This PR provides a partial fix for #2062 by improving array parameter type inference infrastructure. While it doesn't completely resolve the issue, it adds important improvements to how array types are handled in parameter inference.

## Changes

### 1. Array Intrinsic Detection (Standardizer)
- Added `is_array_intrinsic()` to detect array intrinsics: `size`, `lbound`, `ubound`, `shape`, `allocated`, reduction functions, etc.
- Added `mark_intrinsic_array_args()` to mark the first argument of array intrinsics as an array parameter
- Modified `handle_call_or_subscript()` to check for array intrinsic calls before processing as subscripts

### 2. Array Type Preference (Semantic Analyzer)  
- Modified `merge_parameter_type()` to prefer array types (`TARRAY`) over scalar types when merging parameter candidates
- Prevents implicit typing rules (i-n convention) from overriding array types inferred from call sites

## Verification

```bash
fpm test  # All tests pass, no regressions
```

### Test Cases

**Works (fixed-size arrays):**
```fortran
x = [1, 2, 3, 4, 5]
n = get_size(x)
! Parameter correctly inferred as: integer, dimension(5) :: arr
```

**Partial (still has issues with reshape/allocate):**
```fortran
mat = reshape([1.0, 2.0, 3.0, 4.0], [2, 2])
result = matrix_sum(mat)
! Parameter still incorrectly inferred as: integer :: mat
! Should be: real, dimension(:,:), allocatable :: mat
```

## Remaining Issues

The root cause of #2062 persists: parameters with dynamically allocated array arguments (from `reshape()` or `allocate()`) lose their array dimensions during type inference.

**Root cause analysis:**
1. Assignment `mat = reshape(...)` correctly infers `mat` as `real, dimension(:,:), allocatable`
2. `update_identifier_type_in_arena()` correctly updates all `mat` identifier nodes
3. However, when `infer_parameter_types_from_calls()` looks at the call `matrix_sum(mat)`, the array type information is not being retrieved correctly
4. This appears to be a semantic analysis ordering issue or identifier lookup problem

**Next steps for complete fix:**
- Investigate why `arg_node%inferred_type` doesn't have full array information for reshape/allocate results
- May require multi-pass type inference or improved identifier type propagation
- Consider adding debug tracing to understand exact flow

## Impact

- Improves array parameter inference infrastructure
- No regressions (all tests pass)
- Partial improvement for #2062 (helps with intrinsic detection, but reshape/allocate cases still fail)
- Sets foundation for complete fix

## Related Issues

Partial fix for #2062


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Improve array parameter type inference for function parameters

- Add array intrinsic detection (size, lbound, ubound, shape, etc.)

- Mark first arguments of array intrinsics as array parameters

- Prefer array types over scalar types in parameter type merging

- Partial fix for issue #2062 with reshape/allocate edge cases


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Array Intrinsic Call<br/>size, lbound, ubound, etc."] -->|"Detect via<br/>is_array_intrinsic()"| B["Mark First Arg<br/>as Array Parameter"]
  B -->|"Update metadata"| C["Parameter Metadata<br/>is_array flag"]
  D["Type Merging<br/>current vs candidate"] -->|"Prefer TARRAY<br/>over scalar"| E["Inferred Type<br/>Array preferred"]
  C --> F["Improved Type<br/>Inference"]
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic_parameter_analysis.f90</strong><dd><code>Prefer array types in parameter type merging</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_parameter_analysis.f90

<ul><li>Import <code>TARRAY</code> type constant from <code>type_system_unified</code> module<br> <li> Add logic to prefer array types over scalar types when merging <br>parameter type candidates<br> <li> Prevents implicit typing rules (i-n convention) from overriding <br>inferred array types<br> <li> Improves type inference for parameters used with array operations</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2098/files#diff-ec33eeeb2027387965530d39ae5c8410330d637e48dfcf102edf45f4f4e098f7">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>standardizer_function_param_scanner.f90</strong><dd><code>Add array intrinsic detection and parameter marking</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/standardizers/standardizer_function_param_scanner.f90

<ul><li>Add <code>is_array_intrinsic()</code> function to detect array intrinsic functions <br>(size, lbound, ubound, shape, allocated, reduction functions, etc.)<br> <li> Add <code>mark_intrinsic_array_args()</code> subroutine to mark first argument of <br>array intrinsics as array parameters<br> <li> Modify <code>handle_call_or_subscript()</code> to check for array intrinsic calls <br>before processing as subscripts<br> <li> Set array flag and minimum rank for parameters passed to array <br>intrinsics</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2098/files#diff-910907f22b05b7b17f9d271aeee4a65341302941df32651093c4a065688a8972">+51/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

