### PR TITLE
polish: add _t suffix to derived types (fixes #2587)

### DIFF
--- a/src/analysis/variable_usage_dispatcher.f90
+++ b/src/analysis/variable_usage_dispatcher.f90
@@ -209,7 +209,7 @@ contains
 
     ! Process if node children
     subroutine process_if_node_children(arena, node_index, info, ctx)
-        use ast_nodes_control, only: if_node, elseif_wrapper
+        use ast_nodes_control, only: if_node, elseif_wrapper_t
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index
         type(variable_usage_info_t), intent(inout) :: info

--- a/src/ast/nodes/ast_nodes_conditional.f90
+++ b/src/ast/nodes/ast_nodes_conditional.f90
@@ -7,7 +7,7 @@ module ast_nodes_conditional
     private
 
     ! Public types
-    public :: elseif_wrapper, case_wrapper
+    public :: elseif_wrapper_t, case_wrapper_t
     public :: if_node, select_case_node, case_block_node
     public :: case_range_node, case_default_node
     public :: select_type_node, type_guard_block_node
@@ -17,24 +17,24 @@ module ast_nodes_conditional
     public :: create_if, create_select_case, create_select_type, create_select_rank
 
     ! Elseif wrapper (not an AST node itself)
-    type :: elseif_wrapper
+    type :: elseif_wrapper_t
         integer :: condition_index = 0  ! Elseif condition arena index
         integer, allocatable :: body_indices(:)  ! Elseif body arena indices
-    end type elseif_wrapper
+    end type elseif_wrapper_t
 
     ! Case statement wrapper (temporary for parser compatibility)
-    type :: case_wrapper
+    type :: case_wrapper_t
         character(len=:), allocatable :: case_type  ! "case", "case_default"
         class(ast_node), allocatable :: value  ! Case value (optional &
         ! for default)
         type(ast_node_wrapper), allocatable :: body(:)  ! Case body
-    end type case_wrapper
+    end type case_wrapper_t
 
     ! If statement node
     type, extends(ast_node) :: if_node
         integer :: condition_index = 0  ! If condition arena index
         integer, allocatable :: then_body_indices(:)  ! Then body arena indices
-        type(elseif_wrapper), allocatable :: elseif_blocks(:)  ! Elseif blocks (optional)
+        type(elseif_wrapper_t), allocatable :: elseif_blocks(:)  ! Elseif blocks (optional)
         integer, allocatable :: else_body_indices(:)  ! Else body arena indices &
         ! (optional)
     contains
@@ -541,7 +541,7 @@ contains
                        else_body_indices, line, column) result(node)
         integer, intent(in) :: condition_index
         integer, intent(in), optional :: then_body_indices(:)
-        type(elseif_wrapper), intent(in), optional :: elseif_blocks(:)
+        type(elseif_wrapper_t), intent(in), optional :: elseif_blocks(:)
         integer, intent(in), optional :: else_body_indices(:)
         integer, intent(in), optional :: line, column
         type(if_node) :: node

--- a/src/ast/nodes/ast_nodes_control.f90
+++ b/src/ast/nodes/ast_nodes_control.f90
@@ -2,7 +2,7 @@
 ! This module aggregates all control flow AST nodes from specialized modules
 module ast_nodes_control
     ! Import from specialized modules
-    use ast_nodes_conditional, only: elseif_wrapper, case_wrapper, &
+    use ast_nodes_conditional, only: elseif_wrapper_t, case_wrapper_t, &
                                      if_node, select_case_node, &
                                      case_block_node, case_range_node, &
                                      case_default_node, create_if, &
@@ -27,7 +27,7 @@ module ast_nodes_control
     public :: MAX_INDEX_NAME_LENGTH
 
     ! Re-export utility types
-    public :: elseif_wrapper, case_wrapper, association_t
+    public :: elseif_wrapper_t, case_wrapper_t, association_t
     public :: forall_triplet_t, elsewhere_clause_t
 
     ! Re-export all control flow node types

--- a/src/parser/declarations/parser_type_specifications.f90
+++ b/src/parser/declarations/parser_type_specifications.f90
@@ -185,16 +185,16 @@ contains
         character(len=:), allocatable :: none_spec
         integer :: line, column
 
-        type :: implicit_spec_info
+        type :: implicit_spec_info_t
             character(len=:), allocatable :: type_name
             logical :: has_kind = .false.
             integer :: kind_value = 0
             logical :: has_length = .false.
             integer :: length_value = 0
             character(len=64), allocatable :: letter_ranges(:)
-        end type implicit_spec_info
+        end type implicit_spec_info_t
 
-        type(implicit_spec_info), allocatable :: specs(:)
+        type(implicit_spec_info_t), allocatable :: specs(:)
         integer :: spec_count, i
         integer, allocatable :: created_indices(:)
         logical :: parse_success
@@ -306,10 +306,10 @@ contains
         logical function parse_single_spec(parser_ref, specs_ref, count) &
             result(success)
             type(parser_state_t), intent(inout) :: parser_ref
-            type(implicit_spec_info), allocatable, intent(inout) :: specs_ref(:)
+            type(implicit_spec_info_t), allocatable, intent(inout) :: specs_ref(:)
             integer, intent(inout) :: count
             type(token_t) :: local_token
-            type(implicit_spec_info) :: spec
+            type(implicit_spec_info_t) :: spec
             integer :: saved_pos
             integer :: range_count
             character(len=64), allocatable :: tmp_ranges(:)
@@ -374,9 +374,9 @@ contains
         end function parse_single_spec
 
         subroutine append_spec(specs_ref, new_count)
-            type(implicit_spec_info), allocatable, intent(inout) :: specs_ref(:)
+            type(implicit_spec_info_t), allocatable, intent(inout) :: specs_ref(:)
             integer, intent(in) :: new_count
-            type(implicit_spec_info), allocatable :: temp(:)
+            type(implicit_spec_info_t), allocatable :: temp(:)
             integer :: old_size
 
             if (.not. allocated(specs_ref)) then

--- a/src/semantic/analyzers/semantic_function_inference.f90
+++ b/src/semantic/analyzers/semantic_function_inference.f90
@@ -11,7 +11,7 @@ module semantic_function_inference
                                  type_guard_block_node, where_node, &
                                  where_stmt_node, associate_node, &
                                  block_construct_node, forall_node, &
-                                 elseif_wrapper, elsewhere_clause_t
+                                 elseif_wrapper_t, elsewhere_clause_t
     use ast_nodes_data, only: declaration_node
     use semantic_procedure_utils, only: detect_result_name, &
                                         declaration_type_to_mono


### PR DESCRIPTION
## Summary

- Rename `implicit_spec_info` to `implicit_spec_info_t` in `parser_type_specifications.f90`
- Rename `elseif_wrapper` to `elseif_wrapper_t` in `ast_nodes_conditional.f90`
- Rename `case_wrapper` to `case_wrapper_t` in `ast_nodes_conditional.f90`
- Update all references in `ast_nodes_control.f90`, `variable_usage_dispatcher.f90`, and `semantic_function_inference.f90`

This aligns all derived types with the CLAUDE.md naming convention (`<name>_t` suffix).

## Verification

```bash
# Before fix: 3 violations
grep -rn "^\s*type\s*::\s*[a-zA-Z_][a-zA-Z0-9_]*\s*$" src/ --include="*.f90" | grep -v "_t\s*$"
# src/parser/declarations/parser_type_specifications.f90:188:        type :: implicit_spec_info
# src/ast/nodes/ast_nodes_conditional.f90:20:    type :: elseif_wrapper
# src/ast/nodes/ast_nodes_conditional.f90:26:    type :: case_wrapper

# After fix: 0 violations
fpm build  # SUCCESS
fpm test   # All tests pass
```

## Test plan

- [x] Build succeeds (`fpm build`)
- [x] All tests pass (`fpm test`)
- [x] Zero remaining naming violations