### PR TITLE
fix: add dedicated tests for F2003 constructs (fixes #2537)

### DIFF
--- a/examples/f90/f2003_abstract_interface.f90
+++ b/examples/f90/f2003_abstract_interface.f90
@@ -1,0 +1,37 @@
+! Example demonstrating abstract interface in module and procedure scope
+! ISO/IEC 1539-1:2018 Section 15.4.3.2 - Abstract interface blocks
+module abstract_interface_demo_mod
+    implicit none
+
+    ! Module-level abstract interface
+    abstract interface
+        function transform_func(x) result(y)
+            real, intent(in) :: x
+            real :: y
+        end function transform_func
+    end interface
+
+    ! Module-level procedure pointer using abstract interface
+    procedure(transform_func), pointer :: module_func_ptr => null()
+
+contains
+
+    subroutine apply_transform(x, result_val)
+        real, intent(in) :: x
+        real, intent(out) :: result_val
+
+        ! Procedure-level abstract interface
+        abstract interface
+            function unary_func(val) result(res)
+                real, intent(in) :: val
+                real :: res
+            end function unary_func
+        end interface
+
+        procedure(unary_func), pointer :: local_op
+
+        local_op => null()
+        result_val = x * 2.0
+    end subroutine apply_transform
+
+end module abstract_interface_demo_mod

--- a/examples/f90/f2003_associate_construct.f90
+++ b/examples/f90/f2003_associate_construct.f90
@@ -1,0 +1,36 @@
+! Example demonstrating associate construct within procedure bodies
+! ISO/IEC 1539-1:2018 Section 11.1.3 - ASSOCIATE construct
+module associate_construct_demo_mod
+    implicit none
+
+    type :: point_t
+        real :: x
+        real :: y
+    end type point_t
+
+contains
+
+    subroutine process_point(pt, magnitude)
+        type(point_t), intent(in) :: pt
+        real, intent(out) :: magnitude
+
+        ! Associate construct with component access
+        associate (px => pt%x, py => pt%y)
+            magnitude = sqrt(px**2 + py**2)
+            print *, 'Point coordinates:', px, py
+        end associate
+
+    end subroutine process_point
+
+    subroutine compute_scaled(val, result_val)
+        real, intent(in) :: val
+        real, intent(out) :: result_val
+
+        ! Associate with expression
+        associate (scaled_val => val * 2.0)
+            result_val = scaled_val
+        end associate
+
+    end subroutine compute_scaled
+
+end module associate_construct_demo_mod

--- a/examples/f90/f2003_block_construct.f90
+++ b/examples/f90/f2003_block_construct.f90
@@ -1,0 +1,38 @@
+! Example demonstrating block construct within procedure bodies
+! ISO/IEC 1539-1:2018 Section 11.1.4 - BLOCK construct
+module block_construct_demo_mod
+    implicit none
+
+contains
+
+    subroutine compute_with_blocks(arr, n, total)
+        integer, intent(in) :: n
+        real, intent(in) :: arr(n)
+        real, intent(out) :: total
+        integer :: i
+
+        total = 0.0
+
+        ! Block construct inside procedure body
+        block
+            real :: partial_sum
+            partial_sum = 0.0
+            do i = 1, n / 2
+                partial_sum = partial_sum + arr(i)
+            end do
+            total = total + partial_sum
+        end block
+
+        ! Second block with different local scope
+        block
+            real :: partial_sum
+            partial_sum = 0.0
+            do i = n / 2 + 1, n
+                partial_sum = partial_sum + arr(i)
+            end do
+            total = total + partial_sum
+        end block
+
+    end subroutine compute_with_blocks
+
+end module block_construct_demo_mod

--- a/examples/f90/f2003_type_bound_array_call.f90
+++ b/examples/f90/f2003_type_bound_array_call.f90
@@ -1,0 +1,40 @@
+! Example demonstrating type-bound procedure calls with array indices
+! ISO/IEC 1539-1:2018 Section 15.5.1 - Type-bound procedure references
+module type_bound_array_call_mod
+    implicit none
+
+    type :: shape_t
+        integer :: id
+        real :: area
+    contains
+        procedure :: compute => compute_shape
+        procedure :: display => display_shape
+    end type shape_t
+
+contains
+
+    subroutine compute_shape(this, scale_factor)
+        class(shape_t), intent(inout) :: this
+        real, intent(in) :: scale_factor
+        this%area = this%area * scale_factor
+    end subroutine compute_shape
+
+    subroutine display_shape(this)
+        class(shape_t), intent(in) :: this
+        print *, 'Shape ID:', this%id, 'Area:', this%area
+    end subroutine display_shape
+
+    subroutine process_shapes(shapes, n)
+        integer, intent(in) :: n
+        type(shape_t), intent(inout) :: shapes(n)
+        integer :: i
+
+        ! Type-bound procedure calls with array indices
+        do i = 1, n
+            call shapes(i)%compute(2.0)
+            call shapes(i)%display()
+        end do
+
+    end subroutine process_shapes
+
+end module type_bound_array_call_mod

--- a/test/parser/test_f2003_abstract_interface.f90
+++ b/test/parser/test_f2003_abstract_interface.f90
@@ -1,0 +1,90 @@
+program test_f2003_abstract_interface
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use string_utils_mod, only: to_lower
+    use transformation_api, only: transform_context_t, transform_with_context, &
+        & INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    character(len=:), allocatable :: lower_output
+    type(transform_context_t) :: ctx
+    logical :: all_passed
+
+    all_passed = .true.
+
+    call read_example('examples/f90/f2003_abstract_interface.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'f2003_abstract_interface'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform error: ' // trim(error_msg)
+        error stop 1
+    end if
+
+    if (.not. allocated(output_code)) then
+        write (error_unit, '(A)') 'FAIL: no output produced'
+        error stop 1
+    end if
+
+    lower_output = to_lower(output_code)
+
+    call assert_contains(lower_output, 'abstract interface', &
+        & 'FAIL: module-level abstract interface not preserved', all_passed)
+
+    call assert_contains(lower_output, 'end interface', &
+        & 'FAIL: end interface not preserved', all_passed)
+
+    call assert_contains(lower_output, 'function transform_func', &
+        & 'FAIL: abstract interface function not preserved', all_passed)
+
+    call assert_contains(lower_output, 'function unary_func', &
+        & 'FAIL: procedure-level abstract interface not preserved', all_passed)
+
+    call assert_contains(lower_output, 'procedure(transform_func), pointer', &
+        & 'FAIL: module-level procedure pointer not preserved', all_passed)
+
+    call assert_contains(lower_output, 'procedure(unary_func)', &
+        & 'FAIL: local procedure pointer not preserved', all_passed)
+
+    if (all_passed) then
+        print *, 'PASS: F2003 abstract interface constructs parsed correctly'
+    else
+        error stop 1
+    end if
+
+contains
+
+    include '../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    subroutine assert_contains(text, pattern, failure_message, passed)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: pattern
+        character(len=*), intent(in) :: failure_message
+        logical, intent(inout) :: passed
+
+        if (index(text, pattern) == 0) then
+            write (error_unit, '(A)') trim(failure_message)
+            passed = .false.
+        end if
+    end subroutine assert_contains
+
+end program test_f2003_abstract_interface

--- a/test/parser/test_f2003_associate_block.f90
+++ b/test/parser/test_f2003_associate_block.f90
@@ -1,0 +1,159 @@
+program test_f2003_associate_block
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use string_utils_mod, only: to_lower
+    use transformation_api, only: transform_context_t, transform_with_context, &
+        & INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    character(len=:), allocatable :: lower_output
+    type(transform_context_t) :: ctx
+    logical :: all_passed
+
+    all_passed = .true.
+
+    call test_associate_construct(all_passed)
+    call test_block_construct(all_passed)
+
+    if (all_passed) then
+        print *, 'PASS: F2003 associate and block constructs parsed correctly'
+    else
+        error stop 1
+    end if
+
+contains
+
+    include '../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    subroutine test_associate_construct(all_passed)
+        logical, intent(inout) :: all_passed
+        character(len=:), allocatable :: source_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: lower_output
+        type(transform_context_t) :: ctx
+
+        call read_example('examples/f90/f2003_associate_construct.f90', source_code)
+
+        ctx%input_mode = INPUT_MODE_STANDARD
+        ctx%has_filename = .true.
+        ctx%source_name = 'f2003_associate_construct'
+
+        call transform_with_context(source_code, output_code, error_msg, ctx)
+
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            write (error_unit, '(A)') 'FAIL: associate transform error: ' &
+                & // trim(error_msg)
+            all_passed = .false.
+            return
+        end if
+
+        if (.not. allocated(output_code)) then
+            write (error_unit, '(A)') 'FAIL: associate no output produced'
+            all_passed = .false.
+            return
+        end if
+
+        lower_output = to_lower(output_code)
+
+        call assert_contains(lower_output, 'associate', &
+            & 'FAIL: associate keyword not preserved', all_passed)
+
+        call assert_contains(lower_output, 'end associate', &
+            & 'FAIL: end associate not preserved', all_passed)
+
+        call assert_contains(lower_output, 'px => pt%x', &
+            & 'FAIL: associate with component access not preserved', all_passed)
+
+        call assert_contains(lower_output, 'py => pt%y', &
+            & 'FAIL: second associate binding not preserved', all_passed)
+
+        call assert_contains(lower_output, 'scaled_val => val', &
+            & 'FAIL: associate with expression not preserved', all_passed)
+
+    end subroutine test_associate_construct
+
+    subroutine test_block_construct(all_passed)
+        logical, intent(inout) :: all_passed
+        character(len=:), allocatable :: source_code
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: lower_output
+        type(transform_context_t) :: ctx
+        integer :: block_count
+        integer :: pos
+        integer :: search_start
+
+        call read_example('examples/f90/f2003_block_construct.f90', source_code)
+
+        ctx%input_mode = INPUT_MODE_STANDARD
+        ctx%has_filename = .true.
+        ctx%source_name = 'f2003_block_construct'
+
+        call transform_with_context(source_code, output_code, error_msg, ctx)
+
+        if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+            write (error_unit, '(A)') 'FAIL: block transform error: ' &
+                & // trim(error_msg)
+            all_passed = .false.
+            return
+        end if
+
+        if (.not. allocated(output_code)) then
+            write (error_unit, '(A)') 'FAIL: block no output produced'
+            all_passed = .false.
+            return
+        end if
+
+        lower_output = to_lower(output_code)
+
+        block_count = 0
+        search_start = 1
+        do
+            pos = index(lower_output(search_start:), 'end block')
+            if (pos == 0) exit
+            block_count = block_count + 1
+            search_start = search_start + pos + 8
+        end do
+
+        if (block_count < 2) then
+            write (error_unit, '(A,I0,A)') &
+                'FAIL: expected 2 block constructs, found ', &
+                & block_count, ''
+            all_passed = .false.
+            return
+        end if
+
+        call assert_contains(lower_output, 'real :: partial_sum', &
+            & 'FAIL: block-local variable declaration not preserved', all_passed)
+
+    end subroutine test_block_construct
+
+    subroutine assert_contains(text, pattern, failure_message, passed)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: pattern
+        character(len=*), intent(in) :: failure_message
+        logical, intent(inout) :: passed
+
+        if (index(text, pattern) == 0) then
+            write (error_unit, '(A)') trim(failure_message)
+            passed = .false.
+        end if
+    end subroutine assert_contains
+
+end program test_f2003_associate_block

--- a/test/parser/test_f2003_type_bound_array_call.f90
+++ b/test/parser/test_f2003_type_bound_array_call.f90
@@ -1,0 +1,87 @@
+program test_f2003_type_bound_array_call
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use string_utils_mod, only: to_lower
+    use transformation_api, only: transform_context_t, transform_with_context, &
+        & INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    character(len=:), allocatable :: lower_output
+    type(transform_context_t) :: ctx
+    logical :: all_passed
+
+    all_passed = .true.
+
+    call read_example('examples/f90/f2003_type_bound_array_call.f90', source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'f2003_type_bound_array_call'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+
+    if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform error: ' // trim(error_msg)
+        error stop 1
+    end if
+
+    if (.not. allocated(output_code)) then
+        write (error_unit, '(A)') 'FAIL: no output produced'
+        error stop 1
+    end if
+
+    lower_output = to_lower(output_code)
+
+    call assert_contains(lower_output, 'type :: shape_t', &
+        & 'FAIL: type definition not preserved', all_passed)
+
+    call assert_contains(lower_output, 'procedure :: compute', &
+        & 'FAIL: type-bound procedure compute not preserved', all_passed)
+
+    call assert_contains(lower_output, 'procedure :: display', &
+        & 'FAIL: type-bound procedure display not preserved', all_passed)
+
+    call assert_contains(lower_output, 'call shapes(i)%compute', &
+        & 'FAIL: type-bound call with array index not preserved', all_passed)
+
+    call assert_contains(lower_output, 'call shapes(i)%display', &
+        & 'FAIL: second type-bound call with array index not preserved', all_passed)
+
+    if (all_passed) then
+        print *, 'PASS: F2003 type-bound array call constructs parsed correctly'
+    else
+        error stop 1
+    end if
+
+contains
+
+    include '../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    subroutine assert_contains(text, pattern, failure_message, passed)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: pattern
+        character(len=*), intent(in) :: failure_message
+        logical, intent(inout) :: passed
+
+        if (index(text, pattern) == 0) then
+            write (error_unit, '(A)') trim(failure_message)
+            passed = .false.
+        end if
+    end subroutine assert_contains
+
+end program test_f2003_type_bound_array_call


### PR DESCRIPTION
## Summary

Add focused unit and integration tests for Fortran 2003 constructs that were previously only covered by the xfail standard fixture. This enables targeted regression prevention for these specific constructs.

- Add example files following zero-duplication policy for abstract interface, associate, block, and type-bound array call constructs
- Add three targeted test files that reference the examples via `read_example()`
- All constructs validated against ISO/IEC 1539-1:2018 section references

## Test Plan

- [x] `fpm test test_f2003_abstract_interface` passes
- [x] `fpm test test_f2003_associate_block` passes  
- [x] `fpm test test_f2003_type_bound_array_call` passes
- [x] `fpm test test_all_examples` passes (100% success rate)
- [x] Full `fpm test` suite passes

## Verification

```
$ fpm test test_f2003_abstract_interface test_f2003_associate_block test_f2003_type_bound_array_call
 PASS: F2003 abstract interface constructs parsed correctly
 PASS: F2003 associate and block constructs parsed correctly
 PASS: F2003 type-bound array call constructs parsed correctly

$ fpm test test_all_examples 2>&1 | tail -10
Total examples tested: 538
Passed: 522
Failed: 0
XFail (expected): 16
XPass (unexpected): 0
Skipped: 52
Success rate:  100.0%
SUCCESS: All examples behaved as expected
```