### PR TITLE
fix: validate WHERE/ELSEWHERE blocks per Fortran standard (fixes #2562)

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -4,4 +4,4 @@
 f90/issue_256_invalid_syntax.f90
 f90/issue_256_garbage_input.f90
 f90/issue_256_incomplete_expression.f90
-f90/issue_2287_where_elsewhere.f90
+f90/issue_2562_where_invalid_if.f90

--- a/examples/f90/issue_2287_where_elsewhere.f90
+++ b/examples/f90/issue_2287_where_elsewhere.f90
@@ -1,13 +1,26 @@
 program issue_2287_where_elsewhere
+    ! Demonstrates valid WHERE/ELSEWHERE construct per F2018 Section 10.2.3.2
+    ! WHERE body may only contain: array assignments, nested WHERE, nested WHERE stmt
     implicit none
-    integer :: b(2)
+    integer :: a(4), b(4), c(4)
 
-    b = (/1, 0/)
+    a = (/1, 2, 3, 4/)
+    b = (/0, 1, 0, 1/)
+    c = 0
+
+    ! Valid WHERE/ELSEWHERE with array assignments only
     where (b == 0)
-        if (any(b == 0)) then
-            stop 1
-        end if
+        c = a * 10  ! Valid: array assignment
     elsewhere
-        b = 2
+        c = a       ! Valid: array assignment
     end where
+
+    ! Valid nested WHERE construct
+    where (a > 2)
+        where (b == 1)
+            c = 99  ! Valid: nested WHERE with array assignment
+        end where
+    end where
+
+    print *, 'c =', c
 end program issue_2287_where_elsewhere

--- a/examples/f90/issue_2562_where_invalid_if.f90
+++ b/examples/f90/issue_2562_where_invalid_if.f90
@@ -1,0 +1,20 @@
+program issue_2562_where_invalid_if
+    ! This example demonstrates INVALID Fortran per F2018 Section 10.2.3.2
+    ! WHERE/ELSEWHERE body may only contain:
+    !   - Array assignment statements
+    !   - Nested WHERE statements
+    !   - Nested WHERE constructs
+    ! This example intentionally contains an IF construct inside WHERE
+    ! which should be rejected by semantic validation
+    implicit none
+    integer :: b(2)
+
+    b = (/1, 0/)
+    where (b == 0)
+        if (any(b == 0)) then    ! INVALID: IF construct not allowed in WHERE
+            stop 1               ! INVALID: STOP statement not allowed in WHERE
+        end if
+    elsewhere
+        b = 2                    ! Valid: array assignment
+    end where
+end program issue_2562_where_invalid_if

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -9,6 +9,7 @@ submodule(semantic_analyzer) semantic_analyzer_infer_impl
     use semantic_type_lookup_wrapper, only: set_semantic_context_for_lookup, &
                                             clear_semantic_context_for_lookup, &
                                             get_type_with_stored_context
+    use semantic_where_validation, only: validate_where_construct
     implicit none
 
     ! Module-level context for wrapper function (not thread-safe, but works around gfortran bug)

--- a/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part1.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part1.inc
@@ -460,6 +460,9 @@
             type(infer_frame_t) :: post_frame
             integer :: i, j
 
+            ! Validate WHERE body per F2018 Section 10.2.3.2
+            call validate_where_construct(arena, expr, this%errors)
+
             call init_post_frame(current, post_frame)
             call push_frame_local(post_frame)
             if (allocated(expr%elsewhere_clauses)) then

--- a/src/semantic/analyzers/semantic_where_validation.f90
+++ b/src/semantic/analyzers/semantic_where_validation.f90
@@ -1,0 +1,192 @@
+module semantic_where_validation
+    ! Validates WHERE/ELSEWHERE construct body statements per F2018 Section 10.2.3.2
+    ! Only allowed: array assignments, nested WHERE statements, nested WHERE constructs
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: assignment_node, pointer_assignment_node
+    use ast_nodes_array, only: where_node, where_stmt_node
+    use error_handling, only: error_collection_t, result_t, create_error_result, &
+                              ERROR_SEMANTIC
+    use string_utils_mod, only: int_to_string
+    implicit none
+    private
+
+    public :: validate_where_body, validate_where_construct
+
+contains
+
+    ! Validate an entire WHERE construct (main body + elsewhere clauses)
+    subroutine validate_where_construct(arena, node, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(where_node), intent(in) :: node
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        ! Validate main WHERE body
+        if (allocated(node%where_body_indices)) then
+            call validate_where_body(arena, node%where_body_indices, errors, &
+                                     node%line, node%column)
+        end if
+
+        ! Validate all ELSEWHERE clauses
+        if (allocated(node%elsewhere_clauses)) then
+            do i = 1, size(node%elsewhere_clauses)
+                if (allocated(node%elsewhere_clauses(i)%body_indices)) then
+                    call validate_where_body(arena, &
+                                             node%elsewhere_clauses(i)%body_indices, &
+                                             errors, node%line, node%column)
+                end if
+            end do
+        end if
+    end subroutine validate_where_construct
+
+    ! Validate a list of body statements for WHERE/ELSEWHERE
+    subroutine validate_where_body(arena, body_indices, errors, where_line, where_col)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        type(error_collection_t), intent(inout) :: errors
+        integer, intent(in) :: where_line, where_col
+        integer :: i, stmt_index
+        logical :: is_valid
+
+        do i = 1, size(body_indices)
+            stmt_index = body_indices(i)
+            if (stmt_index <= 0 .or. stmt_index > arena%size) cycle
+            if (.not. allocated(arena%entries(stmt_index)%node)) cycle
+
+            is_valid = is_valid_where_body_stmt(arena, stmt_index)
+
+            if (.not. is_valid) then
+                call report_invalid_where_stmt(arena, stmt_index, errors, &
+                                               where_line, where_col)
+            end if
+        end do
+    end subroutine validate_where_body
+
+    ! Check if a statement is valid inside WHERE/ELSEWHERE body
+    ! Per F2018 10.2.3.2: Only array assignments, WHERE stmts, WHERE constructs
+    function is_valid_where_body_stmt(arena, stmt_index) result(is_valid)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: stmt_index
+        logical :: is_valid
+
+        is_valid = .false.
+
+        if (stmt_index <= 0 .or. stmt_index > arena%size) then
+            is_valid = .true.  ! Skip invalid indices
+            return
+        end if
+
+        if (.not. allocated(arena%entries(stmt_index)%node)) then
+            is_valid = .true.  ! Skip unallocated nodes
+            return
+        end if
+
+        select type (node => arena%entries(stmt_index)%node)
+        type is (assignment_node)
+            ! Array assignments are allowed
+            is_valid = .true.
+        type is (where_node)
+            ! Nested WHERE constructs are allowed
+            is_valid = .true.
+        type is (where_stmt_node)
+            ! Nested WHERE statements are allowed
+            is_valid = .true.
+        class default
+            ! All other statement types are invalid in WHERE body
+            is_valid = .false.
+        end select
+    end function is_valid_where_body_stmt
+
+    ! Report an error for invalid statement inside WHERE
+    subroutine report_invalid_where_stmt(arena, stmt_index, errors, where_line, &
+                                         where_col)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: stmt_index
+        type(error_collection_t), intent(inout) :: errors
+        integer, intent(in) :: where_line, where_col
+        type(result_t) :: error_result
+        character(len=:), allocatable :: stmt_type
+        character(len=:), allocatable :: msg
+        integer :: stmt_line, stmt_col
+
+        ! Get statement type name for error message
+        stmt_type = get_stmt_type_name(arena, stmt_index)
+
+        ! Get statement location
+        stmt_line = arena%entries(stmt_index)%node%line
+        stmt_col = arena%entries(stmt_index)%node%column
+
+        msg = "Invalid statement in WHERE construct: " // stmt_type // &
+              " (line " // trim(int_to_string(stmt_line)) // ")"
+
+        error_result = create_error_result( &
+                       msg, &
+                       ERROR_SEMANTIC, &
+                       component="semantic_where_validation", &
+                       context="WHERE construct at line "// &
+                       trim(int_to_string(where_line)), &
+                       suggestion="WHERE/ELSEWHERE may only contain array "// &
+                       "assignments, nested WHERE statements, or "// &
+                       "nested WHERE constructs (F2018 10.2.3.2)" &
+                       )
+
+        call errors%add_result(error_result)
+    end subroutine report_invalid_where_stmt
+
+    ! Get human-readable statement type name
+    function get_stmt_type_name(arena, stmt_index) result(name)
+        use ast_nodes_control, only: if_node, do_loop_node, do_while_node, &
+                                     stop_node, return_node, cycle_node, exit_node, &
+                                     forall_node, select_case_node, pause_node
+        use ast_nodes_io, only: print_statement_node, write_statement_node, &
+                                read_statement_node
+        use ast_nodes_misc, only: allocate_statement_node, deallocate_statement_node
+        use ast_nodes_procedure, only: subroutine_call_node
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: stmt_index
+        character(len=:), allocatable :: name
+
+        name = "unknown statement"
+
+        if (stmt_index <= 0 .or. stmt_index > arena%size) return
+        if (.not. allocated(arena%entries(stmt_index)%node)) return
+
+        select type (node => arena%entries(stmt_index)%node)
+        type is (if_node)
+            name = "IF construct"
+        type is (do_loop_node)
+            name = "DO loop"
+        type is (do_while_node)
+            name = "DO WHILE loop"
+        type is (stop_node)
+            name = "STOP statement"
+        type is (return_node)
+            name = "RETURN statement"
+        type is (cycle_node)
+            name = "CYCLE statement"
+        type is (exit_node)
+            name = "EXIT statement"
+        type is (forall_node)
+            name = "FORALL construct"
+        type is (select_case_node)
+            name = "SELECT CASE construct"
+        type is (pause_node)
+            name = "PAUSE statement"
+        type is (print_statement_node)
+            name = "PRINT statement"
+        type is (write_statement_node)
+            name = "WRITE statement"
+        type is (read_statement_node)
+            name = "READ statement"
+        type is (allocate_statement_node)
+            name = "ALLOCATE statement"
+        type is (deallocate_statement_node)
+            name = "DEALLOCATE statement"
+        type is (subroutine_call_node)
+            name = "CALL statement"
+        class default
+            name = "non-assignment statement"
+        end select
+    end function get_stmt_type_name
+
+end module semantic_where_validation

--- a/test/semantic/test_where_validation.f90
+++ b/test/semantic/test_where_validation.f90
@@ -1,0 +1,269 @@
+program test_where_validation
+    ! Tests that WHERE/ELSEWHERE body validation rejects invalid statements
+    ! per F2018 Section 10.2.3.2
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_core, only: assignment_node
+    use ast_nodes_control, only: if_node, stop_node
+    use ast_nodes_array, only: where_node, elsewhere_clause_t
+    use ast_base, only: LITERAL_LOGICAL, LITERAL_INTEGER
+    use ast_factory, only: push_where
+    use ast_factory_core, only: push_assignment, push_identifier, push_literal
+    use ast_factory_control, only: push_if
+    use ast_factory_statements, only: push_stop
+    use error_handling, only: error_collection_t, create_error_collection
+    use semantic_where_validation, only: validate_where_construct
+    implicit none
+
+    logical :: all_tests_passed
+
+    all_tests_passed = .true.
+
+    print *, '=== WHERE Validation Tests ==='
+    print *
+
+    call test_valid_where_body_with_assignments(all_tests_passed)
+    call test_invalid_where_body_with_if(all_tests_passed)
+    call test_invalid_where_body_with_stop(all_tests_passed)
+    call test_valid_elsewhere_body(all_tests_passed)
+    call test_invalid_elsewhere_body(all_tests_passed)
+
+    print *
+    if (all_tests_passed) then
+        print *, 'All WHERE validation tests PASSED!'
+        stop 0
+    else
+        print *, 'Some WHERE validation tests FAILED!'
+        stop 1
+    end if
+
+contains
+
+    subroutine test_valid_where_body_with_assignments(passed)
+        logical, intent(inout) :: passed
+        type(ast_arena_t) :: arena
+        type(error_collection_t) :: errors
+        integer :: where_idx, mask_idx, assign_idx, target_idx, value_idx
+        integer, allocatable :: body_indices(:)
+
+        print *, 'Testing valid WHERE body with assignments...'
+
+        arena = create_ast_arena()
+        errors = create_error_collection()
+
+        ! Create mask expression
+        mask_idx = push_literal(arena, '.true.', LITERAL_LOGICAL, line=1, column=1)
+
+        ! Create valid assignment statement
+        target_idx = push_identifier(arena, 'a', line=2, column=1)
+        value_idx = push_literal(arena, '1', LITERAL_INTEGER, line=2, column=5)
+        assign_idx = push_assignment(arena, target_idx, value_idx, line=2, column=1)
+
+        ! Create WHERE node with assignment body
+        allocate (body_indices(1))
+        body_indices(1) = assign_idx
+        where_idx = push_where(arena, mask_idx, body_indices, line=1, column=1)
+
+        ! Validate - should have no errors
+        block
+            type(where_node) :: where_nd
+            select type (node => arena%entries(where_idx)%node)
+            type is (where_node)
+                where_nd = node
+            end select
+            call validate_where_construct(arena, where_nd, errors)
+        end block
+
+        if (errors%has_errors()) then
+            print *, '  FAIL: Valid WHERE body incorrectly rejected'
+            passed = .false.
+        else
+            print *, '  PASS: Valid WHERE body accepted'
+        end if
+    end subroutine test_valid_where_body_with_assignments
+
+    subroutine test_invalid_where_body_with_if(passed)
+        logical, intent(inout) :: passed
+        type(ast_arena_t) :: arena
+        type(error_collection_t) :: errors
+        integer :: where_idx, mask_idx, if_idx, cond_idx
+        integer, allocatable :: body_indices(:), if_body(:)
+
+        print *, 'Testing invalid WHERE body with IF construct...'
+
+        arena = create_ast_arena()
+        errors = create_error_collection()
+
+        ! Create mask expression
+        mask_idx = push_literal(arena, '.true.', LITERAL_LOGICAL, line=1, column=1)
+
+        ! Create invalid IF construct
+        cond_idx = push_literal(arena, '.true.', LITERAL_LOGICAL, line=2, column=1)
+        allocate (if_body(0))
+        if_idx = push_if(arena, cond_idx, if_body, line=2, column=1)
+
+        ! Create WHERE node with IF body (invalid)
+        allocate (body_indices(1))
+        body_indices(1) = if_idx
+        where_idx = push_where(arena, mask_idx, body_indices, line=1, column=1)
+
+        ! Validate - should have error
+        block
+            type(where_node) :: where_nd
+            select type (node => arena%entries(where_idx)%node)
+            type is (where_node)
+                where_nd = node
+            end select
+            call validate_where_construct(arena, where_nd, errors)
+        end block
+
+        if (errors%has_errors()) then
+            print *, '  PASS: Invalid IF in WHERE body correctly rejected'
+        else
+            print *, '  FAIL: Invalid IF in WHERE body not detected'
+            passed = .false.
+        end if
+    end subroutine test_invalid_where_body_with_if
+
+    subroutine test_invalid_where_body_with_stop(passed)
+        logical, intent(inout) :: passed
+        type(ast_arena_t) :: arena
+        type(error_collection_t) :: errors
+        integer :: where_idx, mask_idx, stop_idx
+        integer, allocatable :: body_indices(:)
+
+        print *, 'Testing invalid WHERE body with STOP statement...'
+
+        arena = create_ast_arena()
+        errors = create_error_collection()
+
+        ! Create mask expression
+        mask_idx = push_literal(arena, '.true.', LITERAL_LOGICAL, line=1, column=1)
+
+        ! Create invalid STOP statement
+        stop_idx = push_stop(arena, 0, line=2, column=1)
+
+        ! Create WHERE node with STOP body (invalid)
+        allocate (body_indices(1))
+        body_indices(1) = stop_idx
+        where_idx = push_where(arena, mask_idx, body_indices, line=1, column=1)
+
+        ! Validate - should have error
+        block
+            type(where_node) :: where_nd
+            select type (node => arena%entries(where_idx)%node)
+            type is (where_node)
+                where_nd = node
+            end select
+            call validate_where_construct(arena, where_nd, errors)
+        end block
+
+        if (errors%has_errors()) then
+            print *, '  PASS: Invalid STOP in WHERE body correctly rejected'
+        else
+            print *, '  FAIL: Invalid STOP in WHERE body not detected'
+            passed = .false.
+        end if
+    end subroutine test_invalid_where_body_with_stop
+
+    subroutine test_valid_elsewhere_body(passed)
+        logical, intent(inout) :: passed
+        type(ast_arena_t) :: arena
+        type(error_collection_t) :: errors
+        type(elsewhere_clause_t), allocatable :: elsewhere_clauses(:)
+        integer :: where_idx, mask_idx, assign_idx, target_idx, value_idx
+        integer, allocatable :: body_indices(:)
+
+        print *, 'Testing valid ELSEWHERE body with assignments...'
+
+        arena = create_ast_arena()
+        errors = create_error_collection()
+
+        ! Create mask expression
+        mask_idx = push_literal(arena, '.true.', LITERAL_LOGICAL, line=1, column=1)
+
+        ! Create valid assignment for elsewhere
+        target_idx = push_identifier(arena, 'b', line=3, column=1)
+        value_idx = push_literal(arena, '2', LITERAL_INTEGER, line=3, column=5)
+        assign_idx = push_assignment(arena, target_idx, value_idx, line=3, column=1)
+
+        ! Create ELSEWHERE clause with valid assignment
+        allocate (elsewhere_clauses(1))
+        elsewhere_clauses(1)%mask_index = 0  ! Unmasked ELSEWHERE
+        allocate (elsewhere_clauses(1)%body_indices(1))
+        elsewhere_clauses(1)%body_indices(1) = assign_idx
+
+        ! Create WHERE node with empty body and valid ELSEWHERE
+        allocate (body_indices(0))
+        where_idx = push_where(arena, mask_idx, body_indices, &
+                               elsewhere_clauses=elsewhere_clauses, &
+                               line=1, column=1)
+
+        ! Validate - should have no errors
+        block
+            type(where_node) :: where_nd
+            select type (node => arena%entries(where_idx)%node)
+            type is (where_node)
+                where_nd = node
+            end select
+            call validate_where_construct(arena, where_nd, errors)
+        end block
+
+        if (errors%has_errors()) then
+            print *, '  FAIL: Valid ELSEWHERE body incorrectly rejected'
+            passed = .false.
+        else
+            print *, '  PASS: Valid ELSEWHERE body accepted'
+        end if
+    end subroutine test_valid_elsewhere_body
+
+    subroutine test_invalid_elsewhere_body(passed)
+        logical, intent(inout) :: passed
+        type(ast_arena_t) :: arena
+        type(error_collection_t) :: errors
+        type(elsewhere_clause_t), allocatable :: elsewhere_clauses(:)
+        integer :: where_idx, mask_idx, stop_idx
+        integer, allocatable :: body_indices(:)
+
+        print *, 'Testing invalid ELSEWHERE body with STOP...'
+
+        arena = create_ast_arena()
+        errors = create_error_collection()
+
+        ! Create mask expression
+        mask_idx = push_literal(arena, '.true.', LITERAL_LOGICAL, line=1, column=1)
+
+        ! Create invalid STOP statement for elsewhere
+        stop_idx = push_stop(arena, 0, line=3, column=1)
+
+        ! Create ELSEWHERE clause with invalid STOP
+        allocate (elsewhere_clauses(1))
+        elsewhere_clauses(1)%mask_index = 0
+        allocate (elsewhere_clauses(1)%body_indices(1))
+        elsewhere_clauses(1)%body_indices(1) = stop_idx
+
+        ! Create WHERE node with empty body and invalid ELSEWHERE
+        allocate (body_indices(0))
+        where_idx = push_where(arena, mask_idx, body_indices, &
+                               elsewhere_clauses=elsewhere_clauses, &
+                               line=1, column=1)
+
+        ! Validate - should have error
+        block
+            type(where_node) :: where_nd
+            select type (node => arena%entries(where_idx)%node)
+            type is (where_node)
+                where_nd = node
+            end select
+            call validate_where_construct(arena, where_nd, errors)
+        end block
+
+        if (errors%has_errors()) then
+            print *, '  PASS: Invalid STOP in ELSEWHERE correctly rejected'
+        else
+            print *, '  FAIL: Invalid STOP in ELSEWHERE not detected'
+            passed = .false.
+        end if
+    end subroutine test_invalid_elsewhere_body
+
+end program test_where_validation

--- a/test/test_issue_2287_where_elsewhere.f90
+++ b/test/test_issue_2287_where_elsewhere.f90
@@ -13,8 +13,8 @@ program test_issue_2287_where_elsewhere
     type(token_t), allocatable :: tokens(:)
     type(ast_arena_t) :: arena
     integer :: program_index
-    integer :: pos_if, pos_stop, pos_end_if
-    integer :: pos_elsewhere, pos_assignment
+    integer :: pos_where, pos_elsewhere, pos_endwhere
+    integer :: pos_assignment1, pos_assignment2
 
     call read_example('examples/f90/issue_2287_where_elsewhere.f90', source_code)
 
@@ -38,37 +38,55 @@ program test_issue_2287_where_elsewhere
         error stop 1
     end if
 
-    pos_elsewhere = index(output_code, 'elsewhere')
-    if (pos_elsewhere == 0) then
+    ! Check for WHERE construct
+    pos_where = index(output_code, 'where (b == 0)')
+    if (pos_where == 0) then
+        write (error_unit, '(A)') 'FAIL: WHERE construct missing in output'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    ! Check for ELSEWHERE block - search after the WHERE construct
+    ! Note: searching from pos_where to avoid matching program name
+    pos_elsewhere = index(output_code(pos_where:), char(10)//'    elsewhere')
+    if (pos_elsewhere > 0) then
+        pos_elsewhere = pos_elsewhere + pos_where - 1  ! Adjust to global position
+    else
         write (error_unit, '(A)') 'FAIL: ELSEWHERE block missing in output'
         write (error_unit, '(A)') output_code
         error stop 1
     end if
 
-    pos_assignment = index(output_code(pos_elsewhere:), 'b = 2')
-    if (pos_assignment == 0) then
+    ! Check for END WHERE
+    pos_endwhere = index(output_code, 'end where')
+    if (pos_endwhere == 0) then
+        write (error_unit, '(A)') 'FAIL: END WHERE missing in output'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    ! Check WHERE body assignment (c = a * 10)
+    pos_assignment1 = index(output_code, 'c = a * 10')
+    if (pos_assignment1 == 0) then
+        pos_assignment1 = index(output_code, 'c = a*10')
+    end if
+    if (pos_assignment1 == 0) then
+        write (error_unit, '(A)') 'FAIL: WHERE body assignment missing'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    ! Check ELSEWHERE assignment (c = a)
+    pos_assignment2 = index(output_code(pos_elsewhere:), 'c = a')
+    if (pos_assignment2 == 0) then
         write (error_unit, '(A)') 'FAIL: ELSEWHERE assignment missing'
         write (error_unit, '(A)') output_code
         error stop 1
     end if
-    pos_assignment = pos_assignment + pos_elsewhere - 1
-    if (pos_assignment <= pos_elsewhere) then
-        write (error_unit, '(A)') 'FAIL: ELSEWHERE assignment out of order'
-        write (error_unit, '(A)') output_code
-        error stop 1
-    end if
 
-    pos_if = index(output_code, 'if (any(b == 0)) then')
-    pos_stop = index(output_code, 'stop 1')
-    pos_end_if = index(output_code, 'end if')
-    if (pos_if == 0 .or. pos_stop == 0 .or. pos_end_if == 0) then
-        write (error_unit, '(A)') 'FAIL: expected IF/STOP/END IF sequence missing'
-        write (error_unit, '(A)') output_code
-        error stop 1
-    end if
-
-    if (.not. (pos_if < pos_stop .and. pos_stop < pos_end_if)) then
-        write (error_unit, '(A)') 'FAIL: STOP statement moved outside IF block'
+    ! Verify structure order: where < elsewhere < endwhere
+    if (.not. (pos_where < pos_elsewhere .and. pos_elsewhere < pos_endwhere)) then
+        write (error_unit, '(A)') 'FAIL: WHERE/ELSEWHERE/END WHERE out of order'
         write (error_unit, '(A)') output_code
         error stop 1
     end if


### PR DESCRIPTION
## Summary
- Add semantic validation for WHERE/ELSEWHERE body statements per F2018 Section 10.2.3.2
- WHERE blocks may now only contain: array assignments, nested WHERE statements, nested WHERE constructs
- Invalid statements (IF, STOP, CALL, I/O, etc.) are rejected with clear diagnostic messages

## Changes
- **New module**: `src/semantic/analyzers/semantic_where_validation.f90` - validates WHERE body content
- **Semantic integration**: call validation from `schedule_where_node` in infer_impl
- **Example updates**:
  - `issue_2287_where_elsewhere.f90` - updated to demonstrate VALID WHERE usage
  - `issue_2562_where_invalid_if.f90` - new example demonstrating INVALID WHERE detection
- **Test coverage**: `test_where_validation.f90` - unit tests for valid/invalid WHERE detection

## Test Plan
- [x] `fpm test test_where_validation` - WHERE validation unit tests pass
- [x] `fpm test test_issue_2287_where_elsewhere` - roundtrip test passes
- [x] `fpm test test_all_examples` - all example tests pass (539 tests, 100% success rate)
- [x] Full test suite: 0 errors

## Evidence
```
Total examples tested: 539
Passed: 523
Failed: 0
XFail (expected): 16
XPass (unexpected): 0
Skipped: 52
Success rate:  100.0%

SUCCESS: All examples behaved as expected
```