### PR TITLE
fix: parser handles nested legacy array constructors in implied-do (fixes #2455)

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -12,9 +12,6 @@
 # BUGS - Real issues that need fixing
 # ============================================================================
 
-# Codegen bugs
-issue_2455_nested_array_constructor.f90  # BUG: nested array constructors generate malformed syntax (#2455)
-
 # Type inference / monomorphization bugs
 issue_2075_stop_keyword_collision_in_function_param.lf  # BUG: result array conflicts with stop keyword (#2075)
 issue_2153_array_call_scalar_param.lf  # BUG: array variant returns scalar instead of array (#2153)

--- a/src/parser/expressions/parser_expression_arrays.f90
+++ b/src/parser/expressions/parser_expression_arrays.f90
@@ -415,11 +415,13 @@ contains
         integer :: expr_index
         type(token_t) :: current
         type(token_t) :: peek_token
+        type(token_t) :: lookahead_token
         integer :: expr_elem_index
         character(len=:), allocatable :: var_name
         integer :: start_index, end_index, step_index
         integer, allocatable :: body_indices(:)
         integer :: saved_pos
+        logical :: is_legacy_array
 
         expr_index = 0
 
@@ -429,7 +431,17 @@ contains
 
         saved_pos = parser%current_token
         peek_token = parser%peek()
+        ! Check if this is a nested implied-do or a legacy array constructor.
+        ! A legacy array starts with (/ so we should NOT try to recurse into it.
+        is_legacy_array = .false.
         if (peek_token%text == "(") then
+            lookahead_token = parser%get_token_at_index(parser%current_token + 1)
+            if (lookahead_token%text == "/") then
+                is_legacy_array = .true.
+            end if
+        end if
+
+        if (peek_token%text == "(" .and. .not. is_legacy_array) then
             expr_elem_index = parse_nested_implied_do(parser, arena, helpers)
             if (expr_elem_index <= 0) then
                 parser%current_token = saved_pos
@@ -496,7 +508,9 @@ contains
         type(array_parse_helpers_t), intent(in) :: helpers
         type(token_t) :: current
         type(token_t) :: peek_ahead
+        type(token_t) :: lookahead_token
         integer :: saved_pos
+        logical :: is_legacy_array
 
         success = .false.
         if (.not. associated(helpers%parse_comparison)) return
@@ -504,7 +518,17 @@ contains
         current = parser%consume()
 
         peek_ahead = parser%peek()
+        ! Check if this is a nested implied-do or a legacy array constructor.
+        ! A legacy array starts with (/ so we should NOT try to recurse into it.
+        is_legacy_array = .false.
         if (peek_ahead%text == "(") then
+            lookahead_token = parser%get_token_at_index(parser%current_token + 1)
+            if (lookahead_token%text == "/") then
+                is_legacy_array = .true.
+            end if
+        end if
+
+        if (peek_ahead%text == "(" .and. .not. is_legacy_array) then
             saved_pos = parser%current_token
             expr_elem_index = parse_nested_implied_do(parser, arena, helpers)
             if (expr_elem_index <= 0) then


### PR DESCRIPTION
## Summary
- Fix parser bug where nested legacy array constructors inside implied-do loops caused malformed output
- The parser now correctly distinguishes between a nested implied-do `(expr, var=start,end)` and a legacy array constructor `(/ ... /)`

## Root Cause
When parsing nested implied-do constructs like `(/((/(i*j, i=1,j)/), j=1,2)/)`, the parser would see `(` and try to parse a nested implied-do. It would consume the `(` then fail because `/` is not a valid expression start, falling back incorrectly and producing malformed output like `size( = 1, 2)`.

## Fix
Added lookahead check in `parse_nested_implied_do` and `parse_implied_do_header`: before attempting to parse a nested implied-do, verify that `(` is not followed by `/` (which indicates a legacy array constructor that should be handled by `parse_comparison`).

## Verification

**Before fix:**
```fortran
! Input
integer, parameter :: n = size((/((/(i*j, i=1,j)/), j=1,2)/))
! Output (BROKEN)
integer, parameter :: n = size( = 1, 2)
```

**After fix:**
```fortran
! Input
integer, parameter :: n = size((/((/(i*j, i=1,j)/), j=1,2)/))
! Output (CORRECT)
integer, parameter :: n = size([([(i*j, i=1, j)], j=1, 2)])
```

**Test commands:**
```bash
# CLI roundtrip test
echo 'program test
    integer, parameter :: n = size((/((/(i*j, i=1,j)/), j=1,2)/))
end program' | ./build/gfortran_*/app/fortfront
# Output: size([([(i*j, i=1, j)], j=1, 2)])

# Verify generated code compiles
./build/gfortran_*/app/fortfront examples/f90/issue_2455_nested_array_constructor.f90 > /tmp/test.f90
gfortran -c -fsyntax-only /tmp/test.f90  # Exit code: 0

# Full test suite
fpm test test_all_examples
# Success rate: 100.0%
```

## Test plan
- [x] CLI roundtrip produces valid nested array constructor
- [x] Generated code compiles with gfortran
- [x] Existing test `test_issue_2455_argument_syntax_roundtrip` passes
- [x] All 543 examples pass (100% success rate)
- [x] Removed `issue_2455_nested_array_constructor.f90` from expected_failures.txt