### PR TITLE
fix: prevent procedures with ENTRY from being placed in contains block (#2567)

### DIFF
--- a/examples/f90/issue_2070_entry_loses_argument_declarations.f90
+++ b/examples/f90/issue_2070_entry_loses_argument_declarations.f90
@@ -1,20 +1,27 @@
+! Test case for issue #2567: ENTRY statement loses argument declarations
+! This test verifies that procedures with ENTRY statements are NOT
+! incorrectly placed inside a contains block (which is illegal).
+! The function func1 has an ENTRY point func2 with different arguments.
+! Both entry points share the same result variable but take different args.
+
 program test_entry_statement
     implicit none
-    integer :: result
+    integer :: result_val
+    integer, external :: func1, func2
 
-    result = func1(5)
-    print *, "func1(5) =", result
+    result_val = func1(5)
+    print *, "func1(5) =", result_val
 
-    result = func2(3, 4)
-    print *, "func2(3,4) =", result
+    result_val = func2(3, 4)
+    print *, "func2(3,4) =", result_val
 end program test_entry_statement
 
 function func1(x) result(res)
     integer, intent(in) :: x
     integer :: res
+    integer, intent(in) :: a, b
     res = x * 2
     return
-    entry func2(a, b) result(res)
-    integer, intent(in) :: a, b
+entry func2(a, b) result(res)
     res = a + b
 end function func1

--- a/src/frontend/frontend_program_builders.f90
+++ b/src/frontend/frontend_program_builders.f90
@@ -10,6 +10,7 @@ module frontend_program_builders
         end_statement_node, comment_node, directive_node, blank_line_node
     use ast_factory, only: push_implicit_statement
     use standardizer_program, only: insert_contains_statement
+    use procedure_classification, only: procedure_has_entry_statement
     implicit none
     private
 
@@ -22,6 +23,7 @@ module frontend_program_builders
     public :: scan_multi_unit_program
     public :: create_program_from_bare_statements
     public :: merge_procedures_into_program
+    public :: filter_procs_with_entry
 
 contains
 
@@ -60,6 +62,10 @@ contains
                     end select
                 end do
             end if
+
+            ! Filter out procedures with ENTRY statements - they cannot be
+            ! contained in internal program procedures.
+            call filter_procs_with_entry(arena, proc_indices)
 
             if (size(proc_indices) > 0) then
                 if (size(main_stmts) == 0) return
@@ -505,5 +511,26 @@ contains
             is_host = .true.
         end select
     end function is_host_level_statement
+
+    subroutine filter_procs_with_entry(arena, proc_indices)
+        ! Remove procedures containing ENTRY statements from the list.
+        ! ENTRY statements cannot appear in contained (internal) procedures per
+        ! ISO/IEC 1539-1:2018 Section 15.6.2.6.
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(inout) :: proc_indices(:)
+        integer, allocatable :: filtered(:)
+        integer :: i
+
+        if (.not. allocated(proc_indices)) return
+        if (size(proc_indices) == 0) return
+
+        allocate (filtered(0))
+        do i = 1, size(proc_indices)
+            if (.not. procedure_has_entry_statement(arena, proc_indices(i))) then
+                filtered = [filtered, proc_indices(i)]
+            end if
+        end do
+        proc_indices = filtered
+    end subroutine filter_procs_with_entry
 
 end module frontend_program_builders

--- a/src/frontend/frontend_transformation_analysis.f90
+++ b/src/frontend/frontend_transformation_analysis.f90
@@ -11,7 +11,7 @@ module frontend_transformation_analysis
         requires_lazy_internalization, has_existing_module_in_ast
     use frontend_program_builders, only: handle_mixed_construct_container, &
         scan_multi_unit_program, create_program_from_bare_statements, &
-        merge_procedures_into_program
+        merge_procedures_into_program, filter_procs_with_entry
     implicit none
     private
 
@@ -56,6 +56,10 @@ contains
         class default
             return
         end select
+
+        ! Filter out procedures with ENTRY statements - they cannot be contained
+        ! in internal program procedures per ISO/IEC 1539-1:2018 Section 15.6.2.6.
+        call filter_procs_with_entry(arena, proc_indices)
 
         call create_program_from_bare_statements(arena, root_index, &
                                                  main_prog_index, proc_indices, main_stmts)

--- a/src/frontend/frontend_transformation_structure.f90
+++ b/src/frontend/frontend_transformation_structure.f90
@@ -6,7 +6,8 @@ module frontend_transformation_structure
     use ast_nodes_misc, only: contains_node, use_statement_node
     use ast_nodes_data, only: declaration_node, module_node, &
                               mixed_construct_container_node
-    use procedure_classification, only: should_hoist_procedure
+    use procedure_classification, only: should_hoist_procedure, &
+                                        procedure_has_entry_statement
     use frontend_transformation_common, only: transform_context_t, format_options_t
     use compiler_arena, only: compiler_arena_t
     use codegen_arena_interface, only: generate_code_from_arena
@@ -100,6 +101,27 @@ contains
             end if
         end do
     end subroutine filter_hoistable_procedures
+
+    subroutine filter_out_entry_procedures(arena, proc_indices)
+        ! Remove procedures containing ENTRY statements from the list.
+        ! ENTRY statements cannot appear in contained (internal) procedures per
+        ! ISO/IEC 1539-1:2018 Section 15.6.2.6.
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(inout) :: proc_indices(:)
+        integer, allocatable :: filtered(:)
+        integer :: i
+
+        if (.not. allocated(proc_indices)) return
+        if (size(proc_indices) == 0) return
+
+        allocate (filtered(0))
+        do i = 1, size(proc_indices)
+            if (.not. procedure_has_entry_statement(arena, proc_indices(i))) then
+                filtered = [filtered, proc_indices(i)]
+            end if
+        end do
+        proc_indices = filtered
+    end subroutine filter_out_entry_procedures
 
     subroutine remove_procedures_from_body(root_prog, procedures)
         class(program_node), intent(inout) :: root_prog
@@ -407,6 +429,11 @@ contains
         embedded_procs = collect_target_procedures(arena, target_prog_idx)
         call filter_hoistable_procedures(arena, all_procedures, target_prog_idx, &
                                          lifted_procs)
+
+        ! Filter out embedded procedures with ENTRY statements. ENTRY statements
+        ! cannot appear in contained procedures per ISO/IEC 1539-1:2018 Section
+        ! 15.6.2.6. Such procedures must remain external.
+        call filter_out_entry_procedures(arena, embedded_procs)
 
         if (size(embedded_procs) == 0 .and. size(lifted_procs) == 0) return
 

--- a/src/utilities/procedure_classification.f90
+++ b/src/utilities/procedure_classification.f90
@@ -4,12 +4,14 @@ module procedure_classification
     use ast_nodes_data, only: declaration_node, parameter_declaration_node
     use ast_nodes_procedure, only: function_def_node, subroutine_def_node, &
         & get_procedure_params, get_procedure_name
+    use ast_nodes_transfer, only: entry_node
     use string_utils_mod, only: to_lower
     implicit none
     private
 
     public :: should_hoist_procedure
     public :: procedure_has_explicit_types
+    public :: procedure_has_entry_statement
 
 contains
 
@@ -23,6 +25,14 @@ contains
         if (proc_idx <= 0) return
         if (proc_idx > arena%size) return
         if (.not. allocated(arena%entries(proc_idx)%node)) return
+
+        ! ENTRY statements cannot appear in contained procedures (ISO/IEC
+        ! 1539-1:2018 Section 15.6.2.6). Procedures with ENTRY must remain
+        ! external, not hoisted into a programs contains block.
+        if (procedure_has_entry_statement(arena, proc_idx)) then
+            should_hoist = .false.
+            return
+        end if
 
         if (procedure_has_optional_arguments(arena, proc_idx)) then
             should_hoist = .true.
@@ -311,5 +321,52 @@ contains
             end select
         end do
     end function body_declares_external_with_name
+
+    logical function procedure_has_entry_statement(arena, proc_idx) &
+        & result(has_entry)
+        ! Check if a procedure contains ENTRY statements. ENTRY statements cannot
+        ! appear in contained (internal) procedures per ISO/IEC 1539-1:2018
+        ! Section 15.6.2.6. This function is used to prevent hoisting procedures
+        ! with ENTRY statements into a programs contains block.
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_idx
+        integer :: i, idx
+
+        has_entry = .false.
+        if (proc_idx <= 0) return
+        if (proc_idx > arena%size) return
+        if (.not. allocated(arena%entries(proc_idx)%node)) return
+
+        select type (proc_node => arena%entries(proc_idx)%node)
+        type is (function_def_node)
+            if (.not. allocated(proc_node%body_indices)) return
+            has_entry = body_has_entry_statement(arena, proc_node%body_indices)
+        type is (subroutine_def_node)
+            if (.not. allocated(proc_node%body_indices)) return
+            has_entry = body_has_entry_statement(arena, proc_node%body_indices)
+        class default
+            return
+        end select
+    end function procedure_has_entry_statement
+
+    logical function body_has_entry_statement(arena, body_indices) &
+        & result(has_entry)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        integer :: i, idx
+
+        has_entry = .false.
+        do i = 1, size(body_indices)
+            idx = body_indices(i)
+            if (idx <= 0) cycle
+            if (idx > arena%size) cycle
+            if (.not. allocated(arena%entries(idx)%node)) cycle
+            select type (stmt => arena%entries(idx)%node)
+            type is (entry_node)
+                has_entry = .true.
+                return
+            end select
+        end do
+    end function body_has_entry_statement
 
 end module procedure_classification


### PR DESCRIPTION
## Summary
- Fix round-trip regression where ENTRY statements were incorrectly placed inside contained procedures
- ENTRY statements cannot appear in contained (internal) procedures per ISO/IEC 1539-1:2018 Section 15.6.2.6
- Add detection and filtering of procedures containing ENTRY statements across multiple code transformation paths

## Changes
- Add `procedure_has_entry_statement()` function to detect ENTRY statements in procedures
- Add `filter_procs_with_entry()` helper to filter out procedures with ENTRY from lists
- Modify `should_hoist_procedure()` to return false for procedures with ENTRY
- Filter `embedded_procs` in `normalize_multi_unit_container()`
- Filter `proc_indices` in `promote_functions_to_internal_program()`
- Filter in `handle_mixed_construct_container()`
- Update example file with correct syntax and external declarations

## Test Plan
- [x] Verify `test_issue_2162_entry_wrapping` passes
- [x] Run full test suite - all tests pass
- [x] Verify round-trip of ENTRY example produces valid Fortran
- [x] Verify gfortran accepts the output

Fixes #2567