### PR TITLE
fix: recognize INCLUDE line as valid Fortran directive (fixes #2497)

### DIFF
--- a/examples/analysis_only_examples.txt
+++ b/examples/analysis_only_examples.txt
@@ -20,3 +20,4 @@ f90/issue_2281_header_only_declarations.f90
 f90/issue_2283_nested_modules.f90
 f90/issue_2078_include_statement_silently_dropped.f90
 f90/issue_2252_data_value_implied_do.f90
+f90/issue_2497_include_line_standalone.f90

--- a/examples/f90/issue_2497_include_line_standalone.f90
+++ b/examples/f90/issue_2497_include_line_standalone.f90
@@ -1,0 +1,1 @@
+include 'other_file.f90'

--- a/src/utilities/input_validation_part1.inc
+++ b/src/utilities/input_validation_part1.inc
@@ -373,7 +373,9 @@
                     tokens(i)%text == "implicit" .or. tokens(i)%text == "none" .or. &
                     tokens(i)%text == "end" .or. tokens(i)%text == "if" .or. &
                     tokens(i)%text == "do" .or. tokens(i)%text == "print" .or. &
-                    tokens(i)%text == "read" .or. tokens(i)%text == "write") then
+                    tokens(i)%text == "read" .or. tokens(i)%text == "write" .or. &
+                    tokens(i)%text == "use" .or. tokens(i)%text == "include" .or. &
+                    tokens(i)%text == "import") then
                     has_fortran_keywords = .true.
                 end if
             end if

--- a/test/codegen/test_issue_2497_include_line_standalone.f90
+++ b/test/codegen/test_issue_2497_include_line_standalone.f90
@@ -1,0 +1,61 @@
+program test_issue_2497_include_line_standalone
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: errors
+
+    call read_example('examples/f90/issue_2497_include_line_standalone.f90', source)
+
+    call transform_lazy_fortran_string(source, output, errors)
+
+    if (len_trim(errors) > 0) then
+        print *, "Unexpected errors:", trim(errors)
+        error stop 1
+    end if
+
+    if (index(output, "include") == 0) then
+        print *, "ERROR: INCLUDE line was dropped during round-trip"
+        error stop 1
+    end if
+
+    if (index(output, "'other_file.f90'") == 0) then
+        print *, "ERROR: INCLUDE filename was not preserved"
+        error stop 1
+    end if
+
+    print *, "PASS: Standalone INCLUDE line preserved correctly"
+
+contains
+
+    subroutine read_example(filepath, content)
+        character(len=*), intent(in) :: filepath
+        character(len=:), allocatable, intent(out) :: content
+        integer :: unit_num, ios, file_size
+        character(len=1), allocatable :: buffer(:)
+        integer :: i
+
+        open (newunit=unit_num, file=filepath, status='old', &
+              action='read', access='stream', iostat=ios)
+        if (ios /= 0) then
+            print *, "ERROR: Could not open file:", filepath
+            error stop 1
+        end if
+
+        inquire (unit=unit_num, size=file_size)
+        allocate (buffer(file_size))
+        read (unit_num, iostat=ios) buffer
+        close (unit_num)
+
+        if (ios /= 0) then
+            print *, "ERROR: Could not read file:", filepath
+            error stop 1
+        end if
+
+        allocate (character(len=file_size) :: content)
+        do i = 1, file_size
+            content(i:i) = buffer(i)
+        end do
+    end subroutine read_example
+
+end program test_issue_2497_include_line_standalone


### PR DESCRIPTION
## Summary
- Add `include`, `use`, and `import` keywords to input validation whitelist
- The INCLUDE line was already fully implemented in lexer/parser/codegen but blocked at validation

## Root Cause
The `check_for_fortran_content()` function in input validation had a whitelist of recognized keywords. When a file contained only an INCLUDE line (e.g., `include 'other_file.f90'`), it was rejected with `[UNRECOGNIZED_INPUT]` because `include` wasn't in the whitelist.

## ISO Standard Reference
Per **ISO/IEC 1539-1:2018 Section 6.4**, the INCLUDE line is a valid Fortran directive.

## Verification

**Before fix:**
```
$ echo "include 'other_file.f90'" | fpm run
[UNRECOGNIZED_INPUT] Input does not appear to be valid Fortran at line 1, column 1
```

**After fix:**
```
$ echo "include 'other_file.f90'" | fpm run
program main
    implicit none
    include 'other_file.f90'
end program main
```

**Test results:**
```
$ fpm test test_issue_2497_include_line_standalone
PASS: Standalone INCLUDE line preserved correctly

$ fpm test test_issue_2078_include_statement
PASS: INCLUDE statement preserved correctly
```

## Test plan
- [x] New test `test_issue_2497_include_line_standalone` passes
- [x] Existing test `test_issue_2078_include_statement` passes
- [x] Full test suite passes (pre-existing failure in `test_all_examples` for `issue_2142` unchanged)
