### PR TITLE
polish: enforce 88-column line limit (fixes #2585)

### DIFF
--- a/src/analysis/call_graph_builder_mod.f90
+++ b/src/analysis/call_graph_builder_mod.f90
@@ -127,7 +127,8 @@ contains
             call handle_program_node(builder, arena, node_idx, stack, top, &
                                      capacity, children)
         case ('function_def', 'function', 'subroutine_def', 'subroutine')
-            call handle_procedure_node(builder, arena, node_idx, scope_sym, stack, top, &
+            call handle_procedure_node(builder, arena, node_idx, scope_sym, &
+                                       stack, top, &
                                        capacity, children)
         case ('subroutine_call', 'call')
             call handle_call_node(builder, arena, node_idx, scope_sym)

--- a/src/analysis/call_graph_signatures_mod.f90
+++ b/src/analysis/call_graph_signatures_mod.f90
@@ -98,8 +98,8 @@ contains
     end function signature_exists
 
     subroutine add_signature(map, proc_name, param_kinds, return_kind, &
-                            call_site_node, line, column, param_type_strings, &
-                            return_type_string)
+                             call_site_node, line, column, param_type_strings, &
+                             return_type_string)
         type(signatures_map_t), intent(inout) :: map
         character(len=*), intent(in) :: proc_name
         integer, intent(in) :: param_kinds(:)
@@ -129,7 +129,7 @@ contains
             end do
             if (max_len < 1) max_len = 1
             allocate (character(len=max_len) :: new_sig%param_type_strings( &
-                size(param_type_strings)))
+                      size(param_type_strings)))
             do i = 1, size(param_type_strings)
                 new_sig%param_type_strings(i) = trim(param_type_strings(i))
             end do
@@ -138,7 +138,7 @@ contains
         if (present(return_type_string)) then
             if (len_trim(return_type_string) > 0) then
                 allocate (character(len=len_trim(return_type_string)) :: &
-                    new_sig%return_type_string)
+                          new_sig%return_type_string)
                 new_sig%return_type_string = trim(return_type_string)
             end if
         end if
@@ -169,13 +169,13 @@ contains
             map%proc_sigs(proc_idx)%procedure_name = proc_name
             map%proc_sigs(proc_idx)%sig_capacity = 4
             allocate (map%proc_sigs(proc_idx)%signatures( &
-                map%proc_sigs(proc_idx)%sig_capacity))
+                      map%proc_sigs(proc_idx)%sig_capacity))
             map%proc_sigs(proc_idx)%sig_count = 0
         end if
 
         if (allocated(map%proc_sigs(proc_idx)%signatures)) then
             if (signature_exists(map%proc_sigs(proc_idx)%signatures( &
-                1:map%proc_sigs(proc_idx)%sig_count), new_sig)) then
+                                 1:map%proc_sigs(proc_idx)%sig_count), new_sig)) then
                 return
             end if
         end if
@@ -183,8 +183,8 @@ contains
         if (map%proc_sigs(proc_idx)%sig_count >= &
             map%proc_sigs(proc_idx)%sig_capacity) then
             map%proc_sigs(proc_idx)%sig_capacity = max( &
-                map%proc_sigs(proc_idx)%sig_capacity * 2, &
-                map%proc_sigs(proc_idx)%sig_capacity + 4, 4)
+                                             map%proc_sigs(proc_idx)%sig_capacity * 2, &
+                                            map%proc_sigs(proc_idx)%sig_capacity + 4, 4)
             allocate (temp_sigs(map%proc_sigs(proc_idx)%sig_capacity))
             if (map%proc_sigs(proc_idx)%sig_count > 0) then
                 do i = 1, map%proc_sigs(proc_idx)%sig_count
@@ -199,8 +199,8 @@ contains
     end subroutine add_signature
 
     subroutine signatures_map_add_signature(this, proc_name, param_kinds, &
-                                           return_kind, call_site_node, line, column, &
-                                           param_type_strings, return_type_string)
+                                            return_kind, call_site_node, line, column, &
+                                            param_type_strings, return_type_string)
         class(signatures_map_t), intent(inout) :: this
         character(len=*), intent(in) :: proc_name
         integer, intent(in) :: param_kinds(:)
@@ -211,8 +211,8 @@ contains
         character(len=*), intent(in), optional :: return_type_string
 
         call add_signature(this, proc_name, param_kinds, return_kind, &
-                          call_site_node, line, column, param_type_strings, &
-                          return_type_string)
+                           call_site_node, line, column, param_type_strings, &
+                           return_type_string)
     end subroutine signatures_map_add_signature
 
     function get_unique_signatures(map, proc_name, unique_sigs) result(count)
@@ -278,11 +278,11 @@ contains
 
                 if (allocated(src%proc_sigs(i)%signatures)) then
                     allocate (dst%proc_sigs(i)%signatures( &
-                        dst%proc_sigs(i)%sig_capacity))
+                              dst%proc_sigs(i)%sig_capacity))
                     do j = 1, dst%proc_sigs(i)%sig_count
                         if (allocated(src%proc_sigs(i)%signatures(j)%param_kinds)) then
                             allocate (dst%proc_sigs(i)%signatures(j)%param_kinds( &
-                                size(src%proc_sigs(i)%signatures(j)%param_kinds)))
+                                      size(src%proc_sigs(i)%signatures(j)%param_kinds)))
                             dst%proc_sigs(i)%signatures(j)%param_kinds = &
                                 src%proc_sigs(i)%signatures(j)%param_kinds
                         end if
@@ -294,26 +294,26 @@ contains
                             src%proc_sigs(i)%signatures(j)%line
                         dst%proc_sigs(i)%signatures(j)%column = &
                             src%proc_sigs(i)%signatures(j)%column
-                        if (allocated(src%proc_sigs(i)%signatures(j)%param_type_strings)) then
+                  if (allocated(src%proc_sigs(i)%signatures(j)%param_type_strings)) then
                             max_len = 0
-                            do k = 1, size(src%proc_sigs(i)%signatures(j)%param_type_strings)
+                       do k = 1, size(src%proc_sigs(i)%signatures(j)%param_type_strings)
                                 max_len = max(max_len, len_trim( &
-                                    src%proc_sigs(i)%signatures(j)%param_type_strings(k)))
+                                  src%proc_sigs(i)%signatures(j)%param_type_strings(k)))
                             end do
                             if (max_len < 1) max_len = 1
                             allocate (character(len=max_len) :: &
-                                dst%proc_sigs(i)%signatures(j)%param_type_strings( &
-                                size(src%proc_sigs(i)%signatures(j)%param_type_strings)))
-                            do k = 1, size(src%proc_sigs(i)%signatures(j)%param_type_strings)
+                                    dst%proc_sigs(i)%signatures(j)%param_type_strings( &
+                               size(src%proc_sigs(i)%signatures(j)%param_type_strings)))
+                       do k = 1, size(src%proc_sigs(i)%signatures(j)%param_type_strings)
                                 dst%proc_sigs(i)%signatures(j)%param_type_strings(k) = &
-                                    trim(src%proc_sigs(i)%signatures(j)%param_type_strings(k))
+                              trim(src%proc_sigs(i)%signatures(j)%param_type_strings(k))
                             end do
                         end if
-                        if (allocated(src%proc_sigs(i)%signatures(j)%return_type_string)) then
-                            max_len = len_trim(src%proc_sigs(i)%signatures(j)%return_type_string)
+                  if (allocated(src%proc_sigs(i)%signatures(j)%return_type_string)) then
+                   max_len = len_trim(src%proc_sigs(i)%signatures(j)%return_type_string)
                             if (max_len < 1) max_len = 1
                             allocate (character(len=max_len) :: &
-                                dst%proc_sigs(i)%signatures(j)%return_type_string)
+                                      dst%proc_sigs(i)%signatures(j)%return_type_string)
                             dst%proc_sigs(i)%signatures(j)%return_type_string = &
                                 trim(src%proc_sigs(i)%signatures(j)%return_type_string)
                         end if

--- a/src/analysis/variable_usage_core.f90
+++ b/src/analysis/variable_usage_core.f90
@@ -111,7 +111,8 @@ contains
                     integer :: n
 
                     n = size(info%variable_names)
-                    allocate(character(len=max(len(info%variable_names), len(var_name))) :: temp_names(n+1))
+                    allocate (character(len=max(len(info%variable_names), &
+                                                len(var_name))) :: temp_names(n + 1))
                     allocate (temp_counts(n + 1))
                     allocate (temp_indices(n + 1))
 
@@ -154,7 +155,8 @@ contains
 
         ! Deep copy allocatable arrays
         if (allocated(rhs%variable_names)) then
-            allocate(character(len(rhs%variable_names)) :: lhs%variable_names(size(rhs%variable_names)))
+            allocate (character(len(rhs%variable_names)) :: &
+                      lhs%variable_names(size(rhs%variable_names)))
             lhs%variable_names = rhs%variable_names
         end if
 

--- a/src/ast/arena/ast_arena_compat.f90
+++ b/src/ast/arena/ast_arena_compat.f90
@@ -149,7 +149,8 @@ contains
     end function ast_arena_get_next_sibling_compat
 
     ! Compatibility method: get previous sibling
-    function ast_arena_get_previous_sibling_compat(this, node_index) result(prev_sibling)
+    function ast_arena_get_previous_sibling_compat(this, node_index) &
+        result(prev_sibling)
         class(ast_arena_compat_t), intent(in) :: this
         integer, intent(in) :: node_index
         integer :: prev_sibling
@@ -175,7 +176,8 @@ contains
     end function ast_arena_get_previous_sibling_compat
 
     ! Compatibility method: get block statements
-    function ast_arena_get_block_statements_compat(this, block_index) result(stmt_indices)
+    function ast_arena_get_block_statements_compat(this, block_index) &
+        result(stmt_indices)
         class(ast_arena_compat_t), intent(in) :: this
         integer, intent(in) :: block_index
         integer, allocatable :: stmt_indices(:)
@@ -283,7 +285,7 @@ contains
         this%compat_size = this%compat_size + 1
 
         ! Store in compatibility entries array (safe allocation with minimal checking)
-        ! Note: For newly grown entries, node will never be allocated, but we check for safety
+  ! Note: For newly grown entries, node will never be allocated, but we check for safety
         if (allocated(this%entries(this%compat_size)%node)) then
             deallocate (this%entries(this%compat_size)%node)
         end if
@@ -300,7 +302,8 @@ contains
         if (present(parent_index)) then
             this%entries(this%compat_size)%parent_index = parent_index
             if (parent_index > 0 .and. parent_index <= this%compat_size) then
-                this%entries(this%compat_size)%depth = this%entries(parent_index)%depth + 1
+                this%entries(this%compat_size)%depth = &
+                    this%entries(parent_index)%depth + 1
 
                 ! Add this child to parent's children list
                 call add_child_compat(this, parent_index, this%compat_size)
@@ -338,10 +341,11 @@ contains
             ! Only reallocate when we exceed capacity
             if (new_count > size(arena%entries(parent_index)%child_indices)) then
                 ! Double the capacity for amortized O(1) performance
-                allocate (temp_children(size(arena%entries(parent_index)%child_indices) * 2))
+           allocate (temp_children(size(arena%entries(parent_index)%child_indices) * 2))
                 temp_children(1:arena%entries(parent_index)%child_count) = &
-                    arena%entries(parent_index)%child_indices(1:arena%entries(parent_index)%child_count)
-                call move_alloc(temp_children, arena%entries(parent_index)%child_indices)
+    arena%entries(parent_index)%child_indices(1:arena%entries(parent_index)%child_count)
+                call move_alloc(temp_children, &
+                                arena%entries(parent_index)%child_indices)
             end if
 
             ! Add new child at the end

--- a/src/ast/arena/ast_arena_core.f90
+++ b/src/ast/arena/ast_arena_core.f90
@@ -437,7 +437,8 @@ contains
         end if
 
         ! Free the node by incrementing its slot generation (invalidates old handles)
-        this%slot_gen(handle%node_id) = this%slot_gen(handle%node_id) + 1  ! Invalidate old handles
+        this%slot_gen(handle%node_id) = this%slot_gen(handle%node_id) + 1
+        ! Invalidate old handles
         free_result%freed_generation = handle%generation
 
         ! Add slot to free list for reuse

--- a/src/ast/arena/ast_arena_modern.f90
+++ b/src/ast/arena/ast_arena_modern.f90
@@ -59,8 +59,9 @@ contains
         ! Create compatibility layer with explicit capacity
         arena%ast_arena_compat_t = create_ast_arena_compat(capacity)
 
-        ! CRITICAL FIX: Manually set capacity field to ensure it's available at the ast_arena_t level
-        ! This is needed because the parent assignment may not properly propagate all base fields
+        ! CRITICAL FIX: Manually set capacity field to ensure its available
+        ! at the ast_arena_t level. This is needed because the parent
+        ! assignment may not properly propagate all base fields.
         arena%capacity = capacity
         arena%size = 0  ! Initialize size from base_arena_t
         arena%generation = 1  ! Initialize generation from base_arena_t

--- a/src/ast/arena/ast_arena_safe.f90
+++ b/src/ast/arena/ast_arena_safe.f90
@@ -227,7 +227,8 @@ contains
         class(ast_node), intent(in) :: node
         integer, intent(in) :: index
 
-        write (error_unit, *) "ERROR: Unknown AST node type - creating error placeholder"
+        write (error_unit, *) &
+            "ERROR: Unknown AST node type - creating error placeholder"
         allocate (error_node_t :: arena%entries(index)%node)
         select type (error_node => arena%entries(index)%node)
         type is (error_node_t)

--- a/src/ast/factory/ast_factory_arrays.f90
+++ b/src/ast/factory/ast_factory_arrays.f90
@@ -1,7 +1,8 @@
 module ast_factory_arrays
     use ast_arena_modern, only: ast_arena_t, link_children_to_parent
     use ast_nodes_core, only: call_or_subscript_node
-    use ast_nodes_bounds, only: array_bounds_node, array_slice_node, range_expression_node
+    use ast_nodes_bounds, only: array_bounds_node, array_slice_node, &
+                                range_expression_node
     use ast_factory_core, only: push_literal
     use ast_base, only: LITERAL_INTEGER
     use uid_generator, only: generate_uid
@@ -31,8 +32,10 @@ contains
         end_str = int_to_string(end_idx)
 
         ! Create start and end index literals
-        start_literal_idx = push_literal(arena, trim(start_str), LITERAL_INTEGER, line, column)
-        end_literal_idx = push_literal(arena, trim(end_str), LITERAL_INTEGER, line, column)
+        start_literal_idx = push_literal(arena, trim(start_str), LITERAL_INTEGER, &
+                                         line, column)
+        end_literal_idx = push_literal(arena, trim(end_str), LITERAL_INTEGER, &
+                                       line, column)
 
         ! Create subscript node with array section range
         section%uid = generate_uid()

--- a/src/ast/factory/ast_factory_declarations.f90
+++ b/src/ast/factory/ast_factory_declarations.f90
@@ -59,7 +59,8 @@ contains
         end if
     end subroutine assign_dimension_metadata
 
-    pure logical function resolve_optional_flag(optional_value, default_value) result(flag)
+    pure logical function resolve_optional_flag(optional_value, default_value) &
+        result(flag)
         logical, intent(in), optional :: optional_value
         logical, intent(in) :: default_value
 
@@ -288,7 +289,8 @@ contains
     function push_parameter_declaration(arena, name, type_name, kind_value, &
                                         intent_value, is_optional, is_target, &
                                         dimension_indices, line, column, &
-                                        parent_index, character_length_expr) result(param_index)
+                                        parent_index, character_length_expr) &
+        result(param_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: name, type_name
         integer, intent(in), optional :: kind_value, intent_value

--- a/src/ast/factory/ast_factory_expressions.f90
+++ b/src/ast/factory/ast_factory_expressions.f90
@@ -78,8 +78,10 @@ contains
 
     ! Create call or subscript with array slice detection
     function push_call_or_subscript_with_slice_detection(arena, name, &
-            arg_indices, line, column, parent_index, base_expr_index) &
-            result(node_index)
+                                                         arg_indices, line, column, &
+                                                             parent_index, &
+                                                             base_expr_index) &
+        result(node_index)
         use ast_factory_arrays, only: push_array_slice
         use ast_factory_core, only: push_identifier
         type(ast_arena_t), intent(inout) :: arena
@@ -112,12 +114,14 @@ contains
                 array_name_index = push_identifier(arena, name, line, column, &
                                                    parent_index)
                 node_index = push_array_slice(arena, array_name_index, &
-                                              arg_indices, size(arg_indices), line, column, parent_index)
+                                              arg_indices, size(arg_indices), line, &
+                                              column, parent_index)
             end block
         else
             ! Regular function call or array indexing
             node_index = push_call_or_subscript(arena, name, arg_indices, &
-                                                line, column, parent_index, base_expr_index)
+                                                line, column, parent_index, &
+                                                base_expr_index)
         end if
     end function push_call_or_subscript_with_slice_detection
 
@@ -146,11 +150,13 @@ contains
                     case ('identifier')
                         indices(i) = push_identifier(arena, node_name, i, 1)
                     case ('literal_int')
-                        indices(i) = push_literal(arena, node_name, LITERAL_INTEGER, i, 1)
+                        indices(i) = push_literal(arena, node_name, &
+                                                  LITERAL_INTEGER, i, 1)
                     case ('literal_real')
                         indices(i) = push_literal(arena, node_name, LITERAL_REAL, i, 1)
                     case ('literal_string')
-                        indices(i) = push_literal(arena, node_name, LITERAL_STRING, i, 1)
+                        indices(i) = push_literal(arena, node_name, &
+                                                  LITERAL_STRING, i, 1)
                     case default
                         indices(i) = push_identifier(arena, node_name, i, 1)
                     end select

--- a/src/ast/factory/ast_factory_io.f90
+++ b/src/ast/factory/ast_factory_io.f90
@@ -136,8 +136,10 @@ contains
     end function push_read_statement
 
     ! Extended I/O statement functions with iostat/err/end specifiers
-    function push_write_statement_with_iostat(arena, unit_spec, arg_indices, format_spec, &
-                                              iostat_var, line, column, parent_index) result(write_index)
+    function push_write_statement_with_iostat(arena, unit_spec, arg_indices, &
+                                              format_spec, &
+                                              iostat_var, line, column, parent_index) &
+        result(write_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec, format_spec
         integer, intent(in) :: arg_indices(:), iostat_var
@@ -158,7 +160,8 @@ contains
     end function push_write_statement_with_iostat
 
     function push_read_statement_with_err(arena, unit_spec, var_indices, format_spec, &
-                                          err_label, line, column, parent_index) result(read_index)
+                                          err_label, line, column, parent_index) &
+        result(read_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec, format_spec
         integer, intent(in) :: var_indices(:), err_label
@@ -179,7 +182,8 @@ contains
     end function push_read_statement_with_err
 
     function push_read_statement_with_end(arena, unit_spec, var_indices, format_spec, &
-                                          end_label, line, column, parent_index) result(read_index)
+                                          end_label, line, column, parent_index) &
+        result(read_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec, format_spec
         integer, intent(in) :: var_indices(:), end_label
@@ -202,7 +206,8 @@ contains
     function push_read_statement_with_all_specifiers(arena, unit_spec, &
                                                      var_indices, format_spec, &
                                                      iostat_var, err_label, end_label, &
-                                                     line, column, parent_index) result(read_index)
+                                                     line, column, parent_index) &
+        result(read_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec, format_spec
         integer, intent(in) :: var_indices(:), iostat_var, err_label, end_label
@@ -225,8 +230,10 @@ contains
     end function push_read_statement_with_all_specifiers
 
     ! Format descriptor support functions
-    function push_write_statement_with_format(arena, unit_spec, arg_indices, format_spec, &
-                                              line, column, parent_index) result(write_index)
+    function push_write_statement_with_format(arena, unit_spec, arg_indices, &
+                                              format_spec, &
+                                              line, column, parent_index) &
+        result(write_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec, format_spec
         integer, intent(in) :: arg_indices(:)
@@ -248,7 +255,8 @@ contains
 
     function push_write_statement_with_runtime_format(arena, unit_spec, &
                                                       arg_indices, format_var, &
-                                                      line, column, parent_index) result(write_index)
+                                                      line, column, parent_index) &
+        result(write_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec
         integer, intent(in) :: arg_indices(:), format_var
@@ -269,7 +277,7 @@ contains
     end function push_write_statement_with_runtime_format
 
     function push_format_statement(arena, format_spec, line, column, &
-                                    parent_index) result(format_index)
+                                   parent_index) result(format_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: format_spec
         integer, intent(in), optional :: line, column, parent_index

--- a/src/ast/nodes/ast_nodes_conditional.f90
+++ b/src/ast/nodes/ast_nodes_conditional.f90
@@ -34,7 +34,8 @@ module ast_nodes_conditional
     type, extends(ast_node) :: if_node
         integer :: condition_index = 0  ! If condition arena index
         integer, allocatable :: then_body_indices(:)  ! Then body arena indices
-        type(elseif_wrapper_t), allocatable :: elseif_blocks(:)  ! Elseif blocks (optional)
+        type(elseif_wrapper_t), allocatable :: elseif_blocks(:)
+        ! Elseif blocks (optional)
         integer, allocatable :: else_body_indices(:)  ! Else body arena indices &
         ! (optional)
     contains

--- a/src/ast/nodes/ast_nodes_data.f90
+++ b/src/ast/nodes/ast_nodes_data.f90
@@ -37,8 +37,10 @@ module ast_nodes_data
         integer :: kind_value = 0  ! Kind parameter (default none)
         ! (e.g., 8 for real(8))
         logical :: has_kind = .false.  ! Whether kind was specified
-        character(len=:), allocatable :: character_length_expr  ! Character length expression
-        logical :: has_character_length = .false.  ! Whether character length was specified
+        character(len=:), allocatable :: character_length_expr
+        ! Character length expression
+        logical :: has_character_length = .false.
+        ! Whether character length was specified
         character(len=:), allocatable :: intent  ! in, out, inout (for parameters)
         logical :: has_intent = .false.  ! Whether intent was specified
         logical :: is_optional = .false.  ! Whether optional attribute is present
@@ -83,8 +85,10 @@ module ast_nodes_data
         integer :: kind_value = 0  ! Kind parameter (default none)
         ! (e.g., 8 for real(8))
         logical :: has_kind = .false.  ! Whether kind was specified
-        character(len=:), allocatable :: character_length_expr  ! Character length expression
-        logical :: has_character_length = .false.  ! Whether character length was specified
+        character(len=:), allocatable :: character_length_expr
+        ! Character length expression
+        logical :: has_character_length = .false.
+        ! Whether character length was specified
         integer :: intent_type = INTENT_NONE  ! INTENT_IN/OUT/INOUT
         logical :: is_optional = .false.  ! Whether parameter is optional
         logical :: is_target = .false.  ! Whether target attribute is present
@@ -185,7 +189,8 @@ module ast_nodes_data
     ! Mixed construct container node (for Issue #511 mixed construct support)
     type, extends(ast_node), public :: mixed_construct_container_node
         character(len=:), allocatable :: module_name  ! Generated module name
-        integer, allocatable :: implicit_declaration_indices(:)  ! Declarations for module
+        integer, allocatable :: implicit_declaration_indices(:)
+        ! Declarations for module
         integer, allocatable :: explicit_program_indices(:)  ! Explicit program units
     contains
         procedure :: accept => mixed_construct_container_accept

--- a/src/ast/traversal/ast_traversal.f90
+++ b/src/ast/traversal/ast_traversal.f90
@@ -29,7 +29,7 @@ module ast_traversal
 contains
 
     subroutine traverse_procedure_def_indices(arena, param_indices, body_indices, &
-                                               visitor, is_preorder)
+                                              visitor, is_preorder)
         type(ast_arena_t), intent(in) :: arena
         integer, allocatable, intent(in) :: param_indices(:), body_indices(:)
         class(ast_visitor_t), intent(inout) :: visitor
@@ -248,7 +248,8 @@ contains
 
         type is (if_node)
             call append_index(node%condition_index)
-            if (allocated(node%then_body_indices)) call append_array(node%then_body_indices)
+            if (allocated(node%then_body_indices)) call &
+                append_array(node%then_body_indices)
             if (allocated(node%elseif_blocks)) then
                 block
                     integer :: i, j
@@ -262,7 +263,8 @@ contains
                     end do
                 end block
             end if
-            if (allocated(node%else_body_indices)) call append_array(node%else_body_indices)
+            if (allocated(node%else_body_indices)) call &
+                append_array(node%else_body_indices)
 
         type is (do_loop_node)
             call append_index(node%start_expr_index)
@@ -280,17 +282,22 @@ contains
             call append_index(node%default_index)
 
         type is (module_node)
-            if (allocated(node%declaration_indices)) call append_array(node%declaration_indices)
-            if (allocated(node%procedure_indices)) call append_array(node%procedure_indices)
+            if (allocated(node%declaration_indices)) call &
+                append_array(node%declaration_indices)
+            if (allocated(node%procedure_indices)) call &
+                append_array(node%procedure_indices)
 
         type is (derived_type_node)
-            if (allocated(node%component_indices)) call append_array(node%component_indices)
+            if (allocated(node%component_indices)) call &
+                append_array(node%component_indices)
 
         type is (interface_block_node)
-            if (allocated(node%procedure_indices)) call append_array(node%procedure_indices)
+            if (allocated(node%procedure_indices)) call &
+                append_array(node%procedure_indices)
 
         type is (print_statement_node)
-            if (allocated(node%expression_indices)) call append_array(node%expression_indices)
+            if (allocated(node%expression_indices)) call &
+                append_array(node%expression_indices)
 
         class default
             ! Other node types intentionally yield no children here
@@ -490,7 +497,7 @@ contains
         logical, intent(in) :: is_preorder
 
         call traverse_procedure_def_indices(arena, n%param_indices, n%body_indices, &
-                                             visitor, is_preorder)
+                                            visitor, is_preorder)
     end subroutine traverse_function_def_children
 
     subroutine traverse_subroutine_def_children(arena, n, visitor, is_preorder)
@@ -500,7 +507,7 @@ contains
         logical, intent(in) :: is_preorder
 
         call traverse_procedure_def_indices(arena, n%param_indices, n%body_indices, &
-                                             visitor, is_preorder)
+                                            visitor, is_preorder)
     end subroutine traverse_subroutine_def_children
 
     subroutine traverse_call_or_subscript_children(arena, n, visitor, is_preorder)
@@ -605,7 +612,8 @@ contains
         integer :: i
         if (allocated(n%declaration_indices)) then
             do i = 1, size(n%declaration_indices)
-                call traverse_node(arena, n%declaration_indices(i), visitor, is_preorder)
+                call traverse_node(arena, n%declaration_indices(i), visitor, &
+                                   is_preorder)
             end do
         end if
         if (allocated(n%procedure_indices)) then

--- a/src/codegen/codegen_control_flow.f90
+++ b/src/codegen/codegen_control_flow.f90
@@ -384,7 +384,7 @@ contains
                         end if
                     end if
                 class default
-                    ! If the default entry is not a case_default_node, fall back to direct generation
+       ! If the default entry is not a case_default_node, fall back to direct generation
                     body_code = generate_code_from_arena(arena, node%default_index)
                     if (len(body_code) > 0) then
                         code = code // new_line('A') // body_code
@@ -514,7 +514,7 @@ contains
                             code = code // "rank (*)"
                         else if (rank_node%rank_value >= 0) then
                             ! RANK (n)
-                            write(rank_str, '(I0)') rank_node%rank_value
+                            write (rank_str, '(I0)') rank_node%rank_value
                             code = code // "rank (" // trim(rank_str) // ")"
                         end if
 

--- a/src/codegen/codegen_name_mangling.f90
+++ b/src/codegen/codegen_name_mangling.f90
@@ -10,7 +10,8 @@ module codegen_name_mangling
 
 contains
 
-    function mangle_procedure_name(base_name, signature, param_types) result(mangled_name)
+    function mangle_procedure_name(base_name, signature, param_types) &
+        result(mangled_name)
         character(len=*), intent(in) :: base_name
         integer, intent(in) :: signature(:)
         character(len=*), intent(in), optional :: param_types(:)
@@ -120,9 +121,9 @@ contains
         character(len=:), allocatable :: base
 
         if (index(type_desc, 'double precision') > 0 .or. &
-            index(type_desc, 'real(8)') > 0 ) then
+            index(type_desc, 'real(8)') > 0) then
             base = 'r64'
-        else if (index(type_desc, 'real(16)') > 0 ) then
+        else if (index(type_desc, 'real(16)') > 0) then
             base = 'r128'
         else if (index(type_desc, 'real') > 0) then
             base = 'r32'

--- a/src/codegen/codegen_procedure_shared.f90
+++ b/src/codegen/codegen_procedure_shared.f90
@@ -268,7 +268,8 @@ contains
                         type is (declaration_node)
                             if (trim(node%var_name) == trim(param_map(i)%name)) then
                                 if (allocated(node%type_name)) then
-                                    if (index(to_lower(trim(node%type_name)), 'procedure(') == 1) then
+                                    if (index(to_lower(trim(node%type_name)), &
+                                              'procedure(') == 1) then
                                         is_procedure_param = .true.
                                         exit
                                     end if
@@ -443,7 +444,7 @@ contains
                     dim_clause = build_parameter_dimensions(arena, param_node)
                     if (len(dim_clause) == 0) then
                         dim_clause = build_assumed_shape_dimensions( &
-                            param_node%inferred_type)
+                                     param_node%inferred_type)
                     end if
                     decl_line = trim(decl_line) // trim(dim_clause)
                 end if

--- a/src/codegen/codegen_program_header.f90
+++ b/src/codegen/codegen_program_header.f90
@@ -69,7 +69,7 @@ contains
         ! Pass both declaration and legacy storage code (includes namelist) so that
         ! namelist groups can be identified before variable declarations are generated
         extra_decls = collect_program_variable_decls(arena, node, &
-                                                     declaration_statements_code // &
+                                                     declaration_statements_code// &
                                                      legacy_storage_code)
         if (len_trim(extra_decls) > 0) then
             code = code // extra_decls
@@ -318,10 +318,13 @@ contains
         end if
 
         is_header = process_comment_like_node(arena, body_index, &
-                     is_legacy_storage_text(comment_text), non_use_count, &
-                     header_decl_count, use_statements_code, &
-                     intrinsic_statements_code, implicit_statements_code, &
-                     legacy_storage_code, interface_blocks_code)
+                                              is_legacy_storage_text(comment_text), &
+                                                  non_use_count, &
+                                              header_decl_count, use_statements_code, &
+                                              intrinsic_statements_code, &
+                                                  implicit_statements_code, &
+                                              legacy_storage_code, &
+                                                  interface_blocks_code)
     end function process_comment_node
 
     logical function process_directive_node(arena, body_index, ib, non_use_count, &
@@ -349,10 +352,13 @@ contains
         end if
 
         is_header = process_comment_like_node(arena, body_index, &
-                     is_legacy_storage_text(directive_text), non_use_count, &
-                     header_decl_count, use_statements_code, &
-                     intrinsic_statements_code, implicit_statements_code, &
-                     legacy_storage_code, interface_blocks_code)
+                                              is_legacy_storage_text(directive_text), &
+                                                  non_use_count, &
+                                              header_decl_count, use_statements_code, &
+                                              intrinsic_statements_code, &
+                                                  implicit_statements_code, &
+                                              legacy_storage_code, &
+                                                  interface_blocks_code)
     end function process_directive_node
 
     logical function process_comment_like_node(arena, body_index, is_legacy_storage, &
@@ -376,7 +382,7 @@ contains
 
         is_header = .false.
         if (is_legacy_storage .or. ((non_use_count == 0) .and. &
-            header_decl_count == 0)) then
+                                    header_decl_count == 0)) then
             is_header = .true.
             stmt_code = generate_code_from_arena(arena, body_index)
             if (is_legacy_storage) then
@@ -482,7 +488,8 @@ contains
 
         stmt_code = generate_code_from_arena(arena, body_index)
         if (len_trim(stmt_code) > 0) then
-            legacy_storage_code = legacy_storage_code // "    " // stmt_code // new_line('A')
+            legacy_storage_code = legacy_storage_code // "    " // stmt_code // &
+                                  new_line('A')
         end if
     end subroutine process_namelist_statement
 

--- a/src/common/uid_generator.f90
+++ b/src/common/uid_generator.f90
@@ -49,7 +49,8 @@ contains
         integer, intent(in), optional :: generation
 
         if (present(start_value)) then
-            current_uid_value = start_value - 1_int64  ! Pre-decrement for first increment
+            current_uid_value = start_value - 1_int64
+            ! Pre-decrement for first increment
         else
             current_uid_value = 0_int64
         end if

--- a/src/error_handling.f90
+++ b/src/error_handling.f90
@@ -208,13 +208,15 @@ contains
         ! Combine error codes (if both present, use the more severe one)
         if (this%severity >= other%severity) then
             combined%error_code = this%error_code
-            if (allocated(this%error_message)) combined%error_message = this%error_message
+            if (allocated(this%error_message)) combined%error_message = &
+                this%error_message
             if (allocated(this%component)) combined%component = this%component
             if (allocated(this%context)) combined%context = this%context
             if (allocated(this%suggestion)) combined%suggestion = this%suggestion
         else
             combined%error_code = other%error_code
-            if (allocated(other%error_message)) combined%error_message = other%error_message
+            if (allocated(other%error_message)) combined%error_message = &
+                other%error_message
             if (allocated(other%component)) combined%component = other%component
             if (allocated(other%context)) combined%context = other%context
             if (allocated(other%suggestion)) combined%suggestion = other%suggestion
@@ -242,7 +244,8 @@ contains
         res%severity = ERROR_INFO
     end function success_result
 
-    function create_error_result(message, code, component, context, suggestion) result(res)
+    function create_error_result(message, code, component, context, suggestion) &
+        result(res)
         character(len=*), intent(in) :: message
         integer, intent(in), optional :: code
         character(len=*), intent(in), optional :: component, context, suggestion
@@ -299,9 +302,11 @@ contains
         case (ERROR_WARNING)
             error_result = warning_result(message, code, component, context, suggestion)
         case (ERROR_CRITICAL)
-            error_result = critical_result(message, code, component, context, suggestion)
+            error_result = critical_result(message, code, component, context, &
+                                           suggestion)
         case default
-            error_result = create_error_result(message, code, component, context, suggestion)
+            error_result = create_error_result(message, code, component, context, &
+                                               suggestion)
         end select
 
         call this%add_result(error_result)

--- a/src/error_reporting.f90
+++ b/src/error_reporting.f90
@@ -66,7 +66,8 @@ contains
     end function create_error_context
 
     ! Create error context from token
-    function create_error_context_from_token(token, filename, source_lines) result(context)
+    function create_error_context_from_token(token, filename, source_lines) &
+        result(context)
         type(token_t), intent(in) :: token
         character(len=*), intent(in), optional :: filename
         character(len=*), intent(in), optional :: source_lines(:)
@@ -79,7 +80,8 @@ contains
             context%filename = filename
         end if
 
-        if (present(source_lines) .and. token%line > 0 .and. token%line <= size(source_lines)) then
+        if (present(source_lines) .and. token%line > 0 .and. token%line <= &
+            size(source_lines)) then
             context%source_line = source_lines(token%line)
         end if
     end function create_error_context_from_token
@@ -120,7 +122,8 @@ contains
     end subroutine error_collection_add_error
 
     ! Add error with token context
-    subroutine error_collection_add_error_with_token(self, message, token, severity, suggestion)
+    subroutine error_collection_add_error_with_token(self, message, token, severity, &
+                                                     suggestion)
         class(error_collection_t), intent(inout) :: self
         character(len=*), intent(in) :: message
         type(token_t), intent(in) :: token
@@ -132,7 +135,8 @@ contains
     end subroutine error_collection_add_error_with_token
 
     ! Add error with explicit context
-    subroutine error_collection_add_error_with_context(self, message, context, severity, suggestion)
+    subroutine error_collection_add_error_with_context(self, message, context, &
+                                                       severity, suggestion)
         class(error_collection_t), intent(inout) :: self
         character(len=*), intent(in) :: message
         type(error_context_t), intent(in) :: context
@@ -200,14 +204,16 @@ contains
 
         ! Format location if available
         if (error%context%line > 0) then
-            write(location_str, '("line ", I0, ", column ", I0)') error%context%line, error%context%column
+            write (location_str, '("line ", I0, ", column ", I0)') error%context%line, &
+                error%context%column
         else
             location_str = ""
         end if
 
         ! Build formatted message
         if (len_trim(location_str) > 0) then
-            formatted = trim(severity_str) // " at " // trim(location_str) // ": " // error%message
+            formatted = trim(severity_str) // " at " // trim(location_str) // ": " // &
+                        error%message
         else
             formatted = trim(severity_str) // ": " // error%message
         end if
@@ -223,7 +229,8 @@ contains
 
         ! Add suggestion if available
         if (allocated(error%suggestion)) then
-            formatted = formatted // new_line('a') // "  Suggestion: " // error%suggestion
+            formatted = formatted // new_line('a') // "  Suggestion: " // &
+                        error%suggestion
         end if
     end function format_error_message
 

--- a/src/frontend/frontend_program_builders.f90
+++ b/src/frontend/frontend_program_builders.f90
@@ -7,7 +7,8 @@ module frontend_program_builders
     use ast_nodes_procedure, only: subroutine_call_node
     use ast_nodes_data, only: declaration_node
     use ast_nodes_misc, only: implicit_statement_node, contains_node, &
-        end_statement_node, comment_node, directive_node, blank_line_node
+                              end_statement_node, comment_node, directive_node, &
+                                  blank_line_node
     use ast_factory, only: push_implicit_statement
     use standardizer_program, only: insert_contains_statement
     use procedure_classification, only: procedure_has_entry_statement
@@ -71,7 +72,8 @@ contains
                 if (size(main_stmts) == 0) return
 
                 implicit_none_index = push_implicit_statement(arena, .true., &
-                     line=1, column=1, parent_index=0)
+                                                              line=1, column=1, &
+                                                                  parent_index=0)
 
                 body_size = 1 + size(main_stmts) + 1 + size(proc_indices)
                 allocate (new_body(body_size))
@@ -158,7 +160,8 @@ contains
                     call collect_program_procedures(arena, child_index, proc_indices)
                     if (.not. child_is_main_candidate) then
                         if (.not. has_procs) then
-                            call append_program_statements(arena, child_index, main_stmts)
+                            call append_program_statements(arena, child_index, &
+                                                           main_stmts)
                         end if
                     else
                         cycle
@@ -246,7 +249,7 @@ contains
     end subroutine create_program_from_bare_statements
 
     subroutine merge_procedures_into_program(arena, main_prog_index, &
-                                            proc_indices, main_stmts)
+                                             proc_indices, main_stmts)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in) :: main_prog_index
         integer, allocatable, intent(in) :: proc_indices(:)

--- a/src/frontend/frontend_program_unit_scanner.f90
+++ b/src/frontend/frontend_program_unit_scanner.f90
@@ -430,7 +430,7 @@ contains
 
         if (unit_start <= size(tokens)) then
             select case (tokens(unit_start)%kind)
-            ! Check both TK_KEYWORD and TK_IDENTIFIER (keywords can be mixed case)
+                ! Check both TK_KEYWORD and TK_IDENTIFIER (keywords can be mixed case)
             case (TK_KEYWORD, TK_IDENTIFIER)
                 unit_type = to_lower(trim(tokens(unit_start)%text))
                 if (unit_type == "block") block_keyword_pos = unit_start
@@ -441,7 +441,7 @@ contains
                     case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
                         next_pos = next_pos + 1
                         cycle
-                    ! Check both TK_KEYWORD and TK_IDENTIFIER
+                        ! Check both TK_KEYWORD and TK_IDENTIFIER
                     case (TK_KEYWORD, TK_IDENTIFIER)
                         unit_type = to_lower(trim(tokens(next_pos)%text))
                         if (unit_type == "block") block_keyword_pos = next_pos
@@ -661,7 +661,7 @@ contains
             if (tokens(i)%kind == TK_EOF) then
                 unit_end = i - 1
                 exit
-            ! Check both TK_KEYWORD and TK_IDENTIFIER
+                ! Check both TK_KEYWORD and TK_IDENTIFIER
             else if (tokens(i)%kind == TK_KEYWORD .or. &
                      tokens(i)%kind == TK_IDENTIFIER) then
                 if (to_lower(trim(tokens(i)%text)) == "end") then
@@ -683,7 +683,8 @@ contains
                     end if
                     if (i == size(tokens) .or. (i + 1 <= size(tokens) .and. &
                                                 tokens(i + 1)%kind /= TK_KEYWORD .and. &
-                                                tokens(i + 1)%kind /= TK_IDENTIFIER)) then
+                                                tokens(i + 1)%kind /= &
+                                                TK_IDENTIFIER)) then
                         unit_end = i
                         exit
                     end if

--- a/src/frontend/frontend_program_units.f90
+++ b/src/frontend/frontend_program_units.f90
@@ -36,7 +36,8 @@ module frontend_program_units
 contains
 
     ! Main program unit parsing dispatch
-    function parse_program_unit(tokens, arena, has_explicit_program, error_msg) result(unit_index)
+    function parse_program_unit(tokens, arena, has_explicit_program, error_msg) &
+        result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         logical, intent(in) :: has_explicit_program
@@ -82,7 +83,8 @@ contains
                 ! Parse the entire module with its content
                 unit_index = parse_module_unit(trimmed_tokens, arena, parse_error)
             else if (is_program_start(trimmed_tokens, 1)) then
-                unit_index = parse_explicit_program_unit(trimmed_tokens, arena, parse_error)
+                unit_index = parse_explicit_program_unit(trimmed_tokens, arena, &
+                                                         parse_error)
             else if (is_block_data_start(trimmed_tokens, 1)) then
                 ! Parse BLOCK DATA unit
                 unit_index = parse_block_data_unit(trimmed_tokens, arena, parse_error)
@@ -92,7 +94,8 @@ contains
             else
                 ! Mixed module/main files still require implicit main detection
                 unit_index = parse_implicit_main_program(trimmed_tokens, arena, &
-                                                         has_explicit_program, parse_error)
+                                                         has_explicit_program, &
+                                                         parse_error)
             end if
         end block
 
@@ -335,7 +338,6 @@ contains
         integer :: prog_index
         type(parser_prefix_buffer_t) :: prefix_buffer
         character(len=:), allocatable :: errors
-
 
         ! Parse explicit program statement
         prog_index = parse_statement_dispatcher(tokens, arena, prefix_buffer)

--- a/src/frontend/frontend_statement_processing.f90
+++ b/src/frontend/frontend_statement_processing.f90
@@ -323,7 +323,8 @@ contains
                                 proc_index = parse_function_definition(parser, arena, &
                                                                        prefix_buffer)
                             end if
-                            if (proc_index > 0) body_indices = [body_indices, proc_index]
+                            if (proc_index > 0) body_indices = [body_indices, &
+                                                                proc_index]
                             deallocate (proc_tokens)
                             deallocate (prefix_list)
                             allocate (prefix_list(0))
@@ -483,8 +484,10 @@ contains
                         pos = pos + 1
                         do while (pos <= size(tokens) .and. paren_depth > 0)
                             if (tokens(pos)%kind == TK_OPERATOR) then
-                                if (tokens(pos)%text == "(") paren_depth = paren_depth + 1
-                                if (tokens(pos)%text == ")") paren_depth = paren_depth - 1
+                                if (tokens(pos)%text == "(") paren_depth = &
+                                    paren_depth + 1
+                                if (tokens(pos)%text == ")") paren_depth = &
+                                    paren_depth - 1
                             end if
                             pos = pos + 1
                         end do
@@ -562,7 +565,8 @@ contains
                                 do while (next_idx <= size(tokens))
                                     if (tokens(next_idx)%kind == TK_WHITESPACE) then
                                         next_idx = next_idx + 1
-                                    else if (tokens(next_idx)%kind == TK_IDENTIFIER .or. &
+                                    else if (tokens(next_idx)%kind == &
+                                             TK_IDENTIFIER .or. &
                                              tokens(next_idx)%kind == TK_KEYWORD) then
                                         end_pos = next_idx
                                         exit

--- a/src/frontend/frontend_transformation_analysis.f90
+++ b/src/frontend/frontend_transformation_analysis.f90
@@ -4,14 +4,19 @@ module frontend_transformation_analysis
     use ast_nodes_core, only: program_node
     use ast_nodes_data, only: mixed_construct_container_node, module_node
     use frontend_analysis_helpers, only: build_procedure_membership, &
-        analyze_ast_content, analyze_single_unit, &
-        collect_host_assignment_names, collect_program_assignment_names, &
-        collect_procedure_assignment_names, collect_assignment_from_node, &
-        record_identifier_name, append_unique_name, &
-        requires_lazy_internalization, has_existing_module_in_ast
+                                         analyze_ast_content, analyze_single_unit, &
+                                         collect_host_assignment_names, &
+                                             collect_program_assignment_names, &
+                                         collect_procedure_assignment_names, &
+                                             collect_assignment_from_node, &
+                                         record_identifier_name, append_unique_name, &
+                                         requires_lazy_internalization, &
+                                             has_existing_module_in_ast
     use frontend_program_builders, only: handle_mixed_construct_container, &
-        scan_multi_unit_program, create_program_from_bare_statements, &
-        merge_procedures_into_program, filter_procs_with_entry
+                                         scan_multi_unit_program, &
+                                             create_program_from_bare_statements, &
+                                         merge_procedures_into_program, &
+                                             filter_procs_with_entry
     implicit none
     private
 
@@ -52,7 +57,7 @@ contains
             return
         type is (program_node)
             call scan_multi_unit_program(arena, root, main_prog_index, &
-                                        candidate_prog_index, proc_indices, main_stmts)
+                                         candidate_prog_index, proc_indices, main_stmts)
         class default
             return
         end select
@@ -62,11 +67,12 @@ contains
         call filter_procs_with_entry(arena, proc_indices)
 
         call create_program_from_bare_statements(arena, root_index, &
-                                                 main_prog_index, proc_indices, main_stmts)
+                                                 main_prog_index, proc_indices, &
+                                                 main_stmts)
         if (main_prog_index > 0 .and. size(proc_indices) == 0) return
 
         call merge_procedures_into_program(arena, main_prog_index, &
-                                          proc_indices, main_stmts)
+                                           proc_indices, main_stmts)
 
         if (main_prog_index > 0) root_index = main_prog_index
     end subroutine promote_functions_to_internal_program

--- a/src/interfaces/fortfront_c_interface.f90
+++ b/src/interfaces/fortfront_c_interface.f90
@@ -26,7 +26,8 @@ module fortfront_c_interface
 contains
 
     ! Initialize the fortfront library
-    function fortfront_initialize_c() result(status) bind(C, name="fortfront_initialize")
+    function fortfront_initialize_c() result(status) bind(C, &
+                                                          name="fortfront_initialize")
         integer(c_int) :: status
 
         ! Clear any previous error
@@ -59,7 +60,7 @@ contains
 
         ! Check if library is initialized
         if (.not. library_initialized) then
-            call set_last_error("Library not initialized. Call fortfront_initialize() first.")
+      call set_last_error("Library not initialized. Call fortfront_initialize() first.")
             status = -1
             return
         end if
@@ -106,7 +107,7 @@ contains
         call transform_lazy_fortran_string(fortran_source, output, error_msg)
 
         if (len(error_msg) > 0) then
-            call set_last_error("Parse error: " // error_msg)
+            call set_last_error("Parse error: "//error_msg)
             status = -5
             return
         end if
@@ -118,7 +119,8 @@ contains
     end function fortfront_parse_source_c
 
     ! Get last error message
-    function fortfront_get_last_error_c() result(error_ptr) bind(C, name="fortfront_get_last_error")
+    function fortfront_get_last_error_c() result(error_ptr) bind(C, &
+                                                        name="fortfront_get_last_error")
         type(c_ptr) :: error_ptr
 
         if (allocated(last_error_message)) then
@@ -134,16 +136,19 @@ contains
     end subroutine fortfront_clear_error_c
 
     ! Get library version
-    function fortfront_get_version_c() result(version_ptr) bind(C, name="fortfront_get_version")
+    function fortfront_get_version_c() result(version_ptr) bind(C, &
+                                                           name="fortfront_get_version")
         type(c_ptr) :: version_ptr
-        character(len=len(FORTFRONT_VERSION) + 1, kind=c_char), target, save :: version_c
+        character(len=len(FORTFRONT_VERSION) + 1, kind=c_char), target, save &
+            :: version_c
 
         version_c = FORTFRONT_VERSION // c_null_char
         version_ptr = c_loc(version_c)
     end function fortfront_get_version_c
 
     ! Get build information
-    function fortfront_get_build_info_c() result(build_ptr) bind(C, name="fortfront_get_build_info")
+    function fortfront_get_build_info_c() result(build_ptr) bind(C, &
+                                                        name="fortfront_get_build_info")
         type(c_ptr) :: build_ptr
         character(len=len(BUILD_INFO) + 1, kind=c_char), target, save :: build_c
 

--- a/src/memory/arena_memory.f90
+++ b/src/memory/arena_memory.f90
@@ -77,7 +77,8 @@ module arena_memory
         integer :: generation = 1  ! Global generation
     contains
         procedure :: allocate => arena_allocate
-        procedure :: validate => arena_validate  ! Handle validation with generation check
+        procedure :: validate => arena_validate
+        ! Handle validation with generation check
         procedure :: reset => arena_reset
         procedure :: clear => arena_clear
         procedure :: get_stats => arena_get_stats

--- a/src/memory/compiler_arena.f90
+++ b/src/memory/compiler_arena.f90
@@ -6,12 +6,14 @@ module compiler_arena
 
     use arena_memory
     use type_system_arena
-    use ast_arena_modern, only: ast_arena_t, create_ast_arena, ast_arena_stats_t, destroy_ast_arena
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena, ast_arena_stats_t, &
+                                destroy_ast_arena
     use, intrinsic :: iso_fortran_env, only: int64, dp => real64
     implicit none
     private
 
-    public :: compiler_arena_t, compiler_arena_stats_t, create_compiler_arena, destroy_compiler_arena
+    public :: compiler_arena_t, compiler_arena_stats_t, create_compiler_arena, &
+              destroy_compiler_arena
 
     ! Future arena types - placeholders for unified architecture
 
@@ -29,7 +31,8 @@ module compiler_arena
         type(type_arena_t) :: types  ! Type system (already implemented)
         type(ast_arena_t) :: ast  ! AST nodes (modern implementation)
         type(symbol_arena_placeholder_t) :: symbols  ! Symbol tables (placeholder)
-        type(literal_arena_placeholder_t) :: literals  ! String/number literals (placeholder)
+        type(literal_arena_placeholder_t) :: literals
+        ! String/number literals (placeholder)
 
         ! Unified management state
         integer :: generation = 1  ! Global generation counter
@@ -102,7 +105,7 @@ contains
 
         size = this%default_chunk_size
 
-        ! PERFORMANCE FIX: Initialize arenas in-place to avoid assignment operator overhead
+     ! PERFORMANCE FIX: Initialize arenas in-place to avoid assignment operator overhead
         ! Initialize type arena directly (avoid assignment operator deep copy)
         this%types%arena = create_arena(size / 4)  ! Types typically need less memory
         this%types%next_type_id = 1
@@ -239,14 +242,16 @@ contains
             stats%total_memory = stats%total_memory + stats%ast_memory
 
             ! Average utilization across arenas (average type and AST utilization)
-            stats%average_utilization = (type_stats%utilization + ast_stats%utilization) / 2.0_dp
+            stats%average_utilization = (type_stats%utilization + &
+                                         ast_stats%utilization) / 2.0_dp
         end block
 
         ! Future: aggregate statistics from other arenas
 
         ! Calculate allocation rate (allocations per second)
         if (this%total_allocation_time > 0.0_dp) then
-            stats%allocation_rate = real(this%total_allocations, dp) / this%total_allocation_time
+            stats%allocation_rate = real(this%total_allocations, dp) / &
+                                    this%total_allocation_time
         end if
 
         stats%active_generations = this%generation
@@ -310,7 +315,7 @@ contains
 
         ! Optional: Log phase transition for debugging
         ! if (debug_enabled) then
-        !     print *, "Compiler Phase: ", trim(phase_name), " Generation: ", this%generation
+   !     print *, "Compiler Phase: ", trim(phase_name), " Generation: ", this%generation
         ! end if
     end subroutine compiler_arena_next_phase
 

--- a/src/parser/control_flow/parser_control_flow_router.f90
+++ b/src/parser/control_flow/parser_control_flow_router.f90
@@ -9,7 +9,7 @@ module parser_control_flow_router_module
     use parser_if_constructs_module, only: parse_if
     use parser_do_constructs_module, only: parse_do_loop
     use parser_select_constructs_module, only: parse_select_case, parse_select_type, &
-                                              parse_select_rank
+                                               parse_select_rank
     use parser_array_constructs_module, only: parse_where_construct, parse_associate, &
                                               parse_block_construct
     use parser_forall_module, only: parse_forall
@@ -49,7 +49,8 @@ contains
         end select
     end function is_control_flow_keyword
 
-    function route_control_flow(parser, arena, callbacks, parent_index) result(node_index)
+    function route_control_flow(parser, arena, callbacks, parent_index) &
+        result(node_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(statement_callbacks_t), intent(in), optional :: callbacks
@@ -103,14 +104,17 @@ contains
 
                 if (found_keyword) then
                     if (lookahead_token%text == "type") then
-                        node_index = invoke_no_parent(local_callbacks%parse_select_type, &
-                                                      parser, arena)
+                        node_index = &
+                            invoke_no_parent(local_callbacks%parse_select_type, &
+                                             parser, arena)
                     else if (lookahead_token%text == "case") then
-                        node_index = invoke_no_parent(local_callbacks%parse_select_case, &
-                                                      parser, arena)
+                        node_index = &
+                            invoke_no_parent(local_callbacks%parse_select_case, &
+                                             parser, arena)
                     else if (lookahead_token%text == "rank") then
-                        node_index = invoke_no_parent(local_callbacks%parse_select_rank, &
-                                                      parser, arena)
+                        node_index = &
+                            invoke_no_parent(local_callbacks%parse_select_rank, &
+                                             parser, arena)
                     end if
                 end if
             end block
@@ -119,7 +123,8 @@ contains
         case ("forall")
             node_index = invoke_no_parent(local_callbacks%parse_forall, parser, arena)
         case ("associate")
-            node_index = invoke_no_parent(local_callbacks%parse_associate, parser, arena)
+            node_index = invoke_no_parent(local_callbacks%parse_associate, &
+                                          parser, arena)
         case ("block")
             node_index = invoke_no_parent(local_callbacks%parse_block, parser, arena)
         case default

--- a/src/parser/core/parser_state.f90
+++ b/src/parser/core/parser_state.f90
@@ -131,7 +131,8 @@ contains
         class(parser_state_t), intent(in) :: this
         type(token_t) :: current_token
 
-        if (associated(this%tokens) .and. this%current_token >= 1 .and. this%current_token <= size(this%tokens)) then
+        if (associated(this%tokens) .and. this%current_token >= 1 .and. &
+            this%current_token <= size(this%tokens)) then
             current_token = this%tokens(this%current_token)
         else
             ! Return EOF token

--- a/src/parser/core/parser_utils.f90
+++ b/src/parser/core/parser_utils.f90
@@ -90,7 +90,8 @@ contains
         if (token%kind == TK_OPERATOR) then
             call process_operator(token, seen_colon, in_brackets, in_attr, &
                                   bracket_depth, var_count, has_init, has_comma)
-        else if (token%kind == TK_IDENTIFIER .and. seen_colon .and. .not. in_brackets) then
+        else if (token%kind == TK_IDENTIFIER .and. seen_colon .and. .not. &
+                 in_brackets) then
             var_count = var_count + 1
         else if (token%kind == TK_KEYWORD) then
             if (pos > 1 .and. .not. is_attribute_keyword(token%text)) then

--- a/src/parser/declarations/parser_definition_statements.f90
+++ b/src/parser/declarations/parser_definition_statements.f90
@@ -1,9 +1,13 @@
 module parser_definition_statements_module
-    ! Parser module for definition statement types (function, subroutine, interface, derived types)
+! Parser module for definition statement types
+! (function, subroutine, interface, derived types)
     ! This module has been refactored into specialized submodules for maintainability
-    use parser_parameter_handling_module, only: parse_typed_parameters, merge_parameter_attributes
-    use parser_type_definitions_module, only: parse_derived_type, parse_derived_type_parameters
-    use parser_procedure_definitions_module, only: parse_function_definition, parse_subroutine_definition, &
+    use parser_parameter_handling_module, only: parse_typed_parameters, &
+                                                merge_parameter_attributes
+    use parser_type_definitions_module, only: parse_derived_type, &
+                                              parse_derived_type_parameters
+    use parser_procedure_definitions_module, only: parse_function_definition, &
+                                                   parse_subroutine_definition, &
                                                    parse_interface_block
     use parser_statement_utilities_module, only: parse_statement_in_if_block
     implicit none

--- a/src/parser/declarations/parser_interface_block_headers_module.f90
+++ b/src/parser/declarations/parser_interface_block_headers_module.f90
@@ -56,7 +56,8 @@ contains
                         operator_symbol = trim(to_lower(token%text))
                         token = parser%consume()
                         token = parser%peek()
-                        if (token%kind == TK_OPERATOR .and. trim(token%text) == ")") then
+                        if (token%kind == TK_OPERATOR .and. trim(token%text) &
+                            == ")") then
                             token = parser%consume()
                         end if
                     end if

--- a/src/parser/declarations/parser_parameter_handling.f90
+++ b/src/parser/declarations/parser_parameter_handling.f90
@@ -86,7 +86,7 @@ contains
                 do j = 1, size(body_indices)
                     if (body_indices(j) <= 0 .or. body_indices(j) > arena%size) cycle
 
-                    ! CRITICAL FIX for Issue #1121: Check if node is allocated before accessing
+             ! CRITICAL FIX for Issue #1121: Check if node is allocated before accessing
                     if (.not. allocated(arena%entries(body_indices(j))%node)) cycle
 
                     select type (body_node => arena%entries(body_indices(j))%node)

--- a/src/parser/expressions/parser_assignment.f90
+++ b/src/parser/expressions/parser_assignment.f90
@@ -6,7 +6,7 @@ module parser_assignment_module
     use parser_expressions_module, only: parse_range, parse_logical_eqv
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_assignment, push_pointer_assignment, &
-                            push_identifier, push_literal, push_complex_literal
+                           push_identifier, push_literal, push_complex_literal
     use ast_types, only: LITERAL_STRING, LITERAL_INTEGER, LITERAL_REAL, LITERAL_LOGICAL
     use parser_assignment_shared_module, only: parse_multi_variable_assignment_core
     implicit none
@@ -70,7 +70,8 @@ contains
                     if (value_index > 0) then
                         stmt_index = push_pointer_assignment(arena, target_index, &
                                                              value_index, &
-                                                             id_token%line, id_token%column)
+                                                             id_token%line, &
+                                                             id_token%column)
                     end if
                 case ("(", "%")
                     block
@@ -133,11 +134,13 @@ contains
                         if (assignment_op == "=>") then
                             stmt_index = push_pointer_assignment(arena, target_index, &
                                                                  value_index, &
-                                                                 id_token%line, id_token%column)
+                                                                 id_token%line, &
+                                                                 id_token%column)
                         else
                             stmt_index = push_assignment(arena, target_index, &
                                                          value_index, &
-                                                         id_token%line, id_token%column, &
+                                                         id_token%line, &
+                                                         id_token%column, &
                                                          operator_text=assignment_op)
                         end if
                     end if

--- a/src/parser/expressions/parser_expression_helpers.f90
+++ b/src/parser/expressions/parser_expression_helpers.f90
@@ -73,7 +73,7 @@ contains
                                                component_token%text, &
                                                op_token%line, op_token%column)
         else if (component_token%kind == TK_KEYWORD) then
-            ! Keywords are valid component names in Fortran (e.g., "data", "type", "end")
+           ! Keywords are valid component names in Fortran (e.g., "data", "type", "end")
             component_token = parser%consume()
             expr_index = push_component_access(arena, base_expr, &
                                                component_token%text, &

--- a/src/parser/procedures/parser_call.f90
+++ b/src/parser/procedures/parser_call.f90
@@ -76,7 +76,8 @@ contains
 
         token = parser%peek()
         if (token%kind /= TK_IDENTIFIER) then
-            stmt_index = push_literal(arena, "! Error: expected subroutine name after 'call'", &
+            stmt_index = push_literal(arena, &
+                                     "! Error: expected subroutine name after 'call'", &
                                       LITERAL_STRING, line, column)
             return
         end if
@@ -148,7 +149,8 @@ contains
             allocate (arg_indices(0))
         end if
 
-        stmt_index = push_subroutine_call(arena, subroutine_name, arg_indices, line, column)
+        stmt_index = push_subroutine_call(arena, subroutine_name, arg_indices, &
+                                          line, column)
     end function parse_call_statement
 
 end module parser_call_module

--- a/src/parser/procedures/parser_procedure_shared.f90
+++ b/src/parser/procedures/parser_procedure_shared.f90
@@ -35,8 +35,9 @@ contains
                 next_index = parser%current_token + 1
                 lookahead = parser%get_token_at_index(next_index)
                 next_lower = to_lower(trim(lookahead%text))
-                if (trim(next_lower) == "precision" .or. trim(next_lower) == "complex") then
-                    return_type_str = trim(token%text)//" "//trim(lookahead%text)
+                if (trim(next_lower) == "precision" .or. trim(next_lower) == &
+                    "complex") then
+                    return_type_str = trim(token%text) // " " // trim(lookahead%text)
                     token = parser%consume()
                     token = parser%consume()
                 end if

--- a/src/parser/procedures/parser_procedure_signatures.f90
+++ b/src/parser/procedures/parser_procedure_signatures.f90
@@ -97,11 +97,15 @@ contains
                 else
                     next_lower = ""
                 end if
-                if (trim(next_lower) == "precision" .or. trim(next_lower) == "complex") then
-                    call set_return_type_from_token(trim(pending_prefixes(i))//" "//trim(pending_prefixes(i + 1)))
+                if (trim(next_lower) == "precision" .or. trim(next_lower) == &
+                    "complex") then
+                    call set_return_type_from_token( &
+                        trim(pending_prefixes(i))//" "// &
+                        trim(pending_prefixes(i + 1)))
                     i = i + 2; cycle
                 else
-                    call set_return_type_from_token(pending_prefixes(i)); i = i + 1; cycle
+                    call set_return_type_from_token(pending_prefixes(i))
+                    i = i + 1; cycle
                 end if
             case ("recursive")
                 has_recursive_keyword = .true.
@@ -158,7 +162,7 @@ contains
                 matches = text(1:prefix_len) == prefix
             end if
         end function starts_with
-        end subroutine append_pending_prefixes
+    end subroutine append_pending_prefixes
 
     subroutine consume_function_prefix_tokens(parser, prefix_keywords, &
                                               has_recursive_keyword)
@@ -358,38 +362,38 @@ contains
 
         token = parser%peek()
         if (token%kind == TK_OPERATOR .and. token%text == "(") then
-            clause_text = trim(clause_text)//"("
+            clause_text = trim(clause_text) // "("
             token = parser%consume()
 
             token = parser%peek()
             if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
-                clause_text = trim(clause_text)//trim(token%text)
+                clause_text = trim(clause_text) // trim(token%text)
                 token = parser%consume()
 
                 token = parser%peek()
                 if (token%kind == TK_OPERATOR .and. token%text == ",") then
-                    clause_text = trim(clause_text)//","
+                    clause_text = trim(clause_text) // ","
                     token = parser%consume()
 
                     token = parser%peek()
                     if (token%kind == TK_WHITESPACE) then
-                        clause_text = trim(clause_text)//" "
+                        clause_text = trim(clause_text) // " "
                         token = parser%consume()
                     end if
 
                     token = parser%peek()
                     if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
-                        clause_text = trim(clause_text)//trim(token%text)
+                        clause_text = trim(clause_text) // trim(token%text)
                         token = parser%consume()
 
                         token = parser%peek()
                         if (token%kind == TK_OPERATOR .and. token%text == "=") then
-                            clause_text = trim(clause_text)//"="
+                            clause_text = trim(clause_text) // "="
                             token = parser%consume()
 
                             token = parser%peek()
                             if (token%kind == TK_STRING) then
-                                clause_text = trim(clause_text)//trim(token%text)
+                                clause_text = trim(clause_text) // trim(token%text)
                                 token = parser%consume()
                             end if
                         end if
@@ -399,7 +403,7 @@ contains
 
             token = parser%peek()
             if (token%kind == TK_OPERATOR .and. token%text == ")") then
-                clause_text = trim(clause_text)//")"
+                clause_text = trim(clause_text) // ")"
                 token = parser%consume()
             end if
         end if

--- a/src/parser/procedures/parser_result_types.f90
+++ b/src/parser/procedures/parser_result_types.f90
@@ -62,7 +62,8 @@ contains
         node_index = this%node_index
     end function parse_result_get_node
 
-    subroutine parse_result_set_error(this, message, code, component, context, suggestion)
+    subroutine parse_result_set_error(this, message, code, component, context, &
+                                      suggestion)
         class(parse_result_t), intent(inout) :: this
         character(len=*), intent(in) :: message
         integer, intent(in), optional :: code
@@ -111,14 +112,16 @@ contains
         count = this%warnings%get_error_count()
     end function compile_result_get_warning_count
 
-    subroutine compile_result_add_warning(this, message, code, component, context, suggestion)
+    subroutine compile_result_add_warning(this, message, code, component, context, &
+                                          suggestion)
         class(compile_result_t), intent(inout) :: this
         character(len=*), intent(in) :: message
         integer, intent(in), optional :: code
         character(len=*), intent(in), optional :: component, context, suggestion
 
         ! Initialize warnings collection if not already done
-        if (this%warnings%get_error_count() == 0 .and. .not. allocated(this%warnings%errors)) then
+        if (this%warnings%get_error_count() == 0 .and. .not. &
+            allocated(this%warnings%errors)) then
             this%warnings = create_error_collection()
         end if
 
@@ -127,7 +130,8 @@ contains
                                      suggestion=suggestion)
     end subroutine compile_result_add_warning
 
-    subroutine compile_result_set_error(this, message, code, component, context, suggestion)
+    subroutine compile_result_set_error(this, message, code, component, context, &
+                                        suggestion)
         class(compile_result_t), intent(inout) :: this
         character(len=*), intent(in) :: message
         integer, intent(in), optional :: code
@@ -153,7 +157,8 @@ contains
         call parse_res%set_success(node_index)
     end function success_parse_result
 
-    function error_parse_result(message, code, component, context, suggestion) result(parse_res)
+    function error_parse_result(message, code, component, context, suggestion) &
+        result(parse_res)
         character(len=*), intent(in) :: message
         integer, intent(in), optional :: code
         character(len=*), intent(in), optional :: component, context, suggestion
@@ -171,7 +176,8 @@ contains
         call compile_res%set_success(program_index)
     end function success_compile_result
 
-    function error_compile_result(message, code, component, context, suggestion) result(compile_res)
+    function error_compile_result(message, code, component, context, suggestion) &
+        result(compile_res)
         character(len=*), intent(in) :: message
         integer, intent(in), optional :: code
         character(len=*), intent(in), optional :: component, context, suggestion
@@ -301,11 +307,11 @@ contains
                 ! Safety check
                 if (tokens_skipped > 200) then
                     recovery_res = create_error_result( &
-                                   "Error recovery failed: unmatched " // opening_char, &
+                                   "Error recovery failed: unmatched "//opening_char, &
                                    ERROR_PARSER, &
                                    "parser_result_types", &
                                    "recover_to_closing_paren", &
-                                   "Check for missing " // closing_char &
+                                   "Check for missing "//closing_char &
                                    )
                     return
                 end if
@@ -314,11 +320,11 @@ contains
 
         if (nesting_level > 0) then
             recovery_res = create_error_result( &
-                           "Reached end of input with unmatched " // opening_char, &
+                           "Reached end of input with unmatched "//opening_char, &
                            ERROR_PARSER, &
                            "parser_result_types", &
                            "recover_to_closing_paren", &
-                           "Add missing " // closing_char &
+                           "Add missing "//closing_char &
                            )
         else
             recovery_res = success_result()
@@ -326,7 +332,8 @@ contains
     end function recover_to_closing_paren
 
     ! Recover to next occurrence of specific token
-    function recover_to_next_token(parser, target_kind, target_text) result(recovery_res)
+    function recover_to_next_token(parser, target_kind, target_text) &
+        result(recovery_res)
         use parser_state_module, only: parser_state_t
         use lexer_core, only: TK_EOF
         type(parser_state_t), intent(inout) :: parser
@@ -412,11 +419,11 @@ contains
                 ! Safety check
                 if (tokens_skipped > 300) then
                     recovery_res = create_error_result( &
-                                   "Error recovery failed: no synchronization point found", &
+                              "Error recovery failed: no synchronization point found", &
                                    ERROR_PARSER, &
                                    "parser_result_types", &
                                    "skip_to_synchronization_point", &
-                                   "Check for missing end statements or malformed structure" &
+                             "Check for missing end statements or malformed structure" &
                                    )
                     return
                 end if

--- a/src/parser/statements/parser_statement_data_module.f90
+++ b/src/parser/statements/parser_statement_data_module.f90
@@ -252,27 +252,31 @@ contains
             if (step_index > 0) then
                 if (allocated(object_exprs)) then
                     node_index = push_io_implied_do( &
-                        arena, value_expr_index, var_name, &
-                        start_expr_index=start_index, end_expr_index=end_index, &
-                        step_expr_index=step_index, line=line, column=column, &
-                        object_indices=object_exprs)
+                                 arena, value_expr_index, var_name, &
+                                 start_expr_index=start_index, &
+                                     end_expr_index=end_index, &
+                                 step_expr_index=step_index, line=line, column=column, &
+                                 object_indices=object_exprs)
                 else
                     node_index = push_io_implied_do( &
-                        arena, value_expr_index, var_name, &
-                        start_expr_index=start_index, end_expr_index=end_index, &
-                        step_expr_index=step_index, line=line, column=column)
+                                 arena, value_expr_index, var_name, &
+                                 start_expr_index=start_index, &
+                                     end_expr_index=end_index, &
+                                 step_expr_index=step_index, line=line, column=column)
                 end if
             else
                 if (allocated(object_exprs)) then
                     node_index = push_io_implied_do( &
-                        arena, value_expr_index, var_name, &
-                        start_expr_index=start_index, end_expr_index=end_index, &
-                        line=line, column=column, object_indices=object_exprs)
+                                 arena, value_expr_index, var_name, &
+                                 start_expr_index=start_index, &
+                                     end_expr_index=end_index, &
+                                 line=line, column=column, object_indices=object_exprs)
                 else
                     node_index = push_io_implied_do( &
-                        arena, value_expr_index, var_name, &
-                        start_expr_index=start_index, end_expr_index=end_index, &
-                        line=line, column=column)
+                                 arena, value_expr_index, var_name, &
+                                 start_expr_index=start_index, &
+                                     end_expr_index=end_index, &
+                                 line=line, column=column)
                 end if
             end if
         end function create_implied_do_node_helper
@@ -387,8 +391,8 @@ contains
                                 current = parser%peek()
                                 if (current%kind == TK_OPERATOR .and. &
                                     trim(current%text) == "/") then
-                                    ! Accept trailing comma as extension (common compiler
-                                    ! tolerance). Parser continues; codegen emits standard
+                                   ! Accept trailing comma as extension (common compiler
+                                  ! tolerance). Parser continues; codegen emits standard
                                     ! Fortran without trailing comma.
                                     exit
                                 end if

--- a/src/parser/statements/parser_statement_utilities.f90
+++ b/src/parser/statements/parser_statement_utilities.f90
@@ -65,7 +65,6 @@ contains
         end if
     end subroutine clear_stmt_util_additional_indices
 
-
     ! Statement parsing for if blocks - moved here to break circular dependency
     function parse_statement_in_if_block(parser, arena, token) result(stmt_index)
         type(parser_state_t), intent(inout) :: parser
@@ -305,7 +304,8 @@ contains
 
         ! Look for 'then' keyword
         then_token = parser%peek()
-        if (then_token%kind == TK_KEYWORD .and. to_lower(then_token%text) == "then") then
+        if (then_token%kind == TK_KEYWORD .and. to_lower(then_token%text) == &
+            "then") then
             token = parser%consume()
 
             ! Parse then body with efficient growth
@@ -316,7 +316,8 @@ contains
             do while (.not. parser%is_at_end())
                 token = parser%peek()
                 if (token%kind == TK_KEYWORD) then
-                    if (to_lower(token%text) == "else" .or. to_lower(token%text) == "end") then
+                    if (to_lower(token%text) == "else" .or. to_lower(token%text) == &
+                        "end") then
                         exit
                     end if
                 end if
@@ -329,7 +330,7 @@ contains
                         ! Grow array if needed
                         if (then_count >= then_capacity) then
                             then_capacity = then_capacity * 2
-                            allocate(temp_indices(then_capacity))
+                            allocate (temp_indices(then_capacity))
                             temp_indices(1:then_count) = then_body_indices(1:then_count)
                             call move_alloc(temp_indices, then_body_indices)
                         end if
@@ -343,10 +344,10 @@ contains
 
             ! Trim then body to actual size
             if (then_count == 0) then
-                deallocate(then_body_indices)
-                allocate(then_body_indices(0))
+                deallocate (then_body_indices)
+                allocate (then_body_indices(0))
             else if (then_count < then_capacity) then
-                allocate(temp_indices(then_count))
+                allocate (temp_indices(then_count))
                 temp_indices = then_body_indices(1:then_count)
                 call move_alloc(temp_indices, then_body_indices)
             end if
@@ -375,8 +376,9 @@ contains
                             ! Grow array if needed
                             if (else_count >= else_capacity) then
                                 else_capacity = else_capacity * 2
-                                allocate(temp_indices(else_capacity))
-                                temp_indices(1:else_count) = else_body_indices(1:else_count)
+                                allocate (temp_indices(else_capacity))
+                                temp_indices(1:else_count) = &
+                                    else_body_indices(1:else_count)
                                 call move_alloc(temp_indices, else_body_indices)
                             end if
                             else_count = else_count + 1
@@ -390,10 +392,10 @@ contains
 
             ! Trim else body to actual size
             if (else_count == 0) then
-                deallocate(else_body_indices)
-                allocate(else_body_indices(0))
+                deallocate (else_body_indices)
+                allocate (else_body_indices(0))
             else if (else_count < else_capacity) then
-                allocate(temp_indices(else_count))
+                allocate (temp_indices(else_count))
                 temp_indices = else_body_indices(1:else_count)
                 call move_alloc(temp_indices, else_body_indices)
             end if

--- a/src/performance/ast_performance.f90
+++ b/src/performance/ast_performance.f90
@@ -114,7 +114,8 @@ contains
         cache_entries(cache_index)%file_path = file_path
         cache_entries(cache_index)%source_checksum = source_checksum
         call deep_copy_arena(arena, cache_entries(cache_index)%cached_arena)
-        call deep_copy_semantic_context(semantic_ctx, cache_entries(cache_index)%cached_semantic_ctx)
+        call deep_copy_semantic_context(semantic_ctx, &
+                                        cache_entries(cache_index)%cached_semantic_ctx)
         cache_entries(cache_index)%is_valid = .true.
         cache_entries(cache_index)%creation_time = current_time()
         cache_entries(cache_index)%access_count = 0
@@ -127,7 +128,8 @@ contains
 
     end subroutine cache_ast
 
-    function load_cached_ast(file_path, source_checksum, arena, semantic_ctx) result(loaded)
+    function load_cached_ast(file_path, source_checksum, arena, semantic_ctx) &
+        result(loaded)
         character(len=*), intent(in) :: file_path
         character(len=*), intent(in) :: source_checksum
         type(ast_arena_t), intent(out) :: arena
@@ -148,7 +150,8 @@ contains
 
                 ! Load cached data with deep copy
                 call deep_copy_arena(cache_entries(i)%cached_arena, arena)
-                call deep_copy_semantic_context(cache_entries(i)%cached_semantic_ctx, semantic_ctx)
+                call deep_copy_semantic_context(cache_entries(i)%cached_semantic_ctx, &
+                                                semantic_ctx)
                 cache_entries(i)%access_count = cache_entries(i)%access_count + 1
 
                 loaded = .true.
@@ -501,8 +504,10 @@ contains
             dest_arena%entries(i)%child_count = source_arena%entries(i)%child_count
 
             if (allocated(source_arena%entries(i)%child_indices)) then
-                allocate(dest_arena%entries(i)%child_indices(size(source_arena%entries(i)%child_indices)))
-                dest_arena%entries(i)%child_indices = source_arena%entries(i)%child_indices
+                allocate (dest_arena%entries(i)%child_indices( &
+                    size(source_arena%entries(i)%child_indices)))
+                dest_arena%entries(i)%child_indices = &
+                    source_arena%entries(i)%child_indices
             end if
 
             ! Note: Deep copying AST nodes is complex due to polymorphic types

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -139,7 +139,7 @@ contains
                                 else if (allocated(node%var_name)) then
                                     call ctx%scopes%define(node%var_name, scheme)
                                 end if
-                                ! NOTE: update_identifier_type_in_arena available but not needed here
+                   ! NOTE: update_identifier_type_in_arena available but not needed here
                             end block
                         class default
                             continue

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -12,7 +12,8 @@ submodule(semantic_analyzer) semantic_analyzer_infer_impl
     use semantic_where_validation, only: validate_where_construct
     implicit none
 
-    ! Module-level context for wrapper function (not thread-safe, but works around gfortran bug)
+! Module-level context for wrapper function
+! (not thread-safe, but works around gfortran bug)
     class(semantic_context_t), pointer :: g_current_context => null()
     type(ast_arena_t), pointer :: g_current_arena => null()
 

--- a/src/semantic/analyzers/semantic_analyzer_with_checks.f90
+++ b/src/semantic/analyzers/semantic_analyzer_with_checks.f90
@@ -1,7 +1,8 @@
 ! @slow-path
 module semantic_analyzer_with_checks
     ! Enhanced semantic analyzer with validation checks
-    use semantic_analyzer, only: semantic_context_t, create_semantic_context, analyze_program
+    use semantic_analyzer, only: semantic_context_t, create_semantic_context, &
+                                 analyze_program
     use ast_arena_modern, only: ast_arena_t
     implicit none
 

--- a/src/semantic/analyzers/semantic_assignment_inference.f90
+++ b/src/semantic/analyzers/semantic_assignment_inference.f90
@@ -201,7 +201,7 @@ contains
         end if
 
         ! Handle allocatable array assignment from function returns (Issue #2075)
-        ! When assigning from a function returning allocatable array, preserve allocatable
+      ! When assigning from a function returning allocatable array, preserve allocatable
         call handle_allocatable_array_assignment(arena, assignment, expr_typ)
 
         ! Force complex type for variables assigned from complex literals
@@ -329,7 +329,7 @@ contains
                     if (value_node%inferred_type%kind == TARRAY) then
                         if (value_node%inferred_type%alloc_info%is_allocatable) then
                             ! Use the full array type from the function call
-                            ! This ensures expr_typ has both TARRAY kind and allocatable flag
+                       ! This ensures expr_typ has both TARRAY kind and allocatable flag
                             expr_typ = value_node%inferred_type
                         end if
                     end if

--- a/src/semantic/analyzers/semantic_function_inference.f90
+++ b/src/semantic/analyzers/semantic_function_inference.f90
@@ -425,8 +425,8 @@ contains
     end subroutine process_where_node
 
     recursive subroutine process_select_case_node(arena, stmt, result_name, &
-                                                   aliases, param_names, &
-                                                   param_types, selected, fallback)
+                                                  aliases, param_names, &
+                                                  param_types, selected, fallback)
         type(ast_arena_t), intent(in) :: arena
         type(select_case_node), intent(in) :: stmt
         character(len=*), intent(in) :: result_name
@@ -439,7 +439,7 @@ contains
 
         if (allocated(stmt%case_indices)) then
             do i = 1, size(stmt%case_indices)
-            call accumulate_result_assignments(arena, stmt%case_indices(i), &
+                call accumulate_result_assignments(arena, stmt%case_indices(i), &
                                                    result_name, aliases, &
                                                    param_names, param_types, &
                                                    selected, fallback)
@@ -451,8 +451,8 @@ contains
     end subroutine process_select_case_node
 
     recursive subroutine process_select_type_node(arena, stmt, result_name, &
-                                                   aliases, param_names, &
-                                                   param_types, selected, fallback)
+                                                  aliases, param_names, &
+                                                  param_types, selected, fallback)
         type(ast_arena_t), intent(in) :: arena
         type(select_type_node), intent(in) :: stmt
         character(len=*), intent(in) :: result_name
@@ -518,11 +518,13 @@ contains
             if (.not. matches_alias(target%name, aliases)) return
             candidate = infer_expression_type_static(arena, stmt%value_index, &
                                                      param_names, param_types)
-            ! Issue #2066 vs scalar accumulation: distinguish array operations from scalar
-            ! If RHS is array but uses subscripted accesses (e.g., arr(i)), peel to scalar
+          ! Issue #2066 vs scalar accumulation: distinguish array operations from scalar
+          ! If RHS is array but uses subscripted accesses (e.g., arr(i)), peel to scalar
             ! If RHS is whole-array operation (e.g., x * x), keep as array
-            if (candidate%kind == TARRAY .and. .not. is_array_literal_node(arena, stmt%value_index)) then
-                if (expression_uses_subscripted_params(arena, stmt%value_index, param_names)) then
+            if (candidate%kind == TARRAY .and. .not. is_array_literal_node(arena, &
+                                                                 stmt%value_index)) then
+                if (expression_uses_subscripted_params(arena, stmt%value_index, &
+                                                       param_names)) then
                     candidate = safe_peel_array_to_base(candidate)
                 end if
             end if
@@ -550,7 +552,9 @@ contains
         end select
     end function is_array_literal_node
 
-    recursive function expression_uses_subscripted_params(arena, expr_index, param_names) result(uses_subscripts)
+    recursive function expression_uses_subscripted_params(arena, expr_index, &
+                                                          param_names) &
+                                                              result(uses_subscripts)
         use ast_nodes_core, only: call_or_subscript_node, binary_op_node
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: expr_index
@@ -576,9 +580,13 @@ contains
             end if
         type is (binary_op_node)
             ! Recursively check left and right sides
-            uses_subscripts = expression_uses_subscripted_params(arena, node%left_index, param_names)
+            uses_subscripts = expression_uses_subscripted_params(arena, &
+                                                                 node%left_index, &
+                                                                     param_names)
             if (uses_subscripts) return
-            uses_subscripts = expression_uses_subscripted_params(arena, node%right_index, param_names)
+            uses_subscripts = expression_uses_subscripted_params(arena, &
+                                                                 node%right_index, &
+                                                                     param_names)
         end select
     end function expression_uses_subscripted_params
 

--- a/src/semantic/analyzers/semantic_parameter_analysis.f90
+++ b/src/semantic/analyzers/semantic_parameter_analysis.f90
@@ -62,7 +62,8 @@ contains
         ! Merge arrays of different ranks (take maximum rank)
         if (current_type%kind == TARRAY .and. candidate_type%kind == TARRAY) then
             call extract_rank_and_base_type(current_type, rank_current, base_current)
-            call extract_rank_and_base_type(candidate_type, rank_candidate, base_candidate)
+            call extract_rank_and_base_type(candidate_type, rank_candidate, &
+                                            base_candidate)
             if (rank_current == rank_candidate) then
                 if (base_current%kind == base_candidate%kind) then
                     if (base_current%kind /= TCHAR .or. &
@@ -385,8 +386,8 @@ contains
     end function node_contains_call
 
     function infer_type_from_enclosing_function_param(arena, identifier_name, &
-                                                       enclosing_func_index, &
-                                                       next_var_id) &
+                                                      enclosing_func_index, &
+                                                      next_var_id) &
         result(inferred_type)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: identifier_name
@@ -563,7 +564,7 @@ contains
     function infer_base_type_from_call_site(arena, func_node, param_position) &
         result(base_type)
         use type_system_unified, only: TARRAY, type_args_allocated, &
-                                        type_args_size, type_args_element
+                                       type_args_size, type_args_element
         use semantic_type_context, only: infer_expression_type_static
         type(ast_arena_t), intent(in) :: arena
         type(function_def_node), intent(in) :: func_node
@@ -686,7 +687,7 @@ contains
                 if (.not. allocated(arena%entries(assign_node%target_index)%node)) &
                     cycle
                 select type (target_node => &
-                            arena%entries(assign_node%target_index)%node)
+                             arena%entries(assign_node%target_index)%node)
                 type is (identifier_node)
                     if (.not. allocated(target_node%name)) cycle
                     if (trim(target_node%name) == trim(var_name)) then
@@ -773,7 +774,7 @@ contains
     contains
 
         recursive subroutine refine_from_statement(arena, stmt_idx, param_types, &
-                                                    param_names)
+                                                   param_names)
             use ast_nodes_loops, only: do_loop_node
             type(ast_arena_t), intent(inout) :: arena
             integer, intent(in) :: stmt_idx

--- a/src/semantic/analyzers/semantic_undefined_variable_checker.f90
+++ b/src/semantic/analyzers/semantic_undefined_variable_checker.f90
@@ -35,7 +35,7 @@ contains
         ! which the checker doesn't fully understand yet
         if (input_mode == INPUT_MODE_STANDARD) return
 
-        ! Recursively traverse the AST to find identifier nodes and check if they're defined
+    ! Recursively traverse the AST to find identifier nodes and check if they're defined
         call traverse_for_undefined_variables(scopes, errors, arena, prog_index)
     end subroutine check_undefined_variables_generic
 

--- a/src/semantic/analyzers/semantic_validation_utils.f90
+++ b/src/semantic/analyzers/semantic_validation_utils.f90
@@ -60,7 +60,8 @@ contains
         ! - INPUT_MODE_STANDARD: Skip propagation (standard .f90 with implicit none)
         ! - Standard .f90 WITHOUT implicit none: Currently unsupported (future work)
         if (present(input_mode)) then
-            if (input_mode == INPUT_MODE_STANDARD) return  ! Skip propagation if standard mode
+            if (input_mode == INPUT_MODE_STANDARD) return
+            ! Skip propagation if standard mode
         end if
         ! Default: Always propagate (needed for lazy Fortran type inference)
 

--- a/src/semantic/scope_manager.f90
+++ b/src/semantic/scope_manager.f90
@@ -3,7 +3,8 @@ module scope_manager
     use, intrinsic :: iso_fortran_env, only: error_unit
     use type_system_unified
     use identifier_table, only: identifier_table_t, identifier_table_init, &
-                                identifier_table_intern, identifier_table_find, identifier_id_kind
+                                identifier_table_intern, identifier_table_find, &
+                                identifier_id_kind
     use error_handling, only: result_t, create_error_result, &
                               success_result, ERROR_MEMORY
     implicit none
@@ -247,7 +248,7 @@ contains
                         ! Deep copy env via assignment (allocates and copies entries)
                         temp_scopes(i)%env = this%scopes(i)%env
                         call temp_scopes(i)%env%ensure_capacity(max(64, &
-                                                                    temp_scopes(i)%env%count))
+                                                              temp_scopes(i)%env%count))
                         if (associated(this%scopes(i)%identifiers)) then
                             temp_scopes(i)%identifiers => this%identifier_storage
                             temp_scopes(i)%env%identifiers => this%identifier_storage
@@ -275,7 +276,7 @@ contains
         this%scopes(this%depth)%env = new_scope%env
         this%scopes(this%depth)%env%identifiers => this%identifier_storage
         call this%scopes(this%depth)%env%ensure_capacity(max(64, &
-                                                             this%scopes(this%depth)%env%count))
+                                                     this%scopes(this%depth)%env%count))
 
     end subroutine stack_push_scope
 
@@ -322,7 +323,7 @@ contains
         if (this%depth > 0) then
             ! Ensure environment arrays exist for current scope
             call this%scopes(this%depth)%env%ensure_capacity(max(64, &
-                                                                 this%scopes(this%depth)%env%count + 1))
+                                                 this%scopes(this%depth)%env%count + 1))
             ! Use direct scope_define to avoid type-bound procedure issues with arrays
             call scope_define(this%scopes(this%depth), name, scheme)
         else

--- a/src/semantic/types/type_checker.f90
+++ b/src/semantic/types/type_checker.f90
@@ -36,7 +36,8 @@ contains
             case (TARRAY)
                 ! Arrays must have compatible element types and sizes
                 if (type_has_args(from_type) .and. type_has_args(to_type)) then
-                    assignable = is_assignable(type_get_arg(from_type, 1), type_get_arg(to_type, 1))
+                    assignable = is_assignable(type_get_arg(from_type, 1), &
+                                               type_get_arg(to_type, 1))
                     if (assignable .and. from_type%size > 0 .and. to_type%size > 0) then
                         assignable = (from_type%size == to_type%size)
                     end if
@@ -173,7 +174,8 @@ contains
 
         ! Check element types are compatible
         if (type_has_args(array1) .and. type_has_args(array2)) then
-            if (.not. is_assignable(type_get_arg(array1, 1), type_get_arg(array2, 1))) return
+            if (.not. is_assignable(type_get_arg(array1, 1), type_get_arg(array2, &
+                                                                          1))) return
         else
             return
         end if

--- a/src/semantic/types/type_system_unified.f90
+++ b/src/semantic/types/type_system_unified.f90
@@ -237,7 +237,8 @@ contains
         call ensure_arena_initialized()
 
         ! Convert type vars to handles (simplified - we'll store as empty for now)
-        allocate (var_handles(0))  ! Empty for now - full implementation would convert forall_vars
+        allocate (var_handles(0))
+        ! Empty for now - full implementation would convert forall_vars
         vars_handle = store_type_args(global_arena, var_handles)
 
         arena_poly%forall_vars = vars_handle

--- a/src/standardizers/standardizer_allocatable.f90
+++ b/src/standardizers/standardizer_allocatable.f90
@@ -148,7 +148,8 @@ contains
 
     logical function variable_requires_allocatable(name, assigned_vars, &
                                                    assignment_counts, var_count, &
-                                                   is_parameter, is_array) result(needs_alloc)
+                                                   is_parameter, is_array) &
+        result(needs_alloc)
         character(len=*), intent(in) :: name
         character(len=64), intent(in) :: assigned_vars(:)
         integer, intent(in) :: assignment_counts(:)
@@ -328,10 +329,11 @@ contains
         end do
 
         ! Second pass: mark declarations for variables with multiple array assignments
-        ! CRITICAL: Copy indices to local array before iteration to prevent stale access
-        ! When mark_declarations_allocatable modifies the arena (via split_multi_variable_declaration),
-        ! it updates the arena's version of prog%body_indices, but we have a stack copy (intent(in)).
-        ! Using the stale copy causes segfaults when accessing invalid/outdated indices.
+        ! CRITICAL: Copy indices to local array before iteration to prevent stale
+        ! access. When mark_declarations_allocatable modifies the arena (via
+        ! split_multi_variable_declaration), it updates the arenas version of
+        ! prog%body_indices, but we have a stack copy (intent(in)).
+        ! Using stale copy causes segfaults when accessing invalid/outdated indices.
         allocate (local_indices(size(prog%body_indices)))
         local_indices = prog%body_indices
 
@@ -502,7 +504,8 @@ contains
 
         select type (decl => arena%entries(decl_index)%node)
         type is (declaration_node)
-            if (.not. (decl%is_multi_declaration .and. allocated(decl%var_names))) return
+            if (.not. (decl%is_multi_declaration .and. &
+                       allocated(decl%var_names))) return
 
             is_parameter = is_procedure_parameter(arena, decl_index)
             do i = 1, size(decl%var_names)
@@ -553,9 +556,9 @@ contains
             if (.not. (decl_orig%is_multi_declaration .and. &
                        allocated(decl_orig%var_names))) return
 
-            ! CRITICAL: Copy declaration to stack before arena pushes to avoid dangling pointer
+     ! CRITICAL: Copy declaration to stack before arena pushes to avoid dangling pointer
             ! When append_split_declaration pushes to arena, it may trigger reallocation
-            ! which would invalidate the decl_orig selector. Using a stack copy prevents this.
+      ! which would invalidate the decl_orig selector. Using a stack copy prevents this.
             template_decl = decl_orig
 
             allocate (new_indices(size(template_decl%var_names)))
@@ -568,7 +571,8 @@ contains
                                     template_decl%var_names(i), assigned_vars, &
                                     assignment_counts, &
                                     var_count, is_parameter, template_decl%is_array)
-                call append_split_declaration(arena, template_decl, template_decl%var_names(i), &
+                call append_split_declaration(arena, template_decl, &
+                                              template_decl%var_names(i), &
                                               needs_allocatable, prog_index, &
                                               new_indices, new_count)
             end do
@@ -606,7 +610,7 @@ contains
 
         new_decl%is_allocatable = is_allocatable
 
-        ! Adjust dimensions for allocatable arrays (but preserve explicit bounds - fixes #1812)
+ ! Adjust dimensions for allocatable arrays (but preserve explicit bounds - fixes #1812)
         if (is_allocatable .and. new_decl%is_array .and. &
             allocated(new_decl%dimension_indices)) then
             ! Only convert to deferred shape if array does NOT have explicit bounds
@@ -899,7 +903,7 @@ contains
         ! - character strings with deferred length
         ! - arrays flagged by assignment tracking (but NOT if they have explicit bounds)
         if (decl%is_array) then
-            ! Do NOT convert arrays with explicit bounds to allocatable (fixes #1812, #2149)
+        ! Do NOT convert arrays with explicit bounds to allocatable (fixes #1812, #2149)
             ! Arrays like integer :: arr(0:9) or real :: arr(-5:5) must preserve bounds
             ! Arrays from slices like slice1 = arr(1:5) have fixed sizes already set
             if (has_explicit_array_bounds(decl)) then

--- a/src/standardizers/standardizer_core.f90
+++ b/src/standardizers/standardizer_core.f90
@@ -11,7 +11,8 @@ module standardizer_core
     use standardizer_program
     use standardizer_module
     use standardizer_types, only: string_result_t
-    use standardizer_subprograms, only: wrap_function_in_program, wrap_subroutine_in_program
+    use standardizer_subprograms, only: wrap_function_in_program, &
+                                        wrap_subroutine_in_program
     use debug_trace, only: trace_enter, trace_leave
     use standardizer_parameter, only: set_standardizer_input_mode
     implicit none
@@ -78,8 +79,8 @@ contains
             if (.not. allocated(node%body_indices)) return
 
             ! CRITICAL: Copy indices before loop to prevent dangling pointer access
-            ! standardize_program calls split_multi_variable_declaration which modifies arena,
-            ! potentially invalidating the 'node' selector. Using a local copy prevents this.
+      ! standardize_program calls split_multi_variable_declaration which modifies arena,
+       ! potentially invalidating the 'node' selector. Using a local copy prevents this.
             block
                 integer, allocatable :: local_indices(:)
                 allocate (local_indices(size(node%body_indices)))

--- a/src/standardizers/standardizer_declarations_parsing.f90
+++ b/src/standardizers/standardizer_declarations_parsing.f90
@@ -306,7 +306,8 @@ contains
                             ! ISO/IEC 1539-1:2018 Section 8.5.8.2: explicit-shape arrays
                             ! Note: dimension_indices(i)==0 means deferred shape (:)
                             !       dimension_indices(i)>0 means explicit size
-                            if (get_standardizer_input_mode() == INPUT_MODE_STANDARD) then
+                            if (get_standardizer_input_mode() == &
+                                INPUT_MODE_STANDARD) then
                                 if (has_explicit_array_bounds_decl(decl)) then
                                     ! Skip type update - preserve original bounds
                                     return

--- a/src/standardizers/standardizer_function_result_utils.f90
+++ b/src/standardizers/standardizer_function_result_utils.f90
@@ -415,7 +415,7 @@ contains
             if (decl%inferred_type%kind > 0 .and. len_trim(decl%type_name) == 0) then
                 decl%type_name = mono_type_to_string(decl%inferred_type, &
                                                      include_shape=.false., &
-                                                     standardize_real=type_std_enabled, &
+                                                    standardize_real=type_std_enabled, &
                                                      fallback=decl%type_name)
             end if
         end if

--- a/src/standardizers/standardizer_subprograms.f90
+++ b/src/standardizers/standardizer_subprograms.f90
@@ -31,8 +31,8 @@ contains
         if (.not. allocated(prog%body_indices)) return
 
         ! CRITICAL: Copy indices before loop to prevent dangling pointer access
-        ! standardize_function_def and standardize_subroutine_def call push_implicit_statement
-        ! which modifies arena, potentially invalidating the prog selector used in select type
+  ! standardize_function_def and standardize_subroutine_def call push_implicit_statement
+  ! which modifies arena, potentially invalidating the prog selector used in select type
         block
             integer, allocatable :: local_indices(:)
             allocate (local_indices(size(prog%body_indices)))
@@ -45,7 +45,8 @@ contains
                         type is (function_def_node)
                             call standardize_function_def(arena, stmt, local_indices(i))
                         type is (subroutine_def_node)
-                            call standardize_subroutine_def(arena, stmt, local_indices(i))
+                            call standardize_subroutine_def(arena, stmt, &
+                                                            local_indices(i))
                         end select
                     end if
                 end if

--- a/src/utilities/debug_trace.f90
+++ b/src/utilities/debug_trace.f90
@@ -29,10 +29,12 @@ contains
         end if
         ! Optional: file logging (open only if tracing enabled)
         if (enabled) then
-            call get_environment_variable('FORTFRONT_TRACE_FILE', file_name, status=stat)
+            call get_environment_variable('FORTFRONT_TRACE_FILE', file_name, &
+                                          status=stat)
             if (stat == 0 .and. len_trim(file_name) > 0) then
                 ! Preserve any early CLI trace lines by appending instead of replacing.
-                open(newunit=file_u, file=trim(file_name), status='unknown', position='append', action='write')
+                open (newunit=file_u, file=trim(file_name), status='unknown', &
+                      position='append', action='write')
             end if
         end if
     end subroutine trace_init
@@ -54,7 +56,8 @@ contains
         if (.not. enabled) return
         depth = depth + 1
         if (depth > MAX_DEPTH) then
-            write (error_unit, '(A,I0,1X,A)') 'TRACE: Max depth exceeded: ', depth, trim(name)
+            write (error_unit, '(A,I0,1X,A)') 'TRACE: Max depth exceeded: ', &
+                depth, trim(name)
             error stop 1
         end if
         write (error_unit, '(A,I0,2X,A)') '>> depth', depth, trim(name)

--- a/src/utilities/input_validation.f90
+++ b/src/utilities/input_validation.f90
@@ -5,7 +5,8 @@ module input_validation
     ! Cleanly separated from frontend concerns with no circular dependencies
 
     use lexer_core, only: token_t, TK_EOF, TK_KEYWORD, TK_COMMENT, TK_NEWLINE, &
-                          TK_OPERATOR, TK_IDENTIFIER, TK_NUMBER, TK_UNKNOWN, TK_STRING, &
+                          TK_OPERATOR, TK_IDENTIFIER, TK_NUMBER, TK_UNKNOWN, &
+                          TK_STRING, &
                           TK_WHITESPACE, to_lower
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier

--- a/src/utilities/path_validation.f90
+++ b/src/utilities/path_validation.f90
@@ -219,7 +219,7 @@ contains
                 return
             end if
 
-            ! Check for control characters (except newline and tab which are handled elsewhere)
+     ! Check for control characters (except newline and tab which are handled elsewhere)
             if (ichar(c) < 32 .and. ichar(c) /= 9 .and. ichar(c) /= 10) then
                 has_invalid = .true.
                 return

--- a/src/utilities/type_string_utils.f90
+++ b/src/utilities/type_string_utils.f90
@@ -218,11 +218,12 @@ contains
         visited_count = 0
         depth = 0
         call collect_array_dimensions_impl(mono_type, dim_spec, &
-                                          visited_ids, visited_count, depth)
+                                           visited_ids, visited_count, depth)
     end subroutine collect_array_dimensions
 
     recursive subroutine collect_array_dimensions_impl(mono_type, dim_spec, &
-                                                       visited_ids, visited_count, depth)
+                                                       visited_ids, &
+                                                       visited_count, depth)
         type(mono_type_t), intent(in) :: mono_type
         character(len=:), allocatable, intent(inout) :: dim_spec
         integer, intent(inout) :: visited_ids(100)
@@ -260,7 +261,7 @@ contains
             inner_element = type_args_element(mono_type, 1)
             if (inner_element%kind == TARRAY) then
                 call collect_array_dimensions_impl(inner_element, dim_spec, &
-                                                  visited_ids, visited_count, depth)
+                                                   visited_ids, visited_count, depth)
             end if
         end if
 


### PR DESCRIPTION
## Summary

- Applied fprettify to all 64 files containing 182 line-length violations
- Manually fixed 9 lines that fprettify could not auto-split
- Zero 88-column violations remaining in src/

## Changes

**Automated fixes via fprettify:**
- Long function signatures wrapped at parameters
- Complex conditionals split at logical operators
- String concatenations broken at operators
- Long use statements with split import lists

**Manual fixes (9 lines):**
- `src/performance/ast_performance.f90:507` - allocate statement
- `src/parser/procedures/parser_procedure_signatures.f90:102,105` - procedure calls
- `src/parser/declarations/parser_definition_statements.f90:2` - comment
- `src/standardizers/standardizer_allocatable.f90:333-334` - comments
- `src/semantic/analyzers/semantic_analyzer_infer_impl.f90:15` - comment
- `src/ast/arena/ast_arena_modern.f90:62-63` - comments

## Verification

```bash
# Before (182 violations)
find src/ -name "*.f90" -exec grep -Hn '.\{89,\}' {} \; | wc -l
# Result: 182

# After (0 violations)
find src/ -name "*.f90" -exec grep -Hn '.\{89,\}' {} \; | wc -l
# Result: 0

# All tests pass
fpm test
# All fortfront tests passed with STOP 0
```

## Test plan

- [x] Verify zero 88-column violations with grep
- [x] Run full test suite (fpm test) - all tests pass
- [x] No functional changes - formatting only