### PR TITLE
fix: identifier goto misparsed as GO TO (fixes #2271)

### DIFF
--- a/examples/f90/issue_2271_identifier_goto.f90
+++ b/examples/f90/issue_2271_identifier_goto.f90
@@ -1,0 +1,7 @@
+program issue_2271_identifier_goto
+    implicit none
+    integer :: goto
+
+    goto = 1
+    print *, goto
+end program issue_2271_identifier_goto

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -758,63 +758,61 @@ contains
             if (lowered_identifier == "class") then
                 call handle_variable_declaration(parser_ref, arena_ref, stmt_index)
             else if (lowered_identifier == "goto") then
-                ! Handle "goto" as identifier (Fortran allows both "go to" and "goto")
-                ! Parser is at the goto token; caller already
-                ! peeked without consuming it
-                next_token = parser_ref%consume()  ! Consume "goto"
-                next_token = parser_ref%peek()
-                if (next_token%kind == TK_NUMBER .or. &
-                    next_token%kind == TK_IDENTIFIER) then
-                    stmt_index = push_goto(arena_ref, label=trim(next_token%text), &
-                                           line=current_token%line, &
-                                           column=current_token%column)
-                    next_token = parser_ref%consume()  ! Consume the label
+                if (keyword_should_parse_as_identifier(current_token, parser_ref)) then
+                    stmt_index = parse_identifier_assignment(parser_ref, arena_ref)
                 else
-                    ! Invalid goto - missing label
-                    stmt_index = push_goto(arena_ref, label="INVALID_LABEL", &
-                                           line=current_token%line, &
-                                           column=current_token%column)
+                    stmt_index = parse_goto_statement(parser_ref, arena_ref)
                 end if
             else if (lowered_identifier == "continue") then
                 stmt_index = parse_continue_statement(parser_ref, arena_ref)
             else
-                ! Check for labeled construct: identifier : keyword
-                next_token = parser_ref%consume()  ! Consume identifier
-                next_token = parser_ref%peek()
-                if (next_token%kind == TK_OPERATOR .and. next_token%text == ":") then
-                    next_token = parser_ref%consume()  ! Consume colon
-                    next_token = parser_ref%peek()
-                    if (next_token%kind == TK_KEYWORD) then
-                        block
-                            character(len=:), allocatable :: keyword_text
-                            keyword_text = trim(to_lower(next_token%text))
-                            if (keyword_text == "do") then
-                                ! Rewind to label for do loop parser
-                                parser_ref%current_token = parser_ref%current_token - 2
-                                stmt_index = parse_do_loop(parser_ref, arena_ref)
-                                return
-                            else if (is_control_flow_keyword(keyword_text)) then
-                                ! Other control flow keywords - rewind and route
-                                parser_ref%current_token = parser_ref%current_token - 2
-                                stmt_index = route_control_flow(parser_ref, arena_ref)
-                                return
-                            else
-                                ! Not control flow, rewind and parse as assignment
-                                parser_ref%current_token = parser_ref%current_token - 2
-                            end if
-                        end block
-                    else
-                        ! Not a keyword, rewind and parse as assignment
-                        parser_ref%current_token = parser_ref%current_token - 2
-                    end if
-                else
-                    ! Rewind for assignment parsing
-                    parser_ref%current_token = parser_ref%current_token - 1
-                end if
-                call parse_assignment_statement(parser_ref, arena_ref, stmt_index, &
-                                                additional_execution_indices)
+                stmt_index = parse_identifier_assignment(parser_ref, arena_ref)
             end if
         end function handle_identifier_token
+
+        integer function parse_identifier_assignment(parser_ref, arena_ref) &
+            result(stmt_index)
+            type(parser_state_t), intent(inout) :: parser_ref
+            type(ast_arena_t), intent(inout) :: arena_ref
+            type(token_t) :: next_token
+
+            ! Check for labeled construct: identifier : keyword
+            next_token = parser_ref%consume()  ! Consume identifier
+            next_token = parser_ref%peek()
+            if (next_token%kind == TK_OPERATOR .and. next_token%text == ":") then
+                next_token = parser_ref%consume()  ! Consume colon
+                next_token = parser_ref%peek()
+                if (next_token%kind == TK_KEYWORD) then
+                    block
+                        character(len=:), allocatable :: keyword_text
+                        keyword_text = trim(to_lower(next_token%text))
+                        if (keyword_text == "do") then
+                            ! Rewind to label for do loop parser
+                            parser_ref%current_token = parser_ref%current_token - 2
+                            stmt_index = parse_do_loop(parser_ref, arena_ref)
+                            return
+                        else if (is_control_flow_keyword(keyword_text)) then
+                            ! Other control flow keywords - rewind and route
+                            parser_ref%current_token = parser_ref%current_token - 2
+                            stmt_index = route_control_flow(parser_ref, arena_ref)
+                            return
+                        else
+                            ! Not control flow, rewind and parse as assignment
+                            parser_ref%current_token = parser_ref%current_token - 2
+                        end if
+                    end block
+                else
+                    ! Not a keyword, rewind and parse as assignment
+                    parser_ref%current_token = parser_ref%current_token - 2
+                end if
+            else
+                ! Rewind for assignment parsing
+                parser_ref%current_token = parser_ref%current_token - 1
+            end if
+
+            call parse_assignment_statement(parser_ref, arena_ref, stmt_index, &
+                                            additional_execution_indices)
+        end function parse_identifier_assignment
 
         subroutine consume_trivia(parser_ref)
             type(parser_state_t), intent(inout) :: parser_ref

--- a/src/parser/statements/parser_statement_utilities.f90
+++ b/src/parser/statements/parser_statement_utilities.f90
@@ -57,22 +57,13 @@ contains
             end if
         end if
 
-        ! Handle "goto" as identifier (Fortran allows both "go to" and "goto")
+        ! Handle "goto" specially: treat as identifier when assignment is present
         lowered_text = trim(to_lower(token%text))
         if (lowered_text == "goto") then
-            ! Parser is pointing AT the goto token (caller peeked but didn't consume)
-            ! Consume it here, then parse the label
-            next_token = parser%consume()  ! Consume "goto"
-            next_token = parser%peek()
-            if (next_token%kind == TK_NUMBER .or. next_token%kind == &
-                TK_IDENTIFIER) then
-                stmt_index = push_goto(arena, label=trim(next_token%text), &
-                                       line=token%line, column=token%column)
-                next_token = parser%consume()  ! Consume the label
+            if (keyword_should_parse_as_identifier(token, parser)) then
+                stmt_index = parse_assignment_simple(parser, arena)
             else
-                ! Invalid goto - missing label
-                stmt_index = push_goto(arena, label="INVALID_LABEL", &
-                                       line=token%line, column=token%column)
+                stmt_index = parse_goto_statement(parser, arena)
             end if
             return
         end if

--- a/test/integration/issue_tests/test_issue_2271_identifier_goto.f90
+++ b/test/integration/issue_tests/test_issue_2271_identifier_goto.f90
@@ -1,0 +1,89 @@
+program test_issue_2271_identifier_goto
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    print *, '=== Issue #2271: Identifier goto preservation ==='
+
+    if (.not. test_identifier_goto_round_trip()) all_passed = .false.
+
+    print *
+    if (all_passed) then
+        print *, 'Issue #2271 fixed!'
+    else
+        print *, 'Issue #2271 test failed!'
+        stop 1
+    end if
+
+contains
+
+    logical function test_identifier_goto_round_trip()
+        character(len=:), allocatable :: source, output, error_msg
+
+        test_identifier_goto_round_trip = .true.
+        print *, 'Testing identifier named goto...'
+
+        call read_example('examples/f90/issue_2271_identifier_goto.f90', source)
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, '  FAIL: Unexpected error:', trim(error_msg)
+                test_identifier_goto_round_trip = .false.
+                return
+            end if
+        end if
+
+        if (index(output, 'integer :: goto') == 0) then
+            print *, '  FAIL: integer declaration missing'
+            test_identifier_goto_round_trip = .false.
+        else
+            print *, '  PASS: integer declaration preserved'
+        end if
+
+        if (index(output, 'goto = 1') == 0) then
+            print *, '  FAIL: assignment to goto missing'
+            test_identifier_goto_round_trip = .false.
+        else
+            print *, '  PASS: assignment preserved'
+        end if
+
+        if (index(output, 'real :: goto') > 0) then
+            print *, '  FAIL: type rewritten to real'
+            test_identifier_goto_round_trip = .false.
+        else
+            print *, '  PASS: type not rewritten'
+        end if
+
+        if (index(output, 'go to ') > 0) then
+            print *, '  FAIL: fabricated GO TO statement detected'
+            test_identifier_goto_round_trip = .false.
+        else
+            print *, '  PASS: no GO TO injected'
+        end if
+    end function test_identifier_goto_round_trip
+
+    subroutine read_example(filepath, content)
+        character(len=*), intent(in) :: filepath
+        character(len=:), allocatable, intent(out) :: content
+        integer :: unit, file_size, stat
+        character(len=1), allocatable :: buffer(:)
+
+        open (newunit=unit, file=filepath, status='old', access='stream', &
+              form='unformatted', iostat=stat)
+        if (stat /= 0) error stop 'Failed to open example file: ' // filepath
+
+        inquire (unit=unit, size=file_size)
+        allocate (buffer(file_size))
+        read (unit, iostat=stat) buffer
+        if (stat /= 0) error stop 'Failed to read example file: ' // filepath
+        close (unit)
+
+        allocate (character(len=file_size) :: content)
+        content = transfer(buffer, content)
+    end subroutine read_example
+
+end program test_issue_2271_identifier_goto


### PR DESCRIPTION
## Summary
- ensure both the inline IF parser and the general execution parser treat the token `goto` as an identifier when a subsequent assignment/operator is present
- share an identifier-assignment helper so we can reuse the same logic and add an explicit example plus regression test for identifier `goto`

## Verification
- `fpm test --target test_issue_2271_identifier_goto`
- `fpm test` *(fails in `test_all_examples` because `issue_2142_mono_wrong_return_types.lf` still emits invalid code; see `/tmp/fpm-test.log` for the captured failure excerpt)*
