### PR TITLE
fix: DATA implied-do value lists fail to parse (fixes #2252)

### DIFF
--- a/examples/analysis_only_examples.txt
+++ b/examples/analysis_only_examples.txt
@@ -17,3 +17,4 @@ f90/ast_forall_pointer.f90
 f90/call_graph_internal_procedures.f90
 f90/call_graph_module_program_scopes.f90
 f90/issue_2078_include_statement_silently_dropped.f90
+f90/issue_2252_data_value_implied_do.f90

--- a/examples/f90/issue_2252_data_value_implied_do.f90
+++ b/examples/f90/issue_2252_data_value_implied_do.f90
@@ -1,0 +1,9 @@
+program issue_2252_data_value_implied_do
+    implicit none
+    integer :: i
+    real :: coeff(2)
+
+    ! Nonstandard DATA value implied-do regression coverage
+    data coeff/(i*1.0, i=1, 2)/
+    print *, coeff
+end program issue_2252_data_value_implied_do

--- a/src/parser/statements/parser_statement_data_module.f90
+++ b/src/parser/statements/parser_statement_data_module.f90
@@ -276,7 +276,8 @@ contains
                             case ("/")
                                 exit
                             case default
-                                call parser%error("Unexpected token in DATA object list")
+                                call parser%error("Unexpected token in DATA "// &
+                                                  "object list")
                                 return
                             end select
                         else
@@ -346,6 +347,37 @@ contains
                         return
                     end if
                     exit
+                end if
+
+                ! Try parsing implied-do values before falling back to scalars
+                if (current%kind == TK_OPERATOR .and. trim(current%text) == "(") then
+                    value_index = try_parse_data_implied_do()
+                    if (value_index > 0) then
+                        call append_index(values, value_index)
+                        expect_value = .false.
+
+                        call skip_trivia(parser)
+                        current = parser%peek()
+                        if (current%kind == TK_OPERATOR) then
+                            select case (trim(current%text))
+                            case (",")
+                                current = parser%consume()
+                                call skip_trivia(parser)
+                                expect_value = .true.
+                                cycle
+                            case ("/")
+                                exit
+                            case default
+                                call parser%error("Unexpected token in DATA "// &
+                                                  "statement value list")
+                                return
+                            end select
+                        else
+                            call parser%error("Unexpected token in DATA "// &
+                                              "statement value list")
+                            return
+                        end if
+                    end if
                 end if
 
                 value_index = parse_expression_until(parser, arena, [",", "/"])

--- a/test/codegen/test_issue_2252_data_value_implied_do.f90
+++ b/test/codegen/test_issue_2252_data_value_implied_do.f90
@@ -1,0 +1,52 @@
+program test_issue_2252_data_value_implied_do
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit
+    use, intrinsic :: iso_fortran_env, only: iostat_end, iostat_eor
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+
+    call check_value_implied_do()
+    print *, "PASSED"
+
+contains
+
+    subroutine check_value_implied_do()
+        character(len=:), allocatable :: src
+        character(len=:), allocatable :: output
+        character(len=:), allocatable :: error_msg
+        logical :: ok
+
+        call read_example('examples/f90/issue_2252_data_value_implied_do.f90', src)
+        call transform_lazy_fortran_string(src, output, error_msg)
+
+        ok = allocated(output)
+        if (ok) ok = index(output, "data coeff /(i*1.0, i = 1, 2)/") > 0
+        if (ok) ok = .not. allocated(error_msg) .or. len_trim(error_msg) == 0
+
+        if (.not. ok) then
+            print *, "FAILED [value-implied-do]"
+            if (allocated(output)) then
+                print *, trim(output)
+            else
+                print *, "OUTPUT missing"
+            end if
+            if (allocated(error_msg)) then
+                if (len_trim(error_msg) > 0) print *, trim(error_msg)
+            end if
+            stop 1
+        end if
+    end subroutine check_value_implied_do
+
+    include '../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+end program test_issue_2252_data_value_implied_do


### PR DESCRIPTION
## Summary
- allow DATA value lists to parse implied-do loops by reusing the existing helper and treating them exactly like object lists
- add a regression example plus a focused codegen test to lock the behavior down and treat the example as analysis-only because gfortran rejects this extension

## Verification
- `./build/gfortran_E3254EA1FA8B869A/app/fortfront /tmp/issue_data_stmt.f90`
  - no diagnostic; emitted program kept the implied-do value list intact
- `set -o pipefail && fpm test | tail -n 200`
  - exit 0 (see tail output in log snippet); covers the full test suite including the new regression test
