### PR TITLE
fix: document --trace as current feature not future (fixes #2372)

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -21,9 +21,8 @@ fortfront input.lf > output.f90
 # Transform from stdin
 echo "x = 5" | fortfront > output.f90
 
-# With options (future)
-fortfront --trace input.lf > output.f90  # Enable tracing
-fortfront --format input.lf > output.f90  # Format output
+# With options
+fortfront --trace input.lf > output.f90  # Enable debug tracing
 ```
 
 **Command-Line Interface**
@@ -56,8 +55,13 @@ fortfront --format input.lf > output.f90  # Format output
 - Helpful suggestions for fixes
 - Exit with appropriate error code
 
+**CLI Options**
+- `-h, --help` - Show help message
+- `-v, --version` - Show version information
+- `--trace[=on|off]` - Enable/disable debug tracing (overrides FORTFRONT_TRACE env)
+- `--trace-file <path>` - Trace output file path (overrides FORTFRONT_TRACE_FILE env)
+
 **Future CLI Features**
-- `--trace` - Enable debug tracing
 - `--format` - Pretty-print output
 - `--check` - Validate without generating output
 - `--ast` - Print AST in JSON format


### PR DESCRIPTION
## Summary

Fixes #2372 - `app/README.md` incorrectly listed `--trace` as a future CLI feature when it's already implemented.

## Changes

- Moved `--trace[=on|off]` and `--trace-file <path>` from "Future CLI Features" to new "CLI Options" section
- Updated usage example to remove "(future)" comment
- Added documentation of environment variable overrides

## Verification

**CLI help confirms implementation**:
```
$ ./build/gfortran_*/app/fortfront --help
OPTIONS:
    -h, --help     Show this help message
    -v, --version  Show version information
        --trace[=on|off]   Enable/disable tracing (overrides env)
        --trace-file <path>  Trace output file (overrides env)
```

**Feature works correctly**:
```bash
$ echo "x = 5" | ./build/gfortran_*/app/fortfront --trace
program main
    implicit none
    integer :: x
    x = 5
end program main
```

## Acceptance Criteria

- [x] CLI options verified with `--help` output
- [x] Implemented options moved to CLI Options section
- [x] Future section contains only unimplemented features
- [x] Cross-checked with root README.md for consistency
- [x] Test: `fortfront --trace input.lf` works as documented