### PR TITLE
fix: Identifier named 'if' triggers bogus IF diagnostics (fixes #2276)

### DIFF
--- a/examples/f90/issue_2276_identifier_if.f90
+++ b/examples/f90/issue_2276_identifier_if.f90
@@ -1,0 +1,7 @@
+program issue_2276_identifier_if
+    implicit none
+    integer :: if
+
+    if = 1
+    print *, if
+end program issue_2276_identifier_if

--- a/src/parser/core/parser_dispatcher.f90
+++ b/src/parser/core/parser_dispatcher.f90
@@ -16,10 +16,14 @@ module parser_dispatcher_module
     use parser_intrinsic_statements_module, only: parse_intrinsic_statement
     use parser_block_data_module, only: parse_block_data
     use parser_io_statements_module, only: parse_print_statement, &
-                                           parse_write_statement, parse_read_statement, &
-                                           parse_open_statement, parse_close_statement, &
-                                           parse_format_statement, parse_inquire_statement, &
-                                           parse_backspace_statement, parse_rewind_statement, &
+                                           parse_write_statement, &
+                                           parse_read_statement, &
+                                           parse_open_statement, &
+                                           parse_close_statement, &
+                                           parse_format_statement, &
+                                           parse_inquire_statement, &
+                                           parse_backspace_statement, &
+                                           parse_rewind_statement, &
                                            parse_endfile_statement
     use parser_definition_statements_module, only: parse_function_definition, &
                                                    parse_subroutine_definition, &
@@ -116,7 +120,11 @@ contains
             case ("deallocate")
                 stmt_index = parse_deallocate_statement(parser, arena)
             case ("if", "do", "where", "select", "forall", "associate")
-                stmt_index = route_control_flow(parser, arena)
+                if (keyword_should_parse_as_identifier(first_token, parser)) then
+                    stmt_index = parse_assignment_or_expression(parser, arena)
+                else
+                    stmt_index = route_control_flow(parser, arena)
+                end if
             case ("function")
                 stmt_index = parse_function_definition(parser, arena, prefix_buffer)
             case ("subroutine")
@@ -436,7 +444,8 @@ contains
                                     additional_indices = decl_indices(2:)
                                 end if
                             else
-                                stmt_index = parse_declaration(parser, arena)  ! Fallback
+                                stmt_index = parse_declaration(parser, arena)
+                                ! Fallback
                             end if
                         else
                             stmt_index = parse_declaration(parser, arena)  ! Fallback
@@ -908,7 +917,7 @@ contains
 
     ! Clear parser errors
     subroutine clear_parser_errors()
-        if (allocated(last_parser_errors)) deallocate(last_parser_errors)
+        if (allocated(last_parser_errors)) deallocate (last_parser_errors)
         last_parser_errors = ""
     end subroutine clear_parser_errors
 

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -176,17 +176,21 @@ contains
             end if
 
             if (token%kind == TK_KEYWORD .and. is_control_flow_keyword(lowered)) then
-                call flush_pending_prefixes()
-                stmt_index = route_control_flow(parser, arena)
-                ! If routing failed, consume until newline to avoid infinite loop
-                if (stmt_index == 0) then
-                    do while (.not. parser%is_at_end())
-                        block
-                            type(token_t) :: skip_token
-                            skip_token = parser%consume()
-                            if (skip_token%kind == TK_NEWLINE) exit
-                        end block
-                    end do
+                if (keyword_should_parse_as_identifier(token, parser)) then
+                    stmt_index = handle_identifier_token(parser, arena, token)
+                else
+                    call flush_pending_prefixes()
+                    stmt_index = route_control_flow(parser, arena)
+                    ! If routing failed, consume until newline to avoid infinite loop
+                    if (stmt_index == 0) then
+                        do while (.not. parser%is_at_end())
+                            block
+                                type(token_t) :: skip_token
+                                skip_token = parser%consume()
+                                if (skip_token%kind == TK_NEWLINE) exit
+                            end block
+                        end do
+                    end if
                 end if
             else
                 select case (token%kind)
@@ -497,9 +501,11 @@ contains
                     block
                         type(token_t) :: current_token
                         current_token = parser_ref%peek()
-                        if (keyword_should_parse_as_identifier(current_token, parser_ref)) then
-                            call parse_assignment_statement(parser_ref, arena_ref, stmt_index, &
-                                                           additional_execution_indices)
+                        if (keyword_should_parse_as_identifier( &
+                            current_token, parser_ref)) then
+                            call parse_assignment_statement( &
+                                parser_ref, arena_ref, stmt_index, &
+                                additional_execution_indices)
                         else
                             stmt_index = parse_stop_statement(parser_ref, arena_ref)
                         end if
@@ -510,9 +516,11 @@ contains
                     block
                         type(token_t) :: current_token
                         current_token = parser_ref%peek()
-                        if (keyword_should_parse_as_identifier(current_token, parser_ref)) then
-                            call parse_assignment_statement(parser_ref, arena_ref, stmt_index, &
-                                                           additional_execution_indices)
+                        if (keyword_should_parse_as_identifier( &
+                            current_token, parser_ref)) then
+                            call parse_assignment_statement( &
+                                parser_ref, arena_ref, stmt_index, &
+                                additional_execution_indices)
                         else
                             stmt_index = parse_goto_statement(parser_ref, arena_ref)
                         end if
@@ -524,9 +532,11 @@ contains
                     block
                         type(token_t) :: current_token
                         current_token = parser_ref%peek()
-                        if (keyword_should_parse_as_identifier(current_token, parser_ref)) then
-                            call parse_assignment_statement(parser_ref, arena_ref, stmt_index, &
-                                                           additional_execution_indices)
+                        if (keyword_should_parse_as_identifier( &
+                            current_token, parser_ref)) then
+                            call parse_assignment_statement( &
+                                parser_ref, arena_ref, stmt_index, &
+                                additional_execution_indices)
                         else
                             stmt_index = parse_return_statement(parser_ref, arena_ref)
                         end if
@@ -539,9 +549,11 @@ contains
                     block
                         type(token_t) :: current_token
                         current_token = parser_ref%peek()
-                        if (keyword_should_parse_as_identifier(current_token, parser_ref)) then
-                            call parse_assignment_statement(parser_ref, arena_ref, stmt_index, &
-                                                           additional_execution_indices)
+                        if (keyword_should_parse_as_identifier( &
+                            current_token, parser_ref)) then
+                            call parse_assignment_statement( &
+                                parser_ref, arena_ref, stmt_index, &
+                                additional_execution_indices)
                         else
                             stmt_index = parse_cycle_statement(parser_ref, arena_ref)
                         end if
@@ -550,9 +562,11 @@ contains
                     block
                         type(token_t) :: current_token
                         current_token = parser_ref%peek()
-                        if (keyword_should_parse_as_identifier(current_token, parser_ref)) then
-                            call parse_assignment_statement(parser_ref, arena_ref, stmt_index, &
-                                                           additional_execution_indices)
+                        if (keyword_should_parse_as_identifier( &
+                            current_token, parser_ref)) then
+                            call parse_assignment_statement( &
+                                parser_ref, arena_ref, stmt_index, &
+                                additional_execution_indices)
                         else
                             stmt_index = parse_exit_statement(parser_ref, arena_ref)
                         end if
@@ -563,9 +577,11 @@ contains
                     block
                         type(token_t) :: current_token
                         current_token = parser_ref%peek()
-                        if (keyword_should_parse_as_identifier(current_token, parser_ref)) then
-                            call parse_assignment_statement(parser_ref, arena_ref, stmt_index, &
-                                                           additional_execution_indices)
+                        if (keyword_should_parse_as_identifier( &
+                            current_token, parser_ref)) then
+                            call parse_assignment_statement( &
+                                parser_ref, arena_ref, stmt_index, &
+                                additional_execution_indices)
                         else
                             stmt_index = parse_call_statement(parser_ref, arena_ref)
                         end if

--- a/src/parser/statements/parser_keyword_disambiguation.f90
+++ b/src/parser/statements/parser_keyword_disambiguation.f90
@@ -1,6 +1,7 @@
 module parser_keyword_disambiguation_module
     use lexer_core, only: token_t, TK_OPERATOR, TK_COMMENT, TK_WHITESPACE, &
-                          TK_NEWLINE, TK_EOF, TK_KEYWORD, to_lower
+                          TK_NEWLINE, TK_EOF, TK_KEYWORD, TK_IDENTIFIER, &
+                          TK_NUMBER, TK_STRING, to_lower
     use parser_state_module, only: parser_state_t
     implicit none
     private
@@ -54,11 +55,11 @@ contains
     ! Returns true only when no opening parenthesis appears before assignment syntax.
     logical function should_parse_if_as_identifier(parser) result(as_identifier)
         type(parser_state_t), intent(in) :: parser
-        integer :: idx, token_count
+        integer :: idx, token_count, depth
         type(token_t) :: tok
-        logical :: continuation
+        logical :: continuation, expect_component
 
-        as_identifier = .true.
+        as_identifier = .false.
         if (.not. associated(parser%tokens)) return
 
         token_count = size(parser%tokens)
@@ -66,6 +67,8 @@ contains
 
         idx = parser%current_token + 1
         continuation = .false.
+        depth = 0
+        expect_component = .false.
 
         do while (idx <= token_count)
             tok = parser%tokens(idx)
@@ -74,7 +77,7 @@ contains
                 idx = idx + 1
                 cycle
             case (TK_NEWLINE)
-                if (.not. continuation) return
+                if (.not. continuation) exit
                 continuation = .false.
                 idx = idx + 1
                 cycle
@@ -82,23 +85,49 @@ contains
                 select case (tok%text)
                 case ("&")
                     continuation = .true.
-                    idx = idx + 1
-                    cycle
                 case ("(")
-                    as_identifier = .false.
-                    return
-                case ("=", "=>", ";")
-                    as_identifier = .true.
-                    return
+                    if (expect_component) return
+                    depth = depth + 1
+                case (")")
+                    if (depth == 0) return
+                    depth = depth - 1
+                case ("=", "=>")
+                    if (depth == 0 .and. .not. expect_component) then
+                        as_identifier = .true.
+                        return
+                    else
+                        return
+                    end if
+                case ("%")
+                    if (depth == 0 .and. .not. expect_component) then
+                        expect_component = .true.
+                    else
+                        return
+                    end if
+                case (":", ",")
+                    if (depth == 0) return
+                case (";")
+                    exit
                 case default
-                    as_identifier = .true.
-                    return
+                    if (depth == 0) return
                 end select
-            case default
-                as_identifier = .true.
-                return
+            case (TK_IDENTIFIER)
+                if (expect_component) then
+                    expect_component = .false.
+                else if (depth == 0) then
+                    return
+                end if
+            case (TK_NUMBER, TK_STRING)
+                if (depth == 0) return
+            case (TK_KEYWORD)
+                if (depth == 0) return
+            case (TK_EOF)
+                exit
             end select
+            idx = idx + 1
         end do
+
+        as_identifier = .false.
     end function should_parse_if_as_identifier
 
     logical function statement_contains_assignment(parser) result(has_assignment)

--- a/test/test_issue_2276_identifier_if.f90
+++ b/test/test_issue_2276_identifier_if.f90
@@ -1,0 +1,65 @@
+program test_issue_2276_identifier_if
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_declaration, has_assignment, has_print
+
+    call read_example('examples/f90/issue_2276_identifier_if.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2276_identifier_if'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_declaration = index(output_code, 'integer :: if') > 0
+    has_assignment = index(output_code, 'if = 1') > 0
+    has_print = index(output_code, 'print *, if') > 0
+
+    if (.not. has_declaration) then
+        write (error_unit, '(A)') 'FAIL: missing integer :: if declaration'
+        error stop 1
+    end if
+
+    if (.not. has_assignment) then
+        write (error_unit, '(A)') 'FAIL: missing if = 1 assignment'
+        error stop 1
+    end if
+
+    if (.not. has_print) then
+        write (error_unit, '(A)') 'FAIL: missing print *, if statement'
+        error stop 1
+    end if
+
+    print *, 'PASS: identifier named if survives round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2276_identifier_if


### PR DESCRIPTION
## Summary
- tighten `should_parse_if_as_identifier` so `if`-named scalars can be detected without breaking real IF statements
- route keyword tokens back through assignment parsing when disambiguation says they are identifiers
- add the failing program to `examples/f90` and a regression test that exercises the CLI path

## Verification
- `fpm test`
  ```
  All AST traversal tests passed!
  === fortfront API Function Parameter Parsing Tests ===
    PASS: Typed parameter parsing in function definition
    PASS: Keyword parameter names parsed correctly
  All function parameter parsing tests passed!
  ```
- `fpm test --target test_issue_2276_identifier_if`
  ```
  PASS: identifier named if survives round-trip
  ```
