### PR TITLE
fix: Trailing program deleted when file also defines a module (fixes #2265)

### DIFF
--- a/examples/f90/issue_2265_module_program.f90
+++ b/examples/f90/issue_2265_module_program.f90
@@ -1,0 +1,13 @@
+module issue_2265_module_program_mod
+    implicit none
+contains
+    subroutine no_op()
+    end subroutine no_op
+end module issue_2265_module_program_mod
+
+program issue_2265_roundtrip_app
+    use issue_2265_module_program_mod, only: no_op
+    implicit none
+
+    call no_op()
+end program issue_2265_roundtrip_app

--- a/src/codegen/codegen_program_generation.f90
+++ b/src/codegen/codegen_program_generation.f90
@@ -4,7 +4,8 @@ module codegen_program_generation
     use ast_nodes_misc, only: blank_line_node, comment_node, contains_node, &
                               directive_node, end_statement_node, &
                               implicit_statement_node, interface_block_node
-    use ast_nodes_procedure, only: subroutine_def_node
+    use ast_nodes_procedure, only: subroutine_def_node, function_def_node
+    use ast_nodes_data, only: module_node
     use codegen_arena_interface, only: generate_code_from_arena
     use codegen_program_body, only: append_program_body
     use codegen_program_header, only: assemble_program_header
@@ -161,6 +162,72 @@ contains
         end select
     end function emit_interface_only_program
 
+    logical function program_is_module_wrapper(arena, node) result(is_wrapper)
+        type(ast_arena_t), intent(in) :: arena
+        type(program_node), intent(in) :: node
+        integer :: j, child_idx
+
+        is_wrapper = .false.
+
+        if (trim(node%name) /= 'main' .and. trim(node%name) /= '__IMPLICIT_MAIN__') &
+            return
+        if (.not. allocated(node%body_indices)) return
+
+        do j = 1, size(node%body_indices)
+            child_idx = node%body_indices(j)
+            if (child_idx <= 0 .or. child_idx > arena%size) cycle
+            if (.not. allocated(arena%entries(child_idx)%node)) cycle
+            select type (body => arena%entries(child_idx)%node)
+            type is (module_node)
+                is_wrapper = .true.
+            type is (interface_block_node)
+                cycle
+            type is (function_def_node)
+                cycle
+            type is (subroutine_def_node)
+                cycle
+            type is (implicit_statement_node)
+                cycle
+            type is (contains_node)
+                cycle
+            type is (end_statement_node)
+                cycle
+            type is (comment_node)
+                cycle
+            type is (directive_node)
+                cycle
+            type is (blank_line_node)
+                cycle
+            class default
+                return
+            end select
+        end do
+    end function program_is_module_wrapper
+
+    subroutine append_module_wrapper(arena, node, code)
+        type(ast_arena_t), intent(in) :: arena
+        type(program_node), intent(in) :: node
+        character(len=:), allocatable, intent(inout) :: code
+        integer :: j, child_idx
+        character(len=:), allocatable :: module_code
+
+        if (.not. allocated(node%body_indices)) return
+
+        do j = 1, size(node%body_indices)
+            child_idx = node%body_indices(j)
+            if (child_idx <= 0 .or. child_idx > arena%size) cycle
+            if (.not. allocated(arena%entries(child_idx)%node)) cycle
+            select type (mod_node => arena%entries(child_idx)%node)
+            type is (module_node)
+                module_code = generate_code_from_arena(arena, child_idx)
+                if (len(module_code) == 0) cycle
+                if (len(code) > 0) code = code // new_line('A') // &
+                                          new_line('A')
+                code = code // module_code
+            end select
+        end do
+    end subroutine append_module_wrapper
+
     function generate_multi_unit_program(arena, node) result(code)
         type(ast_arena_t), intent(in) :: arena
         type(program_node), intent(in) :: node
@@ -182,6 +249,10 @@ contains
 
             select type (child => arena%entries(child_index)%node)
             type is (program_node)
+                if (program_is_module_wrapper(arena, child)) then
+                    call append_module_wrapper(arena, child, code)
+                    cycle
+                end if
                 if (program_contains_only_interfaces(arena, child_index)) then
                     child_code = emit_interface_only_program(arena, child_index)
                     if (len(child_code) > 0) then

--- a/test/test_issue_2265_trailing_program.f90
+++ b/test/test_issue_2265_trailing_program.f90
@@ -1,0 +1,64 @@
+program test_issue_2265_trailing_program
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_context_t, transform_with_context
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    integer :: module_pos, program_pos
+
+    call read_example('examples/f90/issue_2265_module_program.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2265_module_program'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    module_pos = index(output_code, 'module issue_2265_module_program_mod')
+    program_pos = index(output_code, 'program issue_2265_roundtrip_app')
+
+    if (module_pos == 0) then
+        write (error_unit, '(A)') 'FAIL: module unit missing in output'
+        error stop 1
+    end if
+
+    if (program_pos == 0) then
+        write (error_unit, '(A)') 'FAIL: trailing program missing in output'
+        error stop 1
+    end if
+
+    if (program_pos <= module_pos) then
+        write (error_unit, '(A)') 'FAIL: program emitted before module unexpectedly'
+        error stop 1
+    end if
+
+    print *, 'PASS: module and trailing program both round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2265_trailing_program


### PR DESCRIPTION
## Summary
- detect module-only wrapper programs during multi-unit emission and splice their module bodies ahead of subsequent program units
- add a canonical standard Fortran example plus regression test to ensure modules and explicit programs coexist after a round-trip

## Verification
- `fpm test --target test_issue_2265_trailing_program`
- `fpm test` *(fails: `test_all_examples` reports `issue_2142_mono_wrong_return_types.lf` -> `FAIL (parser error or compilation failed)`; see /tmp/fpm_test.log)*
```
---- FAILURE DETAILS FOR issue_2142_mono_wrong_return_types.lf ----
FAIL (parser error or compilation failed)
```
- `python3 scripts/run_gfortran_roundtrip.py --jobs 1 --timeout 0.1`
  - updates `logs/gfortran_dejagnu_roundtrip_results_summary.json` (current `missing_program_scaffold` count = 1981)
```
$ rg -n '"count": 1981' logs/gfortran_dejagnu_roundtrip_results_summary.json
11:          "count": 1981,
```
