### PR TITLE
fix: [standard-fixtures] Fix roundtrip for enhanced_intrinsics.f90 (fixes #2530)

### DIFF
--- a/examples/standard_fixtures_xfail.txt
+++ b/examples/standard_fixtures_xfail.txt
@@ -23,7 +23,6 @@ submodule_parent_hierarchy.f90  # submodule construct not fully supported #2529
 basic_submodule.f90  # submodule construct not fully supported #2529
 nested_submodule_reference.f90  # submodule construct not fully supported #2529
 submodule_with_procedures.f90  # submodule construct not fully supported #2529
-enhanced_intrinsics.f90  # roundtrip output differs - F2008 intrinsics #2530
 
 # Fortran 2018 fixtures
 select_rank_minimal.f90  # gfortran14 codegen crash with select rank #2534

--- a/src/parser/expressions/parser_expression_arrays.f90
+++ b/src/parser/expressions/parser_expression_arrays.f90
@@ -69,11 +69,9 @@ contains
                 end block
             end if
 
-            if (style == "modern") then
-                value_index = helpers%parse_comparison(parser, arena)
-            else
-                value_index = helpers%parse_unary(parser, arena)
-            end if
+            ! Use parse_comparison for both modern and legacy styles to support
+            ! binary expressions like 2.0*x in array constructors
+            value_index = helpers%parse_comparison(parser, arena)
 
             if (value_index <= 0) then
                 expr_index = 0


### PR DESCRIPTION
## Summary

- Fix legacy array constructor parsing to support binary expressions inside `(/ ... /)` syntax
- Changed `parse_simple_array_elements` to use `parse_comparison` for both modern and legacy styles

## Root Cause

The legacy array constructor parser used `parse_unary` for element expressions, which only handles unary operators like `-x`. Binary expressions like `2.0*x` or `x+y` were incorrectly truncated.

## Fix

Use `parse_comparison` (which handles full expressions) for both modern `[...]` and legacy `(/ ... /)` array constructor syntaxes.

## Verification

```
$ fpm test test_standard_fixtures 2>&1 | grep enhanced_intrinsics
  enhanced_intrinsics.f90 ...  PASS

$ echo 'result_val = norm2((/ x, 2.0*x /))' | fpm run -- 
program main
    implicit none
    real :: result_val
    real :: x
    real, external :: norm2
    result_val = norm2((/x, 2.0*x /))
end program main
```

## Test Results

```
Total fixtures tested: 165
Passed: 157
Failed: 0
XFail (expected): 8
Success rate: 100.0%
```