### PR TITLE
fix: Array from literal declared allocatable (fixes #2166)

### DIFF
--- a/examples/lf/issue_2166_array_literal_allocatable.lf
+++ b/examples/lf/issue_2166_array_literal_allocatable.lf
@@ -1,0 +1,4 @@
+source = [1, 2, 3, 4, 5]
+dest = [0, 0, 0]
+
+dest = source(1:3)

--- a/src/semantic/analyzers/semantic_array_slice.f90
+++ b/src/semantic/analyzers/semantic_array_slice.f90
@@ -23,12 +23,14 @@ contains
         type(mono_type_t) :: base_type
         type(mono_type_t), allocatable :: args(:)
         logical, allocatable :: keep_dim(:)
+        integer, allocatable :: dim_lengths(:)
         integer :: max_dims
         integer :: dims_to_process
         integer :: i
         integer :: bounds_idx
         logical :: is_range
         integer :: substring_len
+        integer :: slice_extent
 
         source_type = get_type_fn(arena, slice_node%array_index)
         if (source_type%kind == TCHAR) then
@@ -52,7 +54,9 @@ contains
         end if
 
         allocate (keep_dim(max_dims))
+        allocate (dim_lengths(max_dims))
         keep_dim = .false.
+        dim_lengths = -1
         dims_to_process = min(max_dims, slice_node%num_dimensions)
         do i = 1, dims_to_process
             bounds_idx = slice_node%bounds_indices(i)
@@ -68,6 +72,10 @@ contains
                 end if
             end if
             keep_dim(i) = is_range
+            if (is_range) then
+                slice_extent = infer_slice_extent(arena, bounds_idx)
+                dim_lengths(i) = slice_extent
+            end if
         end do
 
         if (slice_node%num_dimensions < max_dims) then
@@ -84,15 +92,87 @@ contains
             if (.not. keep_dim(i)) cycle
             allocate (args(1))
             args(1) = typ
-            typ = create_mono_type(TARRAY, args=args)
-            typ%size = 0
-            typ%alloc_info%is_allocatable = .true.
-            typ%alloc_info%needs_allocation_check = .true.
+            if (dim_lengths(i) > 0) then
+                typ = create_mono_type(TARRAY, args=args, &
+                                       array_size=dim_lengths(i))
+                typ%alloc_info%is_allocatable = .false.
+                typ%alloc_info%needs_allocation_check = .false.
+            else
+                typ = create_mono_type(TARRAY, args=args)
+                typ%size = 0
+                typ%alloc_info%is_allocatable = .true.
+                typ%alloc_info%needs_allocation_check = .true.
+            end if
             typ%alloc_info%is_pointer = .false.
             typ%alloc_info%needs_allocatable_string = .false.
             deallocate (args)
         end do
+
+        if (allocated(dim_lengths)) deallocate (dim_lengths)
+        if (allocated(keep_dim)) deallocate (keep_dim)
     end function infer_array_slice_type
+
+    integer function infer_slice_extent(arena, bounds_index) result(extent)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: bounds_index
+        integer :: start_idx
+        integer :: end_idx
+        integer :: stride_idx
+        integer :: start_value
+        integer :: end_value
+        integer :: stride_value
+        integer :: delta
+        integer :: abs_delta
+        integer :: abs_stride
+        logical :: has_start
+        logical :: has_end
+        logical :: has_stride
+
+        extent = -1
+        if (bounds_index <= 0) return
+        if (bounds_index > arena%size) return
+        if (.not. allocated(arena%entries(bounds_index)%node)) return
+
+        select type (bounds => arena%entries(bounds_index)%node)
+        type is (range_expression_node)
+            start_idx = bounds%start_index
+            end_idx = bounds%end_index
+            stride_idx = bounds%stride_index
+        type is (array_bounds_node)
+            start_idx = bounds%lower_bound_index
+            end_idx = bounds%upper_bound_index
+            stride_idx = bounds%stride_index
+        class default
+            return
+        end select
+
+        if (start_idx <= 0) return
+        if (end_idx <= 0) return
+
+        has_start = get_constant_integer_value(arena, start_idx, start_value)
+        has_end = get_constant_integer_value(arena, end_idx, end_value)
+        if (.not. has_start) return
+        if (.not. has_end) return
+
+        if (stride_idx > 0) then
+            has_stride = get_constant_integer_value(arena, stride_idx, &
+                                                    stride_value)
+            if (.not. has_stride) return
+        else
+            stride_value = 1
+        end if
+
+        if (stride_value == 0) return
+
+        delta = end_value - start_value
+        if ((delta >= 0 .and. stride_value < 0) .or. &
+            (delta <= 0 .and. stride_value > 0)) return
+
+        abs_delta = abs(delta)
+        abs_stride = abs(stride_value)
+        extent = abs_delta / abs_stride + 1
+        if (extent <= 0) extent = -1
+    end function infer_slice_extent
 
     integer function infer_character_substring_length(arena, slice_node, &
                                                       base_length) result(len)

--- a/test/codegen/test_array_slicing_codegen.f90
+++ b/test/codegen/test_array_slicing_codegen.f90
@@ -181,13 +181,20 @@ contains
             return
         end if
 
-        if (index(code, 'integer, dimension(:), allocatable :: subset') == 0) then
-            print *, '  FAIL: subset slice not inferred as integer allocatable'
+        if (index(code, 'integer :: subset(3)') == 0 .and. &
+            index(code, 'integer, dimension(3) :: subset') == 0) then
+            print *, '  FAIL: subset slice missing explicit extent'
             test_slice_type_inference = .false.
         end if
 
-        if (index(code, 'real(8), dimension(:), allocatable :: subset') /= 0) then
-            print *, '  FAIL: subset slice still inferred as real(8)'
+        if (index(code, 'allocatable :: subset') /= 0) then
+            print *, '  FAIL: subset slice incorrectly marked allocatable'
+            test_slice_type_inference = .false.
+        end if
+
+        if (index(code, 'real :: subset') /= 0 .or. &
+            index(code, 'real(8) :: subset') /= 0) then
+            print *, '  FAIL: subset slice still inferred as real'
             test_slice_type_inference = .false.
         end if
     end function test_slice_type_inference

--- a/test/semantic/test_array_slice_type_inference.f90
+++ b/test/semantic/test_array_slice_type_inference.f90
@@ -1,7 +1,7 @@
 program test_array_slice_type_inference
     use transformation_api, only: transform_lazy_fortran_string
-    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, &
-        iostat_end, iostat_eor
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit
+    use, intrinsic :: iso_fortran_env, only: iostat_end, iostat_eor
     implicit none
     character(len=:), allocatable :: source, output, error_msg
 
@@ -15,14 +15,22 @@ program test_array_slice_type_inference
         end if
     end if
 
-    if (index(output, 'integer, allocatable :: slice(:)') == 0) then
-        print *, 'FAIL: Expected integer allocatable slice'
+    if (index(output, 'integer :: slice(3)') == 0) then
+        print *, 'FAIL: Expected integer slice with explicit extent'
         print *, 'Output:'
         print *, output
         stop 1
     end if
 
-    if (index(output, 'real, allocatable :: slice(:)') > 0) then
+    if (index(output, 'allocatable :: slice') > 0) then
+        print *, 'FAIL: Slice incorrectly marked allocatable'
+        print *, 'Output:'
+        print *, output
+        stop 1
+    end if
+
+    if (index(output, 'real :: slice') > 0 .or. &
+        index(output, 'real(8) :: slice') > 0) then
         print *, 'FAIL: Found incorrect real type for slice'
         print *, 'Output:'
         print *, output

--- a/test/test_issue_2166_array_literal_allocatable.f90
+++ b/test/test_issue_2166_array_literal_allocatable.f90
@@ -1,0 +1,51 @@
+program test_issue_2166_array_literal_allocatable
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit
+    use, intrinsic :: iso_fortran_env, only: iostat_end, iostat_eor
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    character(:), allocatable :: input_code, output_code, error_msg
+
+    print *, "=== Issue #2166: literal slice destination must be fixed size ==="
+
+    call read_example('examples/lf/issue_2166_array_literal_allocatable.lf', &
+                      input_code)
+
+    call transform_lazy_fortran_string(input_code, output_code, error_msg)
+
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: Transformation failed:", error_msg
+        error stop 1
+    end if
+
+    if (index(output_code, "integer :: dest(3)") == 0) then
+        print *, "FAIL: Missing explicit size declaration for dest"
+        print *, output_code
+        error stop 1
+    end if
+
+    if (index(output_code, "allocatable :: dest") > 0) then
+        print *, "FAIL: dest incorrectly marked allocatable"
+        print *, output_code
+        error stop 1
+    end if
+
+    print *, "PASS: literal slice destination uses explicit extent"
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2166_array_literal_allocatable


### PR DESCRIPTION
## Summary
- infer concrete extents for constant-bound array slices so declarations stay fixed-size instead of silently becoming allocatable
- add the failing lazy-Fortran example plus regression test and update slice-related codegen/semantic checks to expect explicit shapes

## Verification
- `fpm test` (see `/tmp/fpm-test.log`; tail excerpt shows AST traversal + API tests completing successfully)
