### PR TITLE
fix: preserve assumed-rank (..) and allocatable in SELECT RANK (fixes #2561)

### DIFF
--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -54,7 +54,7 @@ module ast_factory
     ! Array-related nodes
     use ast_factory_arrays, only: &
         push_array_section, push_array_bounds, push_array_slice, &
-        push_range_expression, push_assumed_size_bounds
+        push_range_expression, push_assumed_size_bounds, push_assumed_rank_bounds
 
     ! Statement nodes
     use ast_factory_statements, only: &
@@ -114,7 +114,7 @@ module ast_factory
 
     ! Array-related nodes
     public :: push_array_section, push_array_bounds, push_array_slice
-    public :: push_range_expression, push_assumed_size_bounds
+    public :: push_range_expression, push_assumed_size_bounds, push_assumed_rank_bounds
 
     ! Statement nodes
     public :: push_use_statement, push_intrinsic_statement, &

--- a/src/ast/factory/ast_factory_arrays.f90
+++ b/src/ast/factory/ast_factory_arrays.f90
@@ -11,7 +11,7 @@ module ast_factory_arrays
 
     ! Public array node creation functions
     public :: push_array_section, push_array_bounds, push_array_slice
-    public :: push_range_expression, push_assumed_size_bounds
+    public :: push_range_expression, push_assumed_size_bounds, push_assumed_rank_bounds
 
 contains
 
@@ -149,5 +149,26 @@ contains
         call arena%push(bounds, "array_bounds", parent_index)
         bounds_index = arena%size
     end function push_assumed_size_bounds
+
+    ! Create assumed-rank array bounds node (..) and add to stack
+    ! Fortran 2018 feature for SELECT RANK construct
+    function push_assumed_rank_bounds(arena, line, column, parent_index) &
+        result(bounds_index)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: bounds_index
+        type(array_bounds_node) :: bounds
+
+        bounds%uid = generate_uid()
+        bounds%lower_bound_index = 0
+        bounds%upper_bound_index = 0
+        bounds%stride_index = 0
+        bounds%is_assumed_rank = .true.
+        if (present(line)) bounds%line = line
+        if (present(column)) bounds%column = column
+
+        call arena%push(bounds, "array_bounds", parent_index)
+        bounds_index = arena%size
+    end function push_assumed_rank_bounds
 
 end module ast_factory_arrays

--- a/src/ast/nodes/ast_nodes_bounds.f90
+++ b/src/ast/nodes/ast_nodes_bounds.f90
@@ -57,6 +57,7 @@ module ast_nodes_bounds
         logical :: is_assumed_shape = .false.  ! True for (:) bounds
         logical :: is_deferred_shape = .false.  ! True for allocatable/pointer arrays
         logical :: is_assumed_size = .false.  ! True for (*) last dimension
+        logical :: is_assumed_rank = .false.  ! True for (..) assumed-rank arrays
     contains
         procedure :: accept => array_bounds_accept
         procedure :: to_json => array_bounds_to_json
@@ -284,6 +285,7 @@ contains
         call json%add(parent, "is_assumed_shape", this%is_assumed_shape)
         call json%add(parent, "is_deferred_shape", this%is_deferred_shape)
         call json%add(parent, "is_assumed_size", this%is_assumed_size)
+        call json%add(parent, "is_assumed_rank", this%is_assumed_rank)
     end subroutine array_bounds_to_json
 
     subroutine array_slice_to_json(this, json, parent)

--- a/src/codegen/codegen_expressions_part2.inc
+++ b/src/codegen/codegen_expressions_part2.inc
@@ -9,6 +9,12 @@
 
         select type (bounds_node => node)
         type is (array_bounds_node)
+            ! Assumed-rank takes highest precedence (Fortran 2018 ..)
+            if (bounds_node%is_assumed_rank) then
+                code = ".."
+                return
+            end if
+
             ! Assumed-size takes precedence over other flags
             if (bounds_node%is_assumed_size) then
                 code = "*"

--- a/src/codegen/codegen_grouped_body_params_helpers.f90
+++ b/src/codegen/codegen_grouped_body_params_helpers.f90
@@ -117,6 +117,7 @@ contains
         if (node%is_target .or. param_map(first_param_idx)%is_target) then
             code = code // ", target"
         end if
+        if (node%is_allocatable) code = code // ", allocatable"
         if (node%is_pointer) code = code // ", pointer"
     end subroutine add_intent_optional_target
 
@@ -216,6 +217,7 @@ contains
         if (node%is_target .or. param_map(param_idx)%is_target) then
             code = code // ", target"
         end if
+        if (node%is_allocatable) code = code // ", allocatable"
         if (node%is_pointer) code = code // ", pointer"
         dimension_suffix = build_inline_dimension_suffix(arena, node)
         has_dimensions = len(dimension_suffix) > 0

--- a/src/lexer/lexer_core.f90
+++ b/src/lexer/lexer_core.f90
@@ -153,9 +153,14 @@ contains
                 call scan_identifier(src, pos, line_num, col_num, &
                                      tokenize_res%tokens, tokenize_res%token_count)
 
-            case ('.')  ! Logical token, decimal number, or separator between numbers
+            case ('.')  ! Logical token, decimal number, assumed-rank, or separator
                 if (pos < source_len) then
-                    if (src(pos + 1:pos + 1) >= '0' .and. src(pos + 1:pos + 1) &
+                    ! Check for assumed-rank (..) - Fortran 2018 feature
+                    if (src(pos + 1:pos + 1) == '.') then
+                        call scan_assumed_rank_operator(src, pos, line_num, col_num, &
+                                                        tokenize_res%tokens, &
+                                                        tokenize_res%token_count)
+                    else if (src(pos + 1:pos + 1) >= '0' .and. src(pos + 1:pos + 1) &
                         <= '9') then
                         ! Treat as decimal only when previous character is not a digit
                         block
@@ -357,4 +362,30 @@ contains
         temp(1:old_size) = trivia
         call move_alloc(temp, trivia)
     end subroutine resize_trivia_buffer
+
+    ! Scan assumed-rank operator (..) - Fortran 2018 feature for SELECT RANK
+    subroutine scan_assumed_rank_operator(source, pos, line_num, col_num, &
+                                          tokens, token_count)
+        character(len=*), intent(in) :: source
+        integer, intent(inout) :: pos, line_num, col_num, token_count
+        type(token_t), intent(inout) :: tokens(:)
+        integer :: start_pos, start_col
+
+        start_pos = pos
+        start_col = col_num
+
+        ! Consume both dots (..)
+        pos = pos + 2
+        col_num = col_num + 2
+
+        ! Create operator token for assumed-rank
+        if (token_count < size(tokens)) then
+            token_count = token_count + 1
+            tokens(token_count)%kind = TK_OPERATOR
+            tokens(token_count)%text = ".."
+            tokens(token_count)%line = line_num
+            tokens(token_count)%column = start_col
+        end if
+    end subroutine scan_assumed_rank_operator
+
 end module lexer_core

--- a/src/parser/expressions/parser_expressions.f90
+++ b/src/parser/expressions/parser_expressions.f90
@@ -9,7 +9,7 @@ module parser_expressions_module
     use ast_nodes_loops, only: do_loop_node
     use ast_factory, only: push_binary_op, push_literal, push_identifier, &
                            push_range_expression, push_complex_literal, &
-                           push_assumed_size_bounds
+                           push_assumed_size_bounds, push_assumed_rank_bounds
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_expression_helpers_module, only: parse_number_literal, &
                                                 parse_string_literal, &
@@ -734,6 +734,15 @@ contains
         type(token_t) :: op_token
 
         op_token = parser%peek()
+        ! Handle assumed-rank (..) - Fortran 2018 feature for SELECT RANK
+        if (op_token%kind == TK_OPERATOR .and. op_token%text == "..") then
+            op_token = parser%consume()
+            expr_index = push_assumed_rank_bounds(arena, &
+                                                  line=op_token%line, &
+                                                  column=op_token%column)
+            return
+        end if
+
         if (op_token%kind == TK_OPERATOR .and. op_token%text == "*") then
             op_token = parser%consume()
             expr_index = push_assumed_size_bounds(arena, &


### PR DESCRIPTION
## Summary
Preserves assumed-rank `(..)` syntax and `allocatable` attribute in SELECT RANK round-trip.

## Changes
- Added `is_assumed_rank` flag to `array_bounds_node` AST
- Added `push_assumed_rank_bounds` factory function  
- Updated lexer to tokenize `..` as assumed-rank operator
- Updated parser to recognize `(..)` in dimension specs
- Updated codegen to emit `(..)` for assumed-rank bounds
- Fixed missing allocatable attribute on procedure parameters

## Before/After
```fortran
! Before (WRONG)
class(*), intent(out) :: target

! After (CORRECT)  
class(*), intent(out), allocatable :: target(..)
```

## Test plan
- [x] All tests pass (Failed: 0)
- [x] Round-trip verified with gfortran compilation
- [x] Patrick-auditor review: APPROVED