### PR TITLE
fix: Identifier named 'program' nukes the entire file (fixes #2269)

### DIFF
--- a/examples/f90/issue_2269_identifier_program.f90
+++ b/examples/f90/issue_2269_identifier_program.f90
@@ -1,0 +1,6 @@
+program demo_program_kw
+    implicit none
+    integer :: program
+    program = 10
+    print *, program
+end program demo_program_kw

--- a/src/utilities/input_validation.f90
+++ b/src/utilities/input_validation.f90
@@ -470,14 +470,16 @@ contains
             if (tokens(i)%kind == TK_KEYWORD) then
                 select case (tokens(i)%text)
                 case ("program")
-                    ! Only count as program start if NOT preceded by "end"
-                    if (i == 1) then
-                        program_count = program_count + 1
-                        has_program_start = .true.
-                    else if (i > 1 .and. tokens(i - 1)%text /= "end") then
-                        program_count = program_count + 1
-                        has_program_start = .true.
+                    ! Only treat as a new program when this token actually begins a program
+                    if (.not. is_program_statement_start(tokens, i)) cycle
+
+                    ! Skip "end program"
+                    if (i > 1) then
+                        if (tokens(i - 1)%text == "end") cycle
                     end if
+
+                    program_count = program_count + 1
+                    has_program_start = .true.
                 case ("function")
                     ! Check if this is not "end function"
                     if (i == 1) then
@@ -577,6 +579,88 @@ contains
             end select
         end do
     end function is_module_procedure_statement
+
+    logical function is_program_statement_start(tokens, idx) result(is_stmt)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: idx
+        integer :: prev_idx, next_idx
+        character(len=:), allocatable :: lowered, operator_text
+
+        is_stmt = .false.
+        if (idx < 1 .or. idx > size(tokens)) return
+
+        prev_idx = find_previous_significant_token(tokens, idx - 1)
+        if (prev_idx > 0) then
+            select case (tokens(prev_idx)%kind)
+            case (TK_KEYWORD)
+                lowered = to_lower(trim(tokens(prev_idx)%text))
+                if (lowered /= "end" .and. lowered /= "endprogram") return
+            case default
+                return
+            end select
+        end if
+
+        next_idx = find_next_significant_token(tokens, idx + 1)
+        if (next_idx == 0) then
+            is_stmt = .true.
+            return
+        end if
+
+        select case (tokens(next_idx)%kind)
+        case (TK_OPERATOR)
+            operator_text = trim(tokens(next_idx)%text)
+            select case (operator_text)
+            case ("=", "=>", "::", "%", "(", ")", ",", "+", "-", "*", "/", "//")
+                return
+            end select
+        case (TK_IDENTIFIER)
+            is_stmt = .true.
+            return
+        case (TK_KEYWORD)
+            is_stmt = .true.
+            return
+        case (TK_EOF)
+            is_stmt = .true.
+            return
+        case default
+            is_stmt = .true.
+            return
+        end select
+    end function is_program_statement_start
+
+    integer function find_previous_significant_token(tokens, start_idx) result(idx)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_idx
+
+        idx = start_idx
+        do while (idx >= 1)
+            select case (tokens(idx)%kind)
+            case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
+                idx = idx - 1
+                cycle
+            case default
+                return
+            end select
+        end do
+        idx = 0
+    end function find_previous_significant_token
+
+    integer function find_next_significant_token(tokens, start_idx) result(idx)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_idx
+
+        idx = start_idx
+        do while (idx >= 1 .and. idx <= size(tokens))
+            select case (tokens(idx)%kind)
+            case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
+                idx = idx + 1
+                cycle
+            case default
+                return
+            end select
+        end do
+        idx = 0
+    end function find_next_significant_token
 
     ! Check for specifically invalid patterns that should be rejected
     logical function contains_invalid_patterns(tokens) result(is_invalid)

--- a/test/test_issue_2269_identifier_program.f90
+++ b/test/test_issue_2269_identifier_program.f90
@@ -1,0 +1,76 @@
+program test_issue_2269_identifier_program
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_integer_decl, has_assignment, has_print_stmt
+    logical :: has_failure_stub
+
+    call read_example('examples/f90/issue_2269_identifier_program.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2269_identifier_program'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_integer_decl = index(output_code, 'integer :: program') > 0
+    has_assignment = index(output_code, 'program = 10') > 0
+    has_print_stmt = index(output_code, 'print *, program') > 0
+    has_failure_stub = index(output_code, 'COMPILATION FAILED') > 0
+
+    if (.not. has_integer_decl) then
+        write (error_unit, '(A)') 'FAIL: missing integer :: program declaration'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_assignment) then
+        write (error_unit, '(A)') 'FAIL: missing program = 10 assignment'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_print_stmt) then
+        write (error_unit, '(A)') 'FAIL: missing print *, program statement'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (has_failure_stub) then
+        write (error_unit, '(A)') 'FAIL: fallback program stub detected'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    print *, 'PASS: identifier named program survives validation and round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2269_identifier_program

--- a/test/test_parser_keyword_disambiguation.f90
+++ b/test/test_parser_keyword_disambiguation.f90
@@ -1,6 +1,7 @@
 program test_parser_keyword_disambiguation
     use, intrinsic :: iso_fortran_env, only: error_unit
-    use lexer_core, only: token_t, tokenize_core
+    use lexer_core, only: token_t, tokenize_core, to_lower
+    use lexer_token_types, only: TK_KEYWORD, TK_OPERATOR
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier
     implicit none
@@ -8,6 +9,8 @@ program test_parser_keyword_disambiguation
     call test_legacy_implicit_statement_detection()
     call test_identifier_assignment_detection()
     call test_stop_assignment_detection()
+    call test_program_assignment_detection()
+    call test_program_assignment_in_context()
 
     print *, 'PASS: parser keyword disambiguation honors implicit statements'
 
@@ -72,5 +75,73 @@ contains
             error stop 1
         end if
     end subroutine test_stop_assignment_detection
+
+    subroutine test_program_assignment_detection()
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(parser_state_t) :: parser
+        type(token_t) :: first_token
+        logical :: as_identifier
+
+        source = 'program = 10' // new_line('a') // 'end'
+        call tokenize_core(source, tokens)
+        parser = create_parser_state(tokens)
+        first_token = parser%peek()
+        as_identifier = keyword_should_parse_as_identifier(first_token, parser)
+
+        if (.not. as_identifier) then
+            write (error_unit, '(A)') &
+                'FAIL: identifier PROGRAM assignment was not preserved'
+            error stop 1
+        end if
+    end subroutine test_program_assignment_detection
+
+    subroutine test_program_assignment_in_context()
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(parser_state_t) :: parser
+        type(token_t) :: current_token, first_token, next_token
+        logical :: found_assignment, as_identifier
+
+        source = 'program demo_program_kw' // new_line('a') // &
+                 '    implicit none' // new_line('a') // &
+                 '    integer :: program' // new_line('a') // &
+                 '    program = 10' // new_line('a') // &
+                 '    print *, program' // new_line('a') // &
+                 'end program demo_program_kw'
+
+        call tokenize_core(source, tokens)
+        parser = create_parser_state(tokens)
+        found_assignment = .false.
+
+        do while (.not. parser%is_at_end())
+            current_token = parser%peek()
+            if (current_token%kind == TK_KEYWORD) then
+                if (trim(to_lower(current_token%text)) == 'program') then
+                    next_token = parser%get_token_at_index(parser%current_token + 1)
+                    if (next_token%kind == TK_OPERATOR .and. trim(next_token%text) &
+                        == '=') then
+                        found_assignment = .true.
+                        exit
+                    end if
+                end if
+            end if
+            current_token = parser%consume()
+        end do
+
+        if (.not. found_assignment) then
+            write (error_unit, '(A)') 'FAIL: failed to locate program assignment token'
+            error stop 1
+        end if
+
+        first_token = parser%peek()
+        as_identifier = keyword_should_parse_as_identifier(first_token, parser)
+
+        if (.not. as_identifier) then
+            write (error_unit, '(A)') &
+                'FAIL: keyword disambiguation failed inside program body'
+            error stop 1
+        end if
+    end subroutine test_program_assignment_in_context
 
 end program test_parser_keyword_disambiguation


### PR DESCRIPTION
## Summary
- guard the missing-end validator so identifiers named `program` are only counted when they actually start a program construct
- add parser coverage plus an end-to-end test driven by a new `examples/f90` sample to ensure the identifier survives round-trips
- keep the new helpers focused on nearby tokens, preventing the validation pass from nuking valid files with scalar `program`

## Verification
- `fpm test` *(fails: `test_all_examples` exits 1 on the pre-existing nested-internal-procedure example; see `/tmp/fpm-test-2269.log`)*
  ```
  <ERROR> Execution for object " test_all_examples " returned exit code  1
  <ERROR> *cmd_run*:stopping due to failed executions
  STOP 1
  ```
- `fpm test test_parser_keyword_disambiguation`
- `fpm test test_issue_2269_identifier_program`
- `fpm test test_optional_parameter_standard_fortran`
- `fpm test test_issue_2246_identifier_implicit`
- `fpm test test_issue_2278_return_identifier`
- `fpm test test_issue_2255_inline_if_comment`
- `fpm test test_issue_2146_array_type_preserved`
