### PR TITLE
fix: add select rank/type handlers to dispatcher (fixes #2238)

### DIFF
--- a/src/analysis/variable_usage_dispatcher.f90
+++ b/src/analysis/variable_usage_dispatcher.f90
@@ -31,6 +31,8 @@ module variable_usage_dispatcher_module
     public :: process_array_slice_children, process_component_access_children
     public :: process_assignment_node_children, process_program_node_children
     public :: process_literal_node_children, process_procedure_def_body
+    public :: process_select_rank_node_children, process_rank_block_node_children
+    public :: process_select_type_node_children, process_type_guard_block_node_children
 
     ! Public interface for recursive collection
     public :: collect_identifiers_recursive
@@ -168,6 +170,14 @@ contains
             call process_do_while_node_children(arena, node_index, info, ctx)
         case ("select_case")
             call process_select_case_node_children(arena, node_index, info, ctx)
+        case ("select_rank")
+            call process_select_rank_node_children(arena, node_index, info, ctx)
+        case ("rank_block")
+            call process_rank_block_node_children(arena, node_index, info, ctx)
+        case ("select_type")
+            call process_select_type_node_children(arena, node_index, info, ctx)
+        case ("type_guard_block")
+            call process_type_guard_block_node_children(arena, node_index, info, ctx)
         case ("where")
             call process_where_node_children(arena, node_index, info, ctx)
         case ("where_stmt")
@@ -307,6 +317,105 @@ contains
             call push_node(ctx, node%default_index)
         end select
     end subroutine process_select_case_node_children
+
+    ! Process select rank node children
+    subroutine process_select_rank_node_children(arena, node_index, info, ctx)
+        use ast_nodes_conditional, only: select_rank_node
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(variable_usage_info_t), intent(inout) :: info
+        type(traversal_context_t), intent(inout) :: ctx
+
+        integer :: i
+
+        select type (node => arena%entries(node_index)%node)
+        type is (select_rank_node)
+            ! Process selector expression
+            call push_node(ctx, node%selector_index)
+
+            ! Process rank blocks
+            if (allocated(node%rank_indices)) then
+                do i = 1, size(node%rank_indices)
+                    call push_node(ctx, node%rank_indices(i))
+                end do
+            end if
+
+            ! Process default rank
+            call push_node(ctx, node%default_index)
+        end select
+    end subroutine process_select_rank_node_children
+
+    ! Process rank block node children
+    subroutine process_rank_block_node_children(arena, node_index, info, ctx)
+        use ast_nodes_conditional, only: rank_block_node
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(variable_usage_info_t), intent(inout) :: info
+        type(traversal_context_t), intent(inout) :: ctx
+
+        integer :: i
+
+        select type (node => arena%entries(node_index)%node)
+        type is (rank_block_node)
+            ! Process rank body statements
+            if (allocated(node%body_indices)) then
+                do i = 1, size(node%body_indices)
+                    call push_node(ctx, node%body_indices(i))
+                end do
+            end if
+        end select
+    end subroutine process_rank_block_node_children
+
+    ! Process select type node children
+    subroutine process_select_type_node_children(arena, node_index, info, ctx)
+        use ast_nodes_conditional, only: select_type_node
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(variable_usage_info_t), intent(inout) :: info
+        type(traversal_context_t), intent(inout) :: ctx
+
+        integer :: i
+
+        select type (node => arena%entries(node_index)%node)
+        type is (select_type_node)
+            ! Process selector expression
+            call push_node(ctx, node%selector_index)
+
+            ! Process type guard blocks
+            if (allocated(node%guard_indices)) then
+                do i = 1, size(node%guard_indices)
+                    call push_node(ctx, node%guard_indices(i))
+                end do
+            end if
+
+            ! Process default guard
+            call push_node(ctx, node%default_index)
+        end select
+    end subroutine process_select_type_node_children
+
+    ! Process type guard block node children
+    subroutine process_type_guard_block_node_children(arena, node_index, info, ctx)
+        use ast_nodes_conditional, only: type_guard_block_node
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(variable_usage_info_t), intent(inout) :: info
+        type(traversal_context_t), intent(inout) :: ctx
+
+        integer :: i
+
+        select type (node => arena%entries(node_index)%node)
+        type is (type_guard_block_node)
+            ! Process type name if present
+            call push_node(ctx, node%type_name_index)
+
+            ! Process guard body statements
+            if (allocated(node%body_indices)) then
+                do i = 1, size(node%body_indices)
+                    call push_node(ctx, node%body_indices(i))
+                end do
+            end if
+        end select
+    end subroutine process_type_guard_block_node_children
 
     ! Process where node children
     subroutine process_where_node_children(arena, node_index, info, ctx)


### PR DESCRIPTION
## Summary

The variable usage dispatcher was missing handlers for `select_rank`, `rank_block`, `select_type`, and `type_guard_block` AST nodes. When these nodes were encountered during AST traversal, their children were not being pushed to the traversal stack, causing the semantic analysis phase to either miss variable references inside these constructs or hang when processing large programs with select rank/type in loops.

## Changes

Added four new handler subroutines to `src/analysis/variable_usage_dispatcher.f90`:

- `process_select_rank_node_children`: traverses selector expression and rank blocks
- `process_rank_block_node_children`: traverses rank block body statements
- `process_select_type_node_children`: traverses selector expression and type guard blocks
- `process_type_guard_block_node_children`: traverses guard body statements

Added corresponding dispatch cases for `"select_rank"`, `"rank_block"`, `"select_type"`, and `"type_guard_block"` node types.

## Verification

**Reproducer from issue #2238:**
```fortran
program rank_pool
  implicit none
  integer, parameter :: n = 60000
  type :: box
    integer :: value
  end type
  type(box), parameter :: preset(*) = [(box(i), i=1,n)]
  class(*), allocatable :: payload(:)
  integer :: i
  do i = 1, 50
    call populate(payload)
    if (.not. allocated(payload)) stop 1
  end do
contains
  subroutine populate(target)
    class(*), allocatable, intent(out) :: target(..)
    select rank(target)
    rank(1)
      target = preset
    rank default
      stop 2
    end select
  end subroutine populate
end program rank_pool
```

**Before fix:** Hangs for 80+ seconds
**After fix:** Completes in <1 second

```bash
$ timeout 10 ./build/gfortran_*/app/fortfront /tmp/rank_pool.f90 > /tmp/out.f90
$ echo $?
0
```

All existing tests pass.