### PR TITLE
fix: reset type arena between transformations to prevent accumulation

### DIFF
--- a/src/frontend_transformation.f90
+++ b/src/frontend_transformation.f90
@@ -12,6 +12,7 @@ module frontend_transformation
     use ast_arena_modern, only: ast_arena_t
     use semantic_analyzer, only: semantic_context_t, create_semantic_context, &
                                  analyze_program, has_semantic_errors
+    use type_system_unified, only: reset_type_system
     use standardizer, only: standardize_ast, set_standardizer_type_standardization, &
                             get_standardizer_type_standardization, &
                             mark_pointer_targets
@@ -112,6 +113,11 @@ contains
         else
             call shared_arena%reset()
         end if
+
+        ! Reset type system arena to prevent type accumulation across transformations
+        ! CRITICAL: This prevents circular type references and slowdowns when running
+        ! multiple transformations in sequence (e.g., during test suite execution)
+        call reset_type_system()
 
         ! Handle empty or whitespace-only input
         if (is_empty_or_whitespace_only(source)) then

--- a/src/semantic/analyzers/semantic_array_intrinsics.f90
+++ b/src/semantic/analyzers/semantic_array_intrinsics.f90
@@ -108,11 +108,37 @@ contains
         integer, intent(out) :: rank
         type(mono_type_t), intent(out) :: base_type
         type(mono_type_t) :: current
+        integer :: visited_indices(100)
+        integer :: visited_count
+        integer :: i
+        logical :: is_cycle
 
         current = source_type
         call current%sync_from_arena()
         rank = 0
+        visited_count = 0
+
         do while (current%kind == TARRAY .and. current%has_args())
+            ! Detect cycles by checking if we've seen this type_id before
+            is_cycle = .false.
+            do i = 1, visited_count
+                if (visited_indices(i) == current%handle%type_id) then
+                    is_cycle = .true.
+                    exit
+                end if
+            end do
+
+            if (is_cycle) then
+                ! Circular reference detected - stop traversal
+                exit
+            end if
+
+            ! Track this type_id
+            visited_count = visited_count + 1
+            if (visited_count <= size(visited_indices)) then
+                visited_indices(visited_count) = current%handle%type_id
+            end if
+
             rank = rank + 1
             current = current%get_arg(1)
             call current%sync_from_arena()
@@ -376,11 +402,34 @@ contains
             call arg_type%sync_from_arena()
             element_type = arg_type
 
-            do while (element_type%kind == TARRAY .and. &
-                      element_type%has_args())
-                element_type = element_type%get_arg(1)
-                call element_type%sync_from_arena()
-            end do
+            ! Cycle detection for type traversal
+            block
+                integer :: visited_indices(100), visited_count, i
+                logical :: is_cycle
+
+                visited_count = 0
+                do while (element_type%kind == TARRAY .and. &
+                          element_type%has_args())
+                    ! Check for cycles
+                    is_cycle = .false.
+                    do i = 1, visited_count
+                        if (visited_indices(i) == element_type%handle%type_id) then
+                            is_cycle = .true.
+                            exit
+                        end if
+                    end do
+                    if (is_cycle) exit
+
+                    ! Track this type_id
+                    visited_count = visited_count + 1
+                    if (visited_count <= size(visited_indices)) then
+                        visited_indices(visited_count) = element_type%handle%type_id
+                    end if
+
+                    element_type = element_type%get_arg(1)
+                    call element_type%sync_from_arena()
+                end do
+            end block
 
             if (element_type%kind > 0) element_kind = element_type%kind
         end if

--- a/src/semantic/types/type_system_unified.f90
+++ b/src/semantic/types/type_system_unified.f90
@@ -128,6 +128,7 @@ module type_system_unified
     ! Public API functions (compatibility with legacy system)
     public :: create_type_var, create_mono_type, create_poly_type, create_fun_type
     public :: compose_substitutions, occurs_check, free_type_vars
+    public :: reset_type_system
 
     ! Compatibility wrapper functions for type_checker
     public :: type_has_args, type_get_arg, type_get_args_count
@@ -144,6 +145,16 @@ contains
             arena_initialized = .true.
         end if
     end subroutine ensure_arena_initialized
+
+    ! Reset type system arena to prevent accumulation across transformations
+    ! CRITICAL: Must be called at the start of each transformation to prevent
+    ! type IDs from accumulating and causing circular references or slowdowns
+    subroutine reset_type_system()
+        if (arena_initialized) then
+            call destroy_type_arena(global_arena)
+            global_arena = create_type_arena(65536)
+        end if
+    end subroutine reset_type_system
 
     ! Create type variable (compatibility function)
     function create_type_var(id, name) result(tv)

--- a/src/utilities/type_string_utils.f90
+++ b/src/utilities/type_string_utils.f90
@@ -202,15 +202,56 @@ contains
     recursive subroutine collect_array_dimensions(mono_type, dim_spec)
         type(mono_type_t), intent(in) :: mono_type
         character(len=:), allocatable, intent(inout) :: dim_spec
+        integer :: visited_ids(100)
+        integer :: visited_count
+        integer :: depth
+
+        visited_count = 0
+        depth = 0
+        call collect_array_dimensions_impl(mono_type, dim_spec, &
+                                          visited_ids, visited_count, depth)
+    end subroutine collect_array_dimensions
+
+    recursive subroutine collect_array_dimensions_impl(mono_type, dim_spec, &
+                                                       visited_ids, visited_count, depth)
+        type(mono_type_t), intent(in) :: mono_type
+        character(len=:), allocatable, intent(inout) :: dim_spec
+        integer, intent(inout) :: visited_ids(100)
+        integer, intent(inout) :: visited_count
+        integer, intent(inout) :: depth
         character(len=32) :: size_buffer
         type(mono_type_t) :: inner_element
+        integer :: i
+        logical :: is_cycle
+        integer, parameter :: MAX_DEPTH = 50
 
         if (mono_type%kind /= TARRAY) return
+
+        ! Limit recursion depth
+        depth = depth + 1
+        if (depth > MAX_DEPTH) return
+
+        ! Check for cycles
+        is_cycle = .false.
+        do i = 1, visited_count
+            if (visited_ids(i) == mono_type%handle%type_id) then
+                is_cycle = .true.
+                exit
+            end if
+        end do
+        if (is_cycle) return
+
+        ! Track this type_id
+        visited_count = visited_count + 1
+        if (visited_count <= size(visited_ids)) then
+            visited_ids(visited_count) = mono_type%handle%type_id
+        end if
 
         if (type_args_allocated(mono_type) .and. type_args_size(mono_type) > 0) then
             inner_element = type_args_element(mono_type, 1)
             if (inner_element%kind == TARRAY) then
-                call collect_array_dimensions(inner_element, dim_spec)
+                call collect_array_dimensions_impl(inner_element, dim_spec, &
+                                                  visited_ids, visited_count, depth)
             end if
         end if
 
@@ -234,6 +275,6 @@ contains
                 dim_spec = ":" // "," // trim(dim_spec)
             end if
         end if
-    end subroutine collect_array_dimensions
+    end subroutine collect_array_dimensions_impl
 
 end module type_string_utils


### PR DESCRIPTION
## Summary

Fixes test_issue_1962_matmul_rank hang by resetting the global type arena between transformations.

## Root Cause

The global type arena with `save` attribute was never being reset between transformations, causing type accumulation across all 161+ test runs. This led to:
- Memory growth with each test execution
- Type IDs incrementing across tests
- Potential performance degradation

## Solution

1. Added `reset_type_system()` function to `type_system_unified.f90`
2. Call `reset_type_system()` at the start of each transformation in `frontend_transformation.f90`
3. Added cycle detection to type traversal loops as defense-in-depth

## Changes

- `src/frontend_transformation.f90`: Call arena reset at transformation start
- `src/semantic/types/type_system_unified.f90`: Add reset function
- `src/semantic/analyzers/semantic_array_intrinsics.f90`: Add cycle detection
- `src/utilities/type_string_utils.f90`: Add cycle detection

## Testing

- ✅ test_issue_1962_matmul_rank: PASSES
- ✅ Full test suite: ALL PASS (161+ tests)
- ✅ CLI: Works correctly
- ✅ No regressions

Each transformation now starts with a clean type arena, preventing accumulation by architectural design.