### PR TITLE
fix: 'recursive' rejected inside interface blocks (fixes #2290)

### DIFF
--- a/examples/f90/issue_2290_recursive_interface.f90
+++ b/examples/f90/issue_2290_recursive_interface.f90
@@ -1,0 +1,10 @@
+module issue_2290_recursive_interface
+    implicit none
+
+    interface
+        recursive integer function factorial(n) result(res)
+            integer, intent(in) :: n
+        end function factorial
+    end interface
+
+end module issue_2290_recursive_interface

--- a/src/parser/declarations/parser_interface_blocks.f90
+++ b/src/parser/declarations/parser_interface_blocks.f90
@@ -4,6 +4,7 @@ module parser_interface_blocks_module
                           TK_NEWLINE, TK_WHITESPACE
     use parser_state_module, only: parser_state_t
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t
+    use parser_procedure_shared_module, only: consume_optional_kind_spec
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_interface_block, push_module_procedure, &
                            push_import_statement
@@ -245,6 +246,10 @@ contains
                 consumed_token = parser%consume()
                 handled = .true.
                 return
+            else if (is_interface_return_type_keyword(lowered_text)) then
+                call collect_interface_return_type(parser, prefix_buffer, lowered_text)
+                handled = .true.
+                return
             end if
         end if
 
@@ -268,6 +273,52 @@ contains
                     trim(lowered_text) == "nonrecursive" .or. &
                     trim(lowered_text) == "non_recursive"
     end function is_procedure_prefix
+
+    logical function is_interface_return_type_keyword(lowered_text) result(is_type)
+        character(len=*), intent(in) :: lowered_text
+
+        is_type = trim(lowered_text) == "integer" .or. &
+                  trim(lowered_text) == "real" .or. &
+                  trim(lowered_text) == "logical" .or. &
+                  trim(lowered_text) == "character" .or. &
+                  trim(lowered_text) == "complex" .or. &
+                  trim(lowered_text) == "double"
+    end function is_interface_return_type_keyword
+
+    subroutine collect_interface_return_type(parser, prefix_buffer, lowered_text)
+        type(parser_state_t), intent(inout) :: parser
+        type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        character(len=*), intent(in) :: lowered_text
+
+        type(token_t) :: type_token, lookahead_token
+        character(len=:), allocatable :: type_with_kind
+        character(len=:), allocatable :: lookahead_lower
+        character(len=16), allocatable :: prefix_array(:)
+
+        if (trim(lowered_text) == "double") then
+            lookahead_token = parser%get_token_at_index(parser%current_token + 1)
+            lookahead_lower = to_lower(trim(lookahead_token%text))
+            if (trim(lookahead_lower) == "precision" .or. &
+                trim(lookahead_lower) == "complex") then
+                type_token = parser%consume()
+                lookahead_token = parser%consume()
+                type_with_kind = trim(type_token%text)//" "// &
+                                 trim(lookahead_token%text)
+                call consume_optional_kind_spec(parser, type_with_kind)
+                allocate (character(len=16) :: prefix_array(1))
+                prefix_array(1) = trim(type_with_kind)
+                call prefix_buffer%append_all(prefix_array)
+                return
+            end if
+        end if
+
+        type_token = parser%consume()
+        type_with_kind = trim(type_token%text)
+        call consume_optional_kind_spec(parser, type_with_kind)
+        allocate (character(len=16) :: prefix_array(1))
+        prefix_array(1) = trim(type_with_kind)
+        call prefix_buffer%append_all(prefix_array)
+    end subroutine collect_interface_return_type
 
     function parse_module_procedure_statement(parser, arena) result(stmt_index)
         type(parser_state_t), intent(inout) :: parser

--- a/test/codegen/test_issue_2290_recursive_interface.f90
+++ b/test/codegen/test_issue_2290_recursive_interface.f90
@@ -1,0 +1,65 @@
+program test_issue_2290_recursive_interface
+    use fortfront
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+
+    print *, "=== Issue #2290: recursive integer interface signatures ==="
+    call run_recursive_interface_test()
+    print *, "All issue #2290 tests completed"
+
+contains
+
+    subroutine run_recursive_interface_test()
+        logical :: ok
+
+        call read_example('examples/f90/issue_2290_recursive_interface.f90', source)
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, "  ERROR: ", trim(error_msg)
+                stop 1
+            end if
+        end if
+
+        ok = index(output, "recursive integer function factorial") > 0
+        if (.not. ok) then
+            print *, "  FAIL: recursive integer signature missing"
+            print *, trim(output)
+            stop 1
+        end if
+
+        ok = index(output, "result(res)") > 0
+        if (.not. ok) then
+            print *, "  FAIL: result clause missing"
+            print *, trim(output)
+            stop 1
+        end if
+
+        print *, "  PASS: recursive integer interface preserved"
+    end subroutine run_recursive_interface_test
+
+    subroutine read_example(filepath, content)
+        character(len=*), intent(in) :: filepath
+        character(len=:), allocatable, intent(out) :: content
+        integer :: unit, file_size, stat
+        character(len=1), allocatable :: buffer(:)
+
+        open (newunit=unit, file=filepath, status='old', access='stream', &
+              form='unformatted', iostat=stat)
+        if (stat /= 0) error stop 'Failed to open example file: ' // filepath
+
+        inquire (unit=unit, size=file_size)
+        allocate (buffer(file_size))
+        read (unit, iostat=stat) buffer
+        if (stat /= 0) error stop 'Failed to read example file: ' // filepath
+        close (unit)
+
+        allocate (character(len=file_size) :: content)
+        content = transfer(buffer, content)
+    end subroutine read_example
+
+end program test_issue_2290_recursive_interface


### PR DESCRIPTION
## Summary
- allow interface-body parsing to treat type-spec keywords as prefixes so recursive typed declarations stop faulting
- add a focused regression example plus a codegen test to lock the behaviour down

## Verification
- fpm test
- fpm test test_all_examples
- fpm test test_issue_2290_recursive_interface
