### PR TITLE
fix: Identifier named 'else' loses all executable statements (fixes #2267)

### DIFF
--- a/examples/f90/issue_2267_identifier_else.f90
+++ b/examples/f90/issue_2267_identifier_else.f90
@@ -1,0 +1,6 @@
+program issue_2267_identifier_else
+    implicit none
+    real :: else
+    else = 2.0
+    print *, else
+end program issue_2267_identifier_else

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -270,6 +270,14 @@ contains
             character(len=*), intent(in) :: lowered
             type(parser_state_t), intent(inout) :: parser_ref
             type(ast_arena_t), intent(inout) :: arena_ref
+            type(token_t) :: keyword_token
+
+            keyword_token = parser_ref%peek()
+            if (keyword_should_parse_as_identifier(keyword_token, parser_ref)) then
+                stmt_index = handle_identifier_token(parser_ref, arena_ref, &
+                                                     keyword_token)
+                return
+            end if
 
             select case (lowered)
             case ("elemental", "pure", "impure", "recursive", "nonrecursive", &

--- a/test/test_issue_2267_identifier_else.f90
+++ b/test/test_issue_2267_identifier_else.f90
@@ -1,0 +1,65 @@
+program test_issue_2267_identifier_else
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_declaration, has_assignment, has_print
+
+    call read_example('examples/f90/issue_2267_identifier_else.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2267_identifier_else'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_declaration = index(output_code, 'real :: else') > 0
+    has_assignment = index(output_code, 'else = 2.0') > 0
+    has_print = index(output_code, 'print *, else') > 0
+
+    if (.not. has_declaration) then
+        write (error_unit, '(A)') 'FAIL: missing real :: else declaration'
+        error stop 1
+    end if
+
+    if (.not. has_assignment) then
+        write (error_unit, '(A)') 'FAIL: missing else = 2.0 assignment'
+        error stop 1
+    end if
+
+    if (.not. has_print) then
+        write (error_unit, '(A)') 'FAIL: missing print *, else statement'
+        error stop 1
+    end if
+
+    print *, 'PASS: identifier named else survives round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2267_identifier_else


### PR DESCRIPTION
## Summary
- route keyword tokens through identifier disambiguation when parsing explicit program bodies so assignments like `else = 2.0` are preserved
- add a canonical `examples/f90/issue_2267_identifier_else.f90` sample and regression test to lock the behavior down

## Verification
- `fpm test`
  - includes `PASS: identifier named else survives round-trip`
