### PR TITLE
Fix issue #2227 without mentioning build tools

### DIFF
--- a/examples/f90/issue_2227_achar_kind_crash.f90
+++ b/examples/f90/issue_2227_achar_kind_crash.f90
@@ -1,0 +1,4 @@
+program achar_kind4_crash
+  implicit none
+  print *, achar(65, kind=4)
+end program achar_kind4_crash

--- a/src/codegen/codegen_program_body.f90
+++ b/src/codegen/codegen_program_body.f90
@@ -302,10 +302,11 @@ contains
         do i = 1, n
             if (text(i:i) /= '(') cycle
             j = i + 1
-            do while (j <= n .and. is_whitespace_char(text(j:j)))
+            do while (j <= n)
+                if (.not. is_whitespace_char(text(j:j))) exit
                 j = j + 1
             end do
-            if (j + 1 > n) exit
+            if (j > n .or. j + 1 > n) exit
             if (text(j:j + 1) /= 'dp') cycle
             if (j + 2 <= n) then
                 if (is_identifier_char(text(j + 2:j + 2))) cycle
@@ -328,18 +329,24 @@ contains
             if (pos == 0) exit
             pos = start + pos - 1
             idx = pos + 4
-            do while (idx <= n .and. is_whitespace_char(text(idx:idx)))
+            do while (idx <= n)
+                if (.not. is_whitespace_char(text(idx:idx))) exit
                 idx = idx + 1
             end do
-            if (idx > n .or. text(idx:idx) /= '=') then
+            if (idx > n) then
+                start = pos + 4
+                cycle
+            end if
+            if (text(idx:idx) /= '=') then
                 start = pos + 4
                 cycle
             end if
             idx = idx + 1
-            do while (idx <= n .and. is_whitespace_char(text(idx:idx)))
+            do while (idx <= n)
+                if (.not. is_whitespace_char(text(idx:idx))) exit
                 idx = idx + 1
             end do
-            if (idx + 1 > n) then
+            if (idx > n .or. idx + 1 > n) then
                 start = pos + 4
                 cycle
             end if

--- a/test/test_issue_2227_achar_kind_bounds.f90
+++ b/test/test_issue_2227_achar_kind_bounds.f90
@@ -1,0 +1,80 @@
+program test_issue_2227_achar_kind_bounds
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+    character(len=:), allocatable :: input, output, error_msg
+    logical :: test_passed
+    character(len=*), parameter :: example_path = &
+        'examples/f90/issue_2227_achar_kind_crash.f90'
+
+    test_passed = .true.
+
+    ! Test that achar with explicit kind parameter doesn't cause bounds error
+    call test_achar_kind_no_crash()
+
+    if (test_passed) then
+        print *, "test_issue_2227_achar_kind_bounds PASSED"
+    else
+        print *, "test_issue_2227_achar_kind_bounds FAILED"
+        error stop 1
+    end if
+
+contains
+
+    subroutine test_achar_kind_no_crash()
+        call read_example(example_path, input)
+
+        call transform_lazy_fortran_string(input, output, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, "ERROR: Transformation failed:", trim(error_msg)
+            test_passed = .false.
+            return
+        end if
+
+        ! Verify the output contains the achar call with kind parameter
+        if (index(output, 'achar') == 0) then
+            print *, "ERROR: Lost achar intrinsic call"
+            test_passed = .false.
+            return
+        end if
+
+        ! Verify the kind parameter is preserved
+        if (index(output, 'kind') == 0) then
+            print *, "ERROR: Lost kind parameter"
+            test_passed = .false.
+            return
+        end if
+
+        print *, "  - achar with kind parameter processed without crash"
+    end subroutine test_achar_kind_no_crash
+
+    subroutine read_example(filepath, content)
+        character(len=*), intent(in) :: filepath
+        character(len=:), allocatable, intent(out) :: content
+        integer :: unit, stat, file_size
+        character(len=1), allocatable :: buffer(:)
+
+        open (newunit=unit, file=filepath, status='old', access='stream', &
+              form='unformatted', iostat=stat)
+        if (stat /= 0) then
+            print *, "ERROR: Cannot open file:", trim(filepath)
+            error stop 1
+        end if
+
+        inquire (unit=unit, size=file_size)
+        allocate (character(len=file_size) :: content)
+        allocate (buffer(file_size))
+
+        read (unit, iostat=stat) buffer
+        close (unit)
+
+        if (stat /= 0) then
+            print *, "ERROR: Cannot read file:", trim(filepath)
+            error stop 1
+        end if
+
+        content = transfer(buffer, content)
+        deallocate (buffer)
+    end subroutine read_example
+
+end program test_issue_2227_achar_kind_bounds


### PR DESCRIPTION
Fixes #2227

The code generator was crashing with "Substring out of bounds" when processing intrinsic calls with explicit kind parameters (e.g., achar(65, kind=4), char(65, kind=4)).

Root cause: Fortran does not guarantee short-circuit evaluation of logical operators (.and., .or.). The code was using compound conditions like `idx <= n .and. is_whitespace_char(text(idx:idx))`, assuming that if `idx > n`, the second part wouldn't be evaluated. However, compilers may evaluate both operands, causing out-of-bounds substring access.

Changes:
- Rewrote while loops in contains_kind_assignment() to check bounds before accessing substrings
- Rewrote while loops in contains_kind_parentheses() similarly
- Split compound conditions into sequential checks
- Added explicit bounds checks before all substring operations

Test coverage:
- Added examples/f90/issue_2227_achar_kind_crash.f90 reproducer
- Added test/test_issue_2227_achar_kind_bounds.f90 regression test