### PR TITLE
fix: Inline IF comment continuations (fixes #2255)

### DIFF
--- a/src/parser/control_flow/parser_if_constructs.f90
+++ b/src/parser/control_flow/parser_if_constructs.f90
@@ -519,7 +519,8 @@ contains
 
                             ! If there's code immediately after newline, it's likely a continued inline IF
                             ! Otherwise, it looks like a block IF
-                            if (.not. found_code_after_newline) then
+                            if (.not. found_code_after_newline .and. &
+                                .not. inline_has_continuation) then
                                 looks_like_block_if = .true.
                             end if
                         end block


### PR DESCRIPTION
## Summary
- treat inline IF continuations with preceding ampersand as inline even when the next line only holds a comment
- avoid emitting the block-IF suggestion so the inline IF + comment example now round-trips without diagnostics

## Verification
- `fpm test`
  - PASS: inline IF with comment preserves body placement
  - FAIL: test_all_examples → issue_2142_mono_wrong_return_types.lf (known regression tracked in #2142); see log excerpt below
    - `FAIL (parser error or compilation failed)` for `issue_2142_mono_wrong_return_types.lf`
