### PR TITLE
ci: clarify test summary job for branch protection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,19 +241,22 @@ jobs:
         # Run full test suite (same as Linux)
         fpm test --flag "-Wl,--stack,16777216"
 
-  # Summary job for branch protection (org ruleset requires "test" check)
+  # Summary job for branch protection - org ruleset requires "test" to pass
+  # This aggregates the matrix build-test results into a single required check
   test:
+    name: test
     needs: [build-test]
     if: always()
     runs-on: ubuntu-latest
     steps:
       - name: Check test results
         run: |
+          echo "Build-test result: ${{ needs.build-test.result }}"
           if [ "${{ needs.build-test.result }}" != "success" ]; then
-            echo "Tests failed"
+            echo "::error::Tests failed on one or more platforms"
             exit 1
           fi
-          echo "All tests passed"
+          echo "All platform tests passed (Ubuntu + Windows)"
 
   # macOS CI temporarily disabled due to runner issues
   # test-macos:


### PR DESCRIPTION
## Summary

Clarifies the CI test summary job that aggregates matrix build results into a single required check for branch protection.

## Changes

- Add explicit `name: test` to ensure GitHub displays correct check name
- Improve output messaging for clearer CI feedback
- Add comments explaining the purpose of the summary job

## Context

Organization ruleset requires a check named "test" to pass before merging PRs. The existing setup was correct but lacked explicit naming and clear documentation.

## Test Plan

- [ ] CI passes on this PR
- [ ] "test" check appears in PR checks