### PR TITLE
fix: use case-insensitive keyword comparisons (fixes #2505)

### DIFF
--- a/examples/f90/issue_2505_uppercase_end_program.f90
+++ b/examples/f90/issue_2505_uppercase_end_program.f90
@@ -1,0 +1,11 @@
+! Test case for issue #2505: uppercase END PROGRAM fails to parse
+! ISO/IEC 1539-1:2018 Section 3.3.2: Fortran is case-insensitive for keywords
+program main
+    implicit none
+    call sub()
+contains
+    subroutine sub()
+        implicit none
+        print *, "Internal procedure works"
+    end subroutine sub
+END program main

--- a/src/frontend/frontend_program_units.f90
+++ b/src/frontend/frontend_program_units.f90
@@ -380,7 +380,7 @@ contains
 
         is_start = .false.
         if (pos <= size(tokens)) then
-            if (tokens(pos)%kind == TK_KEYWORD .and. tokens(pos)%text == &
+            if (tokens(pos)%kind == TK_KEYWORD .and. to_lower(tokens(pos)%text) == &
                 "program") then
                 is_start = .true.
             end if

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -87,7 +87,7 @@ contains
 
         ! Check if we're already at 'program' keyword
         token = parser%peek()
-        if (token%kind == TK_KEYWORD .and. token%text == "program") then
+        if (token%kind == TK_KEYWORD .and. to_lower(token%text) == "program") then
             ! Consume 'program' keyword
             token = parser%consume()
         else

--- a/src/utilities/input_validation_part1.inc
+++ b/src/utilities/input_validation_part1.inc
@@ -365,19 +365,23 @@
             if (tokens(i)%kind == TK_KEYWORD) then
                 keyword_count = keyword_count + 1
 
-                ! Check for common Fortran keywords
-                if (tokens(i)%text == "program" .or. tokens(i)%text == "function" .or. &
-                    tokens(i)%text == "subroutine" .or. tokens(i)%text == "module" .or. &
-                    tokens(i)%text == "integer" .or. tokens(i)%text == "real" .or. &
-                    tokens(i)%text == "character" .or. tokens(i)%text == "logical" .or. &
-                    tokens(i)%text == "implicit" .or. tokens(i)%text == "none" .or. &
-                    tokens(i)%text == "end" .or. tokens(i)%text == "if" .or. &
-                    tokens(i)%text == "do" .or. tokens(i)%text == "print" .or. &
-                    tokens(i)%text == "read" .or. tokens(i)%text == "write" .or. &
-                    tokens(i)%text == "use" .or. tokens(i)%text == "include" .or. &
-                    tokens(i)%text == "import") then
-                    has_fortran_keywords = .true.
-                end if
+                ! Check for common Fortran keywords (case-insensitive)
+                block
+                    character(len=:), allocatable :: kw_lower
+                    kw_lower = to_lower(tokens(i)%text)
+                    if (kw_lower == "program" .or. kw_lower == "function" .or. &
+                        kw_lower == "subroutine" .or. kw_lower == "module" .or. &
+                        kw_lower == "integer" .or. kw_lower == "real" .or. &
+                        kw_lower == "character" .or. kw_lower == "logical" .or. &
+                        kw_lower == "implicit" .or. kw_lower == "none" .or. &
+                        kw_lower == "end" .or. kw_lower == "if" .or. &
+                        kw_lower == "do" .or. kw_lower == "print" .or. &
+                        kw_lower == "read" .or. kw_lower == "write" .or. &
+                        kw_lower == "use" .or. kw_lower == "include" .or. &
+                        kw_lower == "import") then
+                        has_fortran_keywords = .true.
+                    end if
+                end block
             end if
         end do
 
@@ -445,14 +449,14 @@
             last_col = tokens(i)%column
 
             if (tokens(i)%kind == TK_KEYWORD) then
-                select case (tokens(i)%text)
+                select case (to_lower(tokens(i)%text))
                 case ("program")
                     ! Only treat as a new program when this token actually begins a program
                     if (.not. is_program_statement_start(tokens, i)) cycle
 
                     ! Skip "end program"
                     if (i > 1) then
-                        if (tokens(i - 1)%text == "end") cycle
+                        if (to_lower(tokens(i - 1)%text) == "end") cycle
                     end if
 
                     program_count = program_count + 1
@@ -463,7 +467,7 @@
                     if (i == 1) then
                         function_count = function_count + 1
                         call push_construct(UNIT_FUNCTION)
-                    else if (i > 1 .and. tokens(i - 1)%text /= "end") then
+                    else if (i > 1 .and. to_lower(tokens(i - 1)%text) /= "end") then
                         function_count = function_count + 1
                         call push_construct(UNIT_FUNCTION)
                     end if
@@ -472,7 +476,7 @@
                     if (i == 1) then
                         subroutine_count = subroutine_count + 1
                         call push_construct(UNIT_SUBROUTINE)
-                    else if (i > 1 .and. tokens(i - 1)%text /= "end") then
+                    else if (i > 1 .and. to_lower(tokens(i - 1)%text) /= "end") then
                         subroutine_count = subroutine_count + 1
                         call push_construct(UNIT_SUBROUTINE)
                     end if
@@ -489,14 +493,14 @@
                     if (i == 1) then
                         module_count = module_count + 1
                         call push_construct(UNIT_MODULE)
-                    else if (i > 1 .and. tokens(i - 1)%text /= "end") then
+                    else if (i > 1 .and. to_lower(tokens(i - 1)%text) /= "end") then
                         module_count = module_count + 1
                         call push_construct(UNIT_MODULE)
                     end if
                 case ("end")
                     ! Check what kind of end this is
                     if (i < size(tokens) .and. tokens(i + 1)%kind == TK_KEYWORD) then
-                        select case (tokens(i + 1)%text)
+                        select case (to_lower(tokens(i + 1)%text))
                         case ("program")
                             end_program_count = end_program_count + 1
                             call pop_construct(UNIT_PROGRAM, popped_unit)


### PR DESCRIPTION
## Summary
- Fix case-insensitive keyword comparison in parser for PROGRAM keyword detection
- Fix case-insensitive keyword comparison in is_program_start() for program unit detection
- Fix case-insensitive construct counting in check_missing_end_constructs()
- Fix case-insensitive keyword detection in check_for_fortran_content()

## Root Cause
Fortran is case-insensitive per ISO/IEC 1539-1:2018 Section 3.3.2, but several places in the parser were comparing token text directly to lowercase keyword strings without first lowercasing the token text. This caused uppercase keywords like `END PROGRAM` to fail parsing.

## Verification
```bash
# Before fix: fails with "Missing end program" error
./build/gfortran_*/app/fortfront examples/f90/issue_2505_uppercase_end_program.f90

# After fix: parses correctly
./build/gfortran_*/app/fortfront examples/f90/issue_2505_uppercase_end_program.f90
# Output: program main ... end program main
```

Test suite:
```
fpm test test_all_examples
Total examples tested: 530
Passed: 518
Failed: 0
XFail (expected): 12
Success rate: 100.0%

fpm test
All tests pass
```
