### PR TITLE
fix: polish: clarify STMT_FN_MAX_NAME_LEN usage (fixes #2676)

### DIFF
--- a/src/frontend/frontend_statement_spec_section.f90
+++ b/src/frontend/frontend_statement_spec_section.f90
@@ -15,7 +15,7 @@ module frontend_statement_spec_section
     implicit none
     private
 
-    integer, parameter :: STMT_FN_MAX_NAME_LEN = 128
+    integer, parameter :: STMT_FN_MAX_ARG_NAME_LEN = 128
 
     public :: convert_statement_function_if_needed
     public :: update_spec_section_state
@@ -109,7 +109,8 @@ contains
 
         success = .false.
         if (size(arg_indices) <= 0) return
-        allocate (character(len=STMT_FN_MAX_NAME_LEN) :: arg_names(size(arg_indices)))
+        allocate (character(len=STMT_FN_MAX_ARG_NAME_LEN) :: &
+                  arg_names(size(arg_indices)))
 
         do i = 1, size(arg_indices)
             arg_idx = arg_indices(i)


### PR DESCRIPTION
## Summary
Rename `STMT_FN_MAX_NAME_LEN` to `STMT_FN_MAX_ARG_NAME_LEN` to reflect its actual scope (statement function argument-name allocation) without changing behavior.

## Verification
- See the GitHub Actions checks on this PR.
