### PR TITLE
fix: Identifier 'entry' drops assignments (fixes #2277)

### DIFF
--- a/examples/f90/issue_2277_identifier_entry.f90
+++ b/examples/f90/issue_2277_identifier_entry.f90
@@ -1,0 +1,7 @@
+program issue_2277_identifier_entry
+    implicit none
+    integer :: entry
+
+    entry = 7
+    print *, entry
+end program issue_2277_identifier_entry

--- a/src/parser/procedures/parser_procedure_bodies.f90
+++ b/src/parser/procedures/parser_procedure_bodies.f90
@@ -54,20 +54,33 @@ contains
         end select
     end function token_is_identifier_like
 
-    function try_parse_keyword_assignment(parser, arena) result(stmt_index)
+    function try_parse_keyword_assignment(parser, arena, allow_keyword_tokens) &
+        result(stmt_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
+        logical, intent(in), optional :: allow_keyword_tokens
         integer :: stmt_index
         type(token_t) :: token, assign_token
         integer :: lhs_index, rhs_index
         integer :: saved_token
+        logical :: accept_keyword_tokens
 
         stmt_index = 0
         saved_token = parser%current_token
+        accept_keyword_tokens = .false.
+        if (present(allow_keyword_tokens)) then
+            accept_keyword_tokens = allow_keyword_tokens
+        end if
 
         token = parser%peek()
-        if (.not. token_is_identifier_like(token)) then
-            return
+        if (accept_keyword_tokens) then
+            if (token%kind /= TK_IDENTIFIER .and. token%kind /= TK_KEYWORD) then
+                return
+            end if
+        else
+            if (.not. token_is_identifier_like(token)) then
+                return
+            end if
         end if
 
         lhs_index = push_identifier(arena, token%text, token%line, token%column)
@@ -130,7 +143,7 @@ contains
         integer :: sub_index
         type(token_t) :: token
         character(len=:), allocatable :: subroutine_name
-        integer :: line, column
+        integer :: line, column, stmt_index_local
         integer, allocatable :: param_indices(:), body_indices(:)
         character(len=16), allocatable :: prefix_keywords(:)
         logical :: has_recursive_keyword
@@ -332,9 +345,14 @@ contains
                 end if
             end if
 
-            if (token_is_identifier_like(token)) then
-                integer :: stmt_index_local
-
+            if (token%kind == TK_KEYWORD) then
+                stmt_index_local = try_parse_keyword_assignment(parser, arena, &
+                                                                .true.)
+                if (stmt_index_local > 0) then
+                    body_indices = [body_indices, stmt_index_local]
+                    cycle
+                end if
+            else if (token_is_identifier_like(token)) then
                 stmt_index_local = try_parse_keyword_assignment(parser, arena)
                 if (stmt_index_local > 0) then
                     body_indices = [body_indices, stmt_index_local]
@@ -367,6 +385,10 @@ contains
 
         select case (token%kind)
         case (TK_KEYWORD)
+            stmt_index = try_parse_keyword_assignment(parser, arena, .true.)
+            if (stmt_index > 0) then
+                return
+            end if
             select case (trim(to_lower(token%text)))
             case ("print")
                 stmt_index = parse_print_statement(parser, arena)
@@ -414,16 +436,8 @@ contains
                 ! Handle ENTRY statements
                 stmt_index = parse_entry_statement(parser, arena)
             case default
-                if (token_is_identifier_like(token)) then
-                    stmt_index = try_parse_keyword_assignment(parser, arena)
-                    if (stmt_index == 0) then
-                        token = parser%consume()
-                        stmt_index = 0
-                    end if
-                else
-                    token = parser%consume()
-                    stmt_index = 0
-                end if
+                token = parser%consume()
+                stmt_index = 0
             end select
         case (TK_IDENTIFIER)
             ! Likely assignment statement
@@ -460,12 +474,15 @@ contains
                 body_indices = [body_indices, stmt_index]
             end if
         else if (token%kind /= TK_NEWLINE) then
-            if (token_is_identifier_like(token)) then
+            if (token%kind == TK_KEYWORD) then
+                stmt_index = try_parse_keyword_assignment(parser, arena, .true.)
+            else if (token_is_identifier_like(token)) then
                 stmt_index = try_parse_keyword_assignment(parser, arena)
-                if (stmt_index == 0) then
-                    stmt_index = parse_basic_statement_in_subroutine(parser, arena)
-                end if
             else
+                stmt_index = 0
+            end if
+
+            if (stmt_index == 0) then
                 stmt_index = parse_basic_statement_in_subroutine(parser, arena)
             end if
             if (stmt_index > 0) then

--- a/test/test_issue_2277_identifier_entry.f90
+++ b/test/test_issue_2277_identifier_entry.f90
@@ -1,0 +1,66 @@
+program test_issue_2277_identifier_entry
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_declaration, has_assignment, has_print
+
+    call read_example('examples/f90/issue_2277_identifier_entry.f90', &
+                      source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2277_identifier_entry'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_declaration = index(output_code, 'integer :: entry') > 0
+    has_assignment = index(output_code, 'entry = 7') > 0
+    has_print = index(output_code, 'print *, entry') > 0
+
+    if (.not. has_declaration) then
+        write (error_unit, '(A)') 'FAIL: missing integer :: entry declaration'
+        error stop 1
+    end if
+
+    if (.not. has_assignment) then
+        write (error_unit, '(A)') 'FAIL: missing entry = 7 assignment'
+        error stop 1
+    end if
+
+    if (.not. has_print) then
+        write (error_unit, '(A)') 'FAIL: missing print *, entry statement'
+        error stop 1
+    end if
+
+    print *, 'PASS: identifier named entry survives round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2277_identifier_entry


### PR DESCRIPTION
## Summary
- treat leading keywords as candidate assignment targets before falling back to entry/call/etc. parsing so identifiers named `entry` keep their statements intact
- extend `try_parse_keyword_assignment` so keyword tokens can be parsed as identifiers when needed and reuse it in the procedure body dispatchers
- add `examples/f90/issue_2277_identifier_entry.f90` plus its regression test to guard the fix

## Verification
- `fpm test --target test_issue_2277_identifier_entry`
  - `test_issue_2277_identifier_ent  done.`
  - artifacts: `examples/f90/issue_2277_identifier_entry.f90`, `test/test_issue_2277_identifier_entry.f90`
