### PR TITLE
fix: avoid re-tokenizing in get_trivia_for_ast_node (fixes #2635)

### DIFF
--- a/docs/LIBRARY_USAGE.md
+++ b/docs/LIBRARY_USAGE.md
@@ -88,6 +88,17 @@ call tooling_load_ast_from_string(source, arena, root_index, error_msg)
 call get_trivia_for_ast_node(source, arena, root_index, leading, trailing, found)
 ```
 
+For repeated queries over the same source, tokenize once and reuse:
+
+```fortran
+use fortfront, only: tokenize_core_with_trivia, token_t, get_trivia_for_ast_node_tokens
+
+type(token_t), allocatable :: tokens(:)
+
+call tokenize_core_with_trivia(source, tokens)
+call get_trivia_for_ast_node_tokens(tokens, arena, root_index, leading, trailing, found)
+```
+
 Direct trivia query at an arbitrary source location:
 `get_source_trivia_at(source, line, column)`.
 

--- a/src/cst/cst_trivia_query.f90
+++ b/src/cst/cst_trivia_query.f90
@@ -14,6 +14,7 @@ module cst_trivia_query
     public :: get_trailing_trivia
     public :: get_source_trivia_at
     public :: get_trivia_for_ast_node
+    public :: get_trivia_for_ast_node_tokens
 
 contains
 
@@ -140,6 +141,21 @@ contains
         logical, intent(out) :: found
 
         type(token_t), allocatable :: tokens(:)
+        call tokenize_core_with_trivia(source, tokens)
+        call get_trivia_for_ast_node_tokens(tokens, ast_arena, &
+                                            ast_index, leading, &
+                                            trailing, found)
+    end subroutine get_trivia_for_ast_node
+
+    subroutine get_trivia_for_ast_node_tokens(tokens, ast_arena, ast_index, &
+                                              leading, trailing, found)
+        type(token_t), intent(in) :: tokens(:)
+        type(ast_arena_t), intent(in) :: ast_arena
+        integer, intent(in) :: ast_index
+        type(trivia_t), allocatable, intent(out) :: leading(:)
+        type(trivia_t), allocatable, intent(out) :: trailing(:)
+        logical, intent(out) :: found
+
         integer :: node_line, node_col
         integer :: token_index
 
@@ -147,18 +163,20 @@ contains
         allocate (trailing(0))
         found = .false.
 
-        call get_node_source_location_from_arena(ast_arena, ast_index, node_line, &
+        call get_node_source_location_from_arena(ast_arena, ast_index, &
+                                                 node_line, &
                                                  node_col)
         if (node_line <= 0 .or. node_col <= 0) return
 
-        call tokenize_core_with_trivia(source, tokens)
         token_index = find_token_at(tokens, node_line, node_col)
         if (token_index <= 0) return
 
         call convert_trivia_tokens(tokens(token_index)%leading_trivia, leading)
-        call convert_trivia_tokens(tokens(token_index)%trailing_trivia, trailing)
+        call &
+            convert_trivia_tokens(tokens(token_index)%trailing_trivia, &
+                                  trailing)
         found = .true.
-    end subroutine get_trivia_for_ast_node
+    end subroutine get_trivia_for_ast_node_tokens
 
     function find_token_at(tokens, line, column) result(token_index)
         type(token_t), intent(in) :: tokens(:)
@@ -297,4 +315,3 @@ contains
     end function line_column_to_pos
 
 end module cst_trivia_query
-

--- a/src/fortfront.f90
+++ b/src/fortfront.f90
@@ -87,7 +87,8 @@ module fortfront
     use cst_arena, only: cst_arena_t, cst_handle_t, create_cst_arena
     use cst_trivia_query, only: get_cst_node_for_ast, get_leading_trivia, &
                                 get_trailing_trivia, get_source_trivia_at, &
-                                get_trivia_for_ast_node
+                                get_trivia_for_ast_node, &
+                                get_trivia_for_ast_node_tokens
 
     ! Re-export semantic analyzer functionality
     use semantic_analyzer, only: semantic_context_t, create_semantic_context

--- a/test/api/test_cst_trivia_query.f90
+++ b/test/api/test_cst_trivia_query.f90
@@ -1,7 +1,9 @@
 program test_cst_trivia_query
     use fortfront, only: tooling_load_ast_from_string, ast_arena_t, &
                          get_trivia_for_ast_node, get_source_trivia_at, &
-                         get_node_type_id_from_arena
+                         get_node_type_id_from_arena, &
+                         get_trivia_for_ast_node_tokens, tokenize_core_with_trivia, &
+                         token_t
     use fortfront_types, only: NODE_ASSIGNMENT
     use cst_nodes, only: CST_COMMENT, CST_NEWLINE, CST_WHITESPACE, trivia_t
     implicit none
@@ -15,6 +17,7 @@ program test_cst_trivia_query
 
     if (.not. test_source_trivia_at()) all_passed = .false.
     if (.not. test_trivia_for_assignment_node()) all_passed = .false.
+    if (.not. test_trivia_for_assignment_node_reuse_tokens()) all_passed = .false.
 
     print *
     if (all_passed) then
@@ -180,5 +183,101 @@ contains
         print *, '  PASS: get_trivia_for_ast_node'
     end function test_trivia_for_assignment_node
 
-end program test_cst_trivia_query
+    logical function test_trivia_for_assignment_node_reuse_tokens()
+        character(len=*), parameter :: source = "! header" // new_line('A') // &
+                                       "   x = 1"
+        type(ast_arena_t) :: arena
+        integer :: root_index
+        character(len=:), allocatable :: error_msg
+        integer :: i
+        integer :: assignment_index
+        type(token_t), allocatable :: tokens(:)
+        type(trivia_t), allocatable :: leading_1(:), trailing_1(:)
+        type(trivia_t), allocatable :: leading_2(:), trailing_2(:)
+        type(trivia_t), allocatable :: leading_ref(:), trailing_ref(:)
+        logical :: found_1, found_2, found_ref
 
+        test_trivia_for_assignment_node_reuse_tokens = .true.
+        print *, 'Testing get_trivia_for_ast_node_tokens reuse...'
+
+        call tooling_load_ast_from_string(source, arena, root_index, error_msg)
+        if (len_trim(error_msg) > 0) then
+            print *, '  FAIL: tooling_load_ast_from_string: ', trim(error_msg)
+            test_trivia_for_assignment_node_reuse_tokens = .false.
+            return
+        end if
+
+        assignment_index = 0
+        do i = 1, arena%size
+            if (get_node_type_id_from_arena(arena, i) == NODE_ASSIGNMENT) then
+                assignment_index = i
+                exit
+            end if
+        end do
+
+        if (assignment_index == 0) then
+            print *, '  FAIL: did not find assignment node'
+            test_trivia_for_assignment_node_reuse_tokens = .false.
+            return
+        end if
+
+        call tokenize_core_with_trivia(source, tokens)
+
+        call get_trivia_for_ast_node_tokens(tokens, arena, assignment_index, &
+                                            leading_1, trailing_1, found_1)
+        call get_trivia_for_ast_node_tokens(tokens, arena, assignment_index, &
+                                            leading_2, trailing_2, found_2)
+        call get_trivia_for_ast_node(source, arena, assignment_index, leading_ref, &
+                                     trailing_ref, found_ref)
+
+        if (.not. found_1 .or. .not. found_2 .or. .not. found_ref) then
+            print *, '  FAIL: expected found=true for all trivia queries'
+            test_trivia_for_assignment_node_reuse_tokens = .false.
+            return
+        end if
+
+        if (.not. trivia_equal(leading_1, leading_2)) then
+            print *, '  FAIL: token-reused leading trivia mismatch between calls'
+            test_trivia_for_assignment_node_reuse_tokens = .false.
+            return
+        end if
+
+        if (.not. trivia_equal(trailing_1, trailing_2)) then
+            print *, '  FAIL: token-reused trailing trivia mismatch between calls'
+            test_trivia_for_assignment_node_reuse_tokens = .false.
+            return
+        end if
+
+        if (.not. trivia_equal(leading_1, leading_ref)) then
+            print *, '  FAIL: leading trivia differs from source-based API'
+            test_trivia_for_assignment_node_reuse_tokens = .false.
+            return
+        end if
+
+        if (.not. trivia_equal(trailing_1, trailing_ref)) then
+            print *, '  FAIL: trailing trivia differs from source-based API'
+            test_trivia_for_assignment_node_reuse_tokens = .false.
+            return
+        end if
+
+        print *, '  PASS: get_trivia_for_ast_node_tokens reuse'
+    end function test_trivia_for_assignment_node_reuse_tokens
+
+    logical function trivia_equal(a, b)
+        type(trivia_t), intent(in) :: a(:)
+        type(trivia_t), intent(in) :: b(:)
+
+        integer :: i
+
+        trivia_equal = .false.
+        if (size(a) /= size(b)) return
+
+        do i = 1, size(a)
+            if (a(i)%kind /= b(i)%kind) return
+            if (a(i)%text /= b(i)%text) return
+        end do
+
+        trivia_equal = .true.
+    end function trivia_equal
+
+end program test_cst_trivia_query


### PR DESCRIPTION
### **User description**
Fixes #2635

This adds a token-reuse API for trivia queries to avoid O(N) re-tokenization on repeated calls.

Changes:
- `get_trivia_for_ast_node_tokens(tokens, ...)` accepts a pre-tokenized stream (with trivia).
- `get_trivia_for_ast_node(source, ...)` remains unchanged and now delegates to the token-based API.

## Verification

- `fpm test 2>&1 | tee /tmp/fpm_test_issue_2635.log`
  - Excerpt:
    - `5490: === CST Trivia Query API Tests ===`
    - `5495:   PASS: get_trivia_for_ast_node`
    - `5497:   PASS: get_trivia_for_ast_node_tokens reuse`

- `make check-duplication 2>&1 | tee /tmp/make_check_duplication_issue_2635.log`
  - Excerpt:
    - `✓ PASS: No end-to-end test violations found`


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Adds token-reuse API to avoid O(N) re-tokenization on repeated trivia queries

- New `get_trivia_for_ast_node_tokens()` accepts pre-tokenized stream with trivia

- Original `get_trivia_for_ast_node()` now delegates to token-based API

- Includes comprehensive tests and documentation for token reuse pattern


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Source Code"] -->|tokenize once| B["Token Stream"]
  B -->|reuse| C["get_trivia_for_ast_node_tokens"]
  C -->|query 1| D["Trivia Results"]
  C -->|query 2| E["Trivia Results"]
  A -->|old path| F["get_trivia_for_ast_node"]
  F -->|tokenize| B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cst_trivia_query.f90</strong><dd><code>Extract token-based trivia query API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cst/cst_trivia_query.f90

<ul><li>Extracted core trivia logic into new <code>get_trivia_for_ast_node_tokens()</code> <br>subroutine<br> <li> Refactored <code>get_trivia_for_ast_node()</code> to delegate to token-based API<br> <li> Moved tokenization outside the main logic to enable token reuse<br> <li> Exported new public subroutine <code>get_trivia_for_ast_node_tokens</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2645/files#diff-72755409756a2fb41be9be5bdc3aae01c75b023217548bf3adbacd925deadb60">+22/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>fortfront.f90</strong><dd><code>Export token-based trivia query function</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/fortfront.f90

<ul><li>Added import of new <code>get_trivia_for_ast_node_tokens</code> subroutine<br> <li> Updated module exports to include token-based trivia query function</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2645/files#diff-fad5ae7216bd4521420bbf4c38f2968d1241c3a6518f877ff7d92fe318945c23">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_cst_trivia_query.f90</strong><dd><code>Add comprehensive tests for token reuse API</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/api/test_cst_trivia_query.f90

<ul><li>Added imports for <code>get_trivia_for_ast_node_tokens</code>, <br><code>tokenize_core_with_trivia</code>, and <code>token_t</code><br> <li> Implemented new test <code>test_trivia_for_assignment_node_reuse_tokens()</code> to <br>verify token reuse<br> <li> Added helper function <code>trivia_equal()</code> to compare trivia arrays<br> <li> Test validates consistency between token-reused and source-based APIs</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2645/files#diff-22850069e333659f181a5866bef8acbcc84b48d34c3c9cc43b54d9f5b057eec1">+101/-2</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LIBRARY_USAGE.md</strong><dd><code>Document token reuse API usage pattern</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docs/LIBRARY_USAGE.md

<ul><li>Added documentation section for token reuse pattern<br> <li> Provided example code showing how to tokenize once and reuse tokens<br> <li> Documented performance benefit for repeated queries over same source</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2645/files#diff-8a7dd85634594613485bf96155f6dde47f7418ab4771ab05ec4d4758c298c5bf">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

