### PR TITLE
fix: Bug: Variable used but never declared (no IMPLICIT type error) (fixes #2165)

### DIFF
--- a/examples/lf/issue_2165_variable_undeclared_argument.lf
+++ b/examples/lf/issue_2165_variable_undeclared_argument.lf
@@ -1,0 +1,6 @@
+function double(x)
+    double = x * 2
+end function
+
+result = double(uninitialized_var)
+print *, "Result:", result

--- a/examples/skip_all_examples.txt
+++ b/examples/skip_all_examples.txt
@@ -47,4 +47,5 @@ lf/issue_1814_nested_lazy_function.lf
 lf/issue_2012_subroutine_local_not_inferred.lf
 lf/issue_2016_nested_call_type_mismatch.lf
 lf/issue_2019_statements_after_if_dropped.lf
+lf/issue_2165_variable_undeclared_argument.lf
 lf/issue_652_multi_var_allocatable.lf

--- a/src/standardizers/standardizer_declarations_collection.f90
+++ b/src/standardizers/standardizer_declarations_collection.f90
@@ -546,6 +546,13 @@ contains
                     end select
                 end if
             end if
+
+            if (assign%value_index > 0) then
+                call collect_statement_vars(arena, assign%value_index, &
+                                            var_names, var_types, &
+                                            var_declared, var_count, &
+                                            function_names, func_count)
+            end if
         end select
     end subroutine collect_assignment_vars
 

--- a/test/test_issue_2165_variable_undeclared.f90
+++ b/test/test_issue_2165_variable_undeclared.f90
@@ -1,0 +1,46 @@
+program test_issue_2165_variable_undeclared
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+                                             iostat_eor
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    character(:), allocatable :: input_code, output_code, error_msg
+
+    print *, "=== Issue #2165: Undeclared variable used as argument ==="
+
+    call read_example('examples/lf/issue_2165_variable_undeclared_argument.lf', &
+                      input_code)
+
+    call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: Transformation failed:", trim(error_msg)
+        error stop 1
+    end if
+
+    if (index(output_code, ":: uninitialized_var") == 0) then
+        print *, "FAIL: Missing declaration for uninitialized_var"
+        print *, "Output:"
+        print *, output_code
+        error stop 1
+    end if
+
+    print *, "PASS: Undeclared argument variable inferred correctly"
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2165_variable_undeclared


### PR DESCRIPTION
### **User description**
## Summary
- expand declaration collection to scan assignment RHS expressions so argument-only identifiers receive inferred declarations
- add lazy Fortran example plus regression test ensuring undeclared call arguments no longer break codegen

## Verification
- `fpm test`


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Expand declaration collection to scan assignment RHS expressions

- Ensures undeclared variables used as function arguments receive inferred declarations

- Add regression test and lazy Fortran example for issue #2165


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Assignment Statement"] -->|"scan RHS expression"| B["collect_statement_vars"]
  B -->|"identify identifiers"| C["Infer Variable Declarations"]
  C -->|"prevent codegen errors"| D["Valid Output Code"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>standardizer_declarations_collection.f90</strong><dd><code>Scan assignment RHS for undeclared variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/standardizers/standardizer_declarations_collection.f90

<ul><li>Added RHS expression scanning in <code>collect_assignment_vars</code> subroutine<br> <li> Calls <code>collect_statement_vars</code> on assignment value when present<br> <li> Ensures variables used only on RHS of assignments are declared</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2171/files#diff-6f5e0f4c35ac35dbfab4ae87b50c2c78912d7767c6a9a84861e61da815b2d757">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_2165_variable_undeclared.f90</strong><dd><code>Regression test for undeclared argument variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/test_issue_2165_variable_undeclared.f90

<ul><li>New regression test program for issue #2165<br> <li> Reads lazy Fortran example and transforms it<br> <li> Validates that undeclared argument variable receives inferred <br>declaration<br> <li> Checks for presence of <code>:: uninitialized_var</code> in output</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2171/files#diff-670d00aaf92367ffaa595fa808e01d3d2c8751c192c5db9a94ef0133ee8a2f4f">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>issue_2165_variable_undeclared_argument.lf</strong><dd><code>Example lazy Fortran code for issue #2165</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/lf/issue_2165_variable_undeclared_argument.lf

<ul><li>New lazy Fortran example demonstrating the bug scenario<br> <li> Function call with undeclared variable as argument<br> <li> Tests that transformation correctly infers variable declaration</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2171/files#diff-3e72dcbd0e49f087596fa4a6cdea1bf61b86d980b8d6143e10c6b72270df203a">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>skip_all_examples.txt</strong><dd><code>Update skip list with new example</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/skip_all_examples.txt

<ul><li>Added new example file to skip list<br> <li> Prevents example from being processed in standard example runs</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2171/files#diff-c2baf6bad0f31b48733eaea1d5b99b55b3fcd5e10b5b971893b5484a2e545ad4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

