### PR TITLE
fix: interface block edge cases for standard Fortran round-trip (fixes #2566)

### DIFF
--- a/app/fortfront.f90
+++ b/app/fortfront.f90
@@ -7,7 +7,7 @@ program fortfront_cli
     use debug_trace, only: trace_init, trace_enter, trace_leave
     use cli_env, only: init_cli_trace, parse_trace_option, parse_trace_flag_value
     use process_exit, only: exit_quiet
-    use lexer_api, only: token_t, tokenize_core, TK_KEYWORD, TK_IDENTIFIER
+    use lexer_api, only: token_t, tokenize_core, TK_KEYWORD, TK_IDENTIFIER, to_lower
     use stdout_sanitizer, only: sanitize_redirected_stdout
     use frontend_core, only: normalize_fixed_form_source_text, is_fixed_form_file
     use frontend_tooling_api, only: read_file_contents, message_has_error
@@ -386,20 +386,116 @@ contains
         type(transform_context_t), intent(out) :: context
         character(len=32) :: uuid_str
         integer :: pid, timestamp
+        character(len=:), allocatable :: prog_name
 
-        ! For stdin, default to lazy Fortran mode
-        ! (Standard Fortran should always come from .f90 files with proper extension)
-        context%input_mode = INPUT_MODE_LAZY
+        ! Detect whether stdin input is standard Fortran or lazy Fortran
+        ! Standard Fortran has explicit program/module/subroutine/function structures
+        if (is_standard_fortran_input(input_text, prog_name)) then
+            context%input_mode = INPUT_MODE_STANDARD
+        else
+            context%input_mode = INPUT_MODE_LAZY
+        end if
 
         call get_pid_impl(pid)
         call get_timestamp_impl(timestamp)
         write (uuid_str, '(A,I0,A,I0)') 'stdin_', pid, '_', timestamp
 
         context%source_name = trim(uuid_str)
-        context%module_name = trim(uuid_str)
+        if (allocated(prog_name)) then
+            context%module_name = prog_name
+        else
+            context%module_name = trim(uuid_str)
+        end if
         context%program_name = 'main'
         context%has_filename = .false.
     end subroutine configure_context_from_stdin
+
+    function is_standard_fortran_input(source, prog_name) result(is_standard)
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable, intent(out) :: prog_name
+        logical :: is_standard
+        type(token_t), allocatable :: tokens(:)
+        integer :: i, next_idx
+        character(len=:), allocatable :: lowered
+
+        is_standard = .false.
+        allocate (character(len=0) :: prog_name)
+
+        ! Tokenize the source
+        call tokenize_core(source, tokens)
+        if (.not. allocated(tokens)) return
+        if (size(tokens) == 0) return
+
+        ! Look for standard Fortran structure indicators
+        ! Key indicators:
+        ! 1. program <name> statement at top level
+        ! 2. module <name> statement at top level
+        ! 3. subroutine/function at top level (external procedure)
+        ! 4. interface block at top level
+        do i = 1, size(tokens)
+            if (tokens(i)%kind /= TK_KEYWORD .and. &
+                tokens(i)%kind /= TK_IDENTIFIER) cycle
+
+            lowered = to_lower(trim(tokens(i)%text))
+
+            select case (lowered)
+            case ("program")
+                ! Found program statement - this is standard Fortran
+                is_standard = .true.
+                ! Extract program name
+                next_idx = find_next_identifier_token(tokens, i)
+                if (next_idx > 0) then
+                    prog_name = trim(tokens(next_idx)%text)
+                end if
+                return
+            case ("module")
+                ! Check if followed by identifier (module statement, not module procedure)
+                next_idx = find_next_identifier_token(tokens, i)
+                if (next_idx > 0) then
+                    if (to_lower(trim(tokens(next_idx)%text)) /= "procedure") then
+                        is_standard = .true.
+                        prog_name = trim(tokens(next_idx)%text)
+                        return
+                    end if
+                end if
+            case ("interface", "abstract")
+                ! Interface blocks indicate standard Fortran
+                is_standard = .true.
+                return
+            case ("subroutine", "function")
+                ! Top-level procedure indicates standard Fortran (external procedure)
+                is_standard = .true.
+                next_idx = find_next_identifier_token(tokens, i)
+                if (next_idx > 0) then
+                    prog_name = trim(tokens(next_idx)%text)
+                end if
+                return
+            case ("submodule", "block")
+                ! Submodule or block data - standard Fortran
+                is_standard = .true.
+                return
+            end select
+        end do
+    end function is_standard_fortran_input
+
+    integer function find_next_identifier_token(tokens, start_pos) result(idx)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_pos
+        integer :: i
+
+        idx = 0
+        do i = start_pos + 1, size(tokens)
+            select case (tokens(i)%kind)
+            case (TK_IDENTIFIER)
+                idx = i
+                return
+            case (TK_KEYWORD)
+                ! Some keywords can be used as identifiers in certain contexts
+                idx = i
+                return
+            end select
+        end do
+    end function find_next_identifier_token
 
     subroutine split_filename(filename, basename, extension)
         character(len=:), allocatable, intent(in) :: filename

--- a/examples/f90/issue_2283_nested_modules.f90
+++ b/examples/f90/issue_2283_nested_modules.f90
@@ -1,17 +1,16 @@
+! Issue #2283: Module with internal procedures accessing module data
+! Note: Nested module syntax is NOT valid Fortran. This example demonstrates
+! the valid pattern of using internal (contained) procedures within a module.
 module issue_2283_outer
     implicit none
-    module issue_2283_inner
-        implicit none
-        integer :: inner_value
-    contains
-        subroutine set_inner(value)
-            integer, intent(in) :: value
-            inner_value = value
-        end subroutine set_inner
-    end module issue_2283_inner
+    integer :: module_value
 contains
-    subroutine touch_inner()
-        use issue_2283_inner, only: set_inner
-        call set_inner(1)
-    end subroutine touch_inner
+    subroutine set_module_value(value)
+        integer, intent(in) :: value
+        module_value = value
+    end subroutine set_module_value
+
+    subroutine touch_value()
+        call set_module_value(1)
+    end subroutine touch_value
 end module issue_2283_outer

--- a/src/lexer/lexer_api.f90
+++ b/src/lexer/lexer_api.f90
@@ -9,6 +9,7 @@ module lexer_api
         token_type_name, &
         tokenize_result_t, &
         lexer_options_t, &
+        to_lower, &
         TK_EOF, &
         TK_IDENTIFIER, &
         TK_NUMBER, &
@@ -50,5 +51,6 @@ module lexer_api
 
     ! Utility functions
     public :: token_type_name
+    public :: to_lower
 
 end module lexer_api

--- a/src/parser/declarations/parser_module_structures.f90
+++ b/src/parser/declarations/parser_module_structures.f90
@@ -17,7 +17,8 @@ module parser_module_structures_module
                                                    parse_interface_block
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t, append_prefix_token
     use parser_procedure_shared_module, only: consume_optional_kind_spec
-    use parser_import_resolution_module, only: parse_use_statement
+    use parser_import_resolution_module, only: parse_use_statement, &
+                                              parse_include_statement
     use ast_types, only: LITERAL_STRING
     use parser_type_specifications_module, only: parse_implicit_statement, &
                                                  take_implicit_additional_indices
@@ -127,6 +128,8 @@ contains
             stmt_index = parse_visibility_statement(parser, arena)
         case ("use")
             stmt_index = parse_use_statement(parser, arena)
+        case ("include")
+            stmt_index = parse_include_statement(parser, arena)
         case ("namelist")
             stmt_index = parse_namelist_statement(parser, arena)
         case ("integer", "real", "logical", "character", "complex", "procedure")

--- a/test/test_issue_2283_nested_modules.f90
+++ b/test/test_issue_2283_nested_modules.f90
@@ -7,7 +7,14 @@ program test_issue_2283_nested_modules
 
     character(len=:), allocatable :: source_code, output_code, error_msg
     type(transform_context_t) :: ctx
-    logical :: has_inner_module
+    logical :: has_module_value
+    logical :: has_set_subroutine
+    logical :: has_touch_subroutine
+
+    ! Note: The original issue #2283 reported "nested modules" as valid Fortran,
+    ! but nested module syntax is NOT valid in any Fortran standard.
+    ! This test now validates that a valid module with contained procedures
+    ! survives the round-trip correctly.
 
     call read_example('examples/f90/issue_2283_nested_modules.f90', source_code)
 
@@ -23,16 +30,30 @@ program test_issue_2283_nested_modules
         error stop 1
     end if
 
-    has_inner_module = index(output_code, 'module issue_2283_inner') > 0 .and. &
-        & index(output_code, 'end module issue_2283_inner') > 0
+    ! Verify the module structure is preserved
+    has_module_value = index(output_code, 'module_value') > 0
+    has_set_subroutine = index(output_code, 'set_module_value') > 0
+    has_touch_subroutine = index(output_code, 'touch_value') > 0
 
-    if (.not. has_inner_module) then
-        write (error_unit, '(A)') 'FAIL: nested module lost during round-trip'
+    if (.not. has_module_value) then
+        write (error_unit, '(A)') 'FAIL: module_value lost during round-trip'
         write (error_unit, '(A)') output_code
         error stop 1
     end if
 
-    print *, 'PASS: nested modules survive round-trip'
+    if (.not. has_set_subroutine) then
+        write (error_unit, '(A)') 'FAIL: set_module_value subroutine lost'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    if (.not. has_touch_subroutine) then
+        write (error_unit, '(A)') 'FAIL: touch_value subroutine lost'
+        write (error_unit, '(A)') output_code
+        error stop 1
+    end if
+
+    print *, 'PASS: module with contained procedures survives round-trip'
 
 contains
 


### PR DESCRIPTION
## Summary

- **Standard Fortran detection for stdin**: Added automatic detection of standard Fortran constructs (program/module/subroutine/function/interface) when reading from stdin, preventing invalid lazy Fortran transformations
- **Include statement parsing**: Added include statement handling to module declaration parsing, preserving include directives in round-trip
- **Fixed invalid example**: Replaced invalid nested module syntax (not valid Fortran) with valid module structure containing procedures

## Test plan

- [x] Verified issue_2348 interface blocks are preserved in round-trip
- [x] Verified issue_2389 external subroutines are not wrongly placed in contains
- [x] Verified ast_coverage_module_interface preserves include directive
- [x] Verified issue_2283 example is now valid Fortran
- [x] All tests pass (100%)
- [x] Output validated with gfortran -fsyntax-only

## Files changed

| File | Change |
|------|--------|
| app/fortfront.f90 | Standard Fortran detection for stdin |
| src/lexer/lexer_api.f90 | Export to_lower utility |
| src/parser/declarations/parser_module_structures.f90 | Include statement parsing |
| examples/f90/issue_2283_nested_modules.f90 | Valid Fortran example |
| test/test_issue_2283_nested_modules.f90 | Updated test assertions |