### PR TITLE
polish: split long submodule parsing helpers (fixes #2543)

### DIFF
--- a/src/parser/declarations/parser_submodule_helpers.f90
+++ b/src/parser/declarations/parser_submodule_helpers.f90
@@ -34,6 +34,10 @@ module parser_submodule_helpers_module
     public :: handle_submodule_identifier_assignment
     public :: parse_abstract_interface_in_submodule
 
+    private :: handle_procedure_keyword_in_contains
+    private :: handle_prefix_modifier_in_contains
+    private :: handle_type_prefix_in_contains
+
 contains
 
     function parse_submodule_declaration_statement(parser, arena, &
@@ -85,86 +89,138 @@ contains
         end select
     end function parse_submodule_declaration_statement
 
-    function parse_contains_section_item_submodule(parser, arena, prefix_buffer) &
-        result(stmt_index)
+    function handle_procedure_keyword_in_contains(parser, arena, prefix_buffer, &
+                                                  lowered) result(stmt_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        character(len=*), intent(in) :: lowered
         integer :: stmt_index
-        type(token_t) :: token, lookahead
-        character(len=:), allocatable :: lowered, lookahead_lower, type_with_kind
-        character(len=16), allocatable :: stored(:)
+        type(token_t) :: token
 
         stmt_index = 0
         token = parser%peek()
-        lowered = to_lower(token%text)
 
-        if (token%kind == TK_KEYWORD .and. lowered == "interface") then
+        if (token%kind /= TK_KEYWORD) return
+
+        select case (trim(lowered))
+        case ("interface")
             stmt_index = parse_interface_block(parser, arena, prefix_buffer)
-            return
-        end if
-
-        if (token%kind == TK_KEYWORD .and. lowered == "subroutine") then
+        case ("subroutine")
             stmt_index = parse_subroutine_definition(parser, arena, prefix_buffer)
-            return
-        end if
-
-        if (token%kind == TK_KEYWORD .and. lowered == "function") then
+        case ("function")
             stmt_index = parse_function_definition(parser, arena, prefix_buffer)
-            return
-        end if
+        end select
+    end function handle_procedure_keyword_in_contains
 
-        if (token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER) then
-            lowered = to_lower(token%text)
-            select case (trim(lowered))
-            case ("pure", "elemental", "impure", "recursive", &
-                  "nonrecursive", "non_recursive", "module")
+    function handle_prefix_modifier_in_contains(parser, prefix_buffer, lowered) &
+        result(handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        character(len=*), intent(in) :: lowered
+        logical :: handled
+        type(token_t) :: token
+        character(len=16), allocatable :: stored(:)
+
+        handled = .false.
+
+        select case (trim(lowered))
+        case ("pure", "elemental", "impure", "recursive", &
+              "nonrecursive", "non_recursive", "module")
+            call prefix_buffer%get_all(stored)
+            call append_prefix_token(stored, trim(lowered))
+            call prefix_buffer%set(stored)
+            if (allocated(stored)) deallocate (stored)
+            token = parser%consume()
+            handled = .true.
+        end select
+    end function handle_prefix_modifier_in_contains
+
+    function handle_type_prefix_in_contains(parser, prefix_buffer, lowered) &
+        result(handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        character(len=*), intent(in) :: lowered
+        logical :: handled
+        type(token_t) :: token, lookahead
+        character(len=:), allocatable :: lookahead_lower, type_with_kind
+        character(len=16), allocatable :: stored(:)
+
+        handled = .false.
+
+        select case (trim(lowered))
+        case ("integer", "real", "logical", "character", "complex", &
+              "double", "procedure")
+            call prefix_buffer%get_all(stored)
+            if (trim(lowered) == "double") then
+                lookahead = parser%get_token_at_index(parser%current_token + 1)
+                lookahead_lower = to_lower(trim(lookahead%text))
+                select case (trim(lookahead_lower))
+                case ("precision", "complex")
+                    token = parser%peek()
+                    type_with_kind = trim(token%text) // " " // &
+                        trim(lookahead%text)
+                    token = parser%consume()
+                    token = parser%consume()
+                    call consume_optional_kind_spec(parser, type_with_kind)
+                    call append_prefix_token(stored, type_with_kind)
+                    call prefix_buffer%set(stored)
+                    if (allocated(stored)) deallocate (stored)
+                    handled = .true.
+                    return
+                end select
+            end if
+            token = parser%peek()
+            type_with_kind = trim(token%text)
+            token = parser%consume()
+            call consume_optional_kind_spec(parser, type_with_kind)
+            call append_prefix_token(stored, type_with_kind)
+            call prefix_buffer%set(stored)
+            if (allocated(stored)) deallocate (stored)
+            handled = .true.
+        case ("type", "class")
+            lookahead = parser%get_token_at_index(parser%current_token + 1)
+            if (lookahead%kind == TK_OPERATOR .and. lookahead%text == "(") then
                 call prefix_buffer%get_all(stored)
-                call append_prefix_token(stored, trim(lowered))
-                call prefix_buffer%set(stored)
-                if (allocated(stored)) deallocate (stored)
-                token = parser%consume()
-                stmt_index = -1
-            case ("integer", "real", "logical", "character", "complex", &
-                  "double", "procedure")
-                call prefix_buffer%get_all(stored)
-                if (trim(lowered) == "double") then
-                    lookahead = parser%get_token_at_index(parser%current_token + 1)
-                    lookahead_lower = to_lower(trim(lookahead%text))
-                    select case (trim(lookahead_lower))
-                    case ("precision", "complex")
-                        type_with_kind = trim(token%text) // " " // &
-                            trim(lookahead%text)
-                        token = parser%consume()
-                        token = parser%consume()
-                        call consume_optional_kind_spec(parser, type_with_kind)
-                        call append_prefix_token(stored, type_with_kind)
-                        call prefix_buffer%set(stored)
-                        if (allocated(stored)) deallocate (stored)
-                        stmt_index = -1
-                        return
-                    end select
-                end if
+                token = parser%peek()
                 type_with_kind = trim(token%text)
                 token = parser%consume()
                 call consume_optional_kind_spec(parser, type_with_kind)
                 call append_prefix_token(stored, type_with_kind)
                 call prefix_buffer%set(stored)
                 if (allocated(stored)) deallocate (stored)
+                handled = .true.
+            end if
+        end select
+    end function handle_type_prefix_in_contains
+
+    function parse_contains_section_item_submodule(parser, arena, prefix_buffer) &
+        result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        integer :: stmt_index
+        type(token_t) :: token
+        character(len=:), allocatable :: lowered
+
+        stmt_index = 0
+        token = parser%peek()
+        lowered = to_lower(token%text)
+
+        stmt_index = handle_procedure_keyword_in_contains(parser, arena, &
+                                                          prefix_buffer, lowered)
+        if (stmt_index /= 0) return
+
+        if (token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER) then
+            if (handle_prefix_modifier_in_contains(parser, prefix_buffer, &
+                                                   lowered)) then
                 stmt_index = -1
-            case ("type", "class")
-                lookahead = parser%get_token_at_index(parser%current_token + 1)
-                if (lookahead%kind == TK_OPERATOR .and. lookahead%text == "(") then
-                    call prefix_buffer%get_all(stored)
-                    type_with_kind = trim(token%text)
-                    token = parser%consume()
-                    call consume_optional_kind_spec(parser, type_with_kind)
-                    call append_prefix_token(stored, type_with_kind)
-                    call prefix_buffer%set(stored)
-                    if (allocated(stored)) deallocate (stored)
-                    stmt_index = -1
-                end if
-            end select
+                return
+            end if
+            if (handle_type_prefix_in_contains(parser, prefix_buffer, lowered)) &
+                then
+                stmt_index = -1
+            end if
         end if
     end function parse_contains_section_item_submodule
 

--- a/src/parser/declarations/parser_submodule_structures.f90
+++ b/src/parser/declarations/parser_submodule_structures.f90
@@ -137,6 +137,81 @@ contains
         end if
     end function check_submodule_end
 
+    function handle_specification_statement(parser, arena, prefix_buffer, &
+                                            declaration_indices) result(handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        integer, allocatable, intent(inout) :: declaration_indices(:)
+        logical :: handled
+        type(token_t) :: token
+        integer :: stmt_index
+
+        handled = .false.
+        token = parser%peek()
+
+        if (token%kind == TK_KEYWORD) then
+            if (keyword_should_parse_as_identifier(token, parser)) then
+                call handle_submodule_identifier_assignment(parser, arena, &
+                                                            declaration_indices)
+                handled = .true.
+                return
+            end if
+
+            stmt_index = parse_submodule_declaration_statement(parser, arena, &
+                                                               prefix_buffer)
+            if (stmt_index > 0) then
+                declaration_indices = [declaration_indices, stmt_index]
+                handled = .true.
+            else if (stmt_index == -1) then
+                block
+                    integer, allocatable :: extra_indices(:)
+                    extra_indices = take_implicit_additional_indices()
+                    if (size(extra_indices) > 0) then
+                        declaration_indices = [declaration_indices, extra_indices]
+                    end if
+                end block
+                handled = .true.
+            end if
+        else if (token%kind == TK_IDENTIFIER) then
+            call handle_submodule_identifier_assignment(parser, arena, &
+                                                        declaration_indices)
+            handled = .true.
+        end if
+    end function handle_specification_statement
+
+    function handle_contains_section_statement(parser, arena, prefix_buffer, &
+                                               procedure_indices, lowered) &
+        result(handled)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        integer, allocatable, intent(inout) :: procedure_indices(:)
+        character(len=*), intent(in) :: lowered
+        logical :: handled
+        type(token_t) :: token
+        integer :: stmt_index
+
+        handled = .false.
+        token = parser%peek()
+
+        stmt_index = parse_contains_section_item_submodule(parser, arena, &
+                                                           prefix_buffer)
+        if (stmt_index > 0) then
+            procedure_indices = [procedure_indices, stmt_index]
+            handled = .true.
+        else if (stmt_index == -1) then
+            handled = .true.
+        else
+            if (.not. (token%kind == TK_KEYWORD .and. &
+                       (trim(lowered) == "function" .or. &
+                        trim(lowered) == "subroutine"))) then
+                token = parser%consume()
+                handled = .true.
+            end if
+        end if
+    end function handle_contains_section_statement
+
     subroutine parse_submodule_body(parser, arena, prefix_buffer, &
                                     has_contains, in_contains_section, &
                                     declaration_indices, procedure_indices)
@@ -147,7 +222,6 @@ contains
         integer, allocatable, intent(inout) :: declaration_indices(:)
         integer, allocatable, intent(inout) :: procedure_indices(:)
         type(token_t) :: token
-        integer :: stmt_index
         character(len=:), allocatable :: lowered
 
         do while (.not. parser%is_at_end())
@@ -171,60 +245,19 @@ contains
                 end if
             end if
 
-            if (.not. in_contains_section) then
-                if (token%kind == TK_KEYWORD) then
-                    if (keyword_should_parse_as_identifier(token, parser)) then
-                        call handle_submodule_identifier_assignment(parser, arena, &
-                                                                    declaration_indices)
-                        cycle
-                    end if
-
-                    stmt_index = parse_submodule_declaration_statement(parser, &
-                                                                       arena, &
-                                                                       prefix_buffer)
-                    if (stmt_index > 0) then
-                        declaration_indices = [declaration_indices, stmt_index]
-                        cycle
-                    else if (stmt_index == -1) then
-                        block
-                            integer, allocatable :: extra_indices(:)
-                            extra_indices = take_implicit_additional_indices()
-                            if (size(extra_indices) > 0) then
-                                declaration_indices = [declaration_indices, &
-                                                       extra_indices]
-                            end if
-                        end block
-                        cycle
-                    end if
-                else if (token%kind == TK_IDENTIFIER) then
-                    call handle_submodule_identifier_assignment(parser, arena, &
-                                                                declaration_indices)
-                    cycle
-                end if
-            end if
-
             if (token%kind == TK_COMMENT .or. token%kind == TK_NEWLINE) then
                 token = parser%consume()
                 cycle
             end if
 
-            if (in_contains_section) then
-                stmt_index = parse_contains_section_item_submodule(parser, arena, &
-                                                                   prefix_buffer)
-                if (stmt_index > 0) then
-                    procedure_indices = [procedure_indices, stmt_index]
-                    cycle
-                else if (stmt_index == -1) then
-                    cycle
-                end if
-
-                if (.not. (token%kind == TK_KEYWORD .and. &
-                           (trim(lowered) == "function" .or. trim(lowered) == &
-                            "subroutine"))) then
-                    token = parser%consume()
-                end if
-            else
+            if (.not. in_contains_section) then
+                if (handle_specification_statement(parser, arena, prefix_buffer, &
+                                                   declaration_indices)) cycle
                 token = parser%consume()
+            else
+                if (handle_contains_section_statement(parser, arena, prefix_buffer, &
+                                                      procedure_indices, lowered)) &
+                    cycle
             end if
         end do
     end subroutine parse_submodule_body


### PR DESCRIPTION
## Summary
- Split `parse_contains_section_item_submodule` (~81 lines) and `parse_submodule_body` (~90 lines) into smaller focused helpers
- Both procedures exceeded the 50-line soft target in CLAUDE.md while being under the 100-line hard limit
- Behavior is identical; existing tests guard regressions

## Changes

### parser_submodule_helpers.f90
New private helpers:
- `handle_procedure_keyword_in_contains`: handles interface/function/subroutine keywords
- `handle_prefix_modifier_in_contains`: handles pure/elemental/recursive/module prefixes
- `handle_type_prefix_in_contains`: handles integer/real/double/type/class type prefixes

### parser_submodule_structures.f90
New private helpers:
- `handle_specification_statement`: handles declarations in specification part
- `handle_contains_section_statement`: handles procedures in contains section

## Verification
```
$ fpm test test_f2008_submodule_constructs
 Testing F2008 submodule constructs (ISO/IEC 1539-1:2008 Section 11.2)
   Testing simple submodule parsing...
     PASS: simple submodule
   Testing submodule with contains section...
     PASS: submodule with contains
   Testing submodule JSON serialization...
     PASS: submodule JSON serialization
 PASS: F2008 submodule constructs parsed correctly
```

Full test suite passes with no regressions.