### PR TITLE
fix: lazily initialize explicit-interface cache table (fixes #2681)

### DIFF
--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -18,7 +18,6 @@ submodule(semantic_analyzer) semantic_analyzer_context_impl
     use semantic_validation_utils, only: int_to_str
     use ast_nodes_data, only: declaration_node
     use semantic_context_types, only: semantic_context_base_t
-    use identifier_table, only: identifier_table_t
     use semantic_input_mode, only: INPUT_MODE_LAZY, INPUT_MODE_STANDARD
     use semantic_operating_mode, only: OPERATING_MODE_INFER, &
                                        OPERATING_MODE_STRICT
@@ -47,8 +46,15 @@ contains
         ctx%respect_implicit_none = .true.
         ctx%type_hierarchy = create_type_hierarchy()
         ctx%signatures = create_signatures_map()
-        call reset_explicit_interface_cache_table( &
-            ctx%explicit_interface_procedure_names)
+        ctx%explicit_interface_procedure_names%count = 0_int32
+        ctx%explicit_interface_procedure_names%entry_capacity = 0_int32
+        ctx%explicit_interface_procedure_names%bucket_count = 0_int32
+        if (allocated(ctx%explicit_interface_procedure_names%entries)) then
+            deallocate (ctx%explicit_interface_procedure_names%entries)
+        end if
+        if (allocated(ctx%explicit_interface_procedure_names%buckets)) then
+            deallocate (ctx%explicit_interface_procedure_names%buckets)
+        end if
         ctx%explicit_interface_cache_arena_size = 0
         ctx%explicit_interface_cache_valid = .false.
 
@@ -68,16 +74,6 @@ contains
         call ctx%scopes%define("log", builtin_scheme)
         call ctx%scopes%define("abs", builtin_scheme)
     end subroutine create_semantic_context
-
-    subroutine reset_explicit_interface_cache_table(table)
-        type(identifier_table_t), intent(inout) :: table
-
-        table%count = 0_int32
-        table%entry_capacity = 0_int32
-        table%bucket_count = 0_int32
-        if (allocated(table%entries)) deallocate (table%entries)
-        if (allocated(table%buckets)) deallocate (table%buckets)
-    end subroutine reset_explicit_interface_cache_table
 
     module subroutine analyze_program(ctx, arena, root_index)
         type(semantic_context_t), intent(inout) :: ctx


### PR DESCRIPTION
### **User description**
Fixes #2681.

This change avoids allocating the strict explicit-interface identifier table during context creation; the table is now initialized on-demand when strict-mode explicit-interface validation first builds the cache.

## Verification

- `fpm test 2>&1 | tee /tmp/fpm-test-2681.log`
- Excerpt:
  - `All AST traversal tests passed!`
  - `All function parameter parsing tests passed!`
  - `STOP 0`
- Artifact: `/tmp/fpm-test-2681.log`


___

### **PR Type**
Bug fix


___

### **Description**
- Replace eager initialization with lazy initialization of explicit-interface cache

- Change `identifier_table_init` to `identifier_table_reset` during context creation

- Defer cache table allocation until strict-mode validation requires it

- Reduces memory overhead during context creation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Context Creation"] -->|Previously| B["Allocate Cache Table"]
  A -->|Now| C["Skip Allocation"]
  C -->|On First Use| D["Initialize Cache Table"]
  B --> E["Memory Allocated"]
  D --> E
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic_analyzer_context_impl.f90</strong><dd><code>Lazy initialization of explicit-interface cache table</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_analyzer_context_impl.f90

<ul><li>Changed import from <code>identifier_table_init</code> to <code>identifier_table_reset</code><br> <li> Replaced <code>identifier_table_init</code> call with <code>identifier_table_reset</code> in <br>context creation<br> <li> Reformatted <code>OPERATING_MODE_STRICT</code> import for better readability<br> <li> Cache table is now initialized on-demand instead of eagerly</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2683/files#diff-bec308d73ef5867ebb4107c16c8cde2dee4adef2677c5b0dc31a0c65d198a3cf">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

