### PR TITLE
fix: infer array types from array indexing in function parameters (fixes #2062)

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -12,7 +12,6 @@ issue_1826_enum_program.f90  # enum constructs unsupported; expect diagnostic on
 issue_1827_submodule_with_contents.f90  # submodules unsupported; expect diagnostic only
 issue_1583_computed_goto_minimal.f90
 issue_1816_multiple_returns.lf
-issue_2062_nested_do_missing_var_type_mismatch.lf  # nested DO missing var declaration + type mismatch #2062
 issue_2063_deferred_char_function_syntax.lf  # deferred-length character function invalid syntax #2063
 issue_2066_array_function_rank_mismatch.lf  # elemental-style array function rank mismatch #2066
 issue_2067_implied_do_array_return_rank_mismatch.lf  # implied-do array return rank mismatch #2067

--- a/src/semantic/analyzers/semantic_parameter_analysis.f90
+++ b/src/semantic/analyzers/semantic_parameter_analysis.f90
@@ -810,6 +810,7 @@ contains
             select type (node => arena%entries(stmt_idx)%node)
             type is (call_or_subscript_node)
                 call refine_from_intrinsic_call(node)
+                call refine_from_array_indexing(node)
             type is (assignment_node)
                 if (node%value_index > 0) then
                     call refine_from_statement(arena, node%value_index, &
@@ -896,6 +897,46 @@ contains
                 end select
             end select
         end subroutine refine_from_intrinsic_call
+
+        subroutine refine_from_array_indexing(call_node)
+            type(call_or_subscript_node), intent(in) :: call_node
+            character(len=:), allocatable :: param_name
+            integer :: param_idx, rank
+            type(mono_type_t) :: inferred_array_type, base_type
+
+            if (.not. allocated(call_node%name)) return
+            if (is_intrinsic_function(call_node%name)) return
+            if (.not. allocated(call_node%arg_indices)) return
+            if (size(call_node%arg_indices) == 0) return
+
+            param_name = trim(call_node%name)
+            param_idx = 0
+            do j = 1, size(param_names)
+                if (trim(param_names(j)) == param_name) then
+                    param_idx = j
+                    exit
+                end if
+            end do
+
+            if (param_idx == 0) return
+
+            if (param_types(param_idx)%kind /= TARRAY) then
+                rank = size(call_node%arg_indices)
+
+                base_type = infer_base_type_from_call_site(arena, func_node, &
+                                                           param_idx)
+                if (base_type%kind <= 0 .or. base_type%kind == TVAR) then
+                    base_type = param_types(param_idx)
+                    if (base_type%kind <= 0 .or. base_type%kind == TVAR) then
+                        base_type = create_mono_type(TREAL)
+                    end if
+                end if
+
+                inferred_array_type = build_deferred_shape_array(base_type, rank)
+                call merge_parameter_type(param_types(param_idx), &
+                                          inferred_array_type)
+            end if
+        end subroutine refine_from_array_indexing
 
         function get_dimension_from_size_call(arena, call_node) result(dim)
             use ast_nodes_core, only: literal_node


### PR DESCRIPTION
### **User description**
## Summary
Fixes #2062 by adding array indexing detection to parameter type inference. When a function parameter is used with subscript notation (e.g., `mat(i,j)`), it is now correctly inferred as an array type with rank equal to the number of indices.

## Problem
Previously, function parameters used with array indexing were incorrectly inferred as scalars, causing compilation errors:

```fortran
function matrix_sum(mat)  ! mat parameter
    do i = 1, size(mat, 1)
        do j = 1, size(mat, 2)
            total = total + mat(i, j)  ! array indexing usage
```

Generated (incorrect):
```fortran
real :: mat  ! scalar - causes "argument of 'size' must be an array" error
```

## Solution
Added `refine_from_array_indexing()` subroutine in `semantic_parameter_analysis.f90` that:
1. Detects `call_or_subscript_node` patterns representing array indexing
2. Infers array rank from the number of subscript indices
3. Builds a deferred-shape array type with the inferred base type
4. Skips intrinsic functions to avoid conflicts with existing logic

## Verification

### Test Output
```bash
$ ./build/gfortran_*/app/fortfront examples/lf/issue_2062_nested_do_missing_var_type_mismatch.lf | grep "mat"
    real, dimension(:,:), allocatable :: mat
real function matrix_sum(mat) result(total)
    real, dimension(:,:), allocatable :: mat
```

### Compilation
```bash
$ ./build/gfortran_*/app/fortfront examples/lf/issue_2062_nested_do_missing_var_type_mismatch.lf > /tmp/test.f90
$ gfortran -c /tmp/test.f90 -o /tmp/test.o
# SUCCESS: No errors
```

### Test Results
- All 370 examples tested
- 354 passed (up from 353)
- 16 expected failures (down from 17)
- 0 unexpected failures
- issue_2062 removed from `expected_failures.txt`

## Changes
- `src/semantic/analyzers/semantic_parameter_analysis.f90`: Added array indexing detection
- `examples/expected_failures.txt`: Removed issue_2062 entry

## Test Plan
- [x] Issue example compiles successfully
- [x] Full test suite passes (fpm test)
- [x] Examples test passes (370 examples)
- [x] No regressions in existing functionality


___

### **PR Type**
Bug fix


___

### **Description**
- Infer array types from array indexing in function parameters

- Detect subscript notation usage to determine array rank

- Build deferred-shape array types with inferred base types

- Skip intrinsic functions to avoid logic conflicts


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Parameter used with subscript notation"] --> B["refine_from_array_indexing detects indexing"]
  B --> C["Infer rank from number of indices"]
  C --> D["Build deferred-shape array type"]
  D --> E["Merge with parameter type"]
  E --> F["Parameter correctly typed as array"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic_parameter_analysis.f90</strong><dd><code>Add array indexing detection for parameter type inference</code></dd></summary>
<hr>

src/semantic/analyzers/semantic_parameter_analysis.f90

<ul><li>Added call to <code>refine_from_array_indexing()</code> in <code>refine_from_statement()</code> <br>subroutine<br> <li> Implemented new <code>refine_from_array_indexing()</code> subroutine to detect <br>array indexing patterns<br> <li> Infers array rank from subscript indices count<br> <li> Builds deferred-shape array types with inferred base types<br> <li> Skips intrinsic functions to avoid conflicts</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2102/files#diff-ec33eeeb2027387965530d39ae5c8410330d637e48dfcf102edf45f4f4e098f7">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>expected_failures.txt</strong><dd><code>Remove resolved issue from expected failures</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/expected_failures.txt

<ul><li>Removed <code>issue_2062_nested_do_missing_var_type_mismatch.lf</code> from <br>expected failures list<br> <li> Issue now resolves successfully with array parameter inference</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2102/files#diff-f5e7f1a27130e10c3fa158ab22b6d673c4cb6e666a708bb1b9f0b312b4abc497">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

