### PR TITLE
polish: remove obsolete TODO comments in semantic_validation_utils (fixes #2589)

### DIFF
--- a/src/semantic/analyzers/semantic_validation_utils.f90
+++ b/src/semantic/analyzers/semantic_validation_utils.f90
@@ -59,9 +59,6 @@ contains
         ! - INPUT_MODE_LAZY: Type propagation required (lazy Fortran .lf files)
         ! - INPUT_MODE_STANDARD: Skip propagation (standard .f90 with implicit none)
         ! - Standard .f90 WITHOUT implicit none: Currently unsupported (future work)
-        !
-        ! TODO: Flow context%input_mode from CLI through to semantic analyzer
-        ! TODO: Pass input_mode == INPUT_MODE_STANDARD to skip propagation
         if (present(input_mode)) then
             if (input_mode == INPUT_MODE_STANDARD) return  ! Skip propagation if standard mode
         end if


### PR DESCRIPTION
## Summary

- Remove 2 obsolete TODO comments from `semantic_validation_utils.f90`
- These TODOs described implementing `input_mode` plumbing that was already completed

## Analysis

The TODO comments referenced:
```fortran
! TODO: Flow context%input_mode from CLI through to semantic analyzer
! TODO: Pass input_mode == INPUT_MODE_STANDARD to skip propagation
```

However, the feature is already implemented:
- Line 52: `integer, intent(in), optional :: input_mode` - parameter exists
- Lines 62-64: The logic already checks and returns early for INPUT_MODE_STANDARD

The comments were stale documentation of completed work, violating CLAUDE.md (no placeholders/TODOs).

## Verification

```bash
# Build passes
fpm build
# [100%] Project compiled successfully.

# Tests pass with 0 failures
fpm test 2>&1 | grep "^Failed:"
# Failed: 0
# Failed: 0
# Failed: 0
```

## Test Plan

- [x] Code builds without errors
- [x] All tests pass (0 failures)
- [x] No regressions in semantic validation