### PR TITLE
fix: USE statements disappear when wrapping external procedures (fixes #2292)

### DIFF
--- a/examples/f90/issue_2292_use_preservation.f90
+++ b/examples/f90/issue_2292_use_preservation.f90
@@ -1,0 +1,10 @@
+subroutine reorder(a)
+    use iso_c_binding, only: c_ptr
+    implicit none
+    integer :: i
+    type(c_ptr), intent(in) :: a
+    integer :: j
+
+    i = 0
+    j = 1
+end subroutine reorder

--- a/src/codegen/codegen_subroutine_declarations.f90
+++ b/src/codegen/codegen_subroutine_declarations.f90
@@ -5,6 +5,7 @@ module codegen_subroutine_declarations
     use ast_nodes_io, only: print_statement_node, read_statement_node
     use ast_nodes_loops, only: do_loop_node
     use ast_nodes_procedure, only: subroutine_def_node
+    use ast_nodes_misc, only: use_statement_node
     use codegen_declarations_inference, only: build_parameter_map
     use codegen_procedure_shared, only: build_parameter_clause, gather_prefix, &
                                         copy_indices, apply_default_intents, &
@@ -17,6 +18,7 @@ module codegen_subroutine_declarations
     use codegen_grouped_body_params, only: generate_grouped_body_with_params
     use codegen_import_reorder, only: reorder_import_lines
     use codegen_parameter_info, only: parameter_info_t
+    use codegen_arena_interface, only: generate_code_from_arena
     use type_string_utils, only: mono_type_to_string
     implicit none
     private
@@ -87,16 +89,24 @@ contains
         integer, allocatable :: param_indices(:)
         integer, allocatable :: body_indices(:)
         integer, allocatable :: filtered_body_indices(:)
+        character(len=:), allocatable :: use_section
+        integer, allocatable :: trimmed_indices(:)
 
         call copy_indices(node%param_indices, param_indices)
         call copy_indices(node%body_indices, body_indices)
+
+        call extract_use_statements(arena, body_indices, trimmed_indices, use_section)
+        call move_alloc(trimmed_indices, body_indices)
 
         call build_parameter_map(arena, param_indices, body_indices, param_map, node)
         if (allocated(node%prefix_keywords)) then
             call apply_default_intents(node%prefix_keywords, param_map)
         end if
 
-        body = maybe_add_procedure_implicit_none(arena, body_indices)
+        body = ""
+        if (len_trim(use_section) > 0) body = body // use_section
+
+        body = body // maybe_add_procedure_implicit_none(arena, body_indices)
         body = body // collect_subroutine_parameter_decls(arena, node, param_map)
         body = body // collect_subroutine_local_variable_decls(arena, node, param_map)
 
@@ -415,5 +425,60 @@ contains
             end if
         end select
     end subroutine collect_vars_from_assignment_sub
+
+    subroutine extract_use_statements(arena, original_indices, remaining_indices, &
+                                      use_code)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: original_indices(:)
+        integer, allocatable, intent(out) :: remaining_indices(:)
+        character(len=:), allocatable, intent(out) :: use_code
+        integer :: i, count
+        logical :: is_use_stmt
+        character(len=:), allocatable :: stmt_text
+
+        if (size(original_indices) == 0) then
+            allocate (remaining_indices(0))
+            use_code = ""
+            return
+        end if
+
+        allocate (remaining_indices(size(original_indices)))
+        count = 0
+        use_code = ""
+
+        do i = 1, size(original_indices)
+            is_use_stmt = .false.
+            if (original_indices(i) > 0 .and. original_indices(i) <= arena%size) then
+                if (allocated(arena%entries(original_indices(i))%node)) then
+                    select type (node => arena%entries(original_indices(i))%node)
+                    type is (use_statement_node)
+                        is_use_stmt = .true.
+                        stmt_text = generate_code_from_arena(arena, original_indices(i))
+                        if (len_trim(stmt_text) > 0) then
+                            use_code = use_code // "    " // trim(stmt_text) // &
+                                       new_line('A')
+                        end if
+                    end select
+                end if
+            end if
+
+            if (.not. is_use_stmt) then
+                count = count + 1
+                remaining_indices(count) = original_indices(i)
+            end if
+        end do
+
+        if (count == 0) then
+            deallocate (remaining_indices)
+            allocate (remaining_indices(0))
+        else if (count < size(original_indices)) then
+            block
+                integer, allocatable :: trimmed(:)
+                allocate (trimmed(count))
+                trimmed = remaining_indices(1:count)
+                call move_alloc(trimmed, remaining_indices)
+            end block
+        end if
+    end subroutine extract_use_statements
 
 end module codegen_subroutine_declarations

--- a/src/parser/statements/parser_statement_utilities.f90
+++ b/src/parser/statements/parser_statement_utilities.f90
@@ -3,7 +3,7 @@ module parser_statement_utilities_module
     use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_NUMBER, TK_STRING, &
                           TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, TK_COMMENT, &
                           TK_WHITESPACE, to_lower
-    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_state_module, only: parser_state_t
     use parser_declarations, only: parse_declaration
     use parser_expressions_module, only: parse_comparison
     use parser_io_statements_module, only: parse_print_statement, &
@@ -26,9 +26,10 @@ module parser_statement_utilities_module
     use parser_assignment_module, only: parse_assignment_statement
     use parser_call_module, only: parse_call_statement
     use parser_statement_data_module, only: parse_data_statement
+    use parser_import_resolution_module, only: parse_use_statement
     use ast_arena_modern, only: ast_arena_t
-    use ast_factory, only: push_associate, push_if, push_literal
-    use ast_factory
+    use ast_factory, only: push_associate, push_goto, push_if, &
+                           push_import_statement
     use ast_types, only: LITERAL_STRING
     use ast_nodes_control, only: association_t
     use parser_legacy_statements_module, only: parse_legacy_statement
@@ -86,6 +87,8 @@ contains
                 stmt_index = parse_data_statement(parser, arena)
             case ("call")
                 stmt_index = parse_call_statement(parser, arena)
+            case ("use")
+                stmt_index = parse_use_statement(parser, arena)
             case ("integer", "real", "logical", "character", "complex", &
                   "double", "type", "class", "procedure")
                 ! Check if this is actually an assignment like "double = 5"

--- a/test/parser/test_issue_2292_use_preservation.f90
+++ b/test/parser/test_issue_2292_use_preservation.f90
@@ -1,0 +1,123 @@
+program test_issue_2292_use_preservation
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, &
+        & iostat_end, iostat_eor
+    use lexer_api, only: lex_source
+    use parser_api, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_core, only: program_node
+    use ast_nodes_procedure, only: subroutine_def_node
+    use ast_nodes_misc, only: use_statement_node
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: error_msg
+    type(token_t), allocatable :: tokens(:)
+    type(ast_arena_t) :: arena
+    integer :: root_index
+
+    call read_example('examples/f90/issue_2292_use_preservation.f90', source_code)
+
+    call lex_source(source_code, tokens, error_msg)
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: lexer error: ' // trim(error_msg)
+        error stop 1
+    end if
+
+    arena = create_ast_arena()
+    call parse_tokens(tokens, arena, root_index, error_msg)
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: parser error: ' // trim(error_msg)
+        error stop 1
+    end if
+
+    if (root_index <= 0 .or. root_index > arena%size) then
+        write (error_unit, '(A)') 'FAIL: parser did not return a valid root index'
+        error stop 1
+    end if
+
+    call assert_use_survives(arena, root_index)
+
+    print *, 'PASS: USE statements survive inside wrapped subroutines'
+
+contains
+
+    include '../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    subroutine assert_use_survives(arena, root_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: root_index
+        logical :: found_subroutine
+        integer :: i, idx
+
+        if (.not. allocated(arena%entries(root_index)%node)) then
+            write (error_unit, '(A)') 'FAIL: root node not allocated'
+            error stop 1
+        end if
+
+        found_subroutine = .false.
+        select type (prog => arena%entries(root_index)%node)
+        type is (program_node)
+            if (.not. allocated(prog%body_indices)) then
+                write (error_unit, '(A)') 'FAIL: program body indices not allocated'
+                error stop 1
+            end if
+            do i = 1, size(prog%body_indices)
+                idx = prog%body_indices(i)
+                if (idx <= 0 .or. idx > arena%size) cycle
+                if (.not. allocated(arena%entries(idx)%node)) cycle
+                select type (sub => arena%entries(idx)%node)
+                type is (subroutine_def_node)
+                    found_subroutine = .true.
+                    call assert_subroutine_has_use(arena, sub)
+                    return
+                end select
+            end do
+        class default
+            write (error_unit, '(A)') 'FAIL: root node is not a program'
+            error stop 1
+        end select
+
+        if (.not. found_subroutine) then
+            write (error_unit, '(A)') 'FAIL: no subroutine definition found'
+            error stop 1
+        end if
+    end subroutine assert_use_survives
+
+    subroutine assert_subroutine_has_use(arena, sub_def)
+        type(ast_arena_t), intent(in) :: arena
+        type(subroutine_def_node), intent(in) :: sub_def
+        integer :: i, idx
+
+        if (.not. allocated(sub_def%body_indices)) then
+            write (error_unit, '(A)') 'FAIL: subroutine body not allocated'
+            error stop 1
+        end if
+
+        do i = 1, size(sub_def%body_indices)
+            idx = sub_def%body_indices(i)
+            if (idx <= 0 .or. idx > arena%size) cycle
+            if (.not. allocated(arena%entries(idx)%node)) cycle
+            select type (stmt => arena%entries(idx)%node)
+            type is (use_statement_node)
+                return
+            end select
+        end do
+
+        write (error_unit, '(A)') 'FAIL: subroutine lost USE statement'
+        error stop 1
+    end subroutine assert_subroutine_has_use
+
+end program test_issue_2292_use_preservation

--- a/test/test_issue_2292_use_codegen.f90
+++ b/test/test_issue_2292_use_codegen.f90
@@ -1,0 +1,53 @@
+program test_issue_2292_use_codegen
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use transformation_api, only: transform_with_context, transform_context_t, &
+        & INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    integer :: use_pos
+
+    call read_example('examples/f90/issue_2292_use_preservation.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2292_use_preservation'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    use_pos = index(output_code, 'use iso_c_binding, only: c_ptr')
+    if (use_pos == 0) then
+        write (error_unit, '(A)') 'FAIL: USE statement missing from output'
+        write (error_unit, '(A)') 'Output:'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    print *, 'PASS: Issue #2292 USE statements preserved in output'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2292_use_codegen


### PR DESCRIPTION
## Summary
- preserve `use` statements by extracting them ahead of implicit none generation so wrapped externals keep their imports
- teach the IF-block statement helper to parse `use` statements so the synthetic wrapper can retain them during parsing
- add the reproducer as an example plus parser/codegen regression tests to lock the behavior in place

## Verification
- `fpm test`
  ```
  PASS: issue_2067 allocatable inference works
  PASS: binary input rejected gracefully
  ```
- `fpm test --target test_issue_2292_use_preservation test_issue_2292_use_codegen`
  ```
  PASS: Issue #2292 USE statements preserved in output
  PASS: USE statements survive inside wrapped subroutines
  ```
