### PR TITLE
test: add regression test for quotes in comments (fixes #2496)

### DIFF
--- a/examples/f90/issue_2496_quotes_in_comments.f90
+++ b/examples/f90/issue_2496_quotes_in_comments.f90
@@ -1,0 +1,9 @@
+program main
+    implicit none
+    integer :: x
+
+    print *, "hello"  ! comment with 'quotes' inside
+    x = 5  ! it's working and we don't care
+    x = x + 3  ! another "quoted" comment
+
+end program main

--- a/test/test_issue_2496_quotes_in_comments.f90
+++ b/test/test_issue_2496_quotes_in_comments.f90
@@ -1,0 +1,79 @@
+program test_issue_2496_quotes_in_comments
+    use transformation_api, only: transform_lazy_fortran_string
+    use, intrinsic :: iso_fortran_env, only: error_unit, iostat_end
+    use, intrinsic :: iso_fortran_env, only: iostat_eor, input_unit
+    implicit none
+    character(len=:), allocatable :: source, output, error_msg
+    logical :: success
+
+    print *, "=== Testing Issue #2496: Quotes in Comments ==="
+    print *
+
+    call read_example('examples/f90/issue_2496_quotes_in_comments.f90', source)
+
+    print *, "Parsing source with quotes in comments..."
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: Transformation failed: ' // error_msg
+        stop 1
+    end if
+
+    if (.not. allocated(output) .or. len_trim(output) == 0) then
+        write (error_unit, '(A)') 'FAIL: Transformation produced no output'
+        stop 1
+    end if
+
+    print *, "Transformation: SUCCESS"
+
+    success = .true.
+    success = success .and. verify_contains(output, 'print *', &
+                                            'print statement preserved')
+    success = success .and. verify_contains(output, 'hello', &
+                                            'string literal preserved')
+    success = success .and. verify_contains(output, 'x = 5', &
+                                            'assignment preserved')
+    success = success .and. verify_contains(output, 'x = x + 3', &
+                                            'second assignment preserved')
+
+    if (.not. success) then
+        write (error_unit, '(A)') 'FAIL: Output verification failed'
+        stop 1
+    end if
+
+    print *
+    print *, "PASS: All quotes in comments tests passed"
+    print *, "      Single quotes in comments handled correctly"
+    print *, "      Double quotes in comments handled correctly"
+    print *, "      Code preserved correctly"
+
+contains
+
+    function verify_contains(text, pattern, description) result(found)
+        character(len=*), intent(in) :: text, pattern, description
+        logical :: found
+
+        found = index(text, pattern) > 0
+        if (found) then
+            print *, "  PASS: " // trim(description)
+        else
+            write (error_unit, '(A)') '  FAIL: ' // trim(description)
+            write (error_unit, '(A)') '        Expected pattern: ' // trim(pattern)
+        end if
+    end function verify_contains
+
+    subroutine read_example(filepath, content)
+        character(len=*), intent(in) :: filepath
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., filepath, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(filepath)
+            stop 1
+        end if
+    end subroutine read_example
+
+    include 'common/cli_io_reader.inc'
+
+end program test_issue_2496_quotes_in_comments


### PR DESCRIPTION
## Summary
- Add regression test coverage for quotes inside comments (fixes #2496)
- Confirm lexer correctly handles single and double quotes within comments  
- The described crash behavior could not be reproduced on current main

## Investigation
The issue reported that apostrophes inside comments caused parser crashes. Testing confirms the lexer correctly handles this case:

- `scan_comment` in `lexer_scanners.f90` reads from `!` to end-of-line without interpreting quotes
- The token dispatch in `tokenize_core_safe` correctly routes `!` to comment scanning before checking for quote characters

## Test Plan
- [x] `fpm test test_issue_2496_quotes_in_comments` passes
- [x] Full test suite passes
- [x] Manual verification with multiple quote patterns

## Verification

```
$ printf "program main\n    x = 5 ! it's working\nend program" | ./build/*/app/fortfront
program main
    implicit none
    integer :: x
    x = 5 
end program main

$ fpm test test_issue_2496_quotes_in_comments
=== Testing Issue #2496: Quotes in Comments ===
Parsing source with quotes in comments...
Transformation: SUCCESS
  PASS: print statement preserved
  PASS: string literal preserved  
  PASS: assignment preserved
  PASS: second assignment preserved
PASS: All quotes in comments tests passed
```

ISO Reference: ISO/IEC 1539-1:2018 Section 6.3.2.2 - comment content has no syntactic significance.
