### PR TITLE
fix: correct substring length inference (fixes #2163)

### DIFF
--- a/examples/lf/issue_2163_character_substring_lengths.lf
+++ b/examples/lf/issue_2163_character_substring_lengths.lf
@@ -1,0 +1,4 @@
+text = "Hello World"
+first = text(1:5)
+last = text(7:11)
+middle = text(3:9)

--- a/src/semantic/analyzers/semantic_array_slice.f90
+++ b/src/semantic/analyzers/semantic_array_slice.f90
@@ -1,9 +1,11 @@
 module semantic_array_slice
-    use type_system_unified, only: mono_type_t, create_mono_type, TARRAY
+    use type_system_unified, only: mono_type_t, create_mono_type, TARRAY, TCHAR
     use type_array_safe, only: safe_extract_array_rank
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_bounds, only: array_slice_node, range_expression_node, &
                                 array_bounds_node
+    use ast_nodes_core, only: literal_node
+    use ast_base, only: LITERAL_INTEGER
     use semantic_function_helpers, only: get_type_lookup
     implicit none
     private
@@ -26,8 +28,17 @@ contains
         integer :: i
         integer :: bounds_idx
         logical :: is_range
+        integer :: substring_len
 
         source_type = get_type_fn(arena, slice_node%array_index)
+        if (source_type%kind == TCHAR) then
+            typ = source_type
+            substring_len = infer_character_substring_length(arena, slice_node, &
+                                                             source_type%size)
+            if (substring_len > 0) typ%size = substring_len
+            return
+        end if
+
         if (source_type%kind /= TARRAY) then
             typ = source_type
             return
@@ -82,5 +93,123 @@ contains
             deallocate (args)
         end do
     end function infer_array_slice_type
+
+    integer function infer_character_substring_length(arena, slice_node, &
+                                                      base_length) result(len)
+        type(ast_arena_t), intent(inout) :: arena
+        type(array_slice_node), intent(in) :: slice_node
+        integer, intent(in) :: base_length
+        integer :: bounds_idx
+        integer :: start_expr_idx
+        integer :: end_expr_idx
+        integer :: start_value
+        integer :: end_value
+        logical :: has_start
+        logical :: has_end
+
+        len = -1
+        if (slice_node%num_dimensions <= 0) return
+
+        bounds_idx = slice_node%bounds_indices(1)
+        if (bounds_idx <= 0 .or. bounds_idx > arena%size) return
+        if (.not. allocated(arena%entries(bounds_idx)%node)) return
+
+        select type (bounds => arena%entries(bounds_idx)%node)
+        type is (range_expression_node)
+            start_expr_idx = bounds%start_index
+            end_expr_idx = bounds%end_index
+        type is (array_bounds_node)
+            start_expr_idx = bounds%lower_bound_index
+            end_expr_idx = bounds%upper_bound_index
+        class default
+            return
+        end select
+
+        if (start_expr_idx <= 0) then
+            start_value = 1
+            has_start = .true.
+        else
+            has_start = get_constant_integer_value(arena, start_expr_idx, &
+                                                   start_value)
+        end if
+
+        if (end_expr_idx <= 0) then
+            if (base_length > 0) then
+                end_value = base_length
+                has_end = .true.
+            else
+                has_end = .false.
+            end if
+        else
+            has_end = get_constant_integer_value(arena, end_expr_idx, end_value)
+        end if
+
+        if (.not. (has_start .and. has_end)) then
+            len = -1
+            return
+        end if
+
+        len = end_value - start_value + 1
+        if (len <= 0) len = -1
+    end function infer_character_substring_length
+
+    logical function get_constant_integer_value(arena, expr_index, value) &
+        result(found)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: expr_index
+        integer, intent(out) :: value
+
+        found = .false.
+        value = 0
+
+        if (expr_index <= 0) return
+        if (expr_index > arena%size) return
+        if (.not. allocated(arena%entries(expr_index)%node)) return
+
+        select type (node => arena%entries(expr_index)%node)
+        type is (literal_node)
+            if (node%is_constant .and. node%constant_type == LITERAL_INTEGER) then
+                value = node%constant_integer
+                found = .true.
+                return
+            end if
+
+            if (allocated(node%value)) then
+                found = parse_literal_integer_value(node%value, value)
+            end if
+        class default
+            if (node%is_constant .and. node%constant_type == LITERAL_INTEGER) &
+                then
+                value = node%constant_integer
+                found = .true.
+            end if
+        end select
+    end function get_constant_integer_value
+
+    logical function parse_literal_integer_value(raw_text, number) result(success)
+        character(len=*), intent(in) :: raw_text
+        integer, intent(out) :: number
+        character(len=:), allocatable :: cleaned
+        integer :: underscore_pos
+        integer :: ios
+
+        success = .false.
+        number = 0
+
+        cleaned = trim(adjustl(raw_text))
+        underscore_pos = index(cleaned, '_')
+        if (underscore_pos > 0) then
+            if (underscore_pos == 1) then
+                cleaned = ''
+            else
+                cleaned = cleaned(1:underscore_pos - 1)
+            end if
+        end if
+
+        if (len(cleaned) == 0) return
+
+        read (cleaned, *, iostat=ios) number
+        success = ios == 0
+    end function parse_literal_integer_value
 
 end module semantic_array_slice

--- a/test/integration/issue_tests/test_issue_2163_character_substring_lengths.f90
+++ b/test/integration/issue_tests/test_issue_2163_character_substring_lengths.f90
@@ -1,0 +1,131 @@
+program test_issue_2163_character_substring_lengths
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit
+    use, intrinsic :: iso_fortran_env, only: iostat_end, iostat_eor
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    print *, '=== Issue #2163: Character substring length inference ==='
+
+    if (.not. check_character_substring_lengths()) all_passed = .false.
+
+    print *
+    if (all_passed) then
+        print *, 'Issue #2163 fixed!'
+    else
+        print *, 'Issue #2163 regression detected!'
+        stop 1
+    end if
+
+contains
+
+    include '../../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') '  FAIL: unable to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    logical function check_character_substring_lengths()
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: output
+        character(len=:), allocatable :: error_msg
+        logical :: text_ok
+        logical :: first_ok
+        logical :: last_ok
+        logical :: middle_ok
+
+        check_character_substring_lengths = .true.
+
+        call read_example('examples/lf/issue_2163_character_substring_lengths.lf', &
+                          source)
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                write (error_unit, '(A,A)') '  FAIL: Unexpected error - ', &
+                    trim(error_msg)
+                check_character_substring_lengths = .false.
+                return
+            end if
+        end if
+
+        if (.not. allocated(output)) then
+            write (error_unit, '(A)') '  FAIL: No output generated'
+            check_character_substring_lengths = .false.
+            return
+        end if
+
+        text_ok = contains_typed_variable(output, 'character(len=11)', 'text')
+        first_ok = contains_typed_variable(output, 'character(len=5)', 'first')
+        last_ok = contains_typed_variable(output, 'character(len=5)', 'last')
+        middle_ok = contains_typed_variable(output, 'character(len=7)', 'middle')
+
+        if (.not. text_ok) then
+            write (error_unit, '(A)') '  FAIL: Missing declaration for text'
+            check_character_substring_lengths = .false.
+        end if
+
+        if (.not. first_ok) then
+            write (error_unit, '(A)') '  FAIL: first not inferred as len=5'
+            check_character_substring_lengths = .false.
+        end if
+
+        if (.not. last_ok) then
+            write (error_unit, '(A)') '  FAIL: last not inferred as len=5'
+            check_character_substring_lengths = .false.
+        end if
+
+        if (.not. middle_ok) then
+            write (error_unit, '(A)') '  FAIL: middle not inferred as len=7'
+            check_character_substring_lengths = .false.
+        end if
+
+        if (check_character_substring_lengths) then
+            print *, '  PASS: substring lengths inferred correctly'
+        end if
+    end function check_character_substring_lengths
+
+    logical function contains_typed_variable(text, type_spec, var_name)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: type_spec
+        character(len=*), intent(in) :: var_name
+        integer :: start_pos
+        integer :: segment_len
+        character(len=:), allocatable :: line
+
+        contains_typed_variable = .false.
+        start_pos = 1
+
+        do
+            if (start_pos > len(text)) exit
+            segment_len = index(text(start_pos:), new_line('a'))
+            if (segment_len == 0) then
+                line = text(start_pos:)
+                start_pos = len(text) + 1
+            else
+                line = text(start_pos:start_pos + segment_len - 2)
+                start_pos = start_pos + segment_len
+            end if
+
+            if (len(line) == 0) cycle
+            if (index(line, trim(type_spec)) > 0) then
+                if (index(line, trim(var_name)) > 0) then
+                    contains_typed_variable = .true.
+                    return
+                end if
+            end if
+        end do
+    end function contains_typed_variable
+
+end program test_issue_2163_character_substring_lengths


### PR DESCRIPTION
## Summary
- infer substring length for character slices so declarations no longer inherit the parent length
- add the issue_2163 example to drive the regression scenario
- add an integration test that reads the example and asserts declarations reference the expected lengths even when variables share a line

## Verification
- `fpm test --target test_issue_2163_character_substring_lengths`
  - PASS: substring lengths inferred correctly
- `fpm test`
  - PASS: implied-do array constructor infers real element type
  - PASS: issue_2067 allocatable inference works
  - PASS: empty typed array constructor uses explicit zero-length array
