### PR TITLE
fix: Identifier named 'dimension' drops every assignment (fixes #2266)

### DIFF
--- a/examples/f90/issue_2266_identifier_dimension.f90
+++ b/examples/f90/issue_2266_identifier_dimension.f90
@@ -1,0 +1,7 @@
+program issue_2266_identifier_dimension
+    implicit none
+    real :: dimension
+    dimension = 1.0
+    print *, dimension
+end program issue_2266_identifier_dimension
+

--- a/test/test_issue_2266_identifier_dimension.f90
+++ b/test/test_issue_2266_identifier_dimension.f90
@@ -1,0 +1,67 @@
+program test_issue_2266_identifier_dimension
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_declaration, has_assignment, has_print
+
+    call read_example('examples/f90/issue_2266_identifier_dimension.f90', &
+                      source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2266_identifier_dimension'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_declaration = index(output_code, 'real :: dimension') > 0
+    has_assignment = index(output_code, 'dimension = 1.0') > 0
+    has_print = index(output_code, 'print *, dimension') > 0
+
+    if (.not. has_declaration) then
+        write (error_unit, '(A)') 'FAIL: missing real :: dimension declaration'
+        error stop 1
+    end if
+
+    if (.not. has_assignment) then
+        write (error_unit, '(A)') 'FAIL: missing dimension = 1.0 assignment'
+        error stop 1
+    end if
+
+    if (.not. has_print) then
+        write (error_unit, '(A)') 'FAIL: missing print *, dimension statement'
+        error stop 1
+    end if
+
+    print *, 'PASS: identifier named dimension survives round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2266_identifier_dimension
+


### PR DESCRIPTION
Summary
- Add canonical standard Fortran example for issue #2266.
- Add regression test ensuring identifiers named `dimension` survive round-trip unchanged.

Details
- New example `examples/f90/issue_2266_identifier_dimension.f90` mirrors the issue reproducer:
  - `real :: dimension`
  - `dimension = 1.0`
  - `print *, dimension`
- New test `test/test_issue_2266_identifier_dimension.f90` uses `transform_with_context` with `INPUT_MODE_STANDARD` and `read_example` (via `common/cli_io_reader.inc`) to verify:
  - The declaration `real :: dimension` is present.
  - The assignment `dimension = 1.0` is preserved.
  - The `print *, dimension` statement is preserved.
- This locks in the currently-correct behavior so that future changes cannot regress the handling of identifiers that match the `dimension` keyword.

Verification
- Targeted new test:
  - Command: `fpm test test_issue_2266_identifier_dimension`
  - Output excerpt:
    - `PASS: identifier named dimension survives round-trip`
- Full test suite (note: existing known failure in test_all_examples):
  - Command: `fpm test`
  - Outcome: all tests pass except `test_all_examples` (pre-existing failure; stack shows `FAILURE: Some examples did not transform correctly` and `Execution for object " test_all_examples " returned exit code 1`).
  - No additional failures are introduced by this change.
- Duplication policy check:
  - Command: `make check-duplication`
  - Output excerpt:
    - `VIOLATIONS (must fix): 0 end-to-end tests with inline code`
    - `WARNINGS (review recommended): 13 tests with moderate inline code`
    - `0 PASS: No end-to-end test violations found`

Manual CLI sanity check for the original reproducer
- Input written to `/tmp/retest_dimension.f90`:
  - `program demo_dimension`
  - `    implicit none`
  - `    real :: dimension`
  - `    dimension = 1.0`
  - `    print *, dimension`
  - `end program demo_dimension`
- Command:
  - `build/gfortran_E3254EA1FA8B869A/app/fortfront /tmp/retest_dimension.f90 > /tmp/retest_dimension_out.f90`
  - `diff -u /tmp/retest_dimension.f90 /tmp/retest_dimension_out.f90`
- Diff excerpt (only trailing whitespace differences):
  - `-    dimension = 1.0`
  - `-    print *, dimension`
  - `+    dimension = 1.0 `
  - `+    print *, dimension `
- This confirms the assignment to `dimension` and the print statement both survive round-trip; the new regression test codifies this behavior.
