### PR TITLE
fix: OpenACC directives stripped from output (fixes #2286)

### DIFF
--- a/examples/f90/issue_2286_openacc_internal.f90
+++ b/examples/f90/issue_2286_openacc_internal.f90
@@ -1,0 +1,20 @@
+program issue_2286_openacc_internal
+    implicit none
+    call run_parallel_loop()
+contains
+    subroutine run_parallel_loop()
+        integer :: i
+!$acc parallel loop
+        do i = 1, 3
+            call emit_value(i)
+        end do
+!$acc end parallel loop
+    end subroutine run_parallel_loop
+
+    subroutine emit_value(value)
+        use, intrinsic :: iso_fortran_env, only: output_unit
+        implicit none
+        integer, intent(in) :: value
+        write (output_unit, '(I0)') value
+    end subroutine emit_value
+end program issue_2286_openacc_internal

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -6,7 +6,8 @@ module parser_procedure_definition_bodies_module
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_if_statements_module, only: parse_if_statement_tokens
     use parser_do_constructs_module, only: parse_do_loop
-    use parser_statement_utilities_module, only: parse_statement_in_if_block
+    use parser_statement_utilities_module, only: parse_statement_in_if_block, &
+                                                 parse_comment_or_directive
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t, &
                                            append_prefix_token
     use parser_procedure_shared_module, only: consume_optional_kind_spec
@@ -70,6 +71,14 @@ contains
 
             if (token%kind == TK_NEWLINE) then
                 token = parser%consume()
+                cycle
+            end if
+
+            if (token%kind == TK_COMMENT) then
+                stmt_index = parse_comment_or_directive(parser, arena, token)
+                if (stmt_index > 0) then
+                    body_indices = [body_indices, stmt_index]
+                end if
                 cycle
             end if
 

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -57,8 +57,7 @@ module parser_execution_statements_module
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_program, &
                            push_declaration, push_implicit_statement, push_goto
-    use ast_nodes_misc, only: directive_node, comment_node
-    use uid_generator, only: generate_uid
+    use parser_statement_utilities_module, only: parse_comment_or_directive
     use ast_types, only: LITERAL_STRING, LITERAL_INTEGER, LITERAL_REAL, LITERAL_LOGICAL
     use parser_legacy_statements_module, only: parse_legacy_statement
     implicit none
@@ -869,51 +868,6 @@ contains
                 ignored_token = parser_ref%consume()
             end block
         end subroutine consume_misc
-
-        integer function parse_comment_or_directive(parser_ref, arena_ref, &
-                                                    comment_token) result(node_index)
-            type(parser_state_t), intent(inout) :: parser_ref
-            type(ast_arena_t), intent(inout) :: arena_ref
-            type(token_t), intent(in) :: comment_token
-            type(directive_node) :: directive
-            type(comment_node) :: comment
-            character(len=:), allocatable :: lowered_text
-
-            ! Check if this is a directive (!$omp or !$acc)
-            if (allocated(comment_token%text)) then
-                lowered_text = to_lower(adjustl(comment_token%text))
-                if (len(lowered_text) >= 5) then
-                    if (lowered_text(1:5) == "!$omp" .or. lowered_text(1:5) == "!$acc") then
-                        ! This is a directive
-                        directive%uid = generate_uid()
-                        directive%line = comment_token%line
-                        directive%column = comment_token%column
-                        directive%text = comment_token%text
-                        if (lowered_text(1:5) == "!$omp") directive%is_openmp = .true.
-                        if (lowered_text(1:5) == "!$acc") directive%is_openacc = .true.
-                        call arena_ref%push(directive, "directive")
-                        node_index = arena_ref%size
-                        block
-                            type(token_t) :: ignored_token
-                            ignored_token = parser_ref%consume()
-                        end block
-                        return
-                    end if
-                end if
-            end if
-
-            ! This is a regular comment
-            comment%uid = generate_uid()
-            comment%text = comment_token%text
-            comment%line = comment_token%line
-            comment%column = comment_token%column
-            call arena_ref%push(comment, "comment")
-            node_index = arena_ref%size
-            block
-                type(token_t) :: ignored_token
-                ignored_token = parser_ref%consume()
-            end block
-        end function parse_comment_or_directive
 
         subroutine append_statement(stmt_index, indices)
             integer, intent(in) :: stmt_index

--- a/src/parser/statements/parser_statement_utilities.f90
+++ b/src/parser/statements/parser_statement_utilities.f90
@@ -33,11 +33,13 @@ module parser_statement_utilities_module
                            push_import_statement
     use ast_types, only: LITERAL_STRING
     use ast_nodes_control, only: association_t
+    use ast_nodes_misc, only: directive_node, comment_node
     use parser_legacy_statements_module, only: parse_legacy_statement
+    use uid_generator, only: generate_uid
     implicit none
     private
 
-    public :: parse_statement_in_if_block
+    public :: parse_statement_in_if_block, parse_comment_or_directive
 
 contains
 
@@ -147,6 +149,60 @@ contains
             stmt_index = parse_assignment_simple(parser, arena)
         end select
     end function parse_statement_in_if_block
+
+    ! Shared handling for OpenMP/OpenACC directives and regular comments
+    function parse_comment_or_directive(parser, arena, comment_token) &
+        result(node_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t), intent(in) :: comment_token
+        integer :: node_index
+        type(directive_node) :: directive
+        type(comment_node) :: comment
+        character(len=:), allocatable :: lowered_text
+
+        node_index = 0
+
+        if (allocated(comment_token%text)) then
+            lowered_text = to_lower(adjustl(comment_token%text))
+            if (len(lowered_text) >= 5) then
+                if (lowered_text(1:5) == "!$omp" .or. lowered_text(1:5) == "!$acc") then
+                    directive%uid = generate_uid()
+                    directive%line = comment_token%line
+                    directive%column = comment_token%column
+                    if (allocated(comment_token%text)) then
+                        directive%text = comment_token%text
+                    else
+                        directive%text = "!"
+                    end if
+                    if (lowered_text(1:5) == "!$omp") directive%is_openmp = .true.
+                    if (lowered_text(1:5) == "!$acc") directive%is_openacc = .true.
+                    call arena%push(directive, "directive")
+                    node_index = arena%size
+                    block
+                        type(token_t) :: ignored_token
+                        ignored_token = parser%consume()
+                    end block
+                    return
+                end if
+            end if
+        end if
+
+        comment%uid = generate_uid()
+        if (allocated(comment_token%text)) then
+            comment%text = comment_token%text
+        else
+            comment%text = "!"
+        end if
+        comment%line = comment_token%line
+        comment%column = comment_token%column
+        call arena%push(comment, "comment")
+        node_index = arena%size
+        block
+            type(token_t) :: ignored_token
+            ignored_token = parser%consume()
+        end block
+    end function parse_comment_or_directive
 
     ! Simple assignment parser (utility function)
     function parse_assignment_simple(parser, arena) result(assign_index)

--- a/test/test_issue_2286_openacc_directives.f90
+++ b/test/test_issue_2286_openacc_directives.f90
@@ -1,0 +1,61 @@
+program test_issue_2286_openacc_directives
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_parallel_loop, has_end_parallel
+
+    call read_example('examples/f90/issue_2286_openacc_internal.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2286_openacc_internal'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_parallel_loop = index(output_code, '!$acc parallel loop') > 0
+    has_end_parallel = index(output_code, '!$acc end parallel loop') > 0
+
+    if (.not. has_parallel_loop) then
+        write (error_unit, '(A)') 'FAIL: missing !$acc parallel loop directive'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_end_parallel) then
+        write (error_unit, '(A)') 'FAIL: missing !$acc end parallel loop directive'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    print *, 'PASS: OpenACC directives preserved inside internal procedures'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2286_openacc_directives


### PR DESCRIPTION
## Summary
- share directive/comment parsing helper and reuse it for execution and procedure bodies so sentinel comments always survive AST construction
- append parsed comment/directive nodes when walking procedure bodies instead of skipping comment tokens
- add an examples/f90 program plus regression test that exercises OpenACC directives inside internal procedures

## Verification
- `fpm test`
- `build/gfortran_E3254EA1FA8B869A/app/fortfront examples/f90/issue_2286_openacc_internal.f90 > /tmp/issue_2286_out.f90 && rg -n --fixed-strings '!$acc' /tmp/issue_2286_out.f90`
  - output: `10:!$acc parallel loop`, `14:!$acc end parallel loop`
