### PR TITLE
fix: DATA statement trailing commas as extension (fixes #2565)

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -6,9 +6,7 @@
 issue_2349_data_boz_literals.f90  # NON-COMPLIANT: ISO/IEC 1539-1:2018 7.7 (R764-R767) only allows B/O/Z boz prefixes; X and postfix forms are extensions (#2349)
 issue_2349_data_boz_x_prefix.f90  # NON-COMPLIANT: ISO/IEC 1539-1:2018 7.7 (R764-R767) forbids X'...' boz literals; extension requires -fallow-invalid-boz (#2349)
 issue_2349_data_boz_postfix.f90  # NON-COMPLIANT: ISO/IEC 1539-1:2018 7.7 (R764-R767) forbids postfix '...'z boz literals; extension requires -fallow-invalid-boz (#2349)
-issue_2349_data_trailing_object_comma.f90  # NON-COMPLIANT: ISO/IEC 1539-1:2018 8.6.7 (R838) disallows trailing comma before '/' in DATA object lists
-issue_2349_data_trailing_value_comma.f90  # NON-COMPLIANT: ISO/IEC 1539-1:2018 8.6.7 (R838) disallows trailing comma before '/' in DATA value lists
-issue_2444_data_trailing_comma.f90  # NON-COMPLIANT: ISO/IEC 1539-1:2018 8.6.7 (R838) disallows trailing comma before '/' in DATA value lists
+# Trailing commas now accepted as extension and emitted without trailing comma (#2565)
 
 # Unsupported language features
 

--- a/src/parser/statements/parser_statement_data_module.f90
+++ b/src/parser/statements/parser_statement_data_module.f90
@@ -387,11 +387,10 @@ contains
                                 current = parser%peek()
                                 if (current%kind == TK_OPERATOR .and. &
                                     trim(current%text) == "/") then
-                                    call parser%error("Trailing comma before '/' "// &
-                                                      "in DATA object list is "// &
-                                                      "non-compliant (ISO/IEC "// &
-                                                      "1539-1:2018 8.6.7, R838)")
-                                    return
+                                    ! Accept trailing comma as extension (common compiler
+                                    ! tolerance). Parser continues; codegen emits standard
+                                    ! Fortran without trailing comma.
+                                    exit
                                 end if
                                 cycle
                             case ("/")
@@ -423,11 +422,10 @@ contains
                         current = parser%peek()
                         if (current%kind == TK_OPERATOR .and. &
                             trim(current%text) == "/") then
-                            call parser%error("Trailing comma before '/' in "// &
-                                              "DATA object list is "// &
-                                              "non-compliant (ISO/IEC 1539-1:2018 "// &
-                                              "8.6.7, R838)")
-                            return
+                            ! Accept trailing comma as extension (common compiler
+                            ! tolerance). Parser continues; codegen emits standard
+                            ! Fortran without trailing comma.
+                            exit
                         end if
                         cycle
                     case ("/")
@@ -486,11 +484,10 @@ contains
                                 current = parser%peek()
                                 if (current%kind == TK_OPERATOR .and. &
                                     trim(current%text) == "/") then
-                                    call parser%error("Trailing comma before '/' "// &
-                                                      "in DATA value list is "// &
-                                                      "non-compliant (ISO/IEC "// &
-                                                      "1539-1:2018 8.6.7, R838)")
-                                    return
+                                    ! Accept trailing comma as extension (common
+                                    ! compiler tolerance). Parser continues; codegen
+                                    ! emits standard Fortran without trailing comma.
+                                    exit
                                 end if
                                 cycle
                             case ("/")
@@ -522,11 +519,10 @@ contains
                         current = parser%peek()
                         if (current%kind == TK_OPERATOR .and. &
                             trim(current%text) == "/") then
-                            call parser%error("Trailing comma before '/' in "// &
-                                              "DATA value list is "// &
-                                              "non-compliant (ISO/IEC 1539-1:2018 "// &
-                                              "8.6.7, R838)")
-                            return
+                            ! Accept trailing comma as extension (common compiler
+                            ! tolerance). Parser continues; codegen emits standard
+                            ! Fortran without trailing comma.
+                            exit
                         end if
                         cycle
                     case ("/")

--- a/test/test_issue_2349_data_trailing_commas.f90
+++ b/test/test_issue_2349_data_trailing_commas.f90
@@ -7,23 +7,25 @@ program test_issue_2349_data_trailing_commas
 
     ctx%input_mode = INPUT_MODE_STANDARD
 
-    ! Test 1: Trailing comma in value list (non-compliant)
+    ! Test 1: Trailing comma in value list (accepted as extension)
+    ! Non-standard trailing commas are tolerated by many compilers. We parse
+    ! them and emit compliant Fortran without trailing commas.
     call read_example('examples/f90/issue_2349_data_trailing_value_comma.f90', &
                       source)
     call transform_with_context(source, output, error_msg, ctx)
-    call assert(len_trim(error_msg) > 0, "Trailing comma in value list "// &
-                "must be rejected (ISO/IEC 1539-1:2018 8.6.7, R838)")
-    call assert(index(error_msg, "Trailing comma") > 0, "Error should "// &
-                "mention trailing comma")
+    call assert(len_trim(error_msg) == 0, "Trailing comma in value list "// &
+                "should be accepted as extension: "//trim(error_msg))
+    call assert(index(output, "data arr/1, 2, 3 /") > 0, "Output should "// &
+                "contain DATA statement without trailing comma")
 
-    ! Test 2: Trailing comma in object list (non-compliant)
+    ! Test 2: Trailing comma in object list (accepted as extension)
     call read_example('examples/f90/issue_2349_data_trailing_object_comma.f90', &
                       source)
     call transform_with_context(source, output, error_msg, ctx)
-    call assert(len_trim(error_msg) > 0, "Trailing comma in object list "// &
-                "must be rejected (ISO/IEC 1539-1:2018 8.6.7, R838)")
-    call assert(index(error_msg, "Trailing comma") > 0, "Error should "// &
-                "mention trailing comma")
+    call assert(len_trim(error_msg) == 0, "Trailing comma in object list "// &
+                "should be accepted as extension: "//trim(error_msg))
+    call assert(index(output, "data a, b, c/1, 2, 3 /") > 0, "Output should "// &
+                "contain DATA statement without trailing comma")
 
     ! Test 3: BOZ X prefix (already works, verify no regression)
     call read_example('examples/f90/issue_2349_data_boz_x_prefix.f90', source)


### PR DESCRIPTION
## Summary

Accept trailing commas in DATA statement object and value lists as a common compiler extension. While ISO/IEC 1539-1:2018 8.6.7 (R838) disallows trailing commas, many Fortran compilers tolerate them.

**Changes:**
- Parser now accepts trailing commas instead of raising errors
- Codegen emits standard-compliant Fortran without trailing commas
- Updated test expectations to verify successful parsing
- Removed trailing comma files from expected_failures.txt

## Verification

All 7 DATA statement files from issue #2565 verified:

| File | Status | Notes |
|------|--------|-------|
| issue_2349_data_trailing_object_comma.f90 | FIXED | Trailing comma in object list now accepted |
| issue_2349_data_trailing_value_comma.f90 | FIXED | Trailing comma in value list now accepted |
| issue_2444_data_trailing_comma.f90 | FIXED | Trailing comma now accepted |
| issue_2349_data_boz_literals.f90 | Works | Already worked (requires -fallow-invalid-boz) |
| issue_2349_data_boz_postfix.f90 | Works | Already worked (requires -fallow-invalid-boz) |
| issue_2349_data_boz_x_prefix.f90 | Works | Already worked (requires -fallow-invalid-boz) |
| issue_2252_data_value_implied_do.f90 | Works | Round-trip OK (non-standard extension) |

## Test Results

```
Total examples tested: 538
Passed: 525
Failed: 0
XFail (expected): 13
Success rate: 100.0%
```

## Test plan

- [x] All trailing comma test files now parse and emit valid Fortran
- [x] Round-trip output compiles with gfortran
- [x] test_issue_2349_data_trailing_commas passes
- [x] Full test suite passes with 100% success rate