### PR TITLE
fix: 'elemental' rejected inside interface blocks (fixes #2288)

### DIFF
--- a/examples/f90/issue_2288_elemental_interface.f90
+++ b/examples/f90/issue_2288_elemental_interface.f90
@@ -1,0 +1,8 @@
+module issue_2288_elemental_interface_mod
+    implicit none
+    interface
+        elemental subroutine scale_value(x)
+            real, intent(in) :: x
+        end subroutine scale_value
+    end interface
+end module issue_2288_elemental_interface_mod

--- a/test/test_issue_2288_elemental_interface.f90
+++ b/test/test_issue_2288_elemental_interface.f90
@@ -1,0 +1,60 @@
+program test_issue_2288_elemental_interface
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use transformation_api, only: transform_context_t, transform_with_context, &
+        & INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+
+    call read_example('examples/f90/issue_2288_elemental_interface.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2288_elemental_interface'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+    if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            & trim(error_msg)
+        error stop 1
+    end if
+
+    if (.not. allocated(output_code)) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context produced no output'
+        error stop 1
+    end if
+
+    if (index(output_code, 'elemental subroutine scale_value(') == 0) then
+        write (error_unit, '(A)') &
+            'FAIL: elemental subroutine declaration missing in output'
+        error stop 1
+    end if
+
+    if (index(output_code, 'interface') == 0) then
+        write (error_unit, '(A)') 'FAIL: interface block missing in output'
+        error stop 1
+    end if
+
+    print *, 'PASS: Issue #2288 elemental interface parsed successfully'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2288_elemental_interface


### PR DESCRIPTION
## Summary
- add a canonical standard Fortran example that declares an elemental subroutine inside an interface block
- cover the transformer with a focused regression test so interface parsing keeps accepting the elemental prefix and preserves it in the output

## Verification
- `fpm test --target test_issue_2288_elemental_interface`
  - PASS: Issue #2288 elemental interface parsed successfully
- `build/gfortran_E3254EA1FA8B869A/app/fortfront examples/f90/issue_2288_elemental_interface.f90`
  - emits the interface with `elemental subroutine scale_value` and no diagnostics
- `fpm test`
  - fails in `test_all_examples` because `examples/lf/issue_2142_mono_wrong_return_types.lf` still compiles to invalid code (pre-existing); all earlier suites pass
