### PR TITLE
test: add verification for issue #2458 intrinsic rank errors (fixes #2458)

### DIFF
--- a/examples/f90/issue_2458_multi_array_declaration.f90
+++ b/examples/f90/issue_2458_multi_array_declaration.f90
@@ -1,0 +1,11 @@
+! Test case for issue #2458: Multiple array declarations on one line
+! The bug: real, dimension(:,:), intent(in) :: a, b
+! Was being transformed to: real :: b (scalar) instead of preserving array
+module test_multi_array
+contains
+    subroutine process(a, b, c)
+        real, dimension(:, :), intent(in) :: a, b
+        real, dimension(:, :), intent(out) :: c
+        c = matmul(a, transpose(b))
+    end subroutine process
+end module test_multi_array

--- a/test/test_issue_2458_intrinsic_rank_validation.f90
+++ b/test/test_issue_2458_intrinsic_rank_validation.f90
@@ -1,0 +1,70 @@
+program test_issue_2458_intrinsic_rank_validation
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+    logical :: test_passed
+    character(len=:), allocatable :: source, output, error_msg
+
+    test_passed = .true.
+
+    call test_multi_array_declaration()
+
+    if (test_passed) then
+        print *, "test_issue_2458_intrinsic_rank_validation PASSED"
+    else
+        print *, "test_issue_2458_intrinsic_rank_validation FAILED"
+        error stop 1
+    end if
+
+contains
+
+    subroutine test_multi_array_declaration()
+        call read_example( &
+            'examples/f90/issue_2458_multi_array_declaration.f90', source)
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            print *, "ERROR: Transformation failed:", trim(error_msg)
+            test_passed = .false.
+            return
+        end if
+
+        if (index(output, 'real, intent(in) :: a(:, :), b(:, :)') == 0) then
+            print *, "FAIL: Multi-array declaration not preserved"
+            print *, "Expected: real, intent(in) :: a(:, :), b(:, :)"
+            print *, "Output:", trim(output)
+            test_passed = .false.
+            return
+        end if
+
+        if (index(output, 'transpose(b)') == 0) then
+            print *, "FAIL: transpose call missing"
+            test_passed = .false.
+            return
+        end if
+    end subroutine test_multi_array_declaration
+
+    subroutine read_example(filepath, content)
+        character(len=*), intent(in) :: filepath
+        character(len=:), allocatable, intent(out) :: content
+        integer :: unit, ios
+        character(len=10000) :: line
+
+        content = ""
+        open (newunit=unit, file=filepath, status='old', &
+            action='read', iostat=ios)
+        if (ios /= 0) then
+            print *, "ERROR: Failed to open example file:", filepath
+            error stop 1
+        end if
+
+        do
+            read (unit, '(A)', iostat=ios) line
+            if (ios /= 0) exit
+            if (len(content) > 0) content = content // new_line('a')
+            content = content // trim(line)
+        end do
+
+        close (unit)
+    end subroutine read_example
+
+end program test_issue_2458_intrinsic_rank_validation


### PR DESCRIPTION
## Summary

This PR verifies that issue #2458 (intrinsic function argument type/rank errors) has been resolved by commit 1ca5bfd8.

The issue affected 3 GCC DejaGNU roundtrip test cases:
- `inline_matmul_13.f90`: TRANSPOSE rank error
- `matmul_bounds_9.f90`: TRANSPOSE rank error  
- `internal_pack_22.f90`: PRESENT argument validation

## Root Cause

The codegen was incorrectly handling multi-variable array declarations. When parsing:
```fortran
real, dimension(:,:), intent(in) :: a, b
```

It was being transformed to:
```fortran
real :: b                      ! Wrong: scalar instead of array
real, intent(in) :: a(:, :)
```

This caused `transpose(b)` to fail compilation with:
```
Error: 'matrix' argument of 'transpose' intrinsic must be of rank 2
```

## Fix

Already fixed by commit 1ca5bfd8 "fix: preserve array type in function return type inference (partial fix for #2066)".

The transformation now correctly preserves array dimensions:
```fortran
real, intent(in) :: a(:, :), b(:, :)
```

## Changes

Added verification:
- `examples/f90/issue_2458_multi_array_declaration.f90`: Minimal reproducible test case
- `test/test_issue_2458_intrinsic_rank_validation.f90`: Regression test ensuring multi-array declarations are preserved

## Verification

Tested all 3 GCC DejaGNU cases successfully compile after roundtrip:

```bash
# Test 1: inline_matmul_13.f90
./build/gfortran_*/app/fortfront ../gcc-dev/gcc/gcc/testsuite/gfortran.dg/inline_matmul_13.f90 > /tmp/rt1.f90
gfortran -c /tmp/rt1.f90  # PASS

# Test 2: matmul_bounds_9.f90
./build/gfortran_*/app/fortfront ../gcc-dev/gcc/gcc/testsuite/gfortran.dg/matmul_bounds_9.f90 > /tmp/rt2.f90
gfortran -c /tmp/rt2.f90  # PASS

# Test 3: internal_pack_22.f90
./build/gfortran_*/app/fortfront ../gcc-dev/gcc/gcc/testsuite/gfortran.dg/internal_pack_22.f90 > /tmp/rt3.f90
gfortran -c /tmp/rt3.f90  # PASS
```

Regression test:
```bash
fpm test test_issue_2458_intrinsic_rank_validation
# Output: test_issue_2458_intrinsic_rank_validation PASSED
```

Closes #2458
