### PR TITLE
fix: Parser rejects bare 'end' statements (valid Fortran, affects ~1, (fixes #2347)

### DIFF
--- a/examples/f90/issue_2347_bare_end_module.f90
+++ b/examples/f90/issue_2347_bare_end_module.f90
@@ -1,0 +1,8 @@
+module issue_2347_bare_end_module
+    implicit none
+contains
+    subroutine reset_value(value)
+        integer, intent(out) :: value
+        value = 0
+    end
+end

--- a/examples/f90/issue_2347_bare_end_program.f90
+++ b/examples/f90/issue_2347_bare_end_program.f90
@@ -1,0 +1,14 @@
+program issue_2347_bare_end_program
+    implicit none
+contains
+    subroutine increment(value)
+        integer, intent(inout) :: value
+        value = value + 1
+    end
+
+    integer function double_value(input) result(result_value)
+        integer, intent(in) :: input
+        integer :: result_value
+        result_value = input * 2
+    end
+end

--- a/src/parser/declarations/parser_module_structures.f90
+++ b/src/parser/declarations/parser_module_structures.f90
@@ -69,18 +69,32 @@ contains
             token = parser%peek()
 
             ! Check for end of module
-            if (token%kind == TK_KEYWORD .and. token%text == "end") then
-                ! Look ahead for "module"
-                if (parser%current_token + 1 <= size(parser%tokens)) then
-                    if (parser%tokens(parser%current_token + 1)%kind == &
-                        TK_KEYWORD .and. &
-                        parser%tokens(parser%current_token + 1)%text == "module") then
-                        ! Consume "end module"
-                        token = parser%consume()  ! consume "end"
-                        token = parser%consume()  ! consume "module"
+            if (token%kind == TK_KEYWORD) then
+                lookahead_lower = to_lower(trim(token%text))
+                select case (trim(lookahead_lower))
+                case ("endmodule")
+                    token = parser%consume()
+                    exit
+                case ("end")
+                    if (parser%current_token + 1 <= size(parser%tokens)) then
+                        lookahead = parser%tokens(parser%current_token + 1)
+                        lookahead_lower = to_lower(trim(lookahead%text))
+                        if (lookahead%kind == TK_KEYWORD .and. &
+                            lookahead_lower == "module") then
+                            token = parser%consume()
+                            token = parser%consume()
+                            exit
+                        else if (lookahead%kind == TK_NEWLINE .or. &
+                                 lookahead%kind == TK_COMMENT .or. &
+                                 lookahead%kind == TK_EOF) then
+                            token = parser%consume()
+                            exit
+                        end if
+                    else
+                        token = parser%consume()
                         exit
                     end if
-                end if
+                end select
             end if
 
             ! Check for contains keyword (but not if it's a variable assignment)

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -278,10 +278,23 @@ contains
         type(token_t), allocatable, target :: all_tokens(:)
         integer :: next_idx
         type(token_t) :: token_local
+        character(len=:), allocatable :: lowered_token
+        character(len=:), allocatable :: combined_keyword
 
         is_end = .false.
         if (first_token%kind /= TK_KEYWORD) return
-        if (first_token%text /= "end") return
+
+        lowered_token = to_lower(trim(first_token%text))
+        combined_keyword = "end" // trim(end_keyword)
+
+        if (lowered_token == combined_keyword) then
+            token_local = parser%consume()
+            call consume_optional_identifier_token(parser)
+            is_end = .true.
+            return
+        end if
+
+        if (lowered_token /= "end") return
 
         if (associated(parser%tokens)) then
             allocate (all_tokens(size(parser%tokens)))
@@ -291,22 +304,37 @@ contains
         end if
 
         next_idx = parser%current_token + 1
-        if (next_idx > size(all_tokens)) return
-
-        if (all_tokens(next_idx)%kind == TK_KEYWORD .and. &
-            all_tokens(next_idx)%text == end_keyword) then
+        if (next_idx > size(all_tokens)) then
             token_local = parser%consume()
-            token_local = parser%consume()
-            if (.not. parser%is_at_end()) then
-                token_local = parser%peek()
-                if ((token_local%kind == TK_IDENTIFIER .or. &
-                     token_local%kind == TK_KEYWORD) .and. &
-                    token_local%text == procedure_name) then
-                    token_local = parser%consume()
-                end if
-            end if
             is_end = .true.
+            return
         end if
+
+        select case (all_tokens(next_idx)%kind)
+        case (TK_KEYWORD)
+            if (to_lower(trim(all_tokens(next_idx)%text)) == trim(end_keyword)) then
+                token_local = parser%consume()
+                token_local = parser%consume()
+                if (.not. parser%is_at_end()) then
+                    token_local = parser%peek()
+                    if ((token_local%kind == TK_IDENTIFIER .or. &
+                         token_local%kind == TK_KEYWORD) .and. &
+                        token_local%text == procedure_name) then
+                        token_local = parser%consume()
+                    end if
+                end if
+                is_end = .true.
+                return
+            else
+                return
+            end if
+        case (TK_NEWLINE, TK_COMMENT, TK_EOF)
+            token_local = parser%consume()
+            is_end = .true.
+            return
+        case default
+            return
+        end select
     end function check_procedure_end
 
     subroutine parse_body_statement(parser, arena, first_token, procedure_name, &

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -238,38 +238,72 @@ contains
 
         logical function end_program_encountered(current_token) result(is_end)
             type(token_t), intent(in) :: current_token
+            character(len=:), allocatable :: lowered
+            integer :: next_idx
+            type(token_t) :: lookahead
+
             is_end = .false.
             if (current_token%kind /= TK_KEYWORD) return
 
-            ! Handle "endprogram" (single keyword)
-            if (current_token%text == "endprogram") then
+            lowered = to_lower(trim(current_token%text))
+
+            select case (trim(lowered))
+            case ("endprogram")
                 is_end = .true.
                 return
-            end if
+            case ("end")
+                next_idx = parser%current_token + 1
+                if (next_idx > size(parser%tokens)) then
+                    is_end = .true.
+                    return
+                end if
 
-            ! Handle "end program" (two keywords)
-            if (current_token%text /= "end") return
-            if (parser%current_token + 1 > size(parser%tokens)) return
-            if (parser%tokens(parser%current_token + 1)%kind /= TK_KEYWORD) return
-            if (parser%tokens(parser%current_token + 1)%text /= "program") return
-            is_end = .true.
+                lookahead = parser%tokens(next_idx)
+                if (lookahead%kind == TK_KEYWORD) then
+                    lowered = to_lower(trim(lookahead%text))
+                    if (lowered == "program") then
+                        is_end = .true.
+                        return
+                    else
+                        return
+                    end if
+                else if (lookahead%kind == TK_NEWLINE .or. &
+                         lookahead%kind == TK_COMMENT .or. &
+                         lookahead%kind == TK_EOF) then
+                    is_end = .true.
+                    return
+                end if
+            end select
         end function end_program_encountered
 
         subroutine consume_end_program(parser_ref)
             type(parser_state_t), intent(inout) :: parser_ref
             type(token_t) :: local_token
+            character(len=:), allocatable :: lowered
 
-            ! Consume "endprogram" or "end" "program"
             local_token = parser_ref%consume()
-            if (local_token%text /= "endprogram") then
-                ! Must be "end", consume "program" next
-                local_token = parser_ref%consume()
-            end if
+            lowered = to_lower(trim(local_token%text))
 
-            ! Check for optional program name
-            local_token = parser_ref%peek()
-            if (local_token%kind == TK_IDENTIFIER) then
-                local_token = parser_ref%consume()
+            select case (trim(lowered))
+            case ("endprogram")
+                ! Already consumed entire statement
+            case ("end")
+                if (.not. parser_ref%is_at_end()) then
+                    local_token = parser_ref%peek()
+                    if (local_token%kind == TK_KEYWORD .and. &
+                        to_lower(trim(local_token%text)) == "program") then
+                        local_token = parser_ref%consume()
+                    end if
+                end if
+            case default
+                ! Unexpected token, nothing else to consume
+            end select
+
+            if (.not. parser_ref%is_at_end()) then
+                local_token = parser_ref%peek()
+                if (local_token%kind == TK_IDENTIFIER) then
+                    local_token = parser_ref%consume()
+                end if
             end if
         end subroutine consume_end_program
 

--- a/src/utilities/input_validation.f90
+++ b/src/utilities/input_validation.f90
@@ -450,6 +450,10 @@ contains
         logical :: has_program_start, module_as_identifier
         type(token_t), allocatable, target :: parser_tokens(:)
         type(parser_state_t) :: parser_state
+        integer, allocatable :: construct_stack(:)
+        integer, parameter :: UNIT_NONE = 0, UNIT_PROGRAM = 1, UNIT_FUNCTION = 2
+        integer, parameter :: UNIT_SUBROUTINE = 3, UNIT_MODULE = 4
+        integer :: popped_unit
 
         error_msg = ""
         program_count = 0
@@ -486,19 +490,24 @@ contains
 
                     program_count = program_count + 1
                     has_program_start = .true.
+                    call push_construct(UNIT_PROGRAM)
                 case ("function")
                     ! Check if this is not "end function"
                     if (i == 1) then
                         function_count = function_count + 1
+                        call push_construct(UNIT_FUNCTION)
                     else if (i > 1 .and. tokens(i - 1)%text /= "end") then
                         function_count = function_count + 1
+                        call push_construct(UNIT_FUNCTION)
                     end if
                 case ("subroutine")
                     ! Check if this is not "end subroutine"
                     if (i == 1) then
                         subroutine_count = subroutine_count + 1
+                        call push_construct(UNIT_SUBROUTINE)
                     else if (i > 1 .and. tokens(i - 1)%text /= "end") then
                         subroutine_count = subroutine_count + 1
+                        call push_construct(UNIT_SUBROUTINE)
                     end if
                 case ("module")
                     if (.not. is_module_statement_start(tokens, i)) cycle
@@ -512,8 +521,10 @@ contains
                     ! Check if this is not "end module"
                     if (i == 1) then
                         module_count = module_count + 1
+                        call push_construct(UNIT_MODULE)
                     else if (i > 1 .and. tokens(i - 1)%text /= "end") then
                         module_count = module_count + 1
+                        call push_construct(UNIT_MODULE)
                     end if
                 case ("end")
                     ! Check what kind of end this is
@@ -521,22 +532,42 @@ contains
                         select case (tokens(i + 1)%text)
                         case ("program")
                             end_program_count = end_program_count + 1
+                            call pop_construct(UNIT_PROGRAM, popped_unit)
                         case ("function")
                             end_function_count = end_function_count + 1
+                            call pop_construct(UNIT_FUNCTION, popped_unit)
                         case ("subroutine")
                             end_subroutine_count = end_subroutine_count + 1
+                            call pop_construct(UNIT_SUBROUTINE, popped_unit)
                         case ("module")
+                            end_module_count = end_module_count + 1
+                            call pop_construct(UNIT_MODULE, popped_unit)
+                        end select
+                    else
+                        call pop_construct(popped_unit=popped_unit)
+                        select case (popped_unit)
+                        case (UNIT_PROGRAM)
+                            end_program_count = end_program_count + 1
+                        case (UNIT_FUNCTION)
+                            end_function_count = end_function_count + 1
+                        case (UNIT_SUBROUTINE)
+                            end_subroutine_count = end_subroutine_count + 1
+                        case (UNIT_MODULE)
                             end_module_count = end_module_count + 1
                         end select
                     end if
                 case ("endprogram")
                     end_program_count = end_program_count + 1
+                    call pop_construct(UNIT_PROGRAM, popped_unit)
                 case ("endfunction")
                     end_function_count = end_function_count + 1
+                    call pop_construct(UNIT_FUNCTION, popped_unit)
                 case ("endsubroutine")
                     end_subroutine_count = end_subroutine_count + 1
+                    call pop_construct(UNIT_SUBROUTINE, popped_unit)
                 case ("endmodule")
                     end_module_count = end_module_count + 1
+                    call pop_construct(UNIT_MODULE, popped_unit)
                 end select
             end if
         end do
@@ -566,6 +597,51 @@ contains
                                               "Add 'end module' to close the module definition", &
                                               "MISSING_END")
         end if
+
+    contains
+
+        subroutine push_construct(unit_type)
+            integer, intent(in) :: unit_type
+            integer, allocatable :: tmp(:)
+            integer :: n
+
+            if (.not. allocated(construct_stack)) then
+                allocate (construct_stack(1))
+                construct_stack(1) = unit_type
+                return
+            end if
+
+            n = size(construct_stack)
+            allocate (tmp(n + 1))
+            if (n > 0) tmp(1:n) = construct_stack
+            tmp(n + 1) = unit_type
+            call move_alloc(tmp, construct_stack)
+        end subroutine push_construct
+
+        subroutine pop_construct(expected_unit, popped_unit)
+            integer, intent(in), optional :: expected_unit
+            integer, intent(out) :: popped_unit
+            integer :: n
+
+            popped_unit = UNIT_NONE
+            if (.not. allocated(construct_stack)) return
+            n = size(construct_stack)
+            if (n <= 0) return
+
+            popped_unit = construct_stack(n)
+            if (n == 1) then
+                deallocate (construct_stack)
+            else
+                construct_stack = construct_stack(:n - 1)
+            end if
+
+            if (present(expected_unit)) then
+                if (popped_unit /= expected_unit) then
+                    popped_unit = expected_unit
+                end if
+            end if
+        end subroutine pop_construct
+
     end subroutine check_missing_end_constructs
 
     logical function is_module_procedure_statement(tokens, pos) result(is_module_proc)

--- a/test/test_issue_2347_bare_end.f90
+++ b/test/test_issue_2347_bare_end.f90
@@ -1,0 +1,105 @@
+program test_issue_2347_bare_end
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use transformation_api, only: transform_context_t, transform_with_context, &
+        & INPUT_MODE_STANDARD
+    implicit none
+
+    call verify_program_unit()
+    call verify_module_unit()
+    print *, 'PASS: Issue #2347 bare END statements handled correctly'
+
+contains
+
+    subroutine verify_program_unit()
+        character(len=:), allocatable :: source_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        type(transform_context_t) :: ctx
+
+        call read_example('examples/f90/issue_2347_bare_end_program.f90', &
+            & source_code)
+
+        ctx%input_mode = INPUT_MODE_STANDARD
+        ctx%source_name = 'issue_2347_bare_end_program'
+        ctx%has_filename = .true.
+
+        call transform_with_context(source_code, output_code, error_msg, ctx)
+        call assert_no_error(error_msg, 'program example')
+        call assert_has(output_code, 'end program issue_2347_bare_end_program', &
+            & 'missing end program statement')
+        call assert_has(output_code, 'end subroutine increment', &
+            & 'missing end subroutine statement')
+        call assert_has(output_code, 'end function double_value', &
+            & 'missing end function statement')
+    end subroutine verify_program_unit
+
+    subroutine verify_module_unit()
+        character(len=:), allocatable :: source_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        type(transform_context_t) :: ctx
+
+        call read_example('examples/f90/issue_2347_bare_end_module.f90', &
+            & source_code)
+
+        ctx%input_mode = INPUT_MODE_STANDARD
+        ctx%source_name = 'issue_2347_bare_end_module'
+        ctx%has_filename = .true.
+
+        call transform_with_context(source_code, output_code, error_msg, ctx)
+        call assert_no_error(error_msg, 'module example')
+        call assert_has(output_code, 'end module issue_2347_bare_end_module', &
+            & 'missing end module statement')
+        call assert_has(output_code, 'end subroutine reset_value', &
+            & 'missing end subroutine in module')
+    end subroutine verify_module_unit
+
+    subroutine assert_no_error(message, context)
+        character(len=*), intent(in), optional :: context
+        character(len=:), allocatable, intent(in) :: message
+
+        if (allocated(message)) then
+            if (len_trim(message) > 0) then
+                if (present(context)) then
+                    write (error_unit, '(A)') 'FAIL ('//trim(context)//'): ' // &
+                        & trim(message)
+                else
+                    write (error_unit, '(A)') 'FAIL: ' // trim(message)
+                end if
+                error stop 1
+            end if
+        end if
+    end subroutine assert_no_error
+
+    subroutine assert_has(text, pattern, failure_message)
+        character(len=:), allocatable, intent(in) :: text
+        character(len=*), intent(in) :: pattern
+        character(len=*), intent(in) :: failure_message
+
+        if (.not. allocated(text)) then
+            write (error_unit, '(A)') 'FAIL: Transformation produced no output'
+            error stop 1
+        end if
+
+        if (index(text, trim(pattern)) == 0) then
+            write (error_unit, '(A)') 'FAIL: ' // trim(failure_message)
+            error stop 1
+        end if
+    end subroutine assert_has
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: unable to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2347_bare_end


### PR DESCRIPTION
## Summary
- allow parser modules and procedures to treat bare END as closing tokens and keep stack-balanced
- update validation to count bare END statements for the correct construct type and add regression coverage/examples

## Verification
- `fpm test`
