### PR TITLE
fix: Identifier 'format' still treated as FORMAT statement (fixes #2294)

### DIFF
--- a/examples/f90/issue_2255_inline_if_comment.f90
+++ b/examples/f90/issue_2255_inline_if_comment.f90
@@ -1,0 +1,16 @@
+program issue_2255_inline_if_comment
+    implicit none
+    logical :: flag
+
+    flag = .true.
+    if (flag) &
+    ! comment in continuation line
+        call say_hi()
+
+contains
+
+    subroutine say_hi()
+        print *, 'Hello!'
+    end subroutine say_hi
+
+end program issue_2255_inline_if_comment

--- a/examples/f90/issue_2294_identifier_format.f90
+++ b/examples/f90/issue_2294_identifier_format.f90
@@ -1,0 +1,6 @@
+program issue_2294_identifier_format
+    implicit none
+    integer :: format
+    format = 1
+    print *, format
+end program issue_2294_identifier_format

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -51,6 +51,7 @@ module parser_execution_statements_module
     use parser_type_specifications_module, only: parse_implicit_statement, &
                                                  take_implicit_additional_indices
     use parser_dimension_statements_module, only: parse_dimension_statement
+    use parser_keyword_disambiguation_module, only: looks_like_format_statement
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_program, &
                            push_declaration, push_implicit_statement, push_goto
@@ -464,7 +465,12 @@ contains
                 case ("endfile")
                     stmt_index = parse_endfile_statement(parser_ref, arena_ref)
                 case ("format")
-                    stmt_index = parse_format_statement(parser_ref, arena_ref)
+                    if (looks_like_format_statement(parser_ref)) then
+                        stmt_index = parse_format_statement(parser_ref, arena_ref)
+                    else
+                        stmt_index = handle_identifier_token(parser_ref, arena_ref, &
+                                                            parser_ref%peek())
+                    end if
                 case ("allocate")
                     stmt_index = parse_allocate_statement(parser_ref, arena_ref)
                 case ("deallocate")

--- a/src/parser/statements/parser_keyword_disambiguation.f90
+++ b/src/parser/statements/parser_keyword_disambiguation.f90
@@ -1,0 +1,139 @@
+module parser_keyword_disambiguation_module
+    use lexer_core, only: token_t, TK_OPERATOR, TK_COMMENT, TK_WHITESPACE, &
+                          TK_NEWLINE, TK_EOF, to_lower
+    use parser_state_module, only: parser_state_t
+    implicit none
+    private
+
+    public :: keyword_should_parse_as_identifier
+    public :: looks_like_format_statement
+
+contains
+
+    logical function keyword_should_parse_as_identifier(first_token, parser) &
+        result(as_identifier)
+        type(token_t), intent(in) :: first_token
+        type(parser_state_t), intent(in) :: parser
+        character(len=:), allocatable :: lowered
+
+        as_identifier = .false.
+        if (.not. allocated(first_token%text)) return
+
+        lowered = to_lower(trim(first_token%text))
+        select case (lowered)
+        case ("format")
+            as_identifier = .not. looks_like_format_statement(parser)
+        end select
+    end function keyword_should_parse_as_identifier
+
+    logical function looks_like_format_statement(parser) result(is_format)
+        type(parser_state_t), intent(in) :: parser
+        integer :: idx, depth, token_count
+        type(token_t) :: tok
+        logical :: continuation_allowed
+        logical :: trailing_continuation
+
+        is_format = .false.
+        if (.not. associated(parser%tokens)) return
+
+        token_count = size(parser%tokens)
+        if (token_count == 0) return
+
+        idx = parser%current_token + 1
+        continuation_allowed = .false.
+
+        ! Look for the required opening parenthesis after FORMAT
+        do while (idx <= token_count)
+            tok = parser%tokens(idx)
+            select case (tok%kind)
+            case (TK_WHITESPACE, TK_COMMENT)
+                idx = idx + 1
+                cycle
+            case (TK_NEWLINE)
+                if (.not. continuation_allowed) return
+                continuation_allowed = .false.
+                idx = idx + 1
+                cycle
+            case (TK_OPERATOR)
+                select case (tok%text)
+                case ("&")
+                    continuation_allowed = .true.
+                    idx = idx + 1
+                    cycle
+                case ("(")
+                    exit
+                case default
+                    return
+                end select
+            case default
+                return
+            end select
+        end do
+
+        if (idx > token_count) return
+
+        depth = 1
+        idx = idx + 1
+        continuation_allowed = .false.
+
+        ! Walk the parenthesized format specifier
+        do while (idx <= token_count .and. depth > 0)
+            tok = parser%tokens(idx)
+            select case (tok%kind)
+            case (TK_OPERATOR)
+                select case (tok%text)
+                case ("(")
+                    depth = depth + 1
+                case (")")
+                    depth = depth - 1
+                case ("&")
+                    continuation_allowed = .true.
+                end select
+            case (TK_NEWLINE)
+                if (.not. continuation_allowed) return
+                continuation_allowed = .false.
+            end select
+            idx = idx + 1
+        end do
+
+        if (depth /= 0) return
+
+        trailing_continuation = .false.
+        do while (idx <= token_count)
+            tok = parser%tokens(idx)
+            select case (tok%kind)
+            case (TK_WHITESPACE, TK_COMMENT)
+                idx = idx + 1
+                cycle
+            case (TK_NEWLINE)
+                if (trailing_continuation) then
+                    trailing_continuation = .false.
+                    idx = idx + 1
+                    cycle
+                end if
+                is_format = .true.
+                return
+            case (TK_EOF)
+                is_format = .true.
+                return
+            case (TK_OPERATOR)
+                select case (tok%text)
+                case (";")
+                    is_format = .true.
+                    return
+                case ("&")
+                    trailing_continuation = .true.
+                    idx = idx + 1
+                    cycle
+                case default
+                    return
+                end select
+            case default
+                return
+            end select
+        end do
+
+        is_format = .true.
+    end function looks_like_format_statement
+
+end module parser_keyword_disambiguation_module

--- a/src/parser/statements/parser_statement_core.f90
+++ b/src/parser/statements/parser_statement_core.f90
@@ -27,6 +27,7 @@ module parser_statement_core_module
     use parser_dimension_statements_module, only: parse_dimension_statement
     use parser_statement_detection_module, only: is_block_if, find_statement_end, &
                                                  extend_if_statement_end
+    use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier
     implicit none
     private
 
@@ -86,8 +87,14 @@ contains
         end block
         select case (first_token%kind)
         case (TK_KEYWORD)
-            stmt_index = parse_keyword_statement(first_token, parser, arena, &
-                                                 parent_index, local_callbacks)
+            if (keyword_should_parse_as_identifier(first_token, parser)) then
+                stmt_index = parse_identifier_statement(parser, arena, &
+                                                        parent_index, tokens, &
+                                                        local_callbacks)
+            else
+                stmt_index = parse_keyword_statement(first_token, parser, arena, &
+                                                     parent_index, local_callbacks)
+            end if
         case (TK_IDENTIFIER)
             stmt_index = parse_identifier_statement(parser, arena, parent_index, &
                                                     tokens, local_callbacks)

--- a/test/test_issue_2255_inline_if_comment.f90
+++ b/test/test_issue_2255_inline_if_comment.f90
@@ -1,4 +1,6 @@
 program test_issue_2255_inline_if_comment
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
     use transformation_api, only: transform_lazy_fortran_string
     implicit none
 
@@ -7,49 +9,56 @@ program test_issue_2255_inline_if_comment
     character(len=:), allocatable :: error_msg
     integer :: if_pos, end_if_pos, call_inside_pos, call_after_end
 
-    source = "program demo" // new_line('a') // &
-             "    implicit none" // new_line('a') // &
-             "    logical :: flag" // new_line('a') // new_line('a') // &
-             "    flag = .true." // new_line('a') // new_line('a') // &
-             "    if (flag) &" // new_line('a') // &
-             "    ! comment in continuation line" // new_line('a') // &
-             "        call say_hi()" // new_line('a') // new_line('a') // &
-             "contains" // new_line('a') // new_line('a') // &
-             "    subroutine say_hi()" // new_line('a') // &
-             "        print *, ""Hello!""" // new_line('a') // &
-             "    end subroutine say_hi" // new_line('a') // new_line('a') // &
-             "end program demo"
+    call read_example('examples/f90/issue_2255_inline_if_comment.f90', source)
 
     call transform_lazy_fortran_string(source, output, error_msg)
     if (len_trim(error_msg) > 0) then
-        print *, "FAIL: transformation error:", trim(error_msg)
-        stop 1
+        write (error_unit, '(A)') 'FAIL: transformation error: ' // &
+            trim(error_msg)
+        error stop 1
     end if
 
-    if_pos = index(output, "if (flag) then")
+    if_pos = index(output, 'if (flag) then')
     if (if_pos == 0) then
-        print *, "FAIL: missing IF block in output"
-        stop 1
+        write (error_unit, '(A)') 'FAIL: missing IF block in output'
+        error stop 1
     end if
 
-    end_if_pos = index(output(if_pos:), "end if")
+    end_if_pos = index(output(if_pos:), 'end if')
     if (end_if_pos == 0) then
-        print *, "FAIL: missing END IF in output"
-        stop 1
+        write (error_unit, '(A)') 'FAIL: missing END IF in output'
+        error stop 1
     end if
     end_if_pos = if_pos + end_if_pos - 2
 
-    call_inside_pos = index(output(if_pos:end_if_pos), "call say_hi()")
+    call_inside_pos = index(output(if_pos:end_if_pos), 'call say_hi()')
     if (call_inside_pos == 0) then
-        print *, "FAIL: call say_hi() not inside IF block"
-        stop 1
+        write (error_unit, '(A)') 'FAIL: call say_hi() not inside IF block'
+        error stop 1
     end if
 
-    call_after_end = index(output(end_if_pos:), "call say_hi()")
+    call_after_end = index(output(end_if_pos:), 'call say_hi()')
     if (call_after_end > 0) then
-        print *, "FAIL: call say_hi() duplicated outside IF block"
-        stop 1
+        write (error_unit, '(A)') 'FAIL: call say_hi() duplicated outside IF'
+        error stop 1
     end if
 
-    print *, "PASS: inline IF with comment preserves body placement"
+    print *, 'PASS: inline IF with comment preserves body placement'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
 end program test_issue_2255_inline_if_comment

--- a/test/test_issue_2294_identifier_format.f90
+++ b/test/test_issue_2294_identifier_format.f90
@@ -1,0 +1,65 @@
+program test_issue_2294_identifier_format
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_declaration, has_assignment, has_print
+
+    call read_example('examples/f90/issue_2294_identifier_format.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2294_identifier_format'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_declaration = index(output_code, 'integer :: format') > 0
+    has_assignment = index(output_code, 'format = 1') > 0
+    has_print = index(output_code, 'print *, format') > 0
+
+    if (.not. has_declaration) then
+        write (error_unit, '(A)') 'FAIL: missing integer :: format declaration'
+        error stop 1
+    end if
+
+    if (.not. has_assignment) then
+        write (error_unit, '(A)') 'FAIL: missing format = 1 assignment'
+        error stop 1
+    end if
+
+    if (.not. has_print) then
+        write (error_unit, '(A)') 'FAIL: missing print *, format statement'
+        error stop 1
+    end if
+
+    print *, 'PASS: identifier named format survives round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2294_identifier_format


### PR DESCRIPTION
## Summary
- add a keyword disambiguation helper so `format` is only parsed as a FORMAT statement when its syntax really matches, and reuse it in both the statement core and the execution dispatcher to keep user identifiers untouched
- cover the regression with a new standard-mode round-trip test plus an example, and migrate the existing issue #2255 test to read from examples/ to satisfy the zero-duplication policy
- noted incidental cleanup while staying within the Fortran 2018 conventions (88-col, intents, allocatables)

## Verification
- `fpm test` (PASS)
- `make check-duplication` (PASS)
