### PR TITLE
fix: recognize GO TO two-word form (fixes #2499)

### DIFF
--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -471,7 +471,7 @@ contains
 
         select case (trim(lower_word))
         case ('program', 'end', 'function', 'subroutine', 'if', 'then', 'else', &
-              'goto', 'cycle', 'exit', 'stop', 'pause', 'return', 'entry', 'error', &
+              'go', 'goto', 'cycle', 'exit', 'stop', 'pause', 'return', 'entry', 'error', &
               'continue', 'nullify', 'do', 'while', 'concurrent', 'for', 'integer', &
               'real', 'logical', 'character', 'complex', 'double', 'precision', &
               'implicit', 'none', 'parameter', 'dimension', 'allocatable', &

--- a/src/parser/control_flow/parser_control_statements.f90
+++ b/src/parser/control_flow/parser_control_statements.f90
@@ -279,7 +279,9 @@ contains
             token = parser%consume()
 
             token = parser%peek()
-            if (token%kind == TK_KEYWORD .and. trim(to_lower(token%text)) == "to") then
+            ! Accept 'to' as either keyword or identifier (to is not a reserved word)
+            if ((token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER) .and. &
+                trim(to_lower(token%text)) == "to") then
                 token = parser%consume()
 
                 token = parser%peek()


### PR DESCRIPTION
## Summary

- Add `'go'` to the lexer keyword list so `go to` two-word form is properly tokenized
- Accept `'to'` as identifier in parser since it's not a Fortran reserved word

## Root Cause

When Fortran uses the two-word form `go to`, the token `go` was lexed as `TK_IDENTIFIER` instead of `TK_KEYWORD` because only `'goto'` was in the keyword list. This caused the statement to fall through to identifier assignment parsing and be silently dropped.

Additionally, the parser checked for `'to'` as `TK_KEYWORD` only, but `'to'` is not a reserved word and comes as `TK_IDENTIFIER`.

## ISO Standard Reference

Per ISO/IEC 1539-1:2018 Section 8.2.4 (GO TO statement), both `GOTO` (single word) and `GO TO` (two words) forms are valid.

## Verification

**Simple GO TO:**
```bash
echo 'program test
    go to 100
100 continue
end program' | ./build/gfortran_*/app/fortfront
```
Output: `go to 100` preserved (was silently dropped before)

**Computed GO TO:**
```bash
echo 'program test
    integer :: x = 1
    go to (10, 20, 30) x
10  continue
end program' | ./build/gfortran_*/app/fortfront
```
Output: `go to (10, 20, 30), x` preserved (was silently dropped before)

**gfortran roundtrip tests:**
```
eor_handling_4.f90: pass
pr122369-3.f90: pass
```

## Test Results

- All GO TO related example tests pass (8 tests)
- No regressions: same 5 pre-existing failures as on main branch
