### PR TITLE
fix: recognize standalone PARAMETER statement (fixes #2487)

### DIFF
--- a/examples/f90/issue_2487_parameter_statement.f90
+++ b/examples/f90/issue_2487_parameter_statement.f90
@@ -1,0 +1,8 @@
+program test_parameter_statement
+    implicit none
+    integer :: x
+    character(len=*) :: MY_STRING(1:3)
+    parameter(x=5)
+    parameter(MY_STRING=(/"AC ", "B  ", "C  "/))
+    print *, x, MY_STRING
+end program test_parameter_statement

--- a/src/parser/core/parser_dispatcher_part1.inc
+++ b/src/parser/core/parser_dispatcher_part1.inc
@@ -16,13 +16,13 @@
         select case (first_token%kind)
         case (TK_KEYWORD)
             call dispatch_keyword(parser, arena, prefix_buffer, tokens, &
-                                 first_token, stmt_index)
+                                  first_token, stmt_index)
         case (TK_NUMBER)
             call dispatch_number_token(parser, arena, prefix_buffer, tokens, &
-                                      stmt_index)
+                                       stmt_index)
         case (TK_IDENTIFIER)
             call dispatch_identifier_token(parser, arena, prefix_buffer, &
-                                          first_token, stmt_index)
+                                           first_token, stmt_index)
         case (TK_COMMENT)
             call dispatch_comment_token(parser, arena, first_token, stmt_index)
         case (TK_NEWLINE)
@@ -49,23 +49,24 @@
         if (try_dispatch_io_keyword(parser, arena, lowered_keyword, stmt_index)) &
             return
         if (try_dispatch_control_keyword(parser, arena, first_token, &
-            lowered_keyword, stmt_index)) return
+                                         lowered_keyword, stmt_index)) return
         if (try_dispatch_definition_keyword(parser, arena, prefix_buffer, &
-            first_token, lowered_keyword, stmt_index)) return
+                                            first_token, lowered_keyword, &
+                                                stmt_index)) return
         if (try_dispatch_declaration_keyword(parser, arena, prefix_buffer, &
-            lowered_keyword, stmt_index)) return
+                                             lowered_keyword, stmt_index)) return
         if (try_dispatch_execution_keyword(parser, arena, first_token, &
-            lowered_keyword, stmt_index)) return
+                                           lowered_keyword, stmt_index)) return
         if (try_dispatch_data_keyword(parser, arena, first_token, &
-            lowered_keyword, stmt_index)) return
+                                      lowered_keyword, stmt_index)) return
         if (.not. try_handle_prefix_sequence(parser, arena, prefix_buffer, &
-            stmt_index)) then
+                                             stmt_index)) then
             stmt_index = parse_as_expression(tokens, arena)
         end if
     end subroutine dispatch_keyword
 
     logical function try_dispatch_io_keyword(parser, arena, keyword, &
-        stmt_index) result(handled)
+                                             stmt_index) result(handled)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: keyword
@@ -103,7 +104,7 @@
     end function try_dispatch_io_keyword
 
     logical function try_dispatch_control_keyword(parser, arena, first_token, &
-        keyword, stmt_index) result(handled)
+                                                  keyword, stmt_index) result(handled)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(token_t), intent(in) :: first_token
@@ -126,7 +127,9 @@
     end function try_dispatch_control_keyword
 
     logical function try_dispatch_definition_keyword(parser, arena, &
-        prefix_buffer, first_token, keyword, stmt_index) result(handled)
+                                                     prefix_buffer, first_token, &
+                                                         keyword, stmt_index) &
+                                                         result(handled)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
@@ -162,7 +165,8 @@
     end function try_dispatch_definition_keyword
 
     logical function try_dispatch_declaration_keyword(parser, arena, &
-        prefix_buffer, keyword, stmt_index) result(handled)
+                                                      prefix_buffer, keyword, &
+                                                          stmt_index) result(handled)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
@@ -191,7 +195,7 @@
     end function try_dispatch_declaration_keyword
 
     logical function try_dispatch_execution_keyword(parser, arena, first_token, &
-        keyword, stmt_index) result(handled)
+                                                    keyword, stmt_index) result(handled)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(token_t), intent(in) :: first_token
@@ -228,12 +232,14 @@
     end function try_dispatch_execution_keyword
 
     logical function try_dispatch_data_keyword(parser, arena, first_token, &
-        keyword, stmt_index) result(handled)
+                                               keyword, stmt_index) result(handled)
+        use parser_parameter_statements_module, only: parse_parameter_statement
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(token_t), intent(in) :: first_token
         character(len=*), intent(in) :: keyword
         integer, intent(out) :: stmt_index
+        logical :: param_success
 
         handled = .true.
         select case (keyword)
@@ -241,9 +247,16 @@
             call handle_data_keyword(parser, arena, stmt_index)
         case ("namelist")
             stmt_index = parse_namelist_statement(parser, arena)
+        case ("parameter")
+            param_success = parse_parameter_statement(parser, arena)
+            if (param_success) then
+                stmt_index = 0
+            else
+                stmt_index = parse_assignment_or_expression(parser, arena)
+            end if
         case ("equivalence", "common")
             call handle_legacy_keyword(parser, arena, first_token, keyword, &
-                                      stmt_index)
+                                       stmt_index)
         case ("enum", "enumerator")
             stmt_index = parse_unsupported_statement(keyword, parser, arena)
         case default
@@ -281,7 +294,7 @@
         if (is_abstract_interface) then
             next_token = parser%consume()
             stmt_index = parse_interface_block(parser, arena, prefix_buffer, &
-                                              is_abstract=.true.)
+                                               is_abstract=.true.)
         else
             stmt_index = parse_type_or_declaration(parser, arena, prefix_buffer)
         end if
@@ -496,7 +509,7 @@
     end subroutine handle_legacy_keyword
 
     subroutine dispatch_number_token(parser, arena, prefix_buffer, tokens, &
-                                    stmt_index)
+                                     stmt_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
@@ -552,7 +565,7 @@
     end subroutine dispatch_number_token
 
     subroutine dispatch_identifier_token(parser, arena, prefix_buffer, &
-                                        first_token, stmt_index)
+                                         first_token, stmt_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer

--- a/src/parser/declarations/parser_parameter_statements_module.f90
+++ b/src/parser/declarations/parser_parameter_statements_module.f90
@@ -1,0 +1,239 @@
+module parser_parameter_statements_module
+    use lexer_core, only: token_t, TK_IDENTIFIER, TK_KEYWORD, TK_OPERATOR, &
+        & TK_WHITESPACE, TK_COMMENT, TK_NEWLINE, TK_NUMBER, TK_STRING, to_lower
+    use parser_state_module, only: parser_state_t
+    use parser_expressions_module, only: parse_expression
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_data, only: declaration_node, module_node
+    use ast_nodes_core, only: program_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+    use ast_factory, only: push_declaration
+    implicit none
+    private
+
+    public :: parse_parameter_statement
+
+contains
+
+    logical function parse_parameter_statement(parser, arena) result(success)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t) :: token
+        character(len=:), allocatable :: lowered_keyword
+
+        success = .false.
+        if (parser%is_at_end()) return
+
+        call skip_trivia(parser)
+
+        if (.not. parser%is_at_end()) then
+            token = parser%peek()
+            if (token%kind == TK_KEYWORD) then
+                lowered_keyword = to_lower(token%text)
+                if (trim(lowered_keyword) == "parameter") then
+                    token = parser%consume()
+                    call skip_trivia(parser)
+                end if
+            end if
+        end if
+
+        if (parser%is_at_end()) return
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= "(") return
+        token = parser%consume()
+        call skip_trivia(parser)
+
+        do
+            if (parser%is_at_end()) exit
+
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                token = parser%consume()
+                exit
+            end if
+
+            if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                token = parser%consume()
+                call skip_trivia(parser)
+                cycle
+            end if
+
+            if (.not. token_is_identifier(token)) exit
+
+            if (parse_single_parameter_def(parser, arena)) then
+                success = .true.
+            end if
+
+            call skip_trivia(parser)
+        end do
+    end function parse_parameter_statement
+
+    logical function parse_single_parameter_def(parser, arena) result(applied)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t) :: token
+        type(token_t), allocatable :: expr_tokens(:)
+        character(len=:), allocatable :: var_name
+        integer :: value_index, paren_depth, start_pos, end_pos, tok_count
+
+        applied = .false.
+        if (parser%is_at_end()) return
+
+        token = parser%peek()
+        if (.not. token_is_identifier(token)) return
+        token = parser%consume()
+        var_name = adjustl(trim(token%text))
+
+        call skip_trivia(parser)
+        if (parser%is_at_end()) return
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= "=") return
+        token = parser%consume()
+        call skip_trivia(parser)
+
+        if (parser%is_at_end()) return
+
+        start_pos = parser%current_token
+        paren_depth = 0
+        do while (parser%current_token <= size(parser%tokens))
+            token = parser%tokens(parser%current_token)
+            if (token%kind == TK_OPERATOR) then
+                select case (trim(token%text))
+                case ("(", "[", "(/")
+                    paren_depth = paren_depth + 1
+                case (")", "]", "/)")
+                    if (paren_depth == 0) then
+                        exit
+                    else
+                        paren_depth = paren_depth - 1
+                    end if
+                case (",")
+                    if (paren_depth == 0) exit
+                end select
+            else if (token%kind == TK_NEWLINE) then
+                exit
+            end if
+            parser%current_token = parser%current_token + 1
+        end do
+        end_pos = parser%current_token - 1
+
+        if (end_pos < start_pos) return
+
+        tok_count = end_pos - start_pos + 1
+        allocate (expr_tokens(tok_count + 1))
+        expr_tokens(1:tok_count) = parser%tokens(start_pos:end_pos)
+        expr_tokens(tok_count + 1)%kind = 0
+        expr_tokens(tok_count + 1)%text = ""
+
+        value_index = parse_expression(expr_tokens, arena)
+        if (value_index <= 0) return
+
+        applied = apply_parameter_to_variable(arena, var_name, value_index)
+
+        if (.not. applied) then
+            applied = create_parameter_declaration(arena, var_name, value_index)
+        end if
+    end function parse_single_parameter_def
+
+    subroutine skip_trivia(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            select case (token%kind)
+            case (TK_WHITESPACE, TK_COMMENT, TK_NEWLINE)
+                token = parser%consume()
+            case default
+                exit
+            end select
+        end do
+    end subroutine skip_trivia
+
+    logical function token_is_identifier(token) result(is_ident)
+        type(token_t), intent(in) :: token
+        is_ident = (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD)
+    end function token_is_identifier
+
+    logical function apply_parameter_to_variable(arena, name, value_index) &
+        result(applied)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: value_index
+        character(len=:), allocatable :: target, decl_name
+        integer :: idx
+
+        applied = .false.
+        target = to_lower(adjustl(trim(name)))
+
+        do idx = arena%size, 1, -1
+            if (.not. allocated(arena%entries(idx)%node)) cycle
+            select type (decl => arena%entries(idx)%node)
+            type is (declaration_node)
+                if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
+                    if (apply_parameter_multi(arena, idx, decl, target, &
+                                              value_index)) then
+                        applied = .true.
+                        return
+                    end if
+                end if
+                if (allocated(decl%var_name)) then
+                    decl_name = to_lower(trim(decl%var_name))
+                    if (decl_name == target) then
+                        decl%is_parameter = .true.
+                        decl%has_initializer = .true.
+                        decl%initializer_index = value_index
+                        arena%entries(idx)%node = decl
+                        applied = .true.
+                        return
+                    end if
+                end if
+            end select
+        end do
+    end function apply_parameter_to_variable
+
+    logical function apply_parameter_multi(arena, decl_index, decl, target, &
+                                           value_index) result(updated)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: decl_index
+        type(declaration_node), intent(inout) :: decl
+        character(len=*), intent(in) :: target
+        integer, intent(in) :: value_index
+        integer :: i
+        character(len=:), allocatable :: decl_name
+
+        updated = .false.
+        if (.not. allocated(decl%var_names)) return
+
+        do i = 1, size(decl%var_names)
+            decl_name = to_lower(trim(decl%var_names(i)))
+            if (decl_name == target) then
+                decl%is_parameter = .true.
+                decl%has_initializer = .true.
+                decl%initializer_index = value_index
+                arena%entries(decl_index)%node = decl
+                updated = .true.
+                return
+            end if
+        end do
+    end function apply_parameter_multi
+
+    logical function create_parameter_declaration(arena, name, value_index) &
+        result(created)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: value_index
+        integer :: decl_index
+        character(len=len(name)) :: names(1)
+
+        created = .false.
+        names(1) = name
+        decl_index = push_declaration(arena, type_name="", names=names, &
+                                      is_parameter=.true., &
+                                      initializer_index=value_index)
+        if (decl_index > 0) created = .true.
+    end function create_parameter_declaration
+
+end module parser_parameter_statements_module

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -733,6 +733,16 @@ contains
                         success = parse_dimension_statement(parser_ref, arena_ref)
                     end block
                     stmt_index = 0
+                case ("parameter")
+                    block
+                        use parser_parameter_statements_module, only: &
+                            parse_parameter_statement
+                        type(token_t) :: ignored_token
+                        logical :: success
+                        ignored_token = parser_ref%consume()
+                        success = parse_parameter_statement(parser_ref, arena_ref)
+                    end block
+                    stmt_index = 0
                 case ("namelist")
                     stmt_index = parse_namelist_statement(parser_ref, arena_ref)
                 case ("equivalence", "common")

--- a/src/parser/statements/parser_statement_core.f90
+++ b/src/parser/statements/parser_statement_core.f90
@@ -25,6 +25,7 @@ module parser_statement_core_module
     use parser_statement_data_module, only: parse_data_statement, &
                                             parse_namelist_statement
     use parser_dimension_statements_module, only: parse_dimension_statement
+    use parser_parameter_statements_module, only: parse_parameter_statement
     use parser_statement_detection_module, only: is_block_if, find_statement_end, &
                                                  extend_if_statement_end
     use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier
@@ -194,6 +195,14 @@ contains
 
             if (lowered == "dimension") then
                 if (parse_dimension_statement(parser, arena)) then
+                    stmt_index = STATEMENT_NO_NODE
+                else
+                    stmt_index = 0
+                end if
+            end if
+
+            if (lowered == "parameter") then
+                if (parse_parameter_statement(parser, arena)) then
                     stmt_index = STATEMENT_NO_NODE
                 else
                     stmt_index = 0

--- a/test/test_issue_2487_parameter_statement.f90
+++ b/test/test_issue_2487_parameter_statement.f90
@@ -1,0 +1,133 @@
+program test_issue_2487_parameter_statement
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit
+    use, intrinsic :: iso_fortran_env, only: iostat_end, iostat_eor
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    if (.not. test_simple_parameter()) all_passed = .false.
+    if (.not. test_character_array_parameter()) all_passed = .false.
+    if (.not. test_parameter_in_explicit_program()) all_passed = .false.
+
+    if (all_passed) then
+        print *, "PASS: Issue #2487 parameter statement tests"
+    else
+        print *, "FAIL: Issue #2487 parameter statement tests"
+        stop 1
+    end if
+
+contains
+
+    include 'common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') "FAIL: failed to read " // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    function test_simple_parameter() result(passed)
+        logical :: passed
+        character(len=:), allocatable :: source, output, error_msg
+
+        passed = .true.
+        source = "integer :: x" // char(10) // &
+                 "PARAMETER(X = 5)" // char(10) // &
+                 "print *, x"
+
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            write (error_unit, '(A)') "ERROR: Failed to parse: " // trim(error_msg)
+            passed = .false.
+            return
+        end if
+
+        if (index(output, ", parameter") == 0) then
+            write (error_unit, '(A)') &
+                "ERROR: Expected 'parameter' attribute in declaration"
+            write (error_unit, '(A)') "Output: " // trim(output)
+            passed = .false.
+        end if
+
+        if (index(output, "= 5") == 0) then
+            write (error_unit, '(A)') &
+                "ERROR: Expected initializer '= 5' in declaration"
+            write (error_unit, '(A)') "Output: " // trim(output)
+            passed = .false.
+        end if
+    end function test_simple_parameter
+
+    function test_character_array_parameter() result(passed)
+        logical :: passed
+        character(len=:), allocatable :: source, output, error_msg
+
+        passed = .true.
+        call read_example("examples/f90/issue_2487_parameter_statement.f90", source)
+
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            write (error_unit, '(A)') "ERROR: Failed to parse: " // trim(error_msg)
+            passed = .false.
+            return
+        end if
+
+        if (index(output, ", parameter :: x = 5") == 0) then
+            write (error_unit, '(A)') &
+                "ERROR: Expected 'parameter :: x = 5'"
+            write (error_unit, '(A)') "Output: " // trim(output)
+            passed = .false.
+        end if
+
+        if (index(output, ", parameter :: MY_STRING") == 0) then
+            write (error_unit, '(A)') &
+                "ERROR: Expected 'parameter :: MY_STRING'"
+            write (error_unit, '(A)') "Output: " // trim(output)
+            passed = .false.
+        end if
+    end function test_character_array_parameter
+
+    function test_parameter_in_explicit_program() result(passed)
+        logical :: passed
+        character(len=:), allocatable :: source, output, error_msg
+
+        passed = .true.
+        source = "program main" // char(10) // &
+                 "    integer :: y" // char(10) // &
+                 "    PARAMETER(Y = 42)" // char(10) // &
+                 "end program"
+
+        call transform_lazy_fortran_string(source, output, error_msg)
+
+        if (len_trim(error_msg) > 0) then
+            write (error_unit, '(A)') "ERROR: Failed to parse: " // trim(error_msg)
+            passed = .false.
+            return
+        end if
+
+        if (index(output, ", parameter") == 0) then
+            write (error_unit, '(A)') &
+                "ERROR: Expected 'parameter' attribute in explicit program"
+            write (error_unit, '(A)') "Output: " // trim(output)
+            passed = .false.
+        end if
+
+        if (index(output, "= 42") == 0) then
+            write (error_unit, '(A)') &
+                "ERROR: Expected initializer '= 42'"
+            write (error_unit, '(A)') "Output: " // trim(output)
+            passed = .false.
+        end if
+    end function test_parameter_in_explicit_program
+
+end program test_issue_2487_parameter_statement


### PR DESCRIPTION
## Summary
- Add parser support for standalone PARAMETER statement as defined in ISO/IEC 1539-1:2018 Section 8.6
- The statement form `PARAMETER(X = 5)` is now recognized and properly transforms to declaration with `parameter` attribute
- Works for both lazy Fortran and standard Fortran with explicit `program` blocks

## Test plan
- [x] Added `examples/f90/issue_2487_parameter_statement.f90` example
- [x] Added `test/test_issue_2487_parameter_statement.f90` with unit tests
- [x] Verified simple integer parameter: `integer :: x; PARAMETER(X = 5)` transforms to `integer, parameter :: x = 5`
- [x] Verified character array parameter from issue works
- [x] Verified explicit program body handles PARAMETER correctly
- [x] Full test suite passes (pre-existing failure in `issue_2142_mono_wrong_return_types.lf`)

## Verification
```bash
$ echo 'program main
    character(len=*) :: MY_STRING(1:3)
    PARAMETER(MY_STRING = (/"AC ", "B  ", "C  " /))
end program' | fpm run --
program main
    implicit none
    character(len=*), parameter :: MY_STRING(1:3) = (/"AC ", "B  ", "C  " /)
end program main
```
