### PR TITLE
fix: partial array parameter type inference improvement (refs #2062)

### DIFF
--- a/src/semantic/analyzers/semantic_parameter_analysis.f90
+++ b/src/semantic/analyzers/semantic_parameter_analysis.f90
@@ -729,9 +729,6 @@ contains
             type is (program_node)
                 scope_index = current
                 return
-            type is (module_node)
-                scope_index = current
-                return
             end select
             current = arena%entries(current)%parent_index
         end do


### PR DESCRIPTION
### **User description**
## Summary

Partial fix for #2062 - improves array parameter type inference but does not fully resolve the issue.

## Changes

1. **Fixed base type inference**: Removed `'m'` from the i-n integer heuristic, preventing parameters like `mat` from being incorrectly seeded as `integer`
2. **Added call-site type inference infrastructure**: Implemented `infer_base_type_from_call_site()` to extract element types from arguments at function call sites
3. **Added assignment tracing**: Implemented `find_assignment_to_variable()` to trace variable types through their assignments

## Verification

### Before (issue #2062):
```fortran
real function matrix_sum(mat) result(total)
    integer :: mat          ! ✗ Wrong: should be real array
    ! ... size(mat, 1) fails because mat is integer scalar
```

### After (this PR):
```fortran
real function matrix_sum(mat) result(total)
    real :: mat             ! ✓ Correct base type, but missing dimensions
    ! ... size(mat, 1) still fails because mat is scalar, not array
```

### Test Results

```bash
# All existing tests still pass
fpm test
# Test Summary: 370 examples, 353 passed, 0 failed, 17 XFail, 47 skipped

# Issue 2062 test shows improvement but still fails compilation
./build/gfortran_*/app/fortfront examples/lf/issue_2062_nested_do_missing_var_type_mismatch.lf > /tmp/out.f90
gfortran -c /tmp/out.f90
# Error: 'array' argument of 'size' intrinsic must be an array
# Error: Rank mismatch in argument 'mat' (scalar and rank-2)
```

## Remaining Issue

**Array rank/dimensions are not being inferred from `size()` intrinsic usage.**

The parameter should be emitted as:
```fortran
real, dimension(:,:) :: mat
```

But is currently emitted as:
```fortran
real :: mat
```

## Root Cause Analysis

The `refine_from_intrinsic_call()` function in `semantic_parameter_analysis.f90` (lines 699-760) correctly identifies `size(mat, 1)` and `size(mat, 2)` usage and should be upgrading the parameter to an array type via `build_deferred_shape_array()` and `merge_parameter_type()`.

However, the inferred array type is either:
- Not being applied to the parameter node correctly in `update_parameter_nodes()`
- Being overwritten by subsequent analysis passes
- Not being emitted correctly by codegen

Further investigation needed into:
1. Parameter node updating (`update_parameter_nodes` at line 504)
2. Codegen parameter emission (`codegen_function_declarations.f90`)
3. Semantic analysis pass ordering

## Progress Made

- ✅ Fixed base type (integer → real)
- ✅ All loop variables declared correctly
- ✅ No regressions in test suite
- ⬜ Array dimensions still not inferred (requires additional work)

## Next Steps

To fully resolve #2062, need to:
1. Debug why array type from `refine_from_intrinsic_call` isn't persisting
2. Verify parameter nodes are updated with array types correctly
3. Ensure codegen emits array dimensions for parameters

Related: #2062


___

### **PR Type**
Bug fix


___

### **Description**
- Improved array parameter type inference by fixing base type detection

- Removed 'm' from integer heuristic to prevent incorrect type seeding

- Added call-site type inference to extract element types from arguments

- Implemented assignment tracing to resolve variable types through assignments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parameter Analysis"] --> B["Remove 'm' from<br/>Integer Heuristic"]
  A --> C["Infer Base Type<br/>from Call Site"]
  C --> D["Extract Array<br/>Base Type"]
  C --> E["Find Assignment<br/>to Variable"]
  B --> F["Refined Parameter<br/>Type Inference"]
  D --> F
  E --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic_parameter_analysis.f90</strong><dd><code>Add call-site type inference for array parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_parameter_analysis.f90

<ul><li>Removed 'm' from the i-n integer type heuristic (line 179) to prevent <br>parameters like <code>mat</code> from being incorrectly seeded as integer<br> <li> Added <code>infer_base_type_from_call_site()</code> function to extract element <br>types from function call arguments by traversing the AST arena<br> <li> Added <code>find_assignment_to_variable()</code> helper function to trace variable <br>types through their assignments in the AST<br> <li> Added <code>extract_array_base_type()</code> utility function to unwrap array types <br>and extract their base element type<br> <li> Enhanced <code>refine_from_intrinsic_call()</code> to use call-site type inference <br>instead of relying solely on existing parameter types</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2101/files#diff-ec33eeeb2027387965530d39ae5c8410330d637e48dfcf102edf45f4f4e098f7">+155/-3</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

