### PR TITLE
fix: Bug: Empty typed array constructor declared allocatable without (fixes #2167)

### DIFF
--- a/src/semantic/analyzers/semantic_array_literal.f90
+++ b/src/semantic/analyzers/semantic_array_literal.f90
@@ -138,10 +138,16 @@ contains
 
         array_type = create_mono_type(TARRAY, args=args)
         array_type%size = 0
-        array_type%alloc_info%is_allocatable = .true.
-        array_type%alloc_info%needs_allocation_check = .true.
         array_type%alloc_info%is_pointer = .false.
         array_type%alloc_info%needs_allocatable_string = .false.
+
+        if (explicit_type%kind > 0) then
+            array_type%alloc_info%is_allocatable = .false.
+            array_type%alloc_info%needs_allocation_check = .false.
+        else
+            array_type%alloc_info%is_allocatable = .true.
+            array_type%alloc_info%needs_allocation_check = .true.
+        end if
     end function build_empty_array_type
 
     function build_explicit_array_type(explicit_type, element_count) &

--- a/src/standardizers/standardizer_declarations_array.f90
+++ b/src/standardizers/standardizer_declarations_array.f90
@@ -150,7 +150,8 @@ contains
         allocate (decl_node%dimension_indices(ndims))
 
         do i = 1, ndims
-            if (dimensions(i) > 0) then
+            if (dimensions(i) > 0 .or. &
+                (dimensions(i) == 0 .and. .not. decl_node%is_allocatable)) then
                 write (size_str, '(i0)') dimensions(i)
                 size_literal%uid = generate_uid()
                 size_literal%value = trim(size_str)
@@ -336,7 +337,9 @@ contains
                                                          ndims, dim_sizes)
 
                             do i = 1, ndims
-                                if (dim_sizes(i) > 0) then
+                                if (dim_sizes(i) > 0 .or. &
+                                    (dim_sizes(i) == 0 .and. &
+                                     .not. decl_node%is_allocatable)) then
                                     write (size_str, '(i0)') dim_sizes(i)
                                     size_literal%uid = generate_uid()
                                     size_literal%value = trim(size_str)

--- a/src/standardizers/standardizer_types.f90
+++ b/src/standardizers/standardizer_types.f90
@@ -831,7 +831,7 @@ contains
         integer :: inner_size
 
         if (size(node%element_indices) == 0) then
-            var_type = trim(elem_type_str) // ", dimension(:), allocatable"
+            var_type = trim(elem_type_str) // ", dimension(0)"
             return
         end if
 

--- a/test/integration/issue_tests/test_issue_1973_empty_typed_array_constructor.f90
+++ b/test/integration/issue_tests/test_issue_1973_empty_typed_array_constructor.f90
@@ -20,8 +20,14 @@ program test_issue_1973_empty_typed_array_constructor
         end if
     end if
 
-    if (index(transformed, 'integer, allocatable :: a(:)') == 0) then
-        write (error_unit, '(a)') 'FAIL: allocatable declaration missing'
+    if (index(transformed, 'integer :: a(0)') == 0) then
+        write (error_unit, '(a)') 'FAIL: zero-length declaration missing'
+        write (error_unit, '(a)') transformed
+        stop 1
+    end if
+
+    if (index(transformed, 'allocatable :: a(:)') /= 0) then
+        write (error_unit, '(a)') 'FAIL: allocatable declaration still present'
         write (error_unit, '(a)') transformed
         stop 1
     end if
@@ -39,7 +45,7 @@ program test_issue_1973_empty_typed_array_constructor
     end if
 
     write (error_unit, '(a)') &
-        'PASS: empty typed array constructor preserved with declaration'
+        'PASS: empty typed array constructor uses explicit zero-length array'
 
 contains
 


### PR DESCRIPTION
## Summary
- stop marking typed empty array constructors as allocatable so declarations materialize explicit zero-length shape
- emit literal zero bounds when the declaration is not allocatable and adjust regression coverage

## Verification
- `fpm test`
- `make check-duplication`
