### PR TITLE
fix: Identifier 'stop' becomes an actual STOP (fixes #2273)

### DIFF
--- a/examples/f90/issue_2273_identifier_stop.f90
+++ b/examples/f90/issue_2273_identifier_stop.f90
@@ -1,0 +1,10 @@
+program issue_2273_identifier_stop
+    implicit none
+contains
+    subroutine track_stop()
+        implicit none
+        integer :: stop
+        stop = 1
+        print *, stop
+    end subroutine track_stop
+end program issue_2273_identifier_stop

--- a/src/parser/declarations/parser_declarations_core_module.f90
+++ b/src/parser/declarations/parser_declarations_core_module.f90
@@ -742,6 +742,10 @@ contains
             if (trim(next_lower) == "precision") return
         case ("in", "out", "inout", "data")
             ! Contextual keywords can act as identifiers within declarations
+        case ("stop", "call", "cycle", "exit", "return", "continue", "goto", &
+              "go", "entry", "select", "contains", "else", "dimension", &
+              "common", "program", "module", "if")
+            ! Allow executable keywords in identifier positions
         case ("implicit")
             parser_copy = parser
             if (parser_copy%current_token > 1) then

--- a/src/parser/statements/parser_statement_utilities.f90
+++ b/src/parser/statements/parser_statement_utilities.f90
@@ -27,6 +27,7 @@ module parser_statement_utilities_module
     use parser_call_module, only: parse_call_statement
     use parser_statement_data_module, only: parse_data_statement
     use parser_import_resolution_module, only: parse_use_statement
+    use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_associate, push_goto, push_if, &
                            push_import_statement
@@ -48,6 +49,13 @@ contains
         integer :: stmt_index
         character(len=:), allocatable :: lowered_text
         type(token_t) :: next_token
+
+        if (token%kind == TK_KEYWORD) then
+            if (keyword_should_parse_as_identifier(token, parser)) then
+                stmt_index = parse_assignment_simple(parser, arena)
+                return
+            end if
+        end if
 
         ! Handle "goto" as identifier (Fortran allows both "go to" and "goto")
         lowered_text = trim(to_lower(token%text))

--- a/test/test_issue_2273_identifier_stop.f90
+++ b/test/test_issue_2273_identifier_stop.f90
@@ -1,0 +1,85 @@
+program test_issue_2273_identifier_stop
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_declaration, has_assignment, has_print, has_stop_stmt, &
+        & has_real_decl
+
+    call read_example('examples/f90/issue_2273_identifier_stop.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2273_identifier_stop'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_declaration = index(output_code, 'integer :: stop') > 0
+    has_assignment = index(output_code, 'stop = 1') > 0
+    has_print = index(output_code, 'print *, stop') > 0
+    has_real_decl = index(output_code, 'real :: stop') > 0
+    has_stop_stmt = index(output_code, new_line('a')//'    stop'// &
+        & new_line('a')) > 0 .or. index(output_code, new_line('a')//'stop'// &
+        & new_line('a')) > 0
+
+    if (.not. has_declaration) then
+        write (error_unit, '(A)') 'FAIL: missing integer :: stop declaration'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_assignment) then
+        write (error_unit, '(A)') 'FAIL: missing stop = 1 assignment'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_print) then
+        write (error_unit, '(A)') 'FAIL: missing print *, stop statement'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (has_real_decl) then
+        write (error_unit, '(A)') 'FAIL: unexpected real :: stop declaration'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (has_stop_stmt) then
+        write (error_unit, '(A)') 'FAIL: extraneous STOP statement inserted'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    print *, 'PASS: identifier named stop survives round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2273_identifier_stop

--- a/test/test_parser_keyword_disambiguation.f90
+++ b/test/test_parser_keyword_disambiguation.f90
@@ -7,6 +7,7 @@ program test_parser_keyword_disambiguation
 
     call test_legacy_implicit_statement_detection()
     call test_identifier_assignment_detection()
+    call test_stop_assignment_detection()
 
     print *, 'PASS: parser keyword disambiguation honors implicit statements'
 
@@ -26,7 +27,8 @@ contains
         as_identifier = keyword_should_parse_as_identifier(first_token, parser)
 
         if (as_identifier) then
-            write (error_unit, '(A)') 'FAIL: legacy IMPLICIT statement parsed as identifier'
+            write (error_unit, '(A)') &
+                'FAIL: legacy IMPLICIT statement parsed as identifier'
             error stop 1
         end if
     end subroutine test_legacy_implicit_statement_detection
@@ -45,9 +47,30 @@ contains
         as_identifier = keyword_should_parse_as_identifier(first_token, parser)
 
         if (.not. as_identifier) then
-            write (error_unit, '(A)') 'FAIL: identifier IMPLICIT assignment was not preserved'
+            write (error_unit, '(A)') &
+                'FAIL: identifier IMPLICIT assignment was not preserved'
             error stop 1
         end if
     end subroutine test_identifier_assignment_detection
+
+    subroutine test_stop_assignment_detection()
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(parser_state_t) :: parser
+        type(token_t) :: first_token
+        logical :: as_identifier
+
+        source = 'stop = 1' // new_line('a') // 'end'
+        call tokenize_core(source, tokens)
+        parser = create_parser_state(tokens)
+        first_token = parser%peek()
+        as_identifier = keyword_should_parse_as_identifier(first_token, parser)
+
+        if (.not. as_identifier) then
+            write (error_unit, '(A)') &
+                'FAIL: identifier STOP assignment was not preserved'
+            error stop 1
+        end if
+    end subroutine test_stop_assignment_detection
 
 end program test_parser_keyword_disambiguation


### PR DESCRIPTION
## Summary
- allow the simplified procedure-body parser to honor `keyword_should_parse_as_identifier`, so executable keywords such as `stop` stay assignments even inside contained procedures
- promote the same set of executable keywords to identifiers inside declaration lists, which keeps their explicit type specs instead of synthesizing anonymous declarations
- add a regression example plus parser/unit coverage for identifiers named `stop` to prevent the regression from returning

## Verification
- `fpm test --target test_issue_2273_identifier_stop`
- `fpm test --target test_parser_keyword_disambiguation`
- `fpm test` *(fails in `test_all_examples`; reproduced on `main`, see below)*
- `fpm run --target fortfront -- examples/f90/issue_2273_identifier_stop.f90 > /tmp/issue_2273_out.f90 && diff -u examples/f90/issue_2273_identifier_stop.f90 /tmp/issue_2273_out.f90`

```
$ fpm test
...
<ERROR> Execution for object " test_all_examples " returned exit code  1
FAILURE: Some examples did not transform correctly

$ git checkout main && fpm test --target test_all_examples
<ERROR> Execution for object " test_all_examples " returned exit code  1
=== Test Summary ===
Total examples tested: 427
Failed: 1
```
