### PR TITLE
fix: polish: Mark is_var_declared_in_code as pure function (fixes #2627)

### DIFF
--- a/src/codegen/codegen_loop_vars_mod.f90
+++ b/src/codegen/codegen_loop_vars_mod.f90
@@ -5,7 +5,8 @@ module codegen_loop_vars_mod
 
 contains
 
-    logical function is_var_declared_in_code(code, var_name) result(declared)
+    pure logical function is_var_declared_in_code(code, var_name) &
+        result(declared)
         character(len=*), intent(in) :: code
         character(len=*), intent(in) :: var_name
         integer :: search_start, decl_pos_rel, decl_pos_abs, var_search_start


### PR DESCRIPTION
## Summary

Mark `is_var_declared_in_code` as `pure` in `src/codegen/codegen_loop_vars_mod.f90`.

## Verification

- Command: `fpm test 2>&1 | tee /tmp/fpm-test-2627.log`
- Excerpt:

```
All fortfront API arena tests passed!
STOP 0
...
All function parameter parsing tests passed!
STOP 0
```

- Artifact: `/tmp/fpm-test-2627.log`
