### PR TITLE
fix: Variable named 'common' mutates into REAL/COMMON statement (fixes #2270)

### DIFF
--- a/examples/f90/issue_2270_identifier_common.f90
+++ b/examples/f90/issue_2270_identifier_common.f90
@@ -1,0 +1,8 @@
+program issue_2270_identifier_common
+    implicit none
+    integer :: common
+
+    common = 1
+    print *, common
+end program issue_2270_identifier_common
+

--- a/src/parser/core/parser_dispatcher.f90
+++ b/src/parser/core/parser_dispatcher.f90
@@ -326,7 +326,12 @@ contains
             case ("namelist")
                 stmt_index = parse_namelist_statement(parser, arena)
             case ("equivalence", "common")
-                stmt_index = parse_legacy_statement(lowered_keyword, parser, arena)
+                if (keyword_should_parse_as_identifier(first_token, parser)) then
+                    stmt_index = parse_assignment_or_expression(parser, arena)
+                else
+                    stmt_index = parse_legacy_statement(lowered_keyword, parser, &
+                                                        arena)
+                end if
             case ("enum", "enumerator")
                 stmt_index = parse_unsupported_statement(lowered_keyword, &
                                                          parser, arena)

--- a/test/test_issue_2270_identifier_common.f90
+++ b/test/test_issue_2270_identifier_common.f90
@@ -1,0 +1,87 @@
+program test_issue_2270_identifier_common
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_declaration, has_assignment, has_print, has_real_decl, &
+        & has_common_stmt
+
+    call read_example('examples/f90/issue_2270_identifier_common.f90', &
+        & source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2270_identifier_common'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_declaration = index(output_code, 'integer :: common') > 0
+    has_assignment = index(output_code, 'common = 1') > 0
+    has_print = index(output_code, 'print *, common') > 0
+    has_real_decl = index(output_code, 'real :: common') > 0
+    has_common_stmt = index(output_code, new_line('a')//'    common'// &
+        & new_line('a')) > 0 .or. index(output_code, new_line('a')//'common'// &
+        & new_line('a')) > 0
+
+    if (.not. has_declaration) then
+        write (error_unit, '(A)') 'FAIL: missing integer :: common declaration'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_assignment) then
+        write (error_unit, '(A)') 'FAIL: missing common = 1 assignment'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_print) then
+        write (error_unit, '(A)') 'FAIL: missing print *, common statement'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (has_real_decl) then
+        write (error_unit, '(A)') 'FAIL: unexpected real :: common declaration'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (has_common_stmt) then
+        write (error_unit, '(A)') 'FAIL: extraneous COMMON statement inserted'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    print *, 'PASS: identifier named common survives round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2270_identifier_common
+

--- a/test/test_parser_keyword_disambiguation.f90
+++ b/test/test_parser_keyword_disambiguation.f90
@@ -12,6 +12,7 @@ program test_parser_keyword_disambiguation
     call test_program_assignment_detection()
     call test_program_assignment_in_context()
     call test_module_assignment_in_context()
+    call test_common_assignment_detection()
 
     print *, 'PASS: parser keyword disambiguation honors implicit statements'
 
@@ -192,5 +193,25 @@ contains
             error stop 1
         end if
     end subroutine test_module_assignment_in_context
+
+    subroutine test_common_assignment_detection()
+        character(len=:), allocatable :: source
+        type(token_t), allocatable :: tokens(:)
+        type(parser_state_t) :: parser
+        type(token_t) :: first_token
+        logical :: as_identifier
+
+        source = 'common = 1' // new_line('a') // 'end'
+        call tokenize_core(source, tokens)
+        parser = create_parser_state(tokens)
+        first_token = parser%peek()
+        as_identifier = keyword_should_parse_as_identifier(first_token, parser)
+
+        if (.not. as_identifier) then
+            write (error_unit, '(A)') &
+                'FAIL: identifier COMMON assignment was not preserved'
+            error stop 1
+        end if
+    end subroutine test_common_assignment_detection
 
 end program test_parser_keyword_disambiguation


### PR DESCRIPTION
Summary

- Ensure identifiers named `common` are not rewritten as legacy COMMON statements or ret-typed.
- Add parser-level disambiguation and end-to-end coverage for the `common` identifier case.

Details

- Update `parser_dispatcher` to use `keyword_should_parse_as_identifier` for `equivalence`/`common`, falling back to `parse_assignment_or_expression` when the statement contains `=`/`=>`.
- Extend `test_parser_keyword_disambiguation` with a focused `common = 1` assignment case.
- Add `examples/f90/issue_2270_identifier_common.f90` mirroring the issue repro.
- Add `test_issue_2270_identifier_common` exercising the full transformation pipeline and guarding against `real :: common` or stray `COMMON` statements.

Verification

- `fpm test --target test_issue_2270_identifier_common`
  - PASS: `identifier named common survives round-trip`
- `fpm test --target test_parser_keyword_disambiguation`
  - PASS: `parser keyword disambiguation honors implicit statements`
- `fpm test`
  - All library and issue-specific tests pass.
  - Existing harness `test_all_examples` still exits with `STOP 1` (pre-existing, unchanged by this patch).
- `make check-duplication`
  - PASS: No end-to-end inline-code violations; `test_parser_keyword_disambiguation.f90` flagged only as a unit-test warning.
- Idempotence/artifact check for this issue:
  - `build/gfortran_E3254EA1FA8B869A/app/fortfront examples/f90/issue_2270_identifier_common.f90 > /tmp/issue_2270_out.f90`
  - `build/gfortran_E3254EA1FA8B869A/app/fortfront /tmp/issue_2270_out.f90 > /tmp/issue_2270_out2.f90`
  - `diff -u /tmp/issue_2270_out.f90 /tmp/issue_2270_out2.f90` → no differences
  - `grep -n "real :: common" /tmp/issue_2270_out.f90` → no matches
  - `grep -n "COMMON" /tmp/issue_2270_out.f90` → no matches
