### PR TITLE
fix: Legacy  statements are mangled (fixes #2293)

### DIFF
--- a/examples/f90/issue_2293_legacy_implicit.f
+++ b/examples/f90/issue_2293_legacy_implicit.f
@@ -1,0 +1,5 @@
+      implicit real (a-h)
+      real :: alpha
+      alpha = 1.0
+      print *, alpha
+      end

--- a/src/parser/core/parser_dispatcher.f90
+++ b/src/parser/core/parser_dispatcher.f90
@@ -38,6 +38,8 @@ module parser_dispatcher_module
                                                parse_deallocate_statement
     use parser_execution_statements_module, only: parse_call_statement, &
                                                   parse_program_statement
+    use parser_type_specifications_module, only: parse_implicit_statement, &
+                                                 take_implicit_additional_indices
     use parser_statement_data_module, only: parse_data_statement, &
                                             get_data_additional_indices, &
                                             parse_namelist_statement
@@ -232,6 +234,25 @@ contains
                     stmt_index = parse_assignment_or_expression(parser, arena)
                 else
                     stmt_index = parse_call_statement(parser, arena)
+                end if
+            case ("implicit")
+                if (keyword_should_parse_as_identifier(first_token, parser)) then
+                    stmt_index = parse_assignment_or_expression(parser, arena)
+                else
+                    stmt_index = parse_implicit_statement(parser, arena)
+                    block
+                        integer, allocatable :: extra_indices(:)
+                        extra_indices = take_implicit_additional_indices()
+                        if (size(extra_indices) > 0) then
+                            if (allocated(additional_indices)) then
+                                block
+                                    integer, allocatable :: temp(:)
+                                    call move_alloc(additional_indices, temp)
+                                end block
+                            end if
+                            call move_alloc(extra_indices, additional_indices)
+                        end if
+                    end block
                 end if
             case ("stop")
                 ! Check if this is an identifier assignment like "stop = 42"

--- a/src/parser/statements/parser_keyword_disambiguation.f90
+++ b/src/parser/statements/parser_keyword_disambiguation.f90
@@ -338,7 +338,7 @@ contains
         if (idx > token_count) return
 
         tok = parser%tokens(idx)
-        if (tok%kind /= TK_KEYWORD) return
+        if (tok%kind /= TK_KEYWORD .and. tok%kind /= TK_IDENTIFIER) return
 
         lowered = to_lower(trim(tok%text))
         select case (lowered)

--- a/test/test_issue_2293_legacy_implicit.f90
+++ b/test/test_issue_2293_legacy_implicit.f90
@@ -1,0 +1,65 @@
+program test_issue_2293_legacy_implicit
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: preserved_implicit, has_injected_identifier
+
+    call read_example('examples/f90/issue_2293_legacy_implicit.f', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2293_legacy_implicit.f'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+     &        trim(error_msg)
+        error stop 1
+    end if
+
+    preserved_implicit = index(output_code, 'implicit real (a-h)') > 0
+    has_injected_identifier = index(output_code, 'integer :: implicit') > 0
+
+    if (.not. preserved_implicit) then
+        write (error_unit, '(A)') 'FAIL: legacy IMPLICIT statement was not preserved'
+        error stop 1
+    end if
+
+    if (has_injected_identifier) then
+        write (error_unit, '(A)') 'FAIL: transformer inserted integer :: implicit'
+        error stop 1
+    end if
+
+    if (index(output_code, new_line('a') // '    implicit' // new_line('a')) > 0) &
+        & then
+        write (error_unit, '(A)') 'FAIL: stray bare IMPLICIT line detected'
+        error stop 1
+    end if
+
+    print *, 'PASS: Issue #2293 - legacy IMPLICIT statement preserved'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2293_legacy_implicit

--- a/test/test_parser_keyword_disambiguation.f90
+++ b/test/test_parser_keyword_disambiguation.f90
@@ -1,0 +1,53 @@
+program test_parser_keyword_disambiguation
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use lexer_core, only: token_t, tokenize_core
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier
+    implicit none
+
+    call test_legacy_implicit_statement_detection()
+    call test_identifier_assignment_detection()
+
+    print *, 'PASS: parser keyword disambiguation honors implicit statements'
+
+contains
+
+    subroutine test_legacy_implicit_statement_detection()
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(parser_state_t) :: parser
+        type(token_t) :: first_token
+        logical :: as_identifier
+
+        source = '      implicit real (a-h)' // new_line('a') // '      end'
+        call tokenize_core(source, tokens)
+        parser = create_parser_state(tokens)
+        first_token = parser%peek()
+        as_identifier = keyword_should_parse_as_identifier(first_token, parser)
+
+        if (as_identifier) then
+            write (error_unit, '(A)') 'FAIL: legacy IMPLICIT statement parsed as identifier'
+            error stop 1
+        end if
+    end subroutine test_legacy_implicit_statement_detection
+
+    subroutine test_identifier_assignment_detection()
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(parser_state_t) :: parser
+        type(token_t) :: first_token
+        logical :: as_identifier
+
+        source = 'implicit = 5' // new_line('a') // 'end'
+        call tokenize_core(source, tokens)
+        parser = create_parser_state(tokens)
+        first_token = parser%peek()
+        as_identifier = keyword_should_parse_as_identifier(first_token, parser)
+
+        if (.not. as_identifier) then
+            write (error_unit, '(A)') 'FAIL: identifier IMPLICIT assignment was not preserved'
+            error stop 1
+        end if
+    end subroutine test_identifier_assignment_detection
+
+end program test_parser_keyword_disambiguation


### PR DESCRIPTION
## Summary
- ensure the dispatcher routes `implicit` tokens through the real implicit-statement parser only when they are not plain identifiers, wiring up the multi-statement plumbing
- make the keyword disambiguator treat upcoming implicit-spec tokens (including identifiers) as part of an actual implicit statement so fixed-form sources no longer get rewritten into bogus declarations
- add a legacy fixed-form example plus regression tests that exercise both the parser disambiguation and the end-to-end transform to guard against future regressions

## Verification
- `fpm test --target test_issue_2293_legacy_implicit`
  - PASS: Issue #2293 - legacy IMPLICIT statement preserved
- `fpm test --target test_parser_keyword_disambiguation`
  - PASS: parser keyword disambiguation honors implicit statements
