### PR TITLE
fix: Parser: Support procedure keyword and type declarations in inter (fixes #2348)

### DIFF
--- a/examples/f90/issue_2348_interface_block_procedures.f90
+++ b/examples/f90/issue_2348_interface_block_procedures.f90
@@ -1,0 +1,40 @@
+program issue_2348_interface_block_procedures
+    use, intrinsic :: iso_fortran_env, only: dp => real64, sp => real32
+    implicit none
+
+    interface check_real
+        procedure :: check_r4
+        procedure check_r8
+    end interface check_real
+
+    interface math_helpers
+        integer function integer_abs_value(x)
+            integer, intent(in) :: x
+        end function integer_abs_value
+
+        double precision function double_abs_value(x)
+            double precision, intent(in) :: x
+        end function double_abs_value
+
+        logical function is_positive(x)
+            real, intent(in) :: x
+        end function is_positive
+
+        character(len=1) function status_flag(flag)
+            logical, intent(in) :: flag
+        end function status_flag
+    end interface math_helpers
+
+contains
+
+    real(sp) function check_r4(value)
+        real(sp), intent(in) :: value
+        check_r4 = value
+    end function check_r4
+
+    real(dp) function check_r8(value)
+        real(dp), intent(in) :: value
+        check_r8 = value
+    end function check_r8
+
+end program issue_2348_interface_block_procedures

--- a/src/parser/procedures/parser_procedure_definitions.f90
+++ b/src/parser/procedures/parser_procedure_definitions.f90
@@ -74,7 +74,8 @@ contains
 
         call parse_function_prefix_keywords(parser, prefix_buffer, &
                                             prefix_keywords=prefix_keywords, &
-                                            has_recursive_keyword=has_recursive_keyword)
+                                            has_recursive_keyword= &
+                                            has_recursive_keyword)
         call parse_subroutine_header(parser, subroutine_name, line, column)
         call parse_parameter_list(parser, arena, param_indices)
         call parse_bind_c_clause(parser, bind_c_clause)

--- a/test/test_issue_2348_interface_block_procedures.f90
+++ b/test/test_issue_2348_interface_block_procedures.f90
@@ -1,0 +1,78 @@
+program test_issue_2348_interface_block_procedures
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use string_utils_mod, only: to_lower
+    use transformation_api, only: transform_context_t, transform_with_context, &
+        & INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    character(len=:), allocatable :: lower_output
+    type(transform_context_t) :: ctx
+
+    call read_example('examples/f90/issue_2348_interface_block_procedures.f90', &
+        & source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2348_interface_block_procedures'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+    if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: ' // &
+            & trim(error_msg)
+        error stop 1
+    end if
+
+    if (.not. allocated(output_code)) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context produced no output'
+        error stop 1
+    end if
+
+    lower_output = to_lower(output_code)
+
+    call assert_contains(lower_output, 'procedure :: check_r4', &
+        & 'FAIL: procedure check_r4 not preserved in output')
+    call assert_contains(lower_output, 'procedure check_r8', &
+        & 'FAIL: procedure check_r8 not preserved in output')
+    call assert_contains(lower_output, 'integer function integer_abs_value', &
+        & 'FAIL: integer return type missing for integer_abs_value')
+    call assert_contains(lower_output, 'double precision function double_abs_value', &
+        & 'FAIL: double precision return type missing for double_abs_value')
+    call assert_contains(lower_output, 'logical function is_positive', &
+        & 'FAIL: logical return type missing for is_positive')
+    call assert_contains(lower_output, 'character(len=1) function status_flag', &
+        & 'FAIL: character return type missing for status_flag')
+
+    print *, 'PASS: Issue #2348 interface block procedures parsed successfully'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    subroutine assert_contains(text, pattern, failure_message)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: pattern
+        character(len=*), intent(in) :: failure_message
+
+        if (index(text, pattern) == 0) then
+            write (error_unit, '(A)') trim(failure_message)
+            error stop 1
+        end if
+    end subroutine assert_contains
+
+end program test_issue_2348_interface_block_procedures


### PR DESCRIPTION
## Summary
- add a canonical standard Fortran example covering procedure statements with both :: and bare syntax plus typed function declarations (integer, double precision, logical, character) inside interface blocks; give the contained specific procedures distinct kind combinations so the sample compiles cleanly
- add a regression test that feeds the new example through the standard-mode transformer and asserts that each construct survives the round trip so parser regressions are caught immediately
- keep the new scenario wired into the examples integration run so CLI output is verified alongside the rest of the suite

## Verification
- `fpm test` *(new test passes: `PASS: Issue #2348 interface block procedures parsed successfully`; run still fails in `test_all_examples` at the existing `issue_2142_mono_wrong_return_types.lf` compile step)*
- `make check-duplication`
