### PR TITLE
Fix GitHub issue #2247 with Fortran

### DIFF
--- a/examples/f90/issue_2251_data_implied_do.f90
+++ b/examples/f90/issue_2251_data_implied_do.f90
@@ -1,0 +1,7 @@
+program issue_2251_data_implied_do
+    implicit none
+    integer :: i
+    real :: coeff(2)
+    data (coeff(i), i = 1, 2) /1.0, 2.0/
+    print *, coeff
+end program issue_2251_data_implied_do

--- a/src/parser/statements/parser_statement_data_module.f90
+++ b/src/parser/statements/parser_statement_data_module.f90
@@ -2,12 +2,13 @@ module parser_statement_data_module
     use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_OPERATOR, TK_NEWLINE, &
                           TK_COMMENT, TK_WHITESPACE
     use parser_state_module, only: parser_state_t
-    use parser_expressions_module, only: parse_expression_until
+    use parser_expressions_module, only: parse_expression_until, parse_comparison
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: array_literal_node, binary_op_node, literal_node, &
                               identifier_node
     use ast_factory, only: push_assignment, push_identifier, push_array_literal, &
-                           push_namelist_statement, push_data_statement
+                           push_namelist_statement, push_data_statement, &
+                           push_io_implied_do
     use type_system_unified, only: create_mono_type, TARRAY
     use parser_namelist_shared_module, only: consume_namelist_group
     use ast_base, only: LITERAL_INTEGER
@@ -121,6 +122,114 @@ contains
             end if
         end subroutine store_pending_assignments
 
+        ! Parse DATA implied-do: (object-list, var = start, end [, step])
+        function try_parse_data_implied_do() result(expr_index)
+            integer :: expr_index
+            type(token_t) :: token
+            integer :: saved_pos
+            integer :: value_expr_index
+            integer :: start_index, end_index, step_index
+            character(len=:), allocatable :: var_name
+            integer :: line, column
+
+            expr_index = 0
+            saved_pos = parser%current_token
+
+            token = parser%peek()
+            if (token%kind /= TK_OPERATOR .or. token%text /= "(") return
+            line = token%line
+            column = token%column
+            token = parser%consume()  ! consume '('
+
+            ! Parse the object expression (could be a variable reference)
+            value_expr_index = parse_comparison(parser, arena)
+            if (value_expr_index <= 0) then
+                parser%current_token = saved_pos
+                return
+            end if
+
+            ! Check for comma (required for implied-do)
+            token = parser%peek()
+            if (token%kind /= TK_OPERATOR .or. token%text /= ",") then
+                parser%current_token = saved_pos
+                return
+            end if
+            token = parser%consume()
+
+            ! Check for loop variable (must be identifier)
+            token = parser%peek()
+            if (token%kind /= TK_IDENTIFIER) then
+                parser%current_token = saved_pos
+                return
+            end if
+            var_name = token%text
+            token = parser%consume()
+
+            ! Check for '=' (required)
+            token = parser%peek()
+            if (token%kind /= TK_OPERATOR .or. token%text /= "=") then
+                parser%current_token = saved_pos
+                return
+            end if
+            token = parser%consume()
+
+            ! Parse start expression
+            start_index = parse_comparison(parser, arena)
+            if (start_index <= 0) then
+                parser%current_token = saved_pos
+                return
+            end if
+
+            ! Check for comma (required)
+            token = parser%peek()
+            if (token%kind /= TK_OPERATOR .or. token%text /= ",") then
+                parser%current_token = saved_pos
+                return
+            end if
+            token = parser%consume()
+
+            ! Parse end expression
+            end_index = parse_comparison(parser, arena)
+            if (end_index <= 0) then
+                parser%current_token = saved_pos
+                return
+            end if
+
+            ! Check for optional step expression
+            step_index = 0
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                token = parser%consume()
+                step_index = parse_comparison(parser, arena)
+                if (step_index <= 0) then
+                    parser%current_token = saved_pos
+                    return
+                end if
+            end if
+
+            ! Check for closing parenthesis (required)
+            token = parser%peek()
+            if (token%kind /= TK_OPERATOR .or. token%text /= ")") then
+                parser%current_token = saved_pos
+                return
+            end if
+            token = parser%consume()
+
+            ! Create the implied-do node
+            if (step_index > 0) then
+                expr_index = push_io_implied_do(arena, value_expr_index, var_name, &
+                                                start_expr_index=start_index, &
+                                                end_expr_index=end_index, &
+                                                step_expr_index=step_index, line=line, &
+                                                column=column)
+            else
+                expr_index = push_io_implied_do(arena, value_expr_index, var_name, &
+                                                start_expr_index=start_index, &
+                                                end_expr_index=end_index, line=line, &
+                                                column=column)
+            end if
+        end function try_parse_data_implied_do
+
         subroutine parse_object_list(objects, success)
             integer, allocatable, intent(out) :: objects(:)
             logical, intent(out) :: success
@@ -148,6 +257,36 @@ contains
                     exit
                 end if
 
+                ! Try parsing as implied-do first if we see '('
+                current = parser%peek()
+                if (current%kind == TK_OPERATOR .and. trim(current%text) == "(") then
+                    object_index = try_parse_data_implied_do()
+                    if (object_index > 0) then
+                        call append_index(objects, object_index)
+                        expect_object = .false.
+                        call skip_trivia(parser)
+                        current = parser%peek()
+                        if (current%kind == TK_OPERATOR) then
+                            select case (trim(current%text))
+                            case (",")
+                                current = parser%consume()
+                                call skip_trivia(parser)
+                                expect_object = .true.
+                                cycle
+                            case ("/")
+                                exit
+                            case default
+                                call parser%error("Unexpected token in DATA object list")
+                                return
+                            end select
+                        else
+                            call parser%error("Unexpected token in DATA object list")
+                            return
+                        end if
+                    end if
+                end if
+
+                ! Fall back to regular expression parsing
                 object_index = parse_expression_until(parser, arena, [",", "/"])
                 if (object_index <= 0) return
                 call append_index(objects, object_index)


### PR DESCRIPTION
DATA statements with implied-do object lists like:
  data (coeff(i), i = 1, 2) / 1.0, 2.0 /

were failing with "Unexpected token in DATA object list" error.

This is valid Fortran 2018 syntax where the object list can contain an implied-do construct: (object-list, var = start, end [, step])

Changes:
- Added parse_data_implied_do() function to parse implied-do constructs in DATA object lists, similar to how IO statements handle them
- Modified parse_object_list() to try parsing as implied-do first when encountering '(', then fall back to regular expression parsing
- Added test case examples/f90/issue_2251_data_implied_do.f90

The fix uses the existing io_implied_do_node AST type since the structure is identical (expression + loop control variables).

This resolves the 10 failures in the GCC corpus harness with "Unexpected token in DATA object list" digest signature.