### PR TITLE
fix: add test for dp predefined symbol (fixes #2590)

### DIFF
--- a/examples/lf/dp_predefined_symbol.lf
+++ b/examples/lf/dp_predefined_symbol.lf
@@ -1,0 +1,11 @@
+! Test predefined dp symbol (LFortran Standard)
+! dp is implicitly defined as real64 from iso_fortran_env
+
+! Case 1: dp used as kind suffix in literal
+x = 1.0_dp
+
+! Case 2: dp used in type declaration
+real(dp) :: z
+z = 3.14_dp
+
+print *, x, z

--- a/test/semantic/test_dp_predefined_symbol.f90
+++ b/test/semantic/test_dp_predefined_symbol.f90
@@ -1,0 +1,73 @@
+program test_dp_predefined_symbol
+    ! Test for Issue #2590: Predefine dp symbol as real64 per LFortran Standard
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit
+    use, intrinsic :: iso_fortran_env, only: iostat_end, iostat_eor
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    character(len=:), allocatable :: source, output, error_msg
+    logical :: all_passed
+
+    all_passed = .true.
+    call read_example('examples/lf/dp_predefined_symbol.lf', source)
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'Unexpected error: '//trim(error_msg)
+        error stop 1
+    end if
+
+    ! Verify dp is imported, not declared as a local variable
+    if (index(output, 'use, intrinsic :: iso_fortran_env') == 0) then
+        write (error_unit, '(A)') 'FAIL: Missing iso_fortran_env import'
+        all_passed = .false.
+    end if
+
+    if (index(output, 'dp => real64') == 0) then
+        write (error_unit, '(A)') 'FAIL: Missing dp => real64 clause'
+        all_passed = .false.
+    end if
+
+    ! dp should NOT be declared as a local variable
+    if (index(output, 'integer :: dp') > 0 .or. &
+        index(output, 'real :: dp') > 0) then
+        write (error_unit, '(A)') 'FAIL: dp incorrectly declared as local var'
+        all_passed = .false.
+    end if
+
+    ! Verify dp is used correctly in output
+    if (index(output, '1.0_dp') == 0) then
+        write (error_unit, '(A)') 'FAIL: dp suffix not preserved'
+        all_passed = .false.
+    end if
+
+    if (index(output, 'real(dp)') == 0) then
+        write (error_unit, '(A)') 'FAIL: real(dp) declaration not preserved'
+        all_passed = .false.
+    end if
+
+    if (all_passed) then
+        print *, 'PASS: dp predefined symbol works correctly (Issue #2590)'
+    else
+        write (error_unit, '(A)') 'Output was:'
+        write (error_unit, '(A)') trim(output)
+        error stop 'FAIL: dp predefined symbol regression'
+    end if
+
+contains
+
+    include '../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read '//trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+end program test_dp_predefined_symbol


### PR DESCRIPTION
## Summary
- Adds documentation and test coverage for the existing dp symbol predefinition feature
- The codegen already handles dp as a kind parameter from iso_fortran_env via `maybe_require_dp_kind_use`

When dp is used in:
- Type declarations: `real(dp) :: x`
- Literal suffixes: `1.0_dp`
- `kind=` parameters: `kind=dp`

The system automatically adds:
```fortran
use, intrinsic :: iso_fortran_env, only: dp => real64
```

This PR adds:
- `examples/lf/dp_predefined_symbol.lf`: demonstrates the feature
- `test/semantic/test_dp_predefined_symbol.f90`: verifies the behavior

## Verification
```bash
# Test passes
fpm test test_dp_predefined_symbol
# Output: PASS: dp predefined symbol works correctly (Issue #2590)

# Example transformation
./build/gfortran_*/app/fortfront < examples/lf/dp_predefined_symbol.lf
# Output includes:
# use, intrinsic :: iso_fortran_env, only: dp => real64
# real(dp) :: z
# x = 1.0_dp
```

## Test plan
- [x] New test passes locally
- [x] Full test suite passes
- [x] Example file compiles after transformation