### PR TITLE
fix: Inner modules deleted during round-trip (fixes #2283)

### DIFF
--- a/examples/analysis_only_examples.txt
+++ b/examples/analysis_only_examples.txt
@@ -16,5 +16,6 @@ f90/ast_coverage_control_flow.f90
 f90/ast_forall_pointer.f90
 f90/call_graph_internal_procedures.f90
 f90/call_graph_module_program_scopes.f90
+f90/issue_2283_nested_modules.f90
 f90/issue_2078_include_statement_silently_dropped.f90
 f90/issue_2252_data_value_implied_do.f90

--- a/examples/f90/issue_2283_nested_modules.f90
+++ b/examples/f90/issue_2283_nested_modules.f90
@@ -1,0 +1,17 @@
+module issue_2283_outer
+    implicit none
+    module issue_2283_inner
+        implicit none
+        integer :: inner_value
+    contains
+        subroutine set_inner(value)
+            integer, intent(in) :: value
+            inner_value = value
+        end subroutine set_inner
+    end module issue_2283_inner
+contains
+    subroutine touch_inner()
+        use issue_2283_inner, only: set_inner
+        call set_inner(1)
+    end subroutine touch_inner
+end module issue_2283_outer

--- a/src/parser/declarations/parser_module_structures.f90
+++ b/src/parser/declarations/parser_module_structures.f90
@@ -31,7 +31,7 @@ module parser_module_structures_module
 
 contains
 
-    function parse_module(parser, arena) result(module_index)
+    recursive function parse_module(parser, arena) result(module_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         integer :: module_index
@@ -217,6 +217,15 @@ contains
                             declaration_indices = [declaration_indices, stmt_index]
                         end if
                         cycle
+                    case ("module")
+                        if (.not. is_module_procedure_statement(parser)) then
+                            stmt_index = parse_module(parser, arena)
+                            if (stmt_index > 0) then
+                                declaration_indices = [declaration_indices, &
+                                                       stmt_index]
+                            end if
+                            cycle
+                        end if
                     case ("implicit")
                         ! Parse implicit statement
                         call parse_simple_implicit_in_module(parser, arena, stmt_index)
@@ -365,6 +374,41 @@ contains
                                               procedure_indices, has_contains, &
                                               line, column)
     end function parse_module
+
+    logical function is_module_procedure_statement(parser) result(is_mod_proc)
+        type(parser_state_t), intent(in) :: parser
+        logical :: found_token
+        type(token_t) :: lookahead
+        integer :: next_index
+        integer :: token_count
+        character(len=:), allocatable :: lowered
+
+        is_mod_proc = .false.
+        found_token = .false.
+        token_count = parser%get_token_count()
+        next_index = parser%current_token + 1
+
+        do while (next_index <= token_count)
+            lookahead = parser%get_token_at_index(next_index)
+            select case (lookahead%kind)
+            case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
+                next_index = next_index + 1
+                cycle
+            case default
+                found_token = .true.
+                exit
+            end select
+        end do
+
+        if (.not. found_token) return
+
+        lowered = to_lower(trim(lookahead%text))
+        if (lookahead%kind == TK_KEYWORD) then
+            if (lowered == "procedure") then
+                is_mod_proc = .true.
+            end if
+        end if
+    end function is_module_procedure_statement
 
     integer function handle_enum_construct(parser, arena, keyword) &
         result(stmt_index)

--- a/test/test_issue_2283_nested_modules.f90
+++ b/test/test_issue_2283_nested_modules.f90
@@ -1,0 +1,53 @@
+program test_issue_2283_nested_modules
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, &
+        & iostat_end, iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code, output_code, error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_inner_module
+
+    call read_example('examples/f90/issue_2283_nested_modules.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2283_nested_modules'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_inner_module = index(output_code, 'module issue_2283_inner') > 0 .and. &
+        & index(output_code, 'end module issue_2283_inner') > 0
+
+    if (.not. has_inner_module) then
+        write (error_unit, '(A)') 'FAIL: nested module lost during round-trip'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    print *, 'PASS: nested modules survive round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2283_nested_modules


### PR DESCRIPTION
## Summary
- allow `parse_module` to recurse so nested module declarations are preserved while ignoring real `module procedure` statements
- add `examples/f90/issue_2283_nested_modules.f90` plus a regression test that asserts the inner module survives a round-trip and mark the example as analysis-only so gfortran doesnt reject it during `test_all_examples`

## Verification
- `fpm test` *(fails: `issue_2142_mono_wrong_return_types.lf` still does not compile; same failure reproduced on main)*
- `fpm test --target test_issue_2283_nested_modules`
- `build/gfortran_E3254EA1FA8B869A/app/fortfront examples/f90/issue_2283_nested_modules.f90`
