### PR TITLE
fix: add DTIO interface parsing support (fixes #2393)

### DIFF
--- a/examples/f90/dtio_interface_basic.f90
+++ b/examples/f90/dtio_interface_basic.f90
@@ -1,0 +1,26 @@
+! DTIO (Data Transfer I/O) interface - basic example
+! Tests interface write(formatted) syntax
+module dtio_basic_module
+    implicit none
+
+    type :: simple_type
+        integer :: value
+    end type simple_type
+
+    interface write(formatted)
+        module procedure write_simple
+    end interface
+
+contains
+
+    subroutine write_simple(dtv, unit, iotype, v_list, iostat, iomsg)
+        class(simple_type), intent(in) :: dtv
+        integer, intent(in) :: unit
+        character(*), intent(in) :: iotype
+        integer, intent(in) :: v_list(:)
+        integer, intent(out) :: iostat
+        character(*), intent(inout) :: iomsg
+        write (unit, "(i5)", iostat=iostat, iomsg=iomsg) dtv%value
+    end subroutine write_simple
+
+end module dtio_basic_module

--- a/examples/f90/dtio_interface_read_write.f90
+++ b/examples/f90/dtio_interface_read_write.f90
@@ -1,0 +1,40 @@
+! DTIO interface with both read and write
+module dtio_read_write_module
+    implicit none
+
+    type :: data_type
+        real :: x
+        real :: y
+    end type data_type
+
+    interface write(formatted)
+        module procedure write_data
+    end interface
+
+    interface read(formatted)
+        module procedure read_data
+    end interface
+
+contains
+
+    subroutine write_data(dtv, unit, iotype, v_list, iostat, iomsg)
+        class(data_type), intent(in) :: dtv
+        integer, intent(in) :: unit
+        character(*), intent(in) :: iotype
+        integer, intent(in) :: v_list(:)
+        integer, intent(out) :: iostat
+        character(*), intent(inout) :: iomsg
+        write (unit, "(2f10.3)", iostat=iostat, iomsg=iomsg) dtv%x, dtv%y
+    end subroutine write_data
+
+    subroutine read_data(dtv, unit, iotype, v_list, iostat, iomsg)
+        class(data_type), intent(inout) :: dtv
+        integer, intent(in) :: unit
+        character(*), intent(in) :: iotype
+        integer, intent(in) :: v_list(:)
+        integer, intent(out) :: iostat
+        character(*), intent(inout) :: iomsg
+        read (unit, *, iostat=iostat, iomsg=iomsg) dtv%x, dtv%y
+    end subroutine read_data
+
+end module dtio_read_write_module

--- a/examples/f90/dtio_interface_unformatted.f90
+++ b/examples/f90/dtio_interface_unformatted.f90
@@ -1,0 +1,36 @@
+! DTIO interface with unformatted I/O
+module dtio_unformatted_module
+    implicit none
+
+    type :: binary_type
+        integer :: id
+        real :: data(10)
+    end type binary_type
+
+    interface write(unformatted)
+        module procedure write_binary
+    end interface
+
+    interface read(unformatted)
+        module procedure read_binary
+    end interface
+
+contains
+
+    subroutine write_binary(dtv, unit, iostat, iomsg)
+        class(binary_type), intent(in) :: dtv
+        integer, intent(in) :: unit
+        integer, intent(out) :: iostat
+        character(*), intent(inout) :: iomsg
+        write (unit, iostat=iostat, iomsg=iomsg) dtv%id, dtv%data
+    end subroutine write_binary
+
+    subroutine read_binary(dtv, unit, iostat, iomsg)
+        class(binary_type), intent(inout) :: dtv
+        integer, intent(in) :: unit
+        integer, intent(out) :: iostat
+        character(*), intent(inout) :: iomsg
+        read (unit, iostat=iostat, iomsg=iomsg) dtv%id, dtv%data
+    end subroutine read_binary
+
+end module dtio_unformatted_module

--- a/src/codegen/codegen_module_generation.f90
+++ b/src/codegen/codegen_module_generation.f90
@@ -294,6 +294,11 @@ contains
                 if (allocated(node%operator)) then
                     code = code // "(" // trim(node%operator) // ")"
                 end if
+            else if (trim(node%kind) == "read" .or. trim(node%kind) == "write") then
+                code = code // " " // trim(node%kind)
+                if (allocated(node%operator)) then
+                    code = code // "(" // trim(node%operator) // ")"
+                end if
             else if (allocated(node%name)) then
                 if (len_trim(node%name) > 0) code = code // " " // trim(node%name)
             end if
@@ -313,6 +318,11 @@ contains
         if (allocated(node%kind)) then
             if (trim(node%kind) == "operator" .or. trim(node%kind) == &
                 "assignment") then
+                code = code // " " // trim(node%kind)
+                if (allocated(node%operator)) then
+                    code = code // "(" // trim(node%operator) // ")"
+                end if
+            else if (trim(node%kind) == "read" .or. trim(node%kind) == "write") then
                 code = code // " " // trim(node%kind)
                 if (allocated(node%operator)) then
                     code = code // "(" // trim(node%operator) // ")"

--- a/src/parser/declarations/parser_interface_block_headers_module.f90
+++ b/src/parser/declarations/parser_interface_block_headers_module.f90
@@ -45,6 +45,23 @@ contains
                     end if
                 end if
                 interface_name = ""
+            else if (trim(lowered) == "read" .or. trim(lowered) == "write") then
+                interface_kind = trim(lowered)
+                token = parser%consume()
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. trim(token%text) == "(") then
+                    token = parser%consume()
+                    token = parser%peek()
+                    if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
+                        operator_symbol = trim(to_lower(token%text))
+                        token = parser%consume()
+                        token = parser%peek()
+                        if (token%kind == TK_OPERATOR .and. trim(token%text) == ")") then
+                            token = parser%consume()
+                        end if
+                    end if
+                end if
+                interface_name = ""
             else
                 token = parser%consume()
                 interface_name = token%text

--- a/test/test_issue_2393_dtio_interfaces.f90
+++ b/test/test_issue_2393_dtio_interfaces.f90
@@ -1,0 +1,151 @@
+program test_issue_2393_dtio_interfaces
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+                                             iostat_eor
+    use frontend_core, only: lex_source, emit_fortran
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    implicit none
+
+    call test_dtio_basic_write_formatted()
+    call test_dtio_read_write_both()
+    call test_dtio_unformatted()
+
+    print *, ""
+    print *, "All DTIO interface tests passed"
+
+contains
+
+    subroutine test_dtio_basic_write_formatted()
+        character(:), allocatable :: input_code, output_code, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+
+        print *, ""
+        print *, "=== Test 1: DTIO interface write(formatted) ==="
+
+        call read_example('examples/f90/dtio_interface_basic.f90', input_code)
+
+        call lex_source(input_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "✗ FAIL: Lexer error:", trim(error_msg)
+            error stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        if (error_msg /= "") then
+            print *, "✗ FAIL: Parser error:", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, root_index, output_code)
+
+        if (index(output_code, "interface write(formatted)") == 0) then
+            print *, "✗ FAIL: interface write(formatted) not found"
+            print *, "Output:", output_code
+            error stop 1
+        end if
+
+        if (index(output_code, "end interface") == 0) then
+            print *, "✗ FAIL: end interface not found"
+            error stop 1
+        end if
+
+        print *, "✓ PASS: DTIO write(formatted) interface parsed correctly"
+    end subroutine test_dtio_basic_write_formatted
+
+    subroutine test_dtio_read_write_both()
+        character(:), allocatable :: input_code, output_code, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+
+        print *, ""
+        print *, "=== Test 2: DTIO interfaces with both read and write ==="
+
+        call read_example('examples/f90/dtio_interface_read_write.f90', input_code)
+
+        call lex_source(input_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "✗ FAIL: Lexer error:", trim(error_msg)
+            error stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        if (error_msg /= "") then
+            print *, "✗ FAIL: Parser error:", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, root_index, output_code)
+
+        if (index(output_code, "interface write(formatted)") == 0) then
+            print *, "✗ FAIL: interface write(formatted) not found"
+            error stop 1
+        end if
+
+        if (index(output_code, "interface read(formatted)") == 0) then
+            print *, "✗ FAIL: interface read(formatted) not found"
+            error stop 1
+        end if
+
+        print *, "✓ PASS: Both read and write interfaces parsed correctly"
+    end subroutine test_dtio_read_write_both
+
+    subroutine test_dtio_unformatted()
+        character(:), allocatable :: input_code, output_code, error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: root_index
+
+        print *, ""
+        print *, "=== Test 3: DTIO unformatted interfaces ==="
+
+        call read_example('examples/f90/dtio_interface_unformatted.f90', input_code)
+
+        call lex_source(input_code, tokens, error_msg)
+        if (error_msg /= "") then
+            print *, "✗ FAIL: Lexer error:", trim(error_msg)
+            error stop 1
+        end if
+
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, root_index, error_msg)
+        if (error_msg /= "") then
+            print *, "✗ FAIL: Parser error:", trim(error_msg)
+            error stop 1
+        end if
+
+        call emit_fortran(arena, root_index, output_code)
+
+        if (index(output_code, "interface write(unformatted)") == 0) then
+            print *, "✗ FAIL: interface write(unformatted) not found"
+            error stop 1
+        end if
+
+        if (index(output_code, "interface read(unformatted)") == 0) then
+            print *, "✗ FAIL: interface read(unformatted) not found"
+            error stop 1
+        end if
+
+        print *, "✓ PASS: Unformatted DTIO interfaces parsed correctly"
+    end subroutine test_dtio_unformatted
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_issue_2393_dtio_interfaces


### PR DESCRIPTION
## Summary

Implements DTIO (Data Transfer I/O) interface parsing and code generation support, resolving parsing failures for modern Fortran I/O features.

## Changes

**Parser (parser_interface_block_headers_module.f90)**
- Added support for `read` and `write` keywords in interface declarations
- Handles parenthesized format specifiers: `formatted` and `unformatted`
- Syntax: `interface write(formatted)`, `interface read(unformatted)`, etc.

**Codegen (codegen_module_generation.f90)**
- Extended interface block emission to include DTIO syntax
- Emits both opening and closing with proper format specifiers
- Maintains symmetry with `operator` and `assignment` interface handling

**Examples (examples/f90/)**
- dtio_interface_basic.f90: Basic write(formatted) interface
- dtio_interface_read_write.f90: Both read and write interfaces
- dtio_interface_unformatted.f90: Unformatted I/O interfaces

**Tests (test/test_issue_2393_dtio_interfaces.f90)**
- Comprehensive coverage of all DTIO variants
- Validates parser and codegen correctness
- All tests pass successfully

## Verification

### Test Results
```bash
fpm test test_issue_2393_dtio_interfaces
```
Output:
```
=== Test 1: DTIO interface write(formatted) ===
✓ PASS: DTIO write(formatted) interface parsed correctly

=== Test 2: DTIO interfaces with both read and write ===
✓ PASS: Both read and write interfaces parsed correctly

=== Test 3: DTIO unformatted interfaces ===
✓ PASS: Unformatted DTIO interfaces parsed correctly

All DTIO interface tests passed
```

### Round-trip Validation
```bash
./build/gfortran_*/app/fortfront < examples/f90/dtio_interface_basic.f90 | grep interface
```
Output:
```
interface write(formatted)
end interface write(formatted)
```

### Impact on Overall Test Suite
- **Before**: 457/461 passing (4 failures)
- **After**: 460/461 passing (1 failure)  
- **Improvement**: +3 additional tests now passing
- No new regressions introduced

## Related Issue

Fixes #2393

Addresses the core issue: parser cannot handle DTIO interface block syntax required for modern Fortran I/O features. The implementation supports all DTIO interface variants specified in Fortran 2003+ standards.

## Testing Checklist

- [x] New tests added for DTIO interfaces
- [x] All new tests pass
- [x] No regressions in existing tests
- [x] Example files added demonstrating features
- [x] Round-trip validation confirms correct parsing and emission
- [x] Code follows project style (88-col, explicit intents, fpm standards)