### PR TITLE
fix: strict-mode explicit interface validation (fixes #2592)

### DIFF
--- a/examples/f90/issue_2592_interface_block_explicit_interface_ok.f90
+++ b/examples/f90/issue_2592_interface_block_explicit_interface_ok.f90
@@ -1,0 +1,17 @@
+program issue_2592_interface_block_explicit_interface_ok
+    implicit none
+
+    integer :: x
+
+    interface
+        subroutine external_sub(a)
+            implicit none
+
+            integer, intent(in) :: a
+        end subroutine external_sub
+    end interface
+
+    x = 1
+    call external_sub(x)
+end program issue_2592_interface_block_explicit_interface_ok
+

--- a/examples/f90/issue_2592_internal_procedure_explicit_interface_ok.f90
+++ b/examples/f90/issue_2592_internal_procedure_explicit_interface_ok.f90
@@ -1,0 +1,20 @@
+program issue_2592_internal_procedure_explicit_interface_ok
+    implicit none
+
+    integer :: x
+
+    x = 1
+    call internal_sub(x)
+
+contains
+
+    subroutine internal_sub(a)
+        implicit none
+
+        integer, intent(in) :: a
+
+        print *, a
+    end subroutine internal_sub
+
+end program issue_2592_internal_procedure_explicit_interface_ok
+

--- a/examples/f90/issue_2592_missing_explicit_interface_function.f90
+++ b/examples/f90/issue_2592_missing_explicit_interface_function.f90
@@ -1,0 +1,11 @@
+program issue_2592_missing_explicit_interface_function
+    implicit none
+
+    integer :: x
+    integer :: y
+
+    x = 1
+    y = external_func(x)
+    print *, y
+end program issue_2592_missing_explicit_interface_function
+

--- a/examples/f90/issue_2592_missing_explicit_interface_subroutine.f90
+++ b/examples/f90/issue_2592_missing_explicit_interface_subroutine.f90
@@ -1,0 +1,9 @@
+program issue_2592_missing_explicit_interface_subroutine
+    implicit none
+
+    integer :: x
+
+    x = 1
+    call external_sub(x)
+end program issue_2592_missing_explicit_interface_subroutine
+

--- a/src/frontend/frontend_transformation_pipeline.f90
+++ b/src/frontend/frontend_transformation_pipeline.f90
@@ -39,7 +39,7 @@ module frontend_transformation_pipeline
     use debug_trace, only: trace_init, trace_enter, trace_leave, trace_is_enabled
     use procedure_classification, only: should_hoist_procedure
     use semantic_input_mode, only: INPUT_MODE_LAZY, INPUT_MODE_STANDARD
-    use semantic_operating_mode, only: OPERATING_MODE_STRICT
+    use semantic_operating_mode, only: OPERATING_MODE_INFER, OPERATING_MODE_STRICT
     use frontend_transformation_common, only: format_options_t, &
                                               transform_context_t, shared_arena, &
                                               shared_arena_initialized
@@ -106,11 +106,12 @@ module frontend_transformation_pipeline
 contains
     ! String-based transformation function for CLI usage
     subroutine transform_lazy_fortran_string(input, output, error_msg, &
-                                             enable_ast_wrapping)
+                                             enable_ast_wrapping, operating_mode)
         character(len=*), intent(in) :: input
         character(len=:), allocatable, intent(out) :: output
         character(len=:), allocatable, intent(out) :: error_msg
         logical, intent(in), optional :: enable_ast_wrapping
+        integer, intent(in), optional :: operating_mode
 
         ! Local variables for 4-phase pipeline
         type(token_t), allocatable, target :: tokens(:)
@@ -118,6 +119,7 @@ contains
         integer :: prog_index
         character(len=:), allocatable :: source
         logical :: apply_ast_wrapping
+        integer :: local_operating_mode
 
         allocate (character(len=0) :: error_msg)
         error_msg = ""
@@ -126,6 +128,8 @@ contains
         if (present(enable_ast_wrapping)) then
             apply_ast_wrapping = enable_ast_wrapping
         end if
+        local_operating_mode = OPERATING_MODE_INFER
+        if (present(operating_mode)) local_operating_mode = operating_mode
 
         call trace_init()
 
@@ -233,7 +237,7 @@ contains
         ! Phases 3-5: Semantic Analysis, Standardization, Code Generation
         call trace_enter('phase:final')
         call run_final_phases(shared_arena, prog_index, output, error_msg, &
-                              apply_ast_wrapping)
+                              apply_ast_wrapping, local_operating_mode)
         call trace_leave('phase:final')
         if (error_msg /= "") then
             call trace_leave('transform_lazy_fortran_string')
@@ -338,7 +342,8 @@ contains
         ! For standard Fortran mode, use simple transformation
         if (context%input_mode == INPUT_MODE_STANDARD) then
             call transform_lazy_fortran_string(input, output, error_msg, &
-                                               enable_ast_wrapping=.false.)
+                                               enable_ast_wrapping=.false., &
+                                               operating_mode=context%operating_mode)
             return
         end if
 
@@ -732,12 +737,13 @@ contains
 
     ! Run final phases (semantic, standardization, codegen) using pass manager
     subroutine run_final_phases(compiler_arena, prog_index, output, error_msg, &
-                                enable_ast_wrapping)
+                                enable_ast_wrapping, operating_mode)
         type(compiler_arena_t), target, intent(inout) :: compiler_arena
         integer, intent(inout) :: prog_index
         character(len=:), allocatable, intent(out) :: output
         character(len=:), allocatable, intent(inout) :: error_msg
         logical, intent(in) :: enable_ast_wrapping
+        integer, intent(in) :: operating_mode
         type(pass_manager_t) :: manager
         type(pass_context_t) :: pass_ctx
 
@@ -763,6 +769,7 @@ contains
         pass_ctx%compiler_arena => compiler_arena
         pass_ctx%prog_index = prog_index
         allocate (character(len=0) :: pass_ctx%error_msg)
+        pass_ctx%operating_mode = operating_mode
         pass_ctx%enable_ast_wrapping = enable_ast_wrapping
         pass_ctx%has_functions = .false.
         pass_ctx%has_subroutines = .false.

--- a/src/semantic/analyzers/README.md
+++ b/src/semantic/analyzers/README.md
@@ -87,6 +87,7 @@ For complete semantic analysis concepts including type inference, scope manageme
 | File | Description |
 |------|-------------|
 | semantic_scope_creation.f90 | Create and manage scopes |
+| semantic_explicit_interface_checker.f90 | Strict-mode explicit interface validation for procedure calls |
 | semantic_validation_utils.f90 | Validation helper utilities |
 | semantic_annotation_utils.f90 | AST annotation with type information |
 | semantic_constant_values.f90 | Constant value analysis |

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -6,6 +6,10 @@ submodule(semantic_analyzer) semantic_analyzer_infer_impl
                                    TFUN, TARRAY, TLOGICAL, TINT, TCHAR
     use semantic_type_operations, only: get_common_type
     use ast_nodes_misc, only: data_statement_node
+    use semantic_explicit_interface_checker, only: &
+        validate_explicit_interface_for_function_reference, &
+        validate_explicit_interface_for_subroutine_call
+    use semantic_operating_mode, only: OPERATING_MODE_STRICT
     use semantic_type_lookup_wrapper, only: set_semantic_context_for_lookup, &
                                             clear_semantic_context_for_lookup, &
                                             get_type_with_stored_context

--- a/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
@@ -440,6 +440,10 @@
                                                  module_get_node_type_wrapper)
             call collect_call_signature(this%signatures, arena, expr, node_type, &
                                         node_index)
+            if (this%operating_mode == OPERATING_MODE_STRICT) then
+                call validate_explicit_interface_for_function_reference( &
+                    arena, this%scopes, this%errors, expr, node_index)
+            end if
             call finalize_node(node_index, node_type)
         end subroutine finalize_call_or_subscript
 
@@ -453,6 +457,11 @@
                     type is (subroutine_call_node)
                         call collect_subroutine_signature(this%signatures, arena, &
                                                           call_expr, node_index)
+                        if (this%operating_mode == OPERATING_MODE_STRICT) then
+                            call validate_explicit_interface_for_subroutine_call( &
+                                arena, this%scopes, this%errors, call_expr, &
+                                node_index)
+                        end if
                     end select
                 end if
             end if

--- a/src/semantic/analyzers/semantic_explicit_interface_checker.f90
+++ b/src/semantic/analyzers/semantic_explicit_interface_checker.f90
@@ -1,0 +1,299 @@
+module semantic_explicit_interface_checker
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: call_or_subscript_node, program_node
+    use ast_nodes_data, only: module_node
+    use ast_nodes_misc, only: contains_node, interface_block_node, &
+                              module_procedure_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_call_node, &
+                                   subroutine_def_node
+    use error_handling, only: ERROR_SEMANTIC, create_error_result, &
+                              error_collection_t
+    use intrinsic_registry, only: is_intrinsic_function
+    use scope_manager, only: scope_stack_t
+    use string_utils_mod, only: to_lower
+    use type_system_unified, only: TARRAY, mono_type_t, poly_type_t
+    implicit none
+    private
+
+    public :: validate_explicit_interface_for_function_reference
+    public :: validate_explicit_interface_for_subroutine_call
+
+contains
+
+    subroutine validate_explicit_interface_for_function_reference(arena, scopes, &
+                                                                  errors, expr, &
+                                                                  expr_index)
+        type(ast_arena_t), intent(in) :: arena
+        type(scope_stack_t), intent(inout) :: scopes
+        type(error_collection_t), intent(inout) :: errors
+        type(call_or_subscript_node), intent(in) :: expr
+        integer, intent(in) :: expr_index
+
+        character(len=:), allocatable :: proc_name
+
+        if (.not. allocated(expr%name)) return
+        if (len_trim(expr%name) == 0) return
+        if (expr%base_expr_index /= 0) return
+
+        proc_name = to_lower(trim(expr%name))
+        if (is_intrinsic_function(proc_name)) return
+        if (is_known_array_reference(scopes, proc_name)) return
+        if (has_explicit_interface_in_arena(arena, proc_name)) return
+
+        call emit_missing_explicit_interface(errors, expr%name)
+    end subroutine validate_explicit_interface_for_function_reference
+
+    subroutine validate_explicit_interface_for_subroutine_call(arena, scopes, &
+                                                               errors, expr, &
+                                                               expr_index)
+        type(ast_arena_t), intent(in) :: arena
+        type(scope_stack_t), intent(inout) :: scopes
+        type(error_collection_t), intent(inout) :: errors
+        type(subroutine_call_node), intent(in) :: expr
+        integer, intent(in) :: expr_index
+
+        character(len=:), allocatable :: proc_name
+
+        if (.not. allocated(expr%name)) return
+        if (len_trim(expr%name) == 0) return
+
+        proc_name = to_lower(trim(expr%name))
+        if (is_intrinsic_subroutine(proc_name)) return
+        if (has_explicit_interface_in_arena(arena, proc_name)) return
+
+        call emit_missing_explicit_interface(errors, expr%name)
+    end subroutine validate_explicit_interface_for_subroutine_call
+
+    logical function is_known_array_reference(scopes, name) result(is_array)
+        type(scope_stack_t), intent(inout) :: scopes
+        character(len=*), intent(in) :: name
+
+        type(poly_type_t), allocatable :: scheme
+        type(mono_type_t) :: mono
+
+        is_array = .false.
+        if (len_trim(name) == 0) return
+
+        call scopes%lookup(name, scheme)
+        if (.not. allocated(scheme)) return
+
+        mono = scheme%get_mono()
+        call mono%sync_from_arena()
+        is_array = mono%kind == TARRAY
+    end function is_known_array_reference
+
+    logical function has_explicit_interface_in_arena(arena, name) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+
+        integer :: i
+
+        found = .false.
+        if (len_trim(name) == 0) return
+
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+
+            select type (node => arena%entries(i)%node)
+            type is (interface_block_node)
+                if (interface_block_has_named_procedure(arena, node, name)) then
+                    found = .true.
+                    return
+                end if
+            type is (module_node)
+                if (allocated(node%procedure_indices)) then
+                    if (indices_contain_named_procedure(arena, node%procedure_indices, &
+                                                        name)) then
+                        found = .true.
+                        return
+                    end if
+                end if
+            type is (program_node)
+                if (body_has_internal_procedure_interface(arena, node%body_indices, &
+                                                          name)) then
+                    found = .true.
+                    return
+                end if
+            type is (function_def_node)
+                if (body_has_internal_procedure_interface(arena, node%body_indices, &
+                                                          name)) then
+                    found = .true.
+                    return
+                end if
+            type is (subroutine_def_node)
+                if (body_has_internal_procedure_interface(arena, node%body_indices, &
+                                                          name)) then
+                    found = .true.
+                    return
+                end if
+            class default
+                cycle
+            end select
+        end do
+    end function has_explicit_interface_in_arena
+
+    logical function body_has_internal_procedure_interface(arena, body_indices, &
+                                                           name) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: name
+
+        integer :: i
+        logical :: in_contains
+
+        found = .false.
+        if (len_trim(name) == 0) return
+        if (.not. allocated(body_indices)) return
+        if (size(body_indices) == 0) return
+
+        in_contains = .false.
+        do i = 1, size(body_indices)
+            if (body_indices(i) <= 0 .or. body_indices(i) > arena%size) cycle
+            if (.not. allocated(arena%entries(body_indices(i))%node)) cycle
+
+            select type (node => arena%entries(body_indices(i))%node)
+            type is (contains_node)
+                in_contains = .true.
+            type is (function_def_node)
+                if (.not. in_contains) cycle
+                if (node_name_matches(node%name, name)) then
+                    found = .true.
+                    return
+                end if
+            type is (subroutine_def_node)
+                if (.not. in_contains) cycle
+                if (node_name_matches(node%name, name)) then
+                    found = .true.
+                    return
+                end if
+            class default
+                cycle
+            end select
+        end do
+    end function body_has_internal_procedure_interface
+
+    logical function interface_block_has_named_procedure(arena, iface, name) &
+        result(found)
+        type(ast_arena_t), intent(in) :: arena
+        type(interface_block_node), intent(in) :: iface
+        character(len=*), intent(in) :: name
+
+        found = .false.
+        if (.not. allocated(iface%procedure_indices)) return
+        if (size(iface%procedure_indices) == 0) return
+
+        found = indices_contain_named_procedure(arena, iface%procedure_indices, name)
+    end function interface_block_has_named_procedure
+
+    logical function indices_contain_named_procedure(arena, indices, name) &
+        result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=*), intent(in) :: name
+
+        integer :: i
+
+        found = .false.
+        if (len_trim(name) == 0) return
+        if (size(indices) == 0) return
+
+        do i = 1, size(indices)
+            if (indices(i) <= 0 .or. indices(i) > arena%size) cycle
+            if (.not. allocated(arena%entries(indices(i))%node)) cycle
+
+            select type (proc => arena%entries(indices(i))%node)
+            type is (function_def_node)
+                if (node_name_matches(proc%name, name)) then
+                    found = .true.
+                    return
+                end if
+            type is (subroutine_def_node)
+                if (node_name_matches(proc%name, name)) then
+                    found = .true.
+                    return
+                end if
+            type is (module_procedure_node)
+                if (module_procedure_has_name(proc, name)) then
+                    found = .true.
+                    return
+                end if
+            class default
+                cycle
+            end select
+        end do
+    end function indices_contain_named_procedure
+
+    logical function module_procedure_has_name(node, name) result(found)
+        type(module_procedure_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+
+        integer :: i
+        character(len=:), allocatable :: lowered
+
+        found = .false.
+        if (len_trim(name) == 0) return
+        if (.not. allocated(node%procedure_names)) return
+        if (size(node%procedure_names) == 0) return
+
+        do i = 1, size(node%procedure_names)
+            lowered = to_lower(trim(node%procedure_names(i)%s))
+            if (lowered == name) then
+                found = .true.
+                return
+            end if
+        end do
+    end function module_procedure_has_name
+
+    logical function node_name_matches(node_name, name) result(matches)
+        character(len=:), allocatable, intent(in) :: node_name
+        character(len=*), intent(in) :: name
+
+        matches = .false.
+        if (.not. allocated(node_name)) return
+        if (len_trim(node_name) == 0) return
+        if (to_lower(trim(node_name)) == name) matches = .true.
+    end function node_name_matches
+
+    logical function is_intrinsic_subroutine(name) result(found)
+        character(len=*), intent(in) :: name
+
+        found = .false.
+        if (len_trim(name) == 0) return
+
+        select case (name)
+        case ("cpu_time", "date_and_time", "execute_command_line", &
+              "get_command", "get_command_argument", &
+              "get_environment_variable", "move_alloc", "random_init", &
+              "random_number", "random_seed", "system_clock", "sync_all", &
+              "sync_images", "sync_memory", "lock", "unlock", "event_post", &
+              "event_wait", "event_query", "form_team", "change_team", &
+              "end_team", "co_broadcast", "co_sum", "co_max", "co_min", &
+              "co_reduce", "co_allgather", "co_gather", "co_scatter", &
+              "atomic_define", "atomic_ref", "atomic_cas", "atomic_add", &
+              "atomic_and", "atomic_or", "atomic_xor", "atomic_fetch_add", &
+              "atomic_fetch_and", "atomic_fetch_or", "atomic_fetch_xor")
+            found = .true.
+        case default
+            found = .false.
+        end select
+    end function is_intrinsic_subroutine
+
+    subroutine emit_missing_explicit_interface(errors, original_name)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: original_name
+        character(len=:), allocatable :: message
+        character(len=:), allocatable :: suggestion
+
+        message = "No explicit interface for procedure '" // trim(original_name) // &
+                  "'"
+        suggestion = "Move the procedure into a module or contains block, " // &
+                     "or add an interface block"
+
+        call errors%add_result(create_error_result( &
+                               message, ERROR_SEMANTIC, &
+                               component="semantic_analyzer", &
+                               context="explicit_interface_requirement", &
+                               suggestion=suggestion))
+    end subroutine emit_missing_explicit_interface
+
+end module semantic_explicit_interface_checker

--- a/test/integration/core_features/test_strict_explicit_interface_requirement.f90
+++ b/test/integration/core_features/test_strict_explicit_interface_requirement.f90
@@ -1,0 +1,100 @@
+program test_strict_explicit_interface_requirement
+    use, intrinsic :: iso_fortran_env, only: &
+        error_unit, input_unit, iostat_end, iostat_eor
+    use transformation_api, only: transform_context_t, transform_with_context, &
+                                  INPUT_MODE_STANDARD, OPERATING_MODE_INFER, &
+                                  OPERATING_MODE_STRICT
+    implicit none
+
+    character(len=:), allocatable :: source
+    character(len=:), allocatable :: output
+    character(len=:), allocatable :: error_msg
+    type(transform_context_t) :: ctx
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .false.
+
+    call read_example( &
+        'examples/f90/issue_2592_missing_explicit_interface_subroutine.f90', &
+        source)
+    ctx%operating_mode = OPERATING_MODE_INFER
+    call transform_with_context(source, output, error_msg, ctx)
+    call assert_no_error(error_msg)
+
+    ctx%operating_mode = OPERATING_MODE_STRICT
+    call transform_with_context(source, output, error_msg, ctx)
+    call assert_contains(error_msg, 'No explicit interface for procedure')
+    call assert_contains(error_msg, "external_sub")
+
+    call read_example( &
+        'examples/f90/issue_2592_missing_explicit_interface_function.f90', &
+        source)
+    ctx%operating_mode = OPERATING_MODE_INFER
+    call transform_with_context(source, output, error_msg, ctx)
+    call assert_no_error(error_msg)
+
+    ctx%operating_mode = OPERATING_MODE_STRICT
+    call transform_with_context(source, output, error_msg, ctx)
+    call assert_contains(error_msg, 'No explicit interface for procedure')
+    call assert_contains(error_msg, "external_func")
+
+    call read_example( &
+        'examples/f90/issue_2592_internal_procedure_explicit_interface_ok.f90', &
+        source)
+    ctx%operating_mode = OPERATING_MODE_STRICT
+    call transform_with_context(source, output, error_msg, ctx)
+    call assert_no_error(error_msg)
+
+    call read_example( &
+        'examples/f90/issue_2592_interface_block_explicit_interface_ok.f90', &
+        source)
+    ctx%operating_mode = OPERATING_MODE_STRICT
+    call transform_with_context(source, output, error_msg, ctx)
+    call assert_no_error(error_msg)
+
+    print *, 'PASS: strict mode requires explicit interfaces'
+
+contains
+
+    include '../../common/cli_io_reader.inc'
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(A)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    subroutine assert_no_error(msg)
+        character(len=:), allocatable, intent(in) :: msg
+
+        if (.not. allocated(msg)) return
+        if (len_trim(msg) == 0) return
+        write (error_unit, '(A)') 'FAIL: unexpected error message:'
+        write (error_unit, '(A)') trim(msg)
+        error stop 1
+    end subroutine assert_no_error
+
+    subroutine assert_contains(msg, needle)
+        character(len=:), allocatable, intent(in) :: msg
+        character(len=*), intent(in) :: needle
+
+        if (.not. allocated(msg)) then
+            write (error_unit, '(A)') 'FAIL: expected error message'
+            error stop 1
+        end if
+        if (index(msg, needle) == 0) then
+            write (error_unit, '(A)') 'FAIL: expected message to contain: ' // &
+                trim(needle)
+            write (error_unit, '(A)') 'Got:'
+            write (error_unit, '(A)') trim(msg)
+            error stop 1
+        end if
+    end subroutine assert_contains
+
+end program test_strict_explicit_interface_requirement


### PR DESCRIPTION
## Summary
- Enforce strict-mode explicit interface requirement for procedure calls.
- Propagate `operating_mode` into the standard-Fortran `transform_with_context` path so strict-mode semantic checks run there too.
- Add issue-scoped examples and an integration test for #2592.

## Verification
- `make check-duplication 2>&1 | tee /tmp/fortfront-check-duplication.log`
  - `✓ PASS: No end-to-end test violations found`
- `fpm test 2>&1 | tee /tmp/fortfront-fpm-test-full.log`
  - `All tests passed!`
  - `STOP 0`

## Artifacts
- `/tmp/fortfront-check-duplication.log`
- `/tmp/fortfront-fpm-test-full.log`
