### PR TITLE
fix: Polish: Fix 88-column limit violation in frontend_transformation (fixes #2333)

### DIFF
--- a/src/frontend_transformation.f90
+++ b/src/frontend_transformation.f90
@@ -1896,7 +1896,7 @@ contains
             if (allocated(root%implicit_declaration_indices)) then
                 do i = 1, size(root%implicit_declaration_indices)
                     if (is_host_level_statement(arena, &
-                                                root%implicit_declaration_indices(i))) then
+                        root%implicit_declaration_indices(i))) then
                         main_stmts = [main_stmts, root%implicit_declaration_indices(i)]
                     end if
                 end do


### PR DESCRIPTION
## Summary
- rewrap the `is_host_level_statement` condition in `frontend_transformation.f90` so the continuation line stays within the 88-column limit mandated by CLAUDE.md

## Verification
- `fpm test`
