### PR TITLE
fix: CRITICAL: Nested function definitions cause complete code chaos (fixes #2168)

### DIFF
--- a/examples/lf/issue_playtest5_nested_function_chaos.lf
+++ b/examples/lf/issue_playtest5_nested_function_chaos.lf
@@ -1,0 +1,9 @@
+! Nested internal procedures should halt processing (issue #2168)
+function outer(x)
+    function inner(y)
+        inner = y * 2
+    end function
+    outer = inner(x) + 5
+end function
+
+result = outer(10)

--- a/examples/skip_all_examples.txt
+++ b/examples/skip_all_examples.txt
@@ -44,6 +44,7 @@ lf/issue_1971_inquiry_intrinsics.lf
 lf/issue_1972_do_if_hang.lf
 lf/issue_1973_empty_typed_array_constructor.lf
 lf/issue_1814_nested_lazy_function.lf
+lf/issue_playtest5_nested_function_chaos.lf
 lf/issue_2012_subroutine_local_not_inferred.lf
 lf/issue_2016_nested_call_type_mismatch.lf
 lf/issue_2019_statements_after_if_dropped.lf

--- a/src/frontend_parsing.f90
+++ b/src/frontend_parsing.f90
@@ -39,6 +39,10 @@ module frontend_parsing
     use frontend_mixed_constructs, only: parse_mixed_constructs, &
                                          create_mixed_construct_container_arena, &
                                          parse_declaration_range, parse_program_range
+    use parser_procedure_definition_bodies_module, only: &
+        reset_nested_internal_procedure_error, &
+        has_nested_internal_procedure_error, &
+        get_nested_internal_procedure_message
 
     implicit none
     private
@@ -89,9 +93,11 @@ contains
         logical :: debug_units
         character(len=:), allocatable :: start_text, end_text
         type(token_t), allocatable :: tokens_local(:)
+        character(len=:), allocatable :: nested_error
 
         error_msg = ""
         prog_index = 0
+        call reset_nested_internal_procedure_error()
 
         call ensure_if_do_registration()
 
@@ -152,6 +158,17 @@ contains
                 i = i + 1
             end if
         end do
+
+        if (has_nested_internal_procedure_error()) then
+            nested_error = get_nested_internal_procedure_message()
+            if (allocated(nested_error)) then
+                error_msg = trim(nested_error)
+            else
+                error_msg = 'Nested internal procedures are not supported.'
+            end if
+            prog_index = 0
+            return
+        end if
 
         ! Handle final program structure
         if (unit_count == 0) then

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -1,4 +1,5 @@
 module parser_procedure_definition_bodies_module
+    use, intrinsic :: iso_fortran_env, only: error_unit
     use string_utils_mod, only: to_lower
     use lexer_core, only: token_t, TK_KEYWORD, TK_IDENTIFIER, TK_NEWLINE, &
                           TK_WHITESPACE, TK_OPERATOR, TK_COMMENT, TK_EOF
@@ -15,6 +16,9 @@ module parser_procedure_definition_bodies_module
     private
 
     public :: parse_procedure_body
+    public :: reset_nested_internal_procedure_error
+    public :: has_nested_internal_procedure_error
+    public :: get_nested_internal_procedure_message
 
     abstract interface
         function parse_function_definition_iface(parser, arena, prefix_buffer, &
@@ -36,6 +40,9 @@ module parser_procedure_definition_bodies_module
             integer :: sub_index
         end function parse_subroutine_definition_iface
     end interface
+
+    logical :: nested_internal_procedure_error = .false.
+    character(len=:), allocatable :: nested_internal_procedure_message
 
 contains
 
@@ -77,24 +84,8 @@ contains
             ! Lazy fortran: detect nested internal procedures (not supported)
             if (token%kind == TK_KEYWORD .and. &
                 (token%text == "function" .or. token%text == "subroutine")) then
-                ! Nested internal procedures are not supported in standard Fortran
-                block
-                    use iso_fortran_env, only: error_unit
-                    write (error_unit, '(A)') &
-                        'Error: Nested internal procedures are not supported.'
-                    write (error_unit, '(A,A,A,I0,A,I0)') &
-                        '  Found "', trim(token%text), '" at line ', token%line, &
-                        ', column ', token%column
-                    write (error_unit, '(A)') &
-                        '  Internal procedures cannot contain other internal' // &
-                        ' procedures.'
-                    write (error_unit, '(A)') &
-                        '  Move the inner procedure to the same contains section as'
-                    write (error_unit, '(A)') &
-                        '  the outer procedure.'
-                end block
-                ! Skip this token and continue - will produce partial output
-                token = parser%consume()
+                call record_nested_internal_procedure_error(token, procedure_name)
+                call skip_nested_internal_procedure(parser)
                 cycle
             end if
 
@@ -106,6 +97,126 @@ contains
             end if
         end do
     end subroutine parse_procedure_body
+
+    subroutine reset_nested_internal_procedure_error()
+        nested_internal_procedure_error = .false.
+        if (allocated(nested_internal_procedure_message)) then
+            deallocate (nested_internal_procedure_message)
+        end if
+    end subroutine reset_nested_internal_procedure_error
+
+    logical function has_nested_internal_procedure_error()
+        has_nested_internal_procedure_error = nested_internal_procedure_error
+    end function has_nested_internal_procedure_error
+
+    function get_nested_internal_procedure_message() result(message)
+        character(len=:), allocatable :: message
+
+        if (allocated(nested_internal_procedure_message)) then
+            message = nested_internal_procedure_message
+        else
+            allocate (character(len=0) :: message)
+        end if
+    end function get_nested_internal_procedure_message
+
+    subroutine record_nested_internal_procedure_error(token, procedure_name)
+        type(token_t), intent(in) :: token
+        character(len=*), intent(in) :: procedure_name
+        character(len=32) :: line_str
+        character(len=32) :: column_str
+        character(len=:), allocatable :: message
+        character(len=:), allocatable :: lowered_keyword
+
+        write (line_str, '(I0)') token%line
+        write (column_str, '(I0)') token%column
+        lowered_keyword = to_lower(trim(token%text))
+
+        call write_nested_procedure_error(lowered_keyword, procedure_name, &
+                                          trim(line_str), trim(column_str))
+
+        message = 'Nested internal procedures are not supported.' // &
+                  new_line('a') // 'Found "' // trim(lowered_keyword) // &
+                  '" inside procedure "' // trim(procedure_name) // '" at line ' // &
+                  trim(line_str) // ', column ' // trim(column_str) // '.' // &
+                  new_line('a') // 'Internal procedures cannot contain other ' // &
+                  'internal procedures.' // new_line('a') // 'Move the inner ' // &
+                  'procedure to the same contains section as the outer ' // &
+                  'procedure.'
+
+        if (.not. nested_internal_procedure_error) then
+            nested_internal_procedure_message = message
+            nested_internal_procedure_error = .true.
+        end if
+    end subroutine record_nested_internal_procedure_error
+
+    subroutine write_nested_procedure_error(keyword, procedure_name, line_str, &
+                                            column_str)
+        character(len=*), intent(in) :: keyword
+        character(len=*), intent(in) :: procedure_name
+        character(len=*), intent(in) :: line_str
+        character(len=*), intent(in) :: column_str
+
+        write (error_unit, '(A)') &
+            'Error: Nested internal procedures are not supported.'
+        write (error_unit, '(A)') '  Found "' // trim(keyword) // '" inside "' // &
+            trim(procedure_name) // '" at line ' // trim(line_str) // ', column ' // &
+            trim(column_str) // '.'
+        write (error_unit, '(A)') &
+            '  Internal procedures cannot contain other internal procedures.'
+        write (error_unit, '(A)') &
+            '  Move the inner procedure to the same contains section as the ' // &
+            'outer procedure.'
+    end subroutine write_nested_procedure_error
+
+    subroutine skip_nested_internal_procedure(parser)
+        type(parser_state_t), intent(inout) :: parser
+        integer :: depth
+        type(token_t) :: token
+
+        token = parser%consume()
+        if (token%kind /= TK_KEYWORD) return
+
+        depth = 1
+        do while (depth > 0 .and. .not. parser%is_at_end())
+            token = parser%consume()
+            if (token%kind /= TK_KEYWORD) cycle
+
+            select case (token%text)
+            case ("function", "subroutine")
+                depth = depth + 1
+            case ("end")
+                call consume_end_procedure(parser, depth)
+            end select
+        end do
+    end subroutine skip_nested_internal_procedure
+
+    subroutine consume_end_procedure(parser, depth)
+        type(parser_state_t), intent(inout) :: parser
+        integer, intent(inout) :: depth
+        type(token_t) :: next_token
+
+        if (parser%is_at_end()) return
+
+        next_token = parser%peek()
+        if (next_token%kind == TK_KEYWORD .and. &
+            (next_token%text == "function" .or. next_token%text == "subroutine")) then
+            next_token = parser%consume()
+            depth = depth - 1
+            call consume_optional_identifier_token(parser)
+        end if
+    end subroutine consume_end_procedure
+
+    subroutine consume_optional_identifier_token(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        if (parser%is_at_end()) return
+
+        token = parser%peek()
+        if (token%kind == TK_IDENTIFIER) then
+            token = parser%consume()
+        end if
+    end subroutine consume_optional_identifier_token
 
     logical function check_procedure_end(parser, first_token, end_keyword, &
                                          procedure_name) result(is_end)

--- a/test/error_reporting/test_issue_1814_nested_lazy_function.f90
+++ b/test/error_reporting/test_issue_1814_nested_lazy_function.f90
@@ -1,14 +1,17 @@
 program test_issue_1814_nested_lazy_function
     use, intrinsic :: iso_fortran_env, only: error_unit, input_unit
     use, intrinsic :: iso_fortran_env, only: iostat_end, iostat_eor
-    use frontend_core, only: lex_source, emit_fortran
+    use frontend_core, only: lex_source
     use frontend_parsing, only: parse_tokens
     use lexer_core, only: token_t
     use ast_arena_modern, only: ast_arena_t, create_ast_arena
     implicit none
 
-    call test_nested_function_error_message()
-    print *, 'PASS: nested lazy function emits diagnostic and output'
+    call test_nested_function_error_message( &
+        'examples/lf/issue_1814_nested_lazy_function.lf')
+    call test_nested_function_error_message( &
+        'examples/lf/issue_playtest5_nested_function_chaos.lf')
+    print *, 'PASS: nested lazy functions emit diagnostics and halt parsing'
 
 contains
 
@@ -26,31 +29,37 @@ contains
         end if
     end subroutine read_example
 
-    subroutine test_nested_function_error_message()
+    subroutine test_nested_function_error_message(example_path)
+        character(len=*), intent(in) :: example_path
         character(len=:), allocatable :: input_code
-        character(len=:), allocatable :: output_code
-        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: lex_error
+        character(len=500) :: parse_error
         type(token_t), allocatable :: tokens(:)
         type(ast_arena_t) :: arena
         integer :: prog_index
 
-        call read_example('examples/lf/issue_1814_nested_lazy_function.lf', &
-                          input_code)
+        call read_example(example_path, input_code)
 
         arena = create_ast_arena()
-        call lex_source(input_code, tokens, error_msg)
-        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
-            write (error_unit, '(A)') 'Lexing error: ' // trim(error_msg)
+        call lex_source(input_code, tokens, lex_error)
+        if (allocated(lex_error) .and. len_trim(lex_error) > 0) then
+            write (error_unit, '(A)') 'Lexing error: ' // trim(lex_error)
             error stop 1
         end if
 
-        call parse_tokens(tokens, arena, prog_index, error_msg)
-
-        call emit_fortran(arena, prog_index, output_code)
-
-        if (index(output_code, 'outer') == 0) then
-            write (error_unit, '(A)') 'FAIL: outer function missing from output'
-            write (error_unit, '(A)') trim(output_code)
+        parse_error = ''
+        call parse_tokens(tokens, arena, prog_index, parse_error)
+        if (len_trim(parse_error) == 0) then
+            write (error_unit, '(A)') 'FAIL: nested functions did not raise error'
+            error stop 1
+        end if
+        if (prog_index /= 0) then
+            write (error_unit, '(A)') 'FAIL: parser returned AST despite error'
+            error stop 1
+        end if
+        if (index(parse_error, 'Nested internal procedures are not supported.') == 0) then
+            write (error_unit, '(A)') 'FAIL: diagnostic missing nested procedure text'
+            write (error_unit, '(A)') trim(parse_error)
             error stop 1
         end if
     end subroutine test_nested_function_error_message


### PR DESCRIPTION
## Summary
- record nested internal procedures as fatal parser errors, skip their bodies, and surface the diagnostic through `parse_tokens`
- extend the nested-function regression test plus add the playtest example so we verify parsing now halts before codegen
- keep the invalid example out of the all-examples sweep via `skip_all_examples.txt`

## Verification
- `fpm test | tail -n 20`
