### PR TITLE
fix: populate cst_arena ast_to_cst map (fixes #2668)

### DIFF
--- a/src/cst/cst_arena.f90
+++ b/src/cst/cst_arena.f90
@@ -121,6 +121,10 @@ contains
         this%nodes(this%size)%uid = this%next_uid
         this%generations(this%size) = this%global_generation
 
+        if (this%nodes(this%size)%ast_link > 0) then
+            call this%link_ast(this%size, this%nodes(this%size)%ast_link)
+        end if
+
         ! Create handle
         handle%index = this%size
         handle%generation = this%global_generation

--- a/test/api/test_cst_ast_lookup.f90
+++ b/test/api/test_cst_ast_lookup.f90
@@ -1,6 +1,7 @@
 program test_cst_ast_lookup
-    use fortfront, only: cst_arena_t, cst_handle_t, create_cst_arena, &
-                         create_cst_node, get_cst_node_for_ast, CST_IDENTIFIER
+    use fortfront, only: cst_arena_t, cst_handle_t, cst_node_t, &
+                         create_cst_arena, create_cst_node, get_cst_node_for_ast, &
+                         CST_IDENTIFIER
     implicit none
 
     logical :: all_passed
@@ -28,17 +29,21 @@ contains
         type(cst_arena_t) :: arena
         type(cst_handle_t) :: handle_x
         type(cst_handle_t) :: handle_y
+        type(cst_node_t) :: node_x
+        type(cst_node_t) :: node_y
         integer :: cst_index
 
         test_ast_lookup_map = .true.
         print *, 'Testing get_cst_node_for_ast with arena link map...'
 
         arena = create_cst_arena(4)
-        handle_x = arena%push(create_cst_node(CST_IDENTIFIER, 0, 0, 'x'))
-        handle_y = arena%push(create_cst_node(CST_IDENTIFIER, 0, 0, 'y'))
+        node_x = create_cst_node(CST_IDENTIFIER, 0, 0, 'x')
+        node_x%ast_link = 10
+        handle_x = arena%push(node_x)
 
-        call arena%link_ast(handle_x%index, 10)
-        call arena%link_ast(handle_y%index, 2000)
+        node_y = create_cst_node(CST_IDENTIFIER, 0, 0, 'y')
+        node_y%ast_link = 2000
+        handle_y = arena%push(node_y)
 
         cst_index = get_cst_node_for_ast(arena, 10)
         if (cst_index /= handle_x%index) then


### PR DESCRIPTION
### **User description**
Fixes #2668

## Summary
- Populate `cst_arena_t%ast_to_cst` when CST nodes are pushed with a pre-set `ast_link` (routes through `cst_arena_t%link_ast`).
- Extend CST/AST lookup API test to cover the pre-linked push path.

## Verification
- `fpm test 2>&1 | tee /tmp/fpm-test-issue-2668.log`
- Excerpt from `/tmp/fpm-test-issue-2668.log`:

```text
=== CST AST Lookup API Tests ===

Testing get_cst_node_for_ast with arena link map...
  PASS: get_cst_node_for_ast map lookup
Testing get_cst_node_for_ast stale-map fallback...
  PASS: stale-map fallback

All CST AST lookup tests passed!
STOP 0
```


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Populate `cst_arena_t%ast_to_cst` map when CST nodes are pushed with pre-set `ast_link`

- Automatically call `link_ast` during node push if `ast_link` is already set

- Extend test to verify pre-linked push path works correctly

- Test now creates nodes with `ast_link` before pushing instead of linking after


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CST Node with ast_link"] -->|push| B["push_cst_node"]
  B -->|check ast_link| C{"ast_link > 0?"}
  C -->|yes| D["call link_ast"]
  D -->|populate| E["ast_to_cst map"]
  C -->|no| E
  F["Test: pre-linked nodes"] -->|verify| E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>cst_arena.f90</strong><dd><code>Auto-link AST during CST node push</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/cst/cst_arena.f90

<ul><li>Added automatic <code>link_ast</code> call in <code>push_cst_node</code> when <code>ast_link</code> is <br>pre-set<br> <li> Checks if <code>ast_link > 0</code> after adding node to arena<br> <li> Populates <code>ast_to_cst</code> map during push instead of requiring separate <br>linking call</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2670/files#diff-76469e1aac5a464e0e5eceb18f8849efb486c09e44653cbdfe09c812063e8d3e">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_cst_ast_lookup.f90</strong><dd><code>Test pre-linked CST node push path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/api/test_cst_ast_lookup.f90

<ul><li>Added <code>cst_node_t</code> import to support node creation before push<br> <li> Modified test to set <code>ast_link</code> on nodes before pushing them<br> <li> Removed separate <code>link_ast</code> calls after push, now testing pre-linked <br>push path<br> <li> Test now verifies the automatic linking behavior during push operation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2670/files#diff-6ab10521c47f2ac9b52ff8a6026ab98ffa726e787cd7c02959d9fb1193f75be7">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

