### PR TITLE
fix: add GCC 14 workaround for AST node destructor segfaults (fixes #2617)

### DIFF
--- a/src/ast/factory/ast_factory_control_part1.inc
+++ b/src/ast/factory/ast_factory_control_part1.inc
@@ -43,7 +43,8 @@
                 if (mod(size(elseif_indices), 2) == 0) then
                     allocate (if_stmt%elseif_blocks(size(elseif_indices) / 2))
                     do i = 1, size(elseif_indices) / 2
-                        if_stmt%elseif_blocks(i)%condition_index = elseif_indices(2 * i - 1)
+                        if_stmt%elseif_blocks(i)%condition_index = &
+                            elseif_indices(2 * i - 1)
                         if_stmt%elseif_blocks(i)%body_indices = [elseif_indices(2 * i)]
                     end do
                 end if
@@ -288,7 +289,8 @@
         ! Validate arena is initialized
         validation = validate_arena(arena, "push_forall")
         if (validation%is_failure()) then
-            write (error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
+            write (error_unit, '(A)') "ERROR [ast_factory_control]: " // &
+                validation%get_full_message()
             forall_index = 0
             return
         end if
@@ -299,7 +301,8 @@
         if (use_multi) then
             num_indices = size(index_vars_all)
             if (num_indices <= 0) then
-                write(error_unit, '(A)') "ERROR [ast_factory_control]: FORALL requires at least one index"
+                write (error_unit, '(A)') &
+                    "ERROR [ast_factory_control]: FORALL requires at least one index"
                 forall_index = 0
                 return
             end if
@@ -312,7 +315,7 @@
             if (present(stride_indices_all)) then
                 if (size(stride_indices_all) /= num_indices) then
                     write (error_unit, '(A)') &
-                        "ERROR [ast_factory_control]: FORALL stride array must match index count"
+               "ERROR [ast_factory_control]: FORALL stride array must match index count"
                     forall_index = 0
                     return
                 end if
@@ -349,13 +352,13 @@
 
             if (index_var_len == 0) then
                 write (error_unit, '(A)') &
-                    "ERROR [ast_factory_control]: FORALL index variable name cannot be empty"
+               "ERROR [ast_factory_control]: FORALL index variable name cannot be empty"
                 forall_index = 0
                 return
             end if
             if (index_var_len > MAX_INDEX_NAME_LENGTH) then
                 write (error_unit, '(A)') &
-                    "ERROR [ast_factory_control]: FORALL index variable name exceeds maximum length"
+        "ERROR [ast_factory_control]: FORALL index variable name exceeds maximum length"
                 forall_index = 0
                 return
             end if
@@ -364,14 +367,16 @@
 
             validation = validate_node_index(arena, lower_vals(i), "push_forall start")
             if (validation%is_failure()) then
-                write (error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
+                write (error_unit, '(A)') "ERROR [ast_factory_control]: " // &
+                    validation%get_full_message()
                 forall_index = 0
                 return
             end if
 
             validation = validate_node_index(arena, upper_vals(i), "push_forall end")
             if (validation%is_failure()) then
-                write (error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
+                write (error_unit, '(A)') "ERROR [ast_factory_control]: " // &
+                    validation%get_full_message()
                 forall_index = 0
                 return
             end if
@@ -379,7 +384,8 @@
             if (stride_val > 0) then
                 validation = validate_node_index(arena, stride_val, "push_forall step")
                 if (validation%is_failure()) then
-                    write (error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
+                    write (error_unit, '(A)') "ERROR [ast_factory_control]: " // &
+                        validation%get_full_message()
                     forall_index = 0
                     return
                 end if
@@ -396,7 +402,8 @@
             if (mask_index > 0) then
                 validation = validate_node_index(arena, mask_index, "push_forall mask")
                 if (validation%is_failure()) then
-                    write (error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
+                    write (error_unit, '(A)') "ERROR [ast_factory_control]: " // &
+                        validation%get_full_message()
                     forall_index = 0
                     return
                 end if
@@ -406,9 +413,11 @@
         ! Validate body indices
         if (present(body_indices)) then
             do i = 1, size(body_indices)
-                validation = validate_node_index(arena, body_indices(i), "push_forall body")
+                validation = validate_node_index(arena, body_indices(i), &
+                                                 "push_forall body")
                 if (validation%is_failure()) then
-                    write (error_unit, '(A)') "ERROR [ast_factory_control]: " // validation%get_full_message()
+                    write (error_unit, '(A)') "ERROR [ast_factory_control]: " // &
+                        validation%get_full_message()
                     forall_index = 0
                     return
                 end if
@@ -508,12 +517,19 @@
                 call link_children_to_parent(arena, select_index, case_indices)
             end if
         end if
+
+        ! GCC 14 WORKAROUND: Explicitly deallocate local node components before
+        ! function returns to prevent buggy GCC-generated finalizer from crashing
+        ! See issue #2617 for details on GCC 14 finalizer bugs with extended types
+        if (allocated(select_node%case_indices)) deallocate (select_node%case_indices)
+        if (allocated(select_node%stmt_label)) deallocate (select_node%stmt_label)
     end function push_select_case
 
     ! Create select case node with default case and add to stack
     function push_select_case_with_default(arena, selector_index, case_indices, &
                                            default_index, &
-                                           line, column, parent_index) result(select_index)
+                                           line, column, parent_index) &
+        result(select_index)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in) :: selector_index
         integer, intent(in), optional :: case_indices(:)
@@ -559,6 +575,12 @@
         if (default_index > 0) then
             call link_children_to_parent(arena, select_index, [default_index])
         end if
+
+        ! GCC 14 WORKAROUND: Explicitly deallocate local node components before
+        ! function returns to prevent buggy GCC-generated finalizer from crashing
+        ! See issue #2617 for details on GCC 14 finalizer bugs with extended types
+        if (allocated(select_node%case_indices)) deallocate (select_node%case_indices)
+        if (allocated(select_node%stmt_label)) deallocate (select_node%stmt_label)
     end function push_select_case_with_default
 
     ! Create case block node and add to stack
@@ -600,6 +622,13 @@
                 call link_children_to_parent(arena, case_index, body_indices)
             end if
         end if
+
+        ! GCC 14 WORKAROUND: Explicitly deallocate local node components before
+        ! function returns to prevent buggy GCC-generated finalizer from crashing
+        ! See issue #2617 for details on GCC 14 finalizer bugs with extended types
+        if (allocated(case_node%value_indices)) deallocate (case_node%value_indices)
+        if (allocated(case_node%body_indices)) deallocate (case_node%body_indices)
+        if (allocated(case_node%stmt_label)) deallocate (case_node%stmt_label)
     end function push_case_block
 
     ! Create case range node and add to stack

--- a/src/ast/factory/ast_factory_procedures.f90
+++ b/src/ast/factory/ast_factory_procedures.f90
@@ -59,6 +59,19 @@ contains
                 call link_children_to_parent(arena, func_index, body_indices)
             end if
         end if
+
+        ! GCC 14 WORKAROUND: Explicitly deallocate local node components before
+        ! function returns to prevent buggy GCC-generated finalizer from crashing
+        ! See issue #2617 for details on GCC 14 finalizer bugs with extended types
+        if (allocated(func_def%name)) deallocate (func_def%name)
+        if (allocated(func_def%param_indices)) deallocate (func_def%param_indices)
+        if (allocated(func_def%return_type)) deallocate (func_def%return_type)
+        if (allocated(func_def%result_variable)) deallocate (func_def%result_variable)
+        if (allocated(func_def%prefix_keywords)) deallocate (func_def%prefix_keywords)
+        if (allocated(func_def%param_intents)) deallocate (func_def%param_intents)
+        if (allocated(func_def%body_indices)) deallocate (func_def%body_indices)
+        if (allocated(func_def%bind_c_clause)) deallocate (func_def%bind_c_clause)
+        if (allocated(func_def%stmt_label)) deallocate (func_def%stmt_label)
     end function push_function_def
 
     ! Create subroutine definition node and add to stack
@@ -114,6 +127,17 @@ contains
                 call link_children_to_parent(arena, sub_index, body_indices)
             end if
         end if
+
+        ! GCC 14 WORKAROUND: Explicitly deallocate local node components before
+        ! function returns to prevent buggy GCC-generated finalizer from crashing
+        ! See issue #2617 for details on GCC 14 finalizer bugs with extended types
+        if (allocated(sub_def%name)) deallocate (sub_def%name)
+        if (allocated(sub_def%param_indices)) deallocate (sub_def%param_indices)
+        if (allocated(sub_def%prefix_keywords)) deallocate (sub_def%prefix_keywords)
+        if (allocated(sub_def%param_intents)) deallocate (sub_def%param_intents)
+        if (allocated(sub_def%body_indices)) deallocate (sub_def%body_indices)
+        if (allocated(sub_def%bind_c_clause)) deallocate (sub_def%bind_c_clause)
+        if (allocated(sub_def%stmt_label)) deallocate (sub_def%stmt_label)
     end function push_subroutine_def
 
     ! Create interface block node and add to stack
@@ -206,6 +230,16 @@ contains
                 call link_children_to_parent(arena, module_index, body_indices)
             end if
         end if
+
+        ! GCC 14 WORKAROUND: Explicitly deallocate local node components before
+        ! function returns to prevent buggy GCC-generated finalizer from crashing
+        ! See issue #2617 for details on GCC 14 finalizer bugs with extended types
+        if (allocated(mod_node%name)) deallocate (mod_node%name)
+        if (allocated(mod_node%declaration_indices)) deallocate &
+            (mod_node%declaration_indices)
+        if (allocated(mod_node%procedure_indices)) deallocate &
+            (mod_node%procedure_indices)
+        if (allocated(mod_node%stmt_label)) deallocate (mod_node%stmt_label)
     end function push_module
 
     ! Create complete module node with declaration and procedure indices

--- a/test/ast/test_destructor_segfault.f90
+++ b/test/ast/test_destructor_segfault.f90
@@ -1,0 +1,205 @@
+program test_destructor_segfault
+    ! Test for issue #2617: Segfaults in AST node destructors
+    ! This test exercises AST node creation and cleanup patterns
+    ! that triggered segfaults in ffc when nodes went out of scope.
+    !
+    ! The issue manifests as SIGSEGV in GCC-generated finalizers when:
+    ! 1. Local AST node variables go out of scope in factory functions
+    ! 2. Arena entries are finalized during cleanup
+    !
+    ! This test validates that AST node lifecycle operations are safe.
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_factory_control, only: push_select_case, push_case_block
+    use ast_factory_procedures, only: push_module, push_function_def, &
+                                      push_subroutine_def
+    use ast_factory_core, only: push_literal, push_identifier, push_assignment
+    use ast_base, only: LITERAL_INTEGER
+    implicit none
+
+    integer :: pass_count, test_count
+
+    pass_count = 0
+    test_count = 0
+
+    print *, "=== AST Destructor Segfault Tests (Issue #2617) ==="
+    print *, ""
+
+    call test_case_block_lifecycle()
+    call test_module_node_lifecycle()
+    call test_select_case_with_cases()
+    call test_repeated_arena_operations()
+    call test_module_with_procedures()
+    call test_nested_scopes()
+
+    print *, ""
+    print *, "=== Summary ==="
+    write (*, '(A,I0,A,I0,A)') "Passed: ", pass_count, "/", test_count, " tests"
+
+    if (pass_count == test_count) then
+        print *, "All destructor tests passed!"
+        stop 0
+    else
+        print *, "Some tests failed!"
+        stop 1
+    end if
+
+contains
+
+    subroutine test_case_block_lifecycle()
+        ! Test case_block_node creation and cleanup
+        type(ast_arena_t) :: arena
+        integer :: case_idx, val_idx
+
+        call start_test("case_block_node lifecycle")
+
+        arena = create_ast_arena()
+        val_idx = push_literal(arena, "1", LITERAL_INTEGER, line=1, column=1)
+        case_idx = push_case_block(arena, [val_idx], line=1, column=1)
+
+        if (case_idx > 0) then
+            call pass_test()
+        else
+            call fail_test("Failed to create case_block_node")
+        end if
+        ! Arena goes out of scope here - tests finalization
+    end subroutine test_case_block_lifecycle
+
+    subroutine test_module_node_lifecycle()
+        ! Test module_node creation and cleanup
+        type(ast_arena_t) :: arena
+        integer :: mod_idx
+
+        call start_test("module_node lifecycle")
+
+        arena = create_ast_arena()
+        mod_idx = push_module(arena, "test_module", line=1, column=1)
+
+        if (mod_idx > 0) then
+            call pass_test()
+        else
+            call fail_test("Failed to create module_node")
+        end if
+        ! Arena goes out of scope here - tests finalization
+    end subroutine test_module_node_lifecycle
+
+    subroutine test_select_case_with_cases()
+        ! Test select_case with multiple case blocks
+        type(ast_arena_t) :: arena
+        integer :: sel_idx, case1_idx, case2_idx, expr_idx, val1_idx, val2_idx
+
+        call start_test("select_case with case blocks")
+
+        arena = create_ast_arena()
+        expr_idx = push_literal(arena, "42", LITERAL_INTEGER, line=1, column=1)
+        val1_idx = push_literal(arena, "1", LITERAL_INTEGER, line=2, column=1)
+        val2_idx = push_literal(arena, "2", LITERAL_INTEGER, line=3, column=1)
+        case1_idx = push_case_block(arena, [val1_idx], line=2, column=1)
+        case2_idx = push_case_block(arena, [val2_idx], line=3, column=1)
+        sel_idx = push_select_case(arena, expr_idx, [case1_idx, case2_idx], &
+                                   line=1, column=1)
+
+        if (sel_idx > 0 .and. case1_idx > 0 .and. case2_idx > 0) then
+            call pass_test()
+        else
+            call fail_test("Failed to create select_case construct")
+        end if
+        ! Arena goes out of scope here - tests finalization
+    end subroutine test_select_case_with_cases
+
+    subroutine test_repeated_arena_operations()
+        ! Test repeated arena creation/destruction
+        integer :: i
+
+        call start_test("repeated arena operations (10 iterations)")
+
+        do i = 1, 10
+            block
+                type(ast_arena_t) :: arena
+                integer :: idx
+                character(len=10) :: val_str
+                arena = create_ast_arena()
+                write (val_str, '(I0)') i
+                idx = push_literal(arena, trim(val_str), LITERAL_INTEGER, &
+                                   line=1, column=1)
+                idx = push_case_block(arena, [idx], line=1, column=1)
+                ! Arena finalized at end of block
+            end block
+        end do
+
+        call pass_test()
+    end subroutine test_repeated_arena_operations
+
+    subroutine test_module_with_procedures()
+        ! Test module with contained procedures (simulates ffc test_module_system)
+        type(ast_arena_t) :: arena
+        integer :: mod_idx, func_idx, sub_idx
+
+        call start_test("module with procedures")
+
+        arena = create_ast_arena()
+        func_idx = push_function_def(arena, "my_func", line=2, column=1)
+        sub_idx = push_subroutine_def(arena, "my_sub", line=5, column=1)
+        mod_idx = push_module(arena, "my_module", &
+                              body_indices=[func_idx, sub_idx], &
+                              line=1, column=1)
+
+        if (mod_idx > 0 .and. func_idx > 0 .and. sub_idx > 0) then
+            call pass_test()
+        else
+            call fail_test("Failed to create module with procedures")
+        end if
+        ! Arena goes out of scope here - tests finalization
+    end subroutine test_module_with_procedures
+
+    subroutine test_nested_scopes()
+        ! Test nested scope patterns (simulates complex AST structures)
+        integer :: i
+
+        call start_test("nested scopes (5 iterations)")
+
+        do i = 1, 5
+            block
+                type(ast_arena_t) :: outer_arena
+                integer :: outer_idx
+                outer_arena = create_ast_arena()
+                outer_idx = push_module(outer_arena, "outer_mod", line=1, column=1)
+                block
+                    type(ast_arena_t) :: inner_arena
+                    integer :: inner_idx, case_idx, val_idx
+                    inner_arena = create_ast_arena()
+                    val_idx = push_literal(inner_arena, "1", LITERAL_INTEGER, &
+                                           line=1, column=1)
+                    case_idx = push_case_block(inner_arena, [val_idx], &
+                                               line=1, column=1)
+                    inner_idx = push_module(inner_arena, "inner_mod", line=1, column=1)
+                    ! Inner arena finalized here
+                end block
+                ! Outer arena still valid here
+                if (outer_idx <= 0) then
+                    call fail_test("Nested scope test failed")
+                    return
+                end if
+                ! Outer arena finalized here
+            end block
+        end do
+
+        call pass_test()
+    end subroutine test_nested_scopes
+
+    subroutine start_test(name)
+        character(len=*), intent(in) :: name
+        test_count = test_count + 1
+        write (*, '(A,": ")', advance='no') name
+    end subroutine start_test
+
+    subroutine pass_test()
+        print *, "PASS"
+        pass_count = pass_count + 1
+    end subroutine pass_test
+
+    subroutine fail_test(reason)
+        character(len=*), intent(in) :: reason
+        write (*, '(A,": ",A)') "FAIL", reason
+    end subroutine fail_test
+
+end program test_destructor_segfault


### PR DESCRIPTION
## Summary

- Add GCC 14 workaround for AST node destructor segfaults in factory functions
- Explicitly deallocate local node components before function returns to prevent buggy GCC-generated finalizers from crashing
- Add regression test (test_destructor_segfault.f90) covering AST node lifecycle patterns

## Root Cause

GCC 14 generates incorrect finalizers for derived types that extend types with allocatable components. When local AST node variables go out of scope in factory functions like `push_module`, `push_case_block`, etc., the GCC-generated finalizer crashes with SIGSEGV when trying to free memory.

This issue does not occur on GCC 15.2.1, suggesting it is a GCC 14-specific bug.

## Fix Approach

The fix explicitly deallocates all allocatable components of local AST node variables before the function returns:

```fortran
! GCC 14 WORKAROUND: Explicitly deallocate local node components before
! function returns to prevent buggy GCC-generated finalizer from crashing
! See issue #2617 for details on GCC 14 finalizer bugs with extended types
if (allocated(mod_node%name)) deallocate (mod_node%name)
if (allocated(mod_node%declaration_indices)) deallocate (mod_node%declaration_indices)
...
```

This prevents the GCC finalizer from attempting to deallocate the components, avoiding the crash.

## Affected Functions

- `push_module` (module_node)
- `push_function_def` (function_def_node)
- `push_subroutine_def` (subroutine_def_node)
- `push_select_case` (select_case_node)
- `push_select_case_with_default` (select_case_node)
- `push_case_block` (case_block_node)

## Verification

```
$ fpm test test_destructor_segfault
=== AST Destructor Segfault Tests (Issue #2617) ===

case_block_node lifecycle:  PASS
module_node lifecycle:  PASS
select_case with case blocks:  PASS
repeated arena operations (10 iterations):  PASS
module with procedures:  PASS
nested scopes (5 iterations):  PASS

=== Summary ===
Passed: 6/6 tests
All destructor tests passed!

$ fpm test 2>&1 | tail -10
# All tests pass
```

## Test Plan

- [x] All existing tests pass
- [x] New regression test `test_destructor_segfault.f90` covers:
  - case_block_node lifecycle
  - module_node lifecycle
  - select_case with case blocks
  - Repeated arena operations (10 iterations)
  - Module with procedures
  - Nested scopes (5 iterations)
- [ ] CI passes with GCC 14 (this is the key verification)
