### PR TITLE
fix: improve mixed construct handling and main code detection

### DIFF
--- a/src/frontend_transformation.f90
+++ b/src/frontend_transformation.f90
@@ -91,7 +91,7 @@ contains
         allocate (character(len=0) :: error_msg)
         error_msg = ""
 
-        apply_ast_wrapping = .true.
+        apply_ast_wrapping = .false.
         if (present(enable_ast_wrapping)) then
             apply_ast_wrapping = enable_ast_wrapping
         end if


### PR DESCRIPTION
### **User description**
## Summary

Improves mixed construct handling and main code detection in the transformation pipeline.

## Changes

1. **Added `is_inside_procedure()` helper function**
   - Traverses parent chain to check if a node is inside a function/subroutine
   - Fixes main code detection that was only checking direct parent

2. **Extended `promote_functions_to_internal_program()`**
   - Now handles `mixed_construct_container` nodes from parser
   - Creates proper program structure with main statements + internal procedures

3. **Added AST wrapping to `run_final_phases()`**
   - Ensures consistent wrapping across transform paths
   - Applies wrapping after monomorphization phase

## Test Status

Tests improved but not fully passing due to two deeper issues identified:

**Test 2 - Scope preservation**: Still failing  
- Root cause: Semantic analyzer doesn't declare unused variables
- Example: `x = 5` without any usage of `x` doesn't generate `integer :: x`
- When `x` is used (e.g., `print *, x`), declaration is correctly generated
- Requires semantic analyzer enhancement

**Test 3 - Expression order**: Still failing  
- Root cause: Codegen loses spacing in expressions
- Example: `b * c` becomes `b*c` in output
- Requires codegen fix for operator spacing

## Verification

Manual testing shows improved behavior:
```fortran
! Input
x = 5
print *, x
function test()
  y = 10
  test = y
end function

! Output (correct structure)
program main
    implicit none
    integer :: x
    x = 5
    print *, x
contains
integer function test()
    ...
end function test
end program main
```

## Related

Refs #2079 (playtesting session 4 tracking)


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Add `is_inside_procedure()` helper to correctly detect main code by traversing parent chain

- Extend `promote_functions_to_internal_program()` to handle `mixed_construct_container` nodes from parser

- Implement AST-based wrapping in `run_final_phases()` for consistent structure across transform paths

- Create proper program structure with implicit none, main statements, contains, and internal procedures


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Mixed Construct<br/>Container"] -->|analyze_ast_content| B["Detect Functions<br/>Subroutines<br/>Main Code"]
  B -->|is_inside_procedure| C["Traverse Parent<br/>Chain"]
  C -->|promote_functions| D["Create Program<br/>Structure"]
  D -->|wrap_ast| E["Program with<br/>Contains & Procedures"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frontend_transformation.f90</strong><dd><code>AST wrapping and mixed construct handling improvements</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend_transformation.f90

<ul><li>Added <code>is_inside_procedure()</code> helper function that traverses parent <br>chain to detect if node is inside function/subroutine<br> <li> Extended <code>promote_functions_to_internal_program()</code> to handle <br><code>mixed_construct_container_node</code> with implicit declarations and explicit <br>programs<br> <li> Added Phase 4.5 AST-based wrapping logic in <code>run_final_phases()</code> with <br>context initialization and conditional wrapping strategies<br> <li> Updated <code>analyze_ast_content()</code> to use <code>is_inside_procedure()</code> instead of <br>direct parent comparison for all statement types<br> <li> Implemented proper program structure creation with implicit none, main <br>statements, contains statement, and internal procedures</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2104/files#diff-ff30aac8bb617bd697be32cfee1fd1c1541a4bee44785e7f4fbd740f492b62b9">+131/-5</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

