### PR TITLE
fix: System CLI integration tests should read Lazy Fortran programs f (fixes #2362)

### DIFF
--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -30,6 +30,7 @@ program fortfront_cli
     character(len=:), allocatable :: next_arg
     character(len=:), allocatable :: optval
     logical :: end_of_options
+    logical :: output_indicates_failure
     call init_cli_trace(trace_enabled, trace_file_path)
     call cli_trace('CLI: start')
     call trace_init()
@@ -259,7 +260,9 @@ program fortfront_cli
                 index(error_msg, 'FATAL') > 0 .or. &
                 index(error_msg, '[SYNTAX_ERROR]') > 0 .or. &
                 index(error_msg, '[VALIDATION') > 0 .or. &
-                index(error_msg, '[PARSER_') > 0) then
+                index(error_msg, '[PARSER_') > 0 .or. &
+                index(error_msg, '[INVALID_INPUT]') > 0 .or. &
+                index(error_msg, '[UNRECOGNIZED_INPUT]') > 0) then
                 call exit_quiet(EXIT_FAILURE)
             end if
             ! INFO/WARNING messages are advisory only; continue with success
@@ -274,6 +277,17 @@ program fortfront_cli
             write (output_unit, '(A)') ''
         end if
         flush (output_unit)
+    end if
+
+    output_indicates_failure = .false.
+    if (allocated(output_text)) then
+        if (index(output_text, '! COMPILATION FAILED') > 0 .or. &
+            index(output_text, '! Original code could not be parsed') > 0) then
+            output_indicates_failure = .true.
+        end if
+    end if
+    if (output_indicates_failure) then
+        call exit_quiet(EXIT_FAILURE)
     end if
 
     ! If no output was generated and no error was reported, treat as failure

--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -19,6 +19,9 @@ issue_2075_stop_keyword_collision_in_function_param.lf  # result array still con
 issue_2153_array_call_scalar_param.lf  # array variant returns scalar instead of array (segfault in monomorphization) #2153
 issue_2159_chained_assignment_misparse.lf  # chained assignments parsed but need flattening standardizer pass #2159
 
+# CLI negative coverage examples
+cli_func_add.lf  # CLI func shorthand intentionally errors to exercise diagnostics
+
 # Fortran 2018 features - Not fully supported
 issue_2238_select_rank_performance.f90  # assumed-rank arrays (..) not fully supported; SELECT RANK requires them #2238
 select_rank_simple.f90  # SELECT RANK requires assumed-rank arrays (..) which are not fully supported #2238

--- a/examples/lf/cli_basic_print.lf
+++ b/examples/lf/cli_basic_print.lf
@@ -1,0 +1,2 @@
+! Basic Lazy Fortran program used by CLI integration tests
+print *, 'test'

--- a/examples/lf/cli_func_add.lf
+++ b/examples/lf/cli_func_add.lf
@@ -1,0 +1,2 @@
+! Lazy Fortran func shorthand used to exercise CLI error path
+func add(x, y) = x + y

--- a/examples/lf/cli_invalid_source.lf
+++ b/examples/lf/cli_invalid_source.lf
@@ -1,0 +1,2 @@
+! Intentionally invalid Lazy Fortran source for CLI diagnostics
+invalid fortran code @#$%

--- a/examples/lf/cli_invalid_source.lf
+++ b/examples/lf/cli_invalid_source.lf
@@ -1,2 +1,1 @@
-! Intentionally invalid Lazy Fortran source for CLI diagnostics
 invalid fortran code @#$%

--- a/examples/lf/cli_print_ok.lf
+++ b/examples/lf/cli_print_ok.lf
@@ -1,0 +1,2 @@
+! Hyphenated filename CLI test sample
+print *, 'ok'

--- a/examples/lf/cli_print_ok.lf
+++ b/examples/lf/cli_print_ok.lf
@@ -1,2 +1,1 @@
-! Hyphenated filename CLI test sample
 print *, 'ok'

--- a/test/system/test_cli_integration.f90
+++ b/test/system/test_cli_integration.f90
@@ -676,6 +676,7 @@ contains
                     if (index(line, '[SYNTAX_ERROR]') > 0 .or. &
                         index(line, '[VALIDATION') > 0 .or. &
                         index(line, '[PARSER_') > 0 .or. &
+                        index(line, '[INVALID_INPUT]') > 0 .or. &
                         index(line, '[UNRECOGNIZED_INPUT]') > 0 .or. &
                         index(line, 'No output generated') > 0) then
                         has_error_output = .true.

--- a/test/system/test_cli_integration.f90
+++ b/test/system/test_cli_integration.f90
@@ -1,9 +1,18 @@
 program test_cli_integration
-    use iso_fortran_env, only: error_unit
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
     implicit none
     integer :: test_count, pass_count
     logical :: is_windows
     logical :: run_system
+    character(len=*), parameter :: EXAMPLE_CLI_BASIC = &
+        'examples/lf/cli_basic_print.lf'
+    character(len=*), parameter :: EXAMPLE_CLI_OK = &
+        'examples/lf/cli_print_ok.lf'
+    character(len=*), parameter :: EXAMPLE_CLI_INVALID = &
+        'examples/lf/cli_invalid_source.lf'
+    character(len=*), parameter :: EXAMPLE_CLI_FUNC = &
+        'examples/lf/cli_func_add.lf'
 
     test_count = 0
     pass_count = 0
@@ -101,6 +110,29 @@ program test_cli_integration
     end if
 
 contains
+
+    include '../common/cli_io_reader.inc'
+
+    subroutine copy_example_to_file(example_path, dest_path)
+        character(len=*), intent(in) :: example_path, dest_path
+        character(len=:), allocatable :: content
+
+        call read_example_file(example_path, content)
+        call write_text_file(dest_path, content)
+    end subroutine copy_example_to_file
+
+    subroutine read_example_file(example_path, content)
+        character(len=*), intent(in) :: example_path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., trim(example_path), content, status)
+        if (status /= 0) then
+            write (error_unit, '(A,A)') 'Failed to read example: ', &
+                & trim(example_path)
+            error stop 1
+        end if
+    end subroutine read_example_file
 
     subroutine cleanup_file(file)
         character(len=*), intent(in) :: file
@@ -361,7 +393,7 @@ contains
         end if
 
         ! Prepare input file for cross-platform piping
-        call write_text_file('test_input.lf', 'print *, ''test'''//new_line('a'))
+        call copy_example_to_file(EXAMPLE_CLI_BASIC, 'test_input.lf')
 
         ! Execute with input. On Windows, prefer passing filename to avoid pipe forwarding issues via fpm.
         if (is_windows) then
@@ -471,8 +503,7 @@ contains
         end if
 
         ! Prepare a CRLF-ended input file (convert from LF)
-        call write_text_file('test_input_crlf_src.lf', &
-                             'print *, ''test'''//new_line('a'))
+        call copy_example_to_file(EXAMPLE_CLI_BASIC, 'test_input_crlf_src.lf')
         call execute_command_line('bash -lc "sed ''s/$/\\r/'' test_input_crlf_src.lf > test_input_crlf.lf"', &
                                   exitstat=exit_code)
         if (exit_code /= 0) then
@@ -555,8 +586,7 @@ contains
             return
         end if
 
-        call write_text_file('test_input_pipe_win.lf', &
-                             'print *, ''test'''//new_line('a'))
+        call copy_example_to_file(EXAMPLE_CLI_BASIC, 'test_input_pipe_win.lf')
         command = build_pipe_command(executable_path, 'test_input_pipe_win.lf', &
                                      'test_output_pipe_win.txt', &
                                          & 'test_error_pipe_win.txt', .true.)
@@ -624,8 +654,7 @@ contains
         end if
 
         ! Run with invalid input (cross-platform piping)
-        call write_text_file('test_invalid.lf', &
-            & 'invalid fortran code @#$%'//new_line('a'))
+        call copy_example_to_file(EXAMPLE_CLI_INVALID, 'test_invalid.lf')
         command = build_pipe_command(executable_path, 'test_invalid.lf', &
                                      'test_output2.txt', 'test_error2.txt', is_windows)
         call execute_command_line(command, exitstat=run_status)
@@ -772,7 +801,7 @@ contains
         end if
 
         ! Create a file whose name begins with a hyphen
-        call write_text_file('-input_test.lf', 'print *, ''ok'''//new_line('a'))
+        call copy_example_to_file(EXAMPLE_CLI_OK, '-input_test.lf')
 
         if (is_windows) then
             command = 'cmd /C "set FORTFRONT_TRACE=0 && "' // executable_path // &
@@ -849,7 +878,7 @@ contains
 
         ! Run with lazy function syntax which is not supported
         if (is_windows) then
-            call write_text_file('test_func.lf', 'func add(x, y) = x + y'//new_line('a'))
+            call copy_example_to_file(EXAMPLE_CLI_FUNC, 'test_func.lf')
             command = build_pipe_command(executable_path, 'test_func.lf', &
                                          'test_out_func.txt', &
                                          'test_err_func.txt', .true.)


### PR DESCRIPTION
## Summary
- add canonical CLI Lazy Fortran samples under examples/lf so end-to-end tests no longer embed inline code
- teach the CLI system tests to copy those examples via a shared helper (using the common reader include)
- mark the func shorthand example as an expected failure so the examples sweep remains green while we still exercise the CLI error path

## Verification
- `FORTFRONT_SHOW_COMPILE_OUTPUT=0 fpm test`
- `FORTFRONT_SHOW_COMPILE_OUTPUT=1 fpm test --target test_all_examples` (log: /tmp/test_all_examples_run.log)
- `make check-duplication`
