### PR TITLE
fix: accept Ctrl-Z and form feed in text files (fixes #2392)

### DIFF
--- a/examples/f90/utf8_bom_example.f90
+++ b/examples/f90/utf8_bom_example.f90
@@ -1,0 +1,6 @@
+﻿program utf8_bom_example
+    implicit none
+    integer :: x
+    x = 42
+    print *, x
+end program utf8_bom_example

--- a/src/frontend/frontend_transformation_structure.f90
+++ b/src/frontend/frontend_transformation_structure.f90
@@ -577,8 +577,10 @@ contains
                 has_binary = .true.
                 return
             end if
-            ! Reject control characters except TAB(9), LF(10), CR(13)
-            if (code < 32 .and. code /= 9 .and. code /= 10 .and. code /= 13) then
+            ! Reject control characters except common text file markers:
+            ! TAB(9), LF(10), FF(12), CR(13), Ctrl-Z/SUB(26)
+            if (code < 32 .and. code /= 9 .and. code /= 10 .and. &
+                code /= 12 .and. code /= 13 .and. code /= 26) then
                 has_binary = .true.
                 return
             end if

--- a/test/frontend/test_ctrl_z_acceptance.f90
+++ b/test/frontend/test_ctrl_z_acceptance.f90
@@ -1,0 +1,30 @@
+program test_ctrl_z_acceptance
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use transformation_api, only: transform_lazy_fortran_string
+
+    character(len=:), allocatable :: source, output, error_msg
+
+    ! Ctrl-Z (EOF marker on some systems) should not be treated as binary
+    ! when it appears in comments or at end of file
+    source = 'x = 5' // char(26)
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (index(error_msg, 'binary data') > 0) then
+        write (error_unit, '(A)') 'FAIL: Ctrl-Z file misclassified as binary'
+        write (error_unit, '(A)') trim(error_msg)
+        stop 1
+    end if
+
+    if (.not. allocated(output)) then
+        write (error_unit, '(A)') 'FAIL: no output produced for Ctrl-Z input'
+        stop 1
+    end if
+
+    if (len_trim(output) == 0) then
+        write (error_unit, '(A)') 'FAIL: empty output for Ctrl-Z input'
+        stop 1
+    end if
+
+    write (error_unit, '(A)') 'PASS: Ctrl-Z accepted'
+end program test_ctrl_z_acceptance

--- a/test/frontend/test_utf8_bom_acceptance.f90
+++ b/test/frontend/test_utf8_bom_acceptance.f90
@@ -1,0 +1,30 @@
+program test_utf8_bom_acceptance
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use transformation_api, only: transform_lazy_fortran_string
+
+    character(len=:), allocatable :: source, output, error_msg
+    character(len=3), parameter :: UTF8_BOM = char(239) // char(187) // char(191)
+
+    ! UTF-8 BOM followed by simple Fortran code should not be treated as binary
+    source = UTF8_BOM // 'x = 5'
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (index(error_msg, 'binary data') > 0) then
+        write (error_unit, '(A)') 'FAIL: UTF-8 BOM file misclassified as binary'
+        write (error_unit, '(A)') trim(error_msg)
+        stop 1
+    end if
+
+    if (.not. allocated(output)) then
+        write (error_unit, '(A)') 'FAIL: no output produced for UTF-8 BOM input'
+        stop 1
+    end if
+
+    if (len_trim(output) == 0) then
+        write (error_unit, '(A)') 'FAIL: empty output for UTF-8 BOM input'
+        stop 1
+    end if
+
+    write (error_unit, '(A)') 'PASS: UTF-8 BOM accepted'
+end program test_utf8_bom_acceptance


### PR DESCRIPTION
## Summary

Fixes #2392 - UTF/BOM files incorrectly flagged as binary data

The binary detection logic was rejecting valid text files containing common control characters:
- Ctrl-Z (SUB, character 26): DOS/Windows EOF marker
- Form feed (FF, character 12): Page break character

These characters are commonly found in:
- Windows text files (Ctrl-Z as EOF)
- Formatted documents (form feed for page breaks)
- Legacy Fortran files (both characters were used historically)

## Changes

**Modified: `src/frontend/frontend_transformation_structure.f90:566`**
- Extended `contains_binary_data()` to allow Ctrl-Z (26) and form feed (12)
- Previously only allowed TAB (9), LF (10), CR (13)
- UTF-8 high-bit characters (>=128) already supported

**Added Tests:**
- `test/frontend/test_ctrl_z_acceptance.f90` - Verifies Ctrl-Z handling
- `test/frontend/test_utf8_bom_acceptance.f90` - Verifies UTF-8 BOM handling  
- `examples/f90/utf8_bom_example.f90` - Example with UTF-8 BOM

## Verification

```bash
fpm test test_ctrl_z_acceptance
# PASS: Ctrl-Z accepted

fpm test test_utf8_bom_acceptance  
# PASS: UTF-8 BOM accepted

fpm test test_binary_input_rejection
# PASS: binary input rejected gracefully

fpm test test_utf8_comment_acceptance
# PASS: UTF-8 comment accepted
```

All existing tests pass. Binary rejection still works correctly (null bytes still rejected).

## Test Coverage

Impact on gfortran test suite (from issue description):
- ✅ `ctrl-z.f90` - Will now be accepted
- ✅ `bom_UTF-8.f90` - Already works (high-bit support)
- ⚠️ `bom_UTF16-*.f90`, `bom_UTF-32.f90` - Still require encoding conversion (future work)

UTF-16/UTF-32 files contain null bytes in their encoding and would require full encoding conversion support, which is beyond the scope of this fix.

## Related

- Issue #2393: DTIO interface parsing (separate issue)
- Issue #2394: Performance timeouts (separate issue)