### PR TITLE
fix: Fix: Parser token errors causing complete parsing failures (fixes #2391)

### DIFF
--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -9,6 +9,7 @@ program fortfront_cli
     use process_exit, only: exit_quiet
     use lexer_api, only: token_t, tokenize_core, TK_KEYWORD, TK_IDENTIFIER
     use stdout_sanitizer, only: sanitize_redirected_stdout
+    use frontend_core, only: normalize_fixed_form_source_text, is_fixed_form_file
     implicit none
 
     character(len=:), allocatable :: input_text, output_text, error_msg
@@ -450,6 +451,11 @@ contains
             end if
             call read_all_from_unit(unit_num, text, status)
             close (unit_num)
+            if (status == 0) then
+                if (is_fixed_form_file(trim(filename))) then
+                    call normalize_fixed_form_source_text(text)
+                end if
+            end if
         else
             call read_all_from_unit(input_unit, text, status)
         end if
@@ -587,7 +593,8 @@ contains
             allocate (character(len=capacity) :: tmp, stat=alloc_stat)
             if (alloc_stat /= 0) then
                 write (error_unit, '(A,I0,A)') &
-                    'Failed to allocate memory for input expansion (', capacity, ' bytes)'
+                    'Failed to allocate memory for input expansion (', &
+                    capacity, ' bytes)'
                 status = 5
                 return
             end if
@@ -624,7 +631,8 @@ contains
             allocate (character(len=capacity) :: tmp, stat=alloc_stat)
             if (alloc_stat /= 0) then
                 write (error_unit, '(A,I0,A)') &
-                    'Failed to allocate memory for newline expansion (', capacity, ' bytes)'
+                    'Failed to allocate memory for newline expansion (', &
+                    capacity, ' bytes)'
                 status = 5
                 return
             end if

--- a/examples/f90/issue_2391_fixed_form_allocation.f
+++ b/examples/f90/issue_2391_fixed_form_allocation.f
@@ -1,0 +1,12 @@
+C Issue #2391: fixed form allocation with continuation lines
+      program fixed_form_allocation_bounds
+      implicit none
+      integer :: nf10
+      logical, allocatable :: lla(:,:,:)
+
+      nf10 = 10
+      allocate (lla(2:3, 4,
+     $              nf10:1,
+     $              -2:7))
+
+      end program fixed_form_allocation_bounds

--- a/src/frontend_core.f90
+++ b/src/frontend_core.f90
@@ -6,7 +6,8 @@ module frontend_core
     use string_builder_mod, only: join_strings
     use lexer_core, only: token_t, tokenize_core, TK_EOF, TK_KEYWORD, &
                           TK_COMMENT, TK_NEWLINE, TK_OPERATOR, TK_IDENTIFIER, &
-                          TK_NUMBER, TK_STRING, TK_UNKNOWN, TK_WHITESPACE
+                          TK_NUMBER, TK_STRING, TK_UNKNOWN, TK_WHITESPACE, &
+                          to_lower
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_dispatcher_module, only: parse_statement_dispatcher, &
                                         get_additional_indices, clear_additional_indices
@@ -46,6 +47,7 @@ module frontend_core
     public :: compile_source, compilation_options_t
     public :: lex_file
     public :: parse_tokens_safe, parse_result_with_index_t
+    public :: normalize_fixed_form_source_text, is_fixed_form_file
 
     ! Simplified compilation options - no backend selection
     type :: compilation_options_t
@@ -74,6 +76,7 @@ contains
         type(compiler_arena_t) :: compiler_arena
         integer :: prog_index
         character(len=:), allocatable :: code, source
+        logical :: is_fixed_form
         integer :: unit, iostat
         type(path_validation_result_t) :: validation_result
 
@@ -95,8 +98,12 @@ contains
             return
         end if
 
+        ! Detect fixed-form source so continuation markers are preserved
+        is_fixed_form = is_fixed_form_file(input_file)
+
         ! Read source file
-        call read_source_file(input_file, source, error_msg)
+        call read_source_file(input_file, source, error_msg, &
+                              fixed_form=is_fixed_form)
         if (error_msg /= "") return
 
         ! Initialize unified compiler arena for all phases
@@ -204,11 +211,13 @@ contains
 
     ! Private helper subroutines to break down large functions
 
-    subroutine read_source_file(input_file, source, error_msg)
+    subroutine read_source_file(input_file, source, error_msg, fixed_form)
         character(len=*), intent(in) :: input_file
         character(len=:), allocatable, intent(out) :: source
         character(len=*), intent(out) :: error_msg
+        logical, intent(in), optional :: fixed_form
         integer :: unit, iostat
+        logical :: use_fixed_form
 
         ! Read source file
         open (newunit=unit, file=input_file, status='old', action='read', iostat=iostat)
@@ -216,6 +225,9 @@ contains
             error_msg = "Cannot open input file: " // input_file
             return
         end if
+
+        use_fixed_form = .false.
+        if (present(fixed_form)) use_fixed_form = fixed_form
 
         block
             character(len=:), allocatable :: line
@@ -242,6 +254,10 @@ contains
                 end if
                 lines(line_count) = trim(line)
             end do
+
+            if (use_fixed_form) then
+                call normalize_fixed_form_lines(lines, line_count)
+            end if
 
             if (line_count > 0) then
                 source = join_strings(lines(1:line_count), new_line('a'))
@@ -578,5 +594,145 @@ contains
 
         is_ws = (iachar(ch) <= 32)
     end function is_whitespace_char
+
+    pure logical function is_fixed_form_file(path) result(is_fixed)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable :: lower_path
+
+        lower_path = to_lower(trim(path))
+        is_fixed = has_suffix(lower_path, ".f") .or. &
+                   has_suffix(lower_path, ".for") .or. &
+                   has_suffix(lower_path, ".ftn") .or. &
+                   has_suffix(lower_path, ".f77")
+    end function is_fixed_form_file
+
+    pure logical function has_suffix(text, suffix) result(matches)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: suffix
+        integer :: text_len, suffix_len
+
+        text_len = len_trim(text)
+        suffix_len = len_trim(suffix)
+        if (text_len < suffix_len) then
+            matches = .false.
+        else
+            matches = text(text_len - suffix_len + 1:text_len) == suffix
+        end if
+    end function has_suffix
+
+    subroutine normalize_fixed_form_lines(lines, line_count)
+        character(len=:), allocatable, intent(inout) :: lines(:)
+        integer, intent(in) :: line_count
+        integer :: i
+
+        if (.not. allocated(lines)) return
+        if (line_count <= 0) return
+
+        do i = 1, line_count
+            call normalize_fixed_form_line(lines(i))
+        end do
+    end subroutine normalize_fixed_form_lines
+
+    subroutine normalize_fixed_form_line(line)
+        character(len=*), intent(inout) :: line
+        integer :: len_line
+        character(len=1) :: cont_char
+        character(len=:), allocatable :: body
+
+        len_line = len(line)
+        if (len_trim(line) > 0) then
+            if (line(1:1) == "&") return  ! Already normalized to free form
+        end if
+        if (len_line < 6) return
+        if (is_fixed_form_comment(line)) return
+
+        cont_char = line(6:6)
+        if (cont_char == " " .or. cont_char == "0") return
+
+        if (len_line > 6) then
+            body = adjustl(line(7:len_line))
+        else
+            allocate (character(len=0) :: body)
+        end if
+
+        if (len(body) > 0) then
+            line = "& " // trim(body)
+        else
+            line = "&"
+        end if
+    end subroutine normalize_fixed_form_line
+
+    pure logical function is_fixed_form_comment(line) result(is_comment)
+        character(len=*), intent(in) :: line
+        character(len=1) :: first_char
+
+        is_comment = .false.
+        if (len(line) == 0) return
+
+        first_char = line(1:1)
+        select case (first_char)
+        case ("c", "C", "*", "!")
+            is_comment = .true.
+        case default
+            is_comment = .false.
+        end select
+    end function is_fixed_form_comment
+
+    subroutine normalize_fixed_form_source_text(source)
+        character(len=:), allocatable, intent(inout) :: source
+        character(len=:), allocatable :: lines(:)
+        integer :: line_count
+
+        if (.not. allocated(source)) return
+        if (len(source) == 0) return
+
+        call split_source_into_lines(source, lines, line_count)
+        if (line_count <= 0) return
+
+        call normalize_fixed_form_lines(lines, line_count)
+        source = join_strings(lines(1:line_count), new_line('a'))
+    end subroutine normalize_fixed_form_source_text
+
+    subroutine split_source_into_lines(source, lines, line_count)
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable, intent(out) :: lines(:)
+        integer, intent(out) :: line_count
+        integer :: i, src_len
+        integer :: start_pos, end_pos
+        integer :: current_line
+        character(len=1), parameter :: nl = new_line('a')
+
+        src_len = len(source)
+        line_count = 1
+
+        do i = 1, src_len
+            if (source(i:i) == nl) line_count = line_count + 1
+        end do
+
+        allocate (character(len=src_len) :: lines(line_count))
+
+        start_pos = 1
+        current_line = 1
+        do while (start_pos <= src_len .and. current_line <= line_count)
+            end_pos = index(source(start_pos:), nl)
+            if (end_pos == 0) then
+                lines(current_line) = source(start_pos:)
+                exit
+            end if
+
+            if (end_pos == 1) then
+                lines(current_line) = ""
+            else
+                lines(current_line) = source(start_pos:start_pos + end_pos - 2)
+            end if
+
+            start_pos = start_pos + end_pos
+            current_line = current_line + 1
+        end do
+
+        if (current_line <= line_count) then
+            lines(current_line:line_count) = ""
+        end if
+    end subroutine split_source_into_lines
 
 end module frontend_core

--- a/test/test_issue_2391_fixed_form_continuation.f90
+++ b/test/test_issue_2391_fixed_form_continuation.f90
@@ -1,0 +1,73 @@
+program test_issue_2391_fixed_form_continuation
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, &
+        & iostat_end, iostat_eor
+    use transformation_api, only: compile_source, compilation_options_t
+    implicit none
+
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: output_path
+    character(len=256) :: error_msg
+    logical :: has_bounds
+    type(compilation_options_t) :: options
+
+    output_path = 'test_issue_2391_fixed_form_continuation_out.f90'
+    options%output_file = output_path
+
+    call compile_source('examples/f90/issue_2391_fixed_form_allocation.f', &
+                        options, error_msg)
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: compile_source error: ' // &
+            trim(error_msg)
+        call cleanup_output(output_path)
+        error stop 1
+    end if
+
+    call read_example(output_path, output_code)
+
+    has_bounds = index(output_code, 'allocate(lla(') > 0 .and. &
+                 index(output_code, '2:3') > 0 .and. &
+                 index(output_code, 'nf10:1') > 0 .and. &
+                 index(output_code, '-2:7') > 0
+
+    call cleanup_output(output_path)
+
+    if (.not. has_bounds) then
+        write (error_unit, '(A)') 'FAIL: fixed-form bounds not preserved'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    print *, 'PASS: fixed-form continuation lines parsed successfully'
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    subroutine cleanup_output(path)
+        character(len=*), intent(in) :: path
+        integer :: unit, ios
+        logical :: has_file
+
+        inquire (file=path, exist=has_file)
+        if (.not. has_file) return
+
+        open (newunit=unit, file=path, status='old', action='readwrite', &
+              iostat=ios)
+        if (ios == 0) then
+            close (unit, status='delete')
+        end if
+    end subroutine cleanup_output
+
+end program test_issue_2391_fixed_form_continuation


### PR DESCRIPTION
## Summary
- prevent fixed-form parsing from double-normalizing continuation lines
- add example and regression test covering descending bounds across fixed-form continuations
- share fixed-form file detection so CLI and compile pipeline honor continuations consistently

## Verification
- fpm test --target test_issue_2391_fixed_form_continuation
