### PR TITLE
fix: Standalone subroutines wrapped as internal procedures (fixes #2282)

### DIFF
--- a/examples/f90/issue_2282_external_subroutine.f90
+++ b/examples/f90/issue_2282_external_subroutine.f90
@@ -1,0 +1,5 @@
+subroutine only_demo()
+    implicit none
+    print *, 'hello'
+end subroutine only_demo
+

--- a/src/frontend_transformation.f90
+++ b/src/frontend_transformation.f90
@@ -1894,7 +1894,12 @@ contains
         type is (mixed_construct_container_node)
 ! Handle mixed constructs: implicit declarations (main code) + explicit programs (functions)
             if (allocated(root%implicit_declaration_indices)) then
-                main_stmts = root%implicit_declaration_indices
+                do i = 1, size(root%implicit_declaration_indices)
+                    if (is_host_level_statement(arena, &
+                                                root%implicit_declaration_indices(i))) then
+                        main_stmts = [main_stmts, root%implicit_declaration_indices(i)]
+                    end if
+                end do
             end if
             if (allocated(root%explicit_program_indices)) then
                 do i = 1, size(root%explicit_program_indices)
@@ -1911,8 +1916,11 @@ contains
             end if
 
             ! Create a program with main code and internal procedures
-            ! Handle case where we have procedures (with or without main code)
             if (size(proc_indices) > 0) then
+                if (size(main_stmts) == 0) then
+                    ! No bare statements to wrap; keep procedures external
+                    return
+                end if
      ! Create program structure: implicit none + main statements + contains + procedures
                 implicit_none_index = push_implicit_statement(arena, .true., &
                                                               line=1, column=1, &
@@ -1966,6 +1974,8 @@ contains
                 return
             end if
 
+            return
+
         type is (program_node)
             if (trim(root%name) /= "__MULTI_UNIT__") return
             if (.not. allocated(root%body_indices)) return
@@ -2007,8 +2017,9 @@ contains
                     proc_indices = [proc_indices, child_index]
                 class default
                     ! Non-procedure, non-program statements (bare statements)
-                    ! Always collect them - we'll merge with program node if one exists
-                    main_stmts = [main_stmts, child_index]
+                    if (is_host_level_statement(arena, child_index)) then
+                        main_stmts = [main_stmts, child_index]
+                    end if
                 end select
             end do
 
@@ -2021,6 +2032,7 @@ contains
 
         ! If we have procedures but no program node, create one from bare statements
         if (main_prog_index == 0 .and. size(proc_indices) > 0) then
+            if (size(main_stmts) == 0) return
             ! Create program structure with bare statements + contains + procedures
             implicit_none_index = push_implicit_statement(arena, .true., &
                                                           line=1, column=1, &
@@ -2236,7 +2248,9 @@ contains
                     type is (end_statement_node)
                         cycle
                     class default
-                        main_stmts = [main_stmts, stmt_idx]
+                        if (is_host_level_statement(arena, stmt_idx)) then
+                            main_stmts = [main_stmts, stmt_idx]
+                        end if
                     end select
                 end do
             end select
@@ -2314,6 +2328,28 @@ contains
                 end do
             end select
         end function program_contains_procedures
+
+        logical function is_host_level_statement(arena, node_idx) result(is_host)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: node_idx
+
+            is_host = .false.
+            if (node_idx <= 0 .or. node_idx > arena%size) return
+            if (.not. allocated(arena%entries(node_idx)%node)) return
+
+            select type (stmt => arena%entries(node_idx)%node)
+            type is (assignment_node)
+                is_host = .true.
+            type is (print_statement_node)
+                is_host = .true.
+            type is (if_node)
+                is_host = .true.
+            type is (do_loop_node)
+                is_host = .true.
+            type is (subroutine_call_node)
+                is_host = .true.
+            end select
+        end function is_host_level_statement
     end subroutine promote_functions_to_internal_program
 
     ! Check if AST already contains a module node

--- a/test/integration/issue_tests/test_issue_2282_external_subroutine.f90
+++ b/test/integration/issue_tests/test_issue_2282_external_subroutine.f90
@@ -1,0 +1,63 @@
+program test_issue_2282_external_subroutine
+    use transformation_api, only: transform_with_context, transform_context_t, &
+        INPUT_MODE_STANDARD
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        iostat_eor
+    implicit none
+
+    character(len=:), allocatable :: source, transformed, error_msg
+    type(transform_context_t) :: context
+
+    call read_example('examples/f90/issue_2282_external_subroutine.f90', source)
+
+    context%source_name = 'issue_2282_external_subroutine'
+    context%module_name = context%source_name
+    context%program_name = 'main'
+    context%has_filename = .false.
+    context%input_mode = INPUT_MODE_STANDARD
+
+    call transform_with_context(source, transformed, error_msg, context)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: unexpected error message'
+        write (error_unit, '(A)') trim(error_msg)
+        error stop 'FAIL: transform_with_context returned error'
+    end if
+
+    if (index(transformed, 'program main') > 0) then
+        write (error_unit, '(A)') 'FAIL: synthetic program main emitted'
+        write (error_unit, '(A)') trim(transformed)
+        error stop 'FAIL: external subroutine wrapped'
+    end if
+
+    if (index(transformed, 'contains') > 0) then
+        write (error_unit, '(A)') 'FAIL: unexpected contains block emitted'
+        write (error_unit, '(A)') trim(transformed)
+        error stop 'FAIL: contains emitted for standalone procedure'
+    end if
+
+    if (index(transformed, 'subroutine only_demo') == 0) then
+        write (error_unit, '(A)') 'FAIL: expected subroutine missing'
+        write (error_unit, '(A)') trim(transformed)
+        error stop 'FAIL: subroutine dropped'
+    end if
+
+    print *, 'PASS: test_issue_2282_external_subroutine'
+
+contains
+
+    include '../../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2282_external_subroutine


### PR DESCRIPTION
## Summary
- gate mixed/multi-unit promotion on actual host-level statements so pure external procedures stay external
- add helper filtering executable nodes plus regression example exercising a standalone subroutine path

## Verification
- fpm test --target test_issue_2282_external_subroutine
