### PR TITLE
fix: respect token boundaries in line continuation (fixes #2462)

### DIFF
--- a/src/codegen/codegen_basic_utils.f90
+++ b/src/codegen/codegen_basic_utils.f90
@@ -81,7 +81,7 @@ contains
         character(len=:), allocatable, intent(inout) :: output_code
         integer, intent(in) :: max_len
         integer, parameter :: CONTINUATION_INDENT = 6
-        integer :: pos, last_break, len_line
+        integer :: pos, last_break, len_line, i
         character(len=:), allocatable :: current_line, continuation_str
         logical :: found_break
 
@@ -96,25 +96,28 @@ contains
 
         pos = 1
         do while (pos <= len_line)
-            last_break = pos
+            ! Find the last good break point within MAX_LINE_LENGTH
+            ! Strategy: scan the valid range and remember the LAST break character position
+            last_break = 0  ! Will hold position of last break char found
             found_break = .false.
 
-            ! Find a good break point within MAX_LINE_LENGTH
-            do while (last_break - pos + 1 <= max_len .and. last_break <= len_line)
-                if (input_line(last_break:last_break) == ' ' .or. &
-                    input_line(last_break:last_break) == ',' .or. &
-                    input_line(last_break:last_break) == '(' .or. &
-                    input_line(last_break:last_break) == ')') then
+            ! Scan from pos to min(pos+max_len-1, len_line)
+            do i = pos, min(pos + max_len - 1, len_line)
+                if (input_line(i:i) == ' ' .or. &
+                    input_line(i:i) == ',' .or. &
+                    input_line(i:i) == '(' .or. &
+                    input_line(i:i) == ')') then
+                    ! Remember this position - it's a valid break point
+                    last_break = i
                     found_break = .true.
                 end if
-                last_break = last_break + 1
             end do
 
-            if (.not. found_break .or. last_break > len_line) then
-                ! No good break point found, just break at MAX_LINE_LENGTH
+            ! Determine actual break position
+            if (.not. found_break) then
+                ! No break character found in range - must break at max_len
+                ! This will split a token, but we have no choice
                 last_break = min(pos + max_len - 1, len_line)
-            else
-                last_break = last_break - 1  ! Step back to the break character
             end if
 
             ! Extract the line segment

--- a/test/codegen/test_issue_2462_line_continuation_token_boundaries.f90
+++ b/test/codegen/test_issue_2462_line_continuation_token_boundaries.f90
@@ -1,0 +1,49 @@
+program test_issue_2462_line_continuation_token_boundaries
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use codegen_basic_utils, only: add_line_continuations
+    implicit none
+
+    character(len=:), allocatable :: input_line, output
+    integer :: i
+
+    ! Test 1: Long use statement with identifiers at column boundary
+    input_line = 'use fortfront, only: tooling_parse_options_t, ' // &
+                 'tooling_load_ast_from_string, ast_arena_t, token_t, ' // &
+                 'get_node_type_at, ast_to_json'
+    output = add_line_continuations(input_line)
+
+    ! Verify no identifier is broken mid-word
+    if (index(output, 'ast_to_jso &') > 0) then
+        write (error_unit, '(A)') 'FAIL: identifier ast_to_json broken incorrectly'
+        stop 1
+    end if
+
+    if (index(output, 'ast_to_json') == 0) then
+        write (error_unit, '(A)') 'FAIL: identifier ast_to_json missing from output'
+        stop 1
+    end if
+
+    ! Test 2: Long string parameter with content at boundary
+    input_line = 'character(len=*), parameter :: lazy_code = ' // &
+                 '''sum_neg = 0'' //new_line(''a'') //''sum_pos = 0'' ' // &
+                 '//new_line(''a'') //''do i = 1, 6'''
+    output = add_line_continuations(input_line)
+
+    ! Verify no identifier inside string is broken
+    if (index(output, 'sum_ &') > 0) then
+        write (error_unit, '(A)') 'FAIL: identifier sum_pos broken incorrectly'
+        stop 1
+    end if
+
+    ! Test 3: Verify continuation is added for genuinely long lines
+    input_line = repeat('a', 150)
+    output = add_line_continuations(input_line)
+
+    if (index(output, ' &') == 0) then
+        write (error_unit, '(A)') 'FAIL: expected continuation for very long line'
+        stop 1
+    end if
+
+    print *, 'PASS: Line continuation respects token boundaries'
+
+end program test_issue_2462_line_continuation_token_boundaries


### PR DESCRIPTION
## Summary

Fixed codegen line continuation to respect token boundaries, preventing identifiers and string literals from being broken mid-word when lines exceed the 130-character limit.

## Root Cause

The line continuation logic in `add_line_with_continuation` had a critical bug:
- The loop scanned for break characters (space, comma, parens) and set `found_break = .true.`
- But it **never recorded the position** of break characters
- After scanning, `last_break` pointed beyond the valid range
- This caused breaks at arbitrary column positions, splitting tokens

## Fix

Modified the scan loop to **track the actual position** of each break character:
```fortran
do i = pos, min(pos + max_len - 1, len_line)
    if (input_line(i:i) == ' ' .or. ...) then
        last_break = i  ! Record this position
        found_break = .true.
    end if
end do
```

Now breaks only occur at valid boundaries (whitespace, commas, parentheses).

## Verification

### Before Fix
```fortran
use fortfront, only: ..., ast_to_jso &
n
```

### After Fix
```fortran
use fortfront, only: ..., get_node_type_at,  &
ast_to_json
```

### Test Results
- ✅ New test: `test_issue_2462_line_continuation_token_boundaries` passes
- ✅ All existing continuation tests pass (issues #177, #2254, #2291)
- ✅ 99.8% of examples pass (483/484, 1 pre-existing failure unrelated to this fix)

### Commands
```bash
# Verify the fix
./build/gfortran_*/app/fortfront examples/f90/tooling_lightweight_ast.f90 | head -5

# Run tests
fpm test test_issue_2462_line_continuation_token_boundaries
fpm test test_issue_177_line_continuation
fpm test test_issue_2254_free_form_continuation
fpm test test_issue_2291_operator_continuation
```

### Output
Identifiers `ast_to_json` and `sum_pos` now preserved correctly in generated code.