### PR TITLE
fix: polish: reduce size of contains-section helper module (fixes #2678)

### DIFF
--- a/src/frontend/frontend_statement_contains_section_helpers.f90
+++ b/src/frontend/frontend_statement_contains_section_helpers.f90
@@ -1,6 +1,221 @@
-module frontend_statement_contains_section_helpers
+module frontend_statement_token_walking_helpers
     use lexer_core, only: token_t, TK_COMMENT, TK_EOF, TK_IDENTIFIER, TK_KEYWORD, &
                           TK_NEWLINE, TK_NUMBER, TK_OPERATOR, TK_WHITESPACE, to_lower
+
+    implicit none
+    private
+
+    public :: find_proc_keyword_after_type
+    public :: find_procedure_end
+    public :: skip_type_spec
+    public :: token_is_ignorable
+    public :: token_is_word
+
+contains
+
+    logical function token_is_ignorable(kind) result(ignorable)
+        integer, intent(in) :: kind
+        ignorable = (kind == TK_WHITESPACE .or. kind == TK_NEWLINE .or. &
+                     kind == TK_COMMENT)
+    end function token_is_ignorable
+
+    logical function token_is_word(kind) result(is_word)
+        integer, intent(in) :: kind
+        is_word = (kind == TK_KEYWORD .or. kind == TK_IDENTIFIER)
+    end function token_is_word
+
+    integer function find_proc_keyword_after_type(tokens, start_pos) result(proc_pos)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_pos
+        integer :: pos, paren_depth
+        character(len=:), allocatable :: lowered
+
+        proc_pos = 0
+        pos = start_pos
+
+        pos = pos + 1
+
+        do while (pos <= size(tokens))
+            select case (tokens(pos)%kind)
+            case (TK_WHITESPACE)
+                pos = pos + 1
+            case (TK_KEYWORD, TK_IDENTIFIER)
+                lowered = to_lower(trim(tokens(pos)%text))
+                if (lowered == "function" .or. lowered == "subroutine") then
+                    proc_pos = pos
+                    return
+                else if (lowered == "precision" .or. lowered == "complex") then
+                    pos = pos + 1
+                else
+                    pos = pos + 1
+                end if
+            case (TK_OPERATOR)
+                if (tokens(pos)%text == "(") then
+                    paren_depth = 1
+                    pos = pos + 1
+                    do while (pos <= size(tokens) .and. paren_depth > 0)
+                        if (tokens(pos)%kind == TK_OPERATOR) then
+                            if (tokens(pos)%text == "(") then
+                                paren_depth = paren_depth + 1
+                            end if
+                            if (tokens(pos)%text == ")") then
+                                paren_depth = paren_depth - 1
+                            end if
+                        end if
+                        pos = pos + 1
+                    end do
+                else if (tokens(pos)%text == "*") then
+                    pos = pos + 1
+                    if (pos <= size(tokens)) then
+                        if (tokens(pos)%kind == TK_NUMBER) pos = pos + 1
+                    end if
+                else
+                    pos = pos + 1
+                end if
+            case (TK_NEWLINE, TK_COMMENT, TK_EOF)
+                return
+            case default
+                pos = pos + 1
+            end select
+        end do
+    end function find_proc_keyword_after_type
+
+    subroutine skip_type_spec(tokens, pos)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(inout) :: pos
+        integer :: paren_depth
+        character(len=:), allocatable :: lowered
+
+        pos = pos + 1
+
+        if (pos <= size(tokens)) then
+            if (tokens(pos)%kind == TK_WHITESPACE) pos = pos + 1
+            if (pos <= size(tokens)) then
+                if (tokens(pos)%kind == TK_KEYWORD .or. &
+                    tokens(pos)%kind == TK_IDENTIFIER) then
+                    lowered = to_lower(trim(tokens(pos)%text))
+                    if (lowered == "precision" .or. lowered == "complex") then
+                        pos = pos + 1
+                    end if
+                end if
+            end if
+        end if
+
+        if (pos <= size(tokens)) then
+            if (tokens(pos)%kind == TK_WHITESPACE) pos = pos + 1
+            if (pos <= size(tokens)) then
+                if (tokens(pos)%kind == TK_OPERATOR) then
+                    if (tokens(pos)%text == "(") then
+                        paren_depth = 1
+                        pos = pos + 1
+                        do while (pos <= size(tokens) .and. paren_depth > 0)
+                            if (tokens(pos)%kind == TK_OPERATOR) then
+                                if (tokens(pos)%text == "(") then
+                                    paren_depth = paren_depth + 1
+                                end if
+                                if (tokens(pos)%text == ")") then
+                                    paren_depth = paren_depth - 1
+                                end if
+                            end if
+                            pos = pos + 1
+                        end do
+                    else if (tokens(pos)%text == "*") then
+                        pos = pos + 1
+                        if (pos <= size(tokens)) then
+                            if (tokens(pos)%kind == TK_NUMBER) pos = pos + 1
+                        end if
+                    end if
+                end if
+            end if
+        end if
+    end subroutine skip_type_spec
+
+    subroutine find_procedure_end(tokens, start_pos, proc_type, end_pos)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: start_pos
+        character(len=*), intent(in) :: proc_type
+        integer, intent(out) :: end_pos
+        integer :: i, next_idx
+        character(len=:), allocatable :: lowered, next_lower, combined
+
+        end_pos = start_pos
+        combined = "end" // trim(proc_type)
+
+        do i = start_pos + 1, size(tokens)
+            if (tokens(i)%kind == TK_EOF) then
+                end_pos = i - 1
+                exit
+            end if
+
+            if (tokens(i)%kind == TK_KEYWORD .or. tokens(i)%kind == TK_IDENTIFIER) then
+                lowered = to_lower(trim(tokens(i)%text))
+
+                if (lowered == combined) then
+                    end_pos = i
+                    next_idx = i + 1
+                    do while (next_idx <= size(tokens))
+                        if (tokens(next_idx)%kind == TK_WHITESPACE) then
+                            next_idx = next_idx + 1
+                        else if (tokens(next_idx)%kind == TK_IDENTIFIER .or. &
+                                 tokens(next_idx)%kind == TK_KEYWORD) then
+                            end_pos = next_idx
+                            exit
+                        else
+                            exit
+                        end if
+                    end do
+                    exit
+                end if
+
+                if (lowered == "end") then
+                    next_idx = i + 1
+                    do while (next_idx <= size(tokens))
+                        if (tokens(next_idx)%kind == TK_WHITESPACE) then
+                            next_idx = next_idx + 1
+                        else
+                            exit
+                        end if
+                    end do
+
+                    if (next_idx <= size(tokens)) then
+                        if (tokens(next_idx)%kind == TK_KEYWORD .or. &
+                            tokens(next_idx)%kind == TK_IDENTIFIER) then
+                            next_lower = to_lower(trim(tokens(next_idx)%text))
+                            if (next_lower == proc_type) then
+                                end_pos = next_idx
+                                next_idx = next_idx + 1
+                                do while (next_idx <= size(tokens))
+                                    if (tokens(next_idx)%kind == TK_WHITESPACE) then
+                                        next_idx = next_idx + 1
+                                    else if (tokens(next_idx)%kind == &
+                                             TK_IDENTIFIER .or. &
+                                             tokens(next_idx)%kind == TK_KEYWORD) then
+                                        end_pos = next_idx
+                                        exit
+                                    else
+                                        exit
+                                    end if
+                                end do
+                                exit
+                            end if
+                        end if
+                    end if
+                end if
+            end if
+
+            end_pos = i
+        end do
+    end subroutine find_procedure_end
+
+end module frontend_statement_token_walking_helpers
+
+module frontend_statement_contains_section_helpers
+    use lexer_core, only: token_t, TK_EOF, to_lower
+    use frontend_statement_token_walking_helpers, only: find_proc_keyword_after_type, &
+                                                        find_procedure_end, &
+                                                        skip_type_spec, &
+                                                        token_is_ignorable, &
+                                                        token_is_word
     use parser_definition_statements_module, only: parse_function_definition, &
                                                    parse_subroutine_definition
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t
@@ -77,17 +292,6 @@ contains
 
         if (allocated(prefix_list)) deallocate (prefix_list)
     end subroutine scan_contains_section
-
-    logical function token_is_ignorable(kind) result(ignorable)
-        integer, intent(in) :: kind
-        ignorable = (kind == TK_WHITESPACE .or. kind == TK_NEWLINE .or. &
-                     kind == TK_COMMENT)
-    end function token_is_ignorable
-
-    logical function token_is_word(kind) result(is_word)
-        integer, intent(in) :: kind
-        is_word = (kind == TK_KEYWORD .or. kind == TK_IDENTIFIER)
-    end function token_is_word
 
     logical function handle_contains_end(lowered, pos, end_pos) result(should_end)
         character(len=*), intent(in) :: lowered
@@ -291,188 +495,4 @@ contains
         deallocate (proc_tokens)
         call reset_contains_prefix_list(prefix_list)
     end subroutine parse_contains_subroutine_span
-
-    integer function find_proc_keyword_after_type(tokens, start_pos) result(proc_pos)
-        type(token_t), intent(in) :: tokens(:)
-        integer, intent(in) :: start_pos
-        integer :: pos, paren_depth
-        character(len=:), allocatable :: lowered
-
-        proc_pos = 0
-        pos = start_pos
-
-        pos = pos + 1
-
-        do while (pos <= size(tokens))
-            select case (tokens(pos)%kind)
-            case (TK_WHITESPACE)
-                pos = pos + 1
-            case (TK_KEYWORD, TK_IDENTIFIER)
-                lowered = to_lower(trim(tokens(pos)%text))
-                if (lowered == "function" .or. lowered == "subroutine") then
-                    proc_pos = pos
-                    return
-                else if (lowered == "precision" .or. lowered == "complex") then
-                    pos = pos + 1
-                else
-                    pos = pos + 1
-                end if
-            case (TK_OPERATOR)
-                if (tokens(pos)%text == "(") then
-                    paren_depth = 1
-                    pos = pos + 1
-                    do while (pos <= size(tokens) .and. paren_depth > 0)
-                        if (tokens(pos)%kind == TK_OPERATOR) then
-                            if (tokens(pos)%text == "(") then
-                                paren_depth = paren_depth + 1
-                            end if
-                            if (tokens(pos)%text == ")") then
-                                paren_depth = paren_depth - 1
-                            end if
-                        end if
-                        pos = pos + 1
-                    end do
-                else if (tokens(pos)%text == "*") then
-                    pos = pos + 1
-                    if (pos <= size(tokens)) then
-                        if (tokens(pos)%kind == TK_NUMBER) pos = pos + 1
-                    end if
-                else
-                    pos = pos + 1
-                end if
-            case (TK_NEWLINE, TK_COMMENT, TK_EOF)
-                return
-            case default
-                pos = pos + 1
-            end select
-        end do
-    end function find_proc_keyword_after_type
-
-    subroutine skip_type_spec(tokens, pos)
-        type(token_t), intent(in) :: tokens(:)
-        integer, intent(inout) :: pos
-        integer :: paren_depth
-        character(len=:), allocatable :: lowered
-
-        pos = pos + 1
-
-        if (pos <= size(tokens)) then
-            if (tokens(pos)%kind == TK_WHITESPACE) pos = pos + 1
-            if (pos <= size(tokens)) then
-                if (tokens(pos)%kind == TK_KEYWORD .or. &
-                    tokens(pos)%kind == TK_IDENTIFIER) then
-                    lowered = to_lower(trim(tokens(pos)%text))
-                    if (lowered == "precision" .or. lowered == "complex") then
-                        pos = pos + 1
-                    end if
-                end if
-            end if
-        end if
-
-        if (pos <= size(tokens)) then
-            if (tokens(pos)%kind == TK_WHITESPACE) pos = pos + 1
-            if (pos <= size(tokens)) then
-                if (tokens(pos)%kind == TK_OPERATOR) then
-                    if (tokens(pos)%text == "(") then
-                        paren_depth = 1
-                        pos = pos + 1
-                        do while (pos <= size(tokens) .and. paren_depth > 0)
-                            if (tokens(pos)%kind == TK_OPERATOR) then
-                                if (tokens(pos)%text == "(") then
-                                    paren_depth = paren_depth + 1
-                                end if
-                                if (tokens(pos)%text == ")") then
-                                    paren_depth = paren_depth - 1
-                                end if
-                            end if
-                            pos = pos + 1
-                        end do
-                    else if (tokens(pos)%text == "*") then
-                        pos = pos + 1
-                        if (pos <= size(tokens)) then
-                            if (tokens(pos)%kind == TK_NUMBER) pos = pos + 1
-                        end if
-                    end if
-                end if
-            end if
-        end if
-    end subroutine skip_type_spec
-
-    subroutine find_procedure_end(tokens, start_pos, proc_type, end_pos)
-        type(token_t), intent(in) :: tokens(:)
-        integer, intent(in) :: start_pos
-        character(len=*), intent(in) :: proc_type
-        integer, intent(out) :: end_pos
-        integer :: i, next_idx
-        character(len=:), allocatable :: lowered, next_lower, combined
-
-        end_pos = start_pos
-        combined = "end" // trim(proc_type)
-
-        do i = start_pos + 1, size(tokens)
-            if (tokens(i)%kind == TK_EOF) then
-                end_pos = i - 1
-                exit
-            end if
-
-            if (tokens(i)%kind == TK_KEYWORD .or. tokens(i)%kind == TK_IDENTIFIER) then
-                lowered = to_lower(trim(tokens(i)%text))
-
-                if (lowered == combined) then
-                    end_pos = i
-                    next_idx = i + 1
-                    do while (next_idx <= size(tokens))
-                        if (tokens(next_idx)%kind == TK_WHITESPACE) then
-                            next_idx = next_idx + 1
-                        else if (tokens(next_idx)%kind == TK_IDENTIFIER .or. &
-                                 tokens(next_idx)%kind == TK_KEYWORD) then
-                            end_pos = next_idx
-                            exit
-                        else
-                            exit
-                        end if
-                    end do
-                    exit
-                end if
-
-                if (lowered == "end") then
-                    next_idx = i + 1
-                    do while (next_idx <= size(tokens))
-                        if (tokens(next_idx)%kind == TK_WHITESPACE) then
-                            next_idx = next_idx + 1
-                        else
-                            exit
-                        end if
-                    end do
-
-                    if (next_idx <= size(tokens)) then
-                        if (tokens(next_idx)%kind == TK_KEYWORD .or. &
-                            tokens(next_idx)%kind == TK_IDENTIFIER) then
-                            next_lower = to_lower(trim(tokens(next_idx)%text))
-                            if (next_lower == proc_type) then
-                                end_pos = next_idx
-                                next_idx = next_idx + 1
-                                do while (next_idx <= size(tokens))
-                                    if (tokens(next_idx)%kind == TK_WHITESPACE) then
-                                        next_idx = next_idx + 1
-                                    else if (tokens(next_idx)%kind == &
-                                             TK_IDENTIFIER .or. &
-                                             tokens(next_idx)%kind == TK_KEYWORD) then
-                                        end_pos = next_idx
-                                        exit
-                                    else
-                                        exit
-                                    end if
-                                end do
-                                exit
-                            end if
-                        end if
-                    end if
-                end if
-            end if
-
-            end_pos = i
-        end do
-    end subroutine find_procedure_end
-
 end module frontend_statement_contains_section_helpers


### PR DESCRIPTION
### **User description**
## Summary

- Split `frontend_statement_contains_section_helpers` by extracting low-level token-walking routines into `frontend_statement_token_walking_helpers` (same source file) to keep each module well under the 500-line guideline.

## Verification

- `fpm test 2>&1 | tee /tmp/fortfront_fpm_test_issue2678.log`

Output excerpt:

```
All tests passed!
All fortfront API integration tests passed!
All function parameter parsing tests passed!
STOP 0
```

Artifacts:

- `/tmp/fortfront_fpm_test_issue2678.log`


___

### **PR Type**
Enhancement


___

### **Description**
- Extract token-walking routines into separate module

- Create `frontend_statement_token_walking_helpers` module

- Move low-level helper functions to new module

- Reduce `frontend_statement_contains_section_helpers` size


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["frontend_statement_contains_section_helpers<br/>original module"] -->|"extract token-walking<br/>routines"| B["frontend_statement_token_walking_helpers<br/>new module"]
  B -->|"import helpers"| C["frontend_statement_contains_section_helpers<br/>refactored module"]
  B -->|"contains"| D["find_proc_keyword_after_type<br/>skip_type_spec<br/>find_procedure_end<br/>token_is_ignorable<br/>token_is_word"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Refactoring</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>frontend_statement_contains_section_helpers.f90</strong><dd><code>Split module into token-walking helpers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/frontend/frontend_statement_contains_section_helpers.f90

<ul><li>Created new <code>frontend_statement_token_walking_helpers</code> module at file <br>start<br> <li> Extracted five low-level token-walking helper functions to new module<br> <li> Added public interface exports for extracted functions<br> <li> Updated <code>frontend_statement_contains_section_helpers</code> to import helpers <br>from new module<br> <li> Removed original function definitions from contains section</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2682/files#diff-10e5a8a1681b9de1a46fde3d2ac5d7e2995eb8c6688ffa27065df19018408ac8">+216/-196</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

