### PR TITLE
fix: remove unused imports in symbol_table_api (fixes #2616)

### DIFF
--- a/src/semantic/symbol_table_api.f90
+++ b/src/semantic/symbol_table_api.f90
@@ -1,14 +1,10 @@
 module symbol_table_api
     ! Symbol Table Query API for external tools (fluff, LSP, etc.)
     ! Provides functions to query symbols from semantic_context_t
-    use, intrinsic :: iso_fortran_env, only: error_unit
     use fortfront_types, only: symbol_info_t, scope_info_t
-    use type_system_unified, only: mono_type_t, poly_type_t, TVAR
-    use scope_manager, only: scope_stack_t, scope_t, SCOPE_GLOBAL, SCOPE_MODULE, &
-                             SCOPE_FUNCTION, SCOPE_SUBROUTINE, SCOPE_BLOCK, &
-                             SCOPE_INTERFACE
-    use identifier_table, only: identifier_table_t, identifier_table_get, &
-                                identifier_id_kind
+    use type_system_unified, only: mono_type_t, poly_type_t
+    use scope_manager, only: scope_stack_t, scope_t
+    use identifier_table, only: identifier_table_get
     implicit none
     private
 


### PR DESCRIPTION
## Summary
Remove unused imports from `src/semantic/symbol_table_api.f90` to comply with minimal import principle.

### Removed Imports
- `error_unit` from `iso_fortran_env` - imported but never used
- `TVAR` from `type_system_unified` - imported but never used
- `identifier_table_t` and `identifier_id_kind` from `identifier_table` - imported but only `identifier_table_get` is used
- `SCOPE_GLOBAL`, `SCOPE_MODULE`, `SCOPE_FUNCTION`, `SCOPE_SUBROUTINE`, `SCOPE_BLOCK`, `SCOPE_INTERFACE` from `scope_manager` - imported but only `scope_stack_t` and `scope_t` are used

## Verification
```
fpm build  # SUCCESS
fpm test   # 719 PASS, 0 FAIL
```

## Test Plan
- [x] Build passes
- [x] All 719 tests pass
- [x] No regressions introduced