### PR TITLE
fix: Identifier 'cycle' rewritten into loop control (fixes #2274)

### DIFF
--- a/examples/f90/issue_2274_identifier_cycle.f90
+++ b/examples/f90/issue_2274_identifier_cycle.f90
@@ -1,0 +1,11 @@
+program issue_2274_identifier_cycle
+    implicit none
+contains
+    subroutine track_cycle_value()
+        implicit none
+        integer :: cycle
+
+        cycle = 1
+        print *, cycle
+    end subroutine track_cycle_value
+end program issue_2274_identifier_cycle

--- a/test/test_issue_2274_identifier_cycle.f90
+++ b/test/test_issue_2274_identifier_cycle.f90
@@ -1,0 +1,92 @@
+program test_issue_2274_identifier_cycle
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+    logical :: has_declaration, has_assignment, has_print, has_real_decl, &
+        & has_cycle_stmt, has_failure_stub
+
+    call read_example('examples/f90/issue_2274_identifier_cycle.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2274_identifier_cycle'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    has_declaration = index(output_code, 'integer :: cycle') > 0
+    has_assignment = index(output_code, 'cycle = 1') > 0
+    has_print = index(output_code, 'print *, cycle') > 0
+    has_real_decl = index(output_code, 'real :: cycle') > 0
+    has_cycle_stmt = index(output_code, new_line('a')//'    cycle'// &
+        & new_line('a')) > 0 .or. index(output_code, new_line('a')//'cycle'// &
+        & new_line('a')) > 0
+    has_failure_stub = index(output_code, 'COMPILATION FAILED') > 0
+
+    if (.not. has_declaration) then
+        write (error_unit, '(A)') 'FAIL: missing integer :: cycle declaration'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_assignment) then
+        write (error_unit, '(A)') 'FAIL: missing cycle = 1 assignment'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_print) then
+        write (error_unit, '(A)') 'FAIL: missing print *, cycle statement'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (has_real_decl) then
+        write (error_unit, '(A)') 'FAIL: unexpected real :: cycle declaration'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (has_cycle_stmt) then
+        write (error_unit, '(A)') 'FAIL: stray CYCLE statement detected'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (has_failure_stub) then
+        write (error_unit, '(A)') 'FAIL: fallback stub detected in cycle test'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    print *, 'PASS: identifier named cycle survives round-trip'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2274_identifier_cycle


### PR DESCRIPTION
## Summary
- replace the issue_2274 example with a program that declares, assigns, and prints an integer named `cycle`
- add a regression test that ensures the identifier survives the standard-mode transformation without spawning stray `cycle` statements or real declarations

## Verification
- `fpm test`
  - fails in existing suites `test_issue_1566_interface_block` (missing `call` statement, see test/test_issue_1566_interface_block.f90:99) and `test_all_examples` (fails on ast_module_interface_type.f90, issue_2250_pure_interface.f90, issue_1744_operator_interface.f90, issue_2142_mono_wrong_return_types.lf, issue_1411_generic_module.lf)
- `fpm test test_issue_1566_interface_block`
  - FAIL: `call statement not found in output` (pre-existing regression)
- `fpm test test_all_examples`
  - FAIL: same five known examples as listed above; suite reports 5/449 failures
- `build/gfortran_E3254EA1FA8B869A/app/fortfront /tmp/retest_cycle.f90 >/tmp/retest_cycle_out.f90 && diff -u /tmp/retest_cycle.f90 /tmp/retest_cycle_out.f90`
  - diff only shows trailing whitespace; the integer declaration, assignment, and print remain intact
