### PR TITLE
fix: treat zero-sized array constructors as strict size-known (fixes #2694)

### DIFF
--- a/examples/lf/issue_2694_strict_zero_iter_implied_do.lf
+++ b/examples/lf/issue_2694_strict_zero_iter_implied_do.lf
@@ -1,0 +1,9 @@
+program main
+    implicit none
+
+    integer :: i
+    integer, allocatable :: arr(:)
+
+    arr = [(i, i=1, 0)]
+    arr = [1]
+end program main

--- a/examples/lf/issue_2694_strict_zero_sized_array_constructor.lf
+++ b/examples/lf/issue_2694_strict_zero_sized_array_constructor.lf
@@ -1,0 +1,8 @@
+program main
+    implicit none
+
+    integer, allocatable :: arr(:)
+
+    arr = [integer ::]
+    arr = [1]
+end program main

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc
@@ -53,7 +53,7 @@
         if (.not. allocated(name)) return
 
         rhs_size = static_array_literal_size(arena, assignment%value_index)
-        if (rhs_size <= 0) return
+        if (rhs_size < 0) return
 
         prog_index = find_containing_program_index(arena, assignment_index)
         if (prog_index <= 0) return
@@ -64,7 +64,7 @@
 
         prev_size = find_prev_literal_assignment_size(arena, prog_index, &
                                                       assignment_index, name)
-        if (prev_size <= 0) return
+        if (prev_size < 0) return
         if (prev_size == rhs_size) return
 
         message = 'Strict mode forbids automatic allocatable array ' // &
@@ -135,22 +135,25 @@
         integer(int64) :: max_arr_size
         integer :: elem_size
 
-        arr_size = 0
+        arr_size = -1
         if (expr_index <= 0 .or. expr_index > arena%size) return
         if (.not. allocated(arena%entries(expr_index)%node)) return
 
         select type (node => arena%entries(expr_index)%node)
         type is (array_literal_node)
-            if (.not. allocated(node%element_indices)) return
+            if (.not. allocated(node%element_indices)) then
+                arr_size = 0
+                return
+            end if
             total_size = 0_int64
             max_arr_size = int(huge(arr_size), kind=int64)
             do i = 1, size(node%element_indices)
                 if (node%element_indices(i) <= 0) then
-                    arr_size = 0
+                    arr_size = -1
                     return
                 end if
                 if (node%element_indices(i) > arena%size) then
-                    arr_size = 0
+                    arr_size = -1
                     return
                 end if
                 if (.not. &
@@ -158,12 +161,12 @@
                     return
                 elem_size = static_array_literal_element_size(arena, &
                                                               node%element_indices(i))
-                if (elem_size <= 0) then
-                    arr_size = 0
+                if (elem_size < 0) then
+                    arr_size = -1
                     return
                 end if
                 if (total_size > max_arr_size - int(elem_size, kind=int64)) then
-                    arr_size = 0
+                    arr_size = -1
                     return
                 end if
                 total_size = total_size + int(elem_size, kind=int64)
@@ -179,7 +182,7 @@
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: expr_index
 
-        elem_size = 0
+        elem_size = -1
         if (expr_index <= 0 .or. expr_index > arena%size) return
         if (.not. allocated(arena%entries(expr_index)%node)) return
 
@@ -213,7 +216,7 @@
         integer(int64) :: total_size
         integer(int64) :: max_implied_size
 
-        implied_size = 0
+        implied_size = -1
         if (do_index <= 0 .or. do_index > arena%size) return
         if (.not. allocated(arena%entries(do_index)%node)) return
 
@@ -261,12 +264,12 @@
             do i = 1, size(loop%body_indices)
                 body_elem_size = static_array_literal_element_size(arena, &
                                                                    loop%body_indices(i))
-                if (body_elem_size <= 0) then
-                    implied_size = 0
+                if (body_elem_size < 0) then
+                    implied_size = -1
                     return
                 end if
                 if (body_size > max_implied_size - int(body_elem_size, kind=int64)) then
-                    implied_size = 0
+                    implied_size = -1
                     return
                 end if
                 body_size = body_size + int(body_elem_size, kind=int64)
@@ -274,13 +277,13 @@
 
             if (iter_count > 0_int64) then
                 if (body_size > max_implied_size / iter_count) then
-                    implied_size = 0
+                    implied_size = -1
                     return
                 end if
             end if
             total_size = iter_count * body_size
             if (total_size > max_implied_size) then
-                implied_size = 0
+                implied_size = -1
                 return
             end if
             implied_size = int(total_size, kind=kind(implied_size))
@@ -369,7 +372,7 @@
         integer :: pos
         integer :: candidate_size
 
-        prev_size = 0
+        prev_size = -1
         pos = program_body_position(arena, prog_index, current_index)
         if (pos <= 1) return
 
@@ -381,7 +384,7 @@
             type is (assignment_node)
                 candidate_size = assignment_literal_size_if_target_name( &
                                  arena, node, name)
-                if (candidate_size > 0) then
+                if (candidate_size >= 0) then
                     prev_size = candidate_size
                     return
                 end if
@@ -447,7 +450,7 @@
 
         integer :: lhs_index
 
-        arr_size = 0
+        arr_size = -1
         lhs_index = assignment%target_index
         if (lhs_index <= 0 .or. lhs_index > arena%size) return
         if (.not. allocated(arena%entries(lhs_index)%node)) return

--- a/test/integration/issue_tests/test_issue_2694_strict_zero_sized_array_literals.f90
+++ b/test/integration/issue_tests/test_issue_2694_strict_zero_sized_array_literals.f90
@@ -1,0 +1,84 @@
+program test_issue_2694_strict_zero_sized_array_literals
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use transformation_api, only: transform_context_t, &
+                                  transform_with_context, &
+                                  INPUT_MODE_LAZY, &
+                                  OPERATING_MODE_INFER, &
+                                  OPERATING_MODE_STRICT
+    implicit none
+
+    call check_example( &
+        'examples/lf/issue_2694_strict_zero_sized_array_constructor.lf')
+    call check_example( &
+        'examples/lf/issue_2694_strict_zero_iter_implied_do.lf')
+
+    write (error_unit, '(a)') &
+        'PASS: strict mode treats known empty array constructors as size-known'
+
+contains
+
+    include '../../common/cli_io_reader.inc'
+
+    subroutine check_example(path)
+        character(len=*), intent(in) :: path
+
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: output
+        character(len=:), allocatable :: source
+        type(transform_context_t) :: ctx
+
+        call read_example(path, source)
+
+        ctx%input_mode = INPUT_MODE_LAZY
+        ctx%has_filename = .false.
+
+        ctx%operating_mode = OPERATING_MODE_INFER
+        call transform_with_context(source, output, error_msg, ctx)
+        call assert_no_error(error_msg)
+
+        ctx%operating_mode = OPERATING_MODE_STRICT
+        call transform_with_context(source, output, error_msg, ctx)
+        call assert_contains(error_msg, 'forbids automatic allocatable array '// &
+                             'reallocation')
+    end subroutine check_example
+
+    subroutine read_example(path, content)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: content
+        integer :: status
+
+        call read_all_stdin_or_file(.true., path, content, status)
+        if (status /= 0) then
+            write (error_unit, '(a)') 'FAIL: failed to read ' // trim(path)
+            error stop 1
+        end if
+    end subroutine read_example
+
+    subroutine assert_no_error(msg)
+        character(len=:), allocatable, intent(in) :: msg
+
+        if (.not. allocated(msg)) return
+        if (len_trim(msg) == 0) return
+        write (error_unit, '(a)') 'FAIL: unexpected error message:'
+        write (error_unit, '(a)') trim(msg)
+        error stop 1
+    end subroutine assert_no_error
+
+    subroutine assert_contains(msg, needle)
+        character(len=:), allocatable, intent(in) :: msg
+        character(len=*), intent(in) :: needle
+
+        if (.not. allocated(msg)) then
+            write (error_unit, '(a)') 'FAIL: expected error message'
+            error stop 1
+        end if
+        if (index(msg, needle) == 0) then
+            write (error_unit, '(a)') 'FAIL: expected message to contain: ' // &
+                trim(needle)
+            write (error_unit, '(a)') 'Got:'
+            write (error_unit, '(a)') trim(msg)
+            error stop 1
+        end if
+    end subroutine assert_contains
+
+end program test_issue_2694_strict_zero_sized_array_literals


### PR DESCRIPTION
### **User description**
Fixes #2694.

## Summary

Strict-mode allocatable LHS reallocation validation now treats statically known zero-sized array constructors (including zero-iteration implied-do) as size-known (0), instead of skipping them as unknown.

## Verification

- `fpm clean --all`
- `fpm test test_issue_2694_strict_zero_sized_array_literals`
  - Output: `PASS: strict mode treats known empty array constructors as size-known`
- `fpm test test_strict_allocatable_lhs_reallocation`
  - Output: `PASS: strict mode forbids allocatable lhs reallocation`
- `make check-duplication`
  - Output: `✓ PASS: No end-to-end test violations found`

## Artifacts

- `examples/lf/issue_2694_strict_zero_sized_array_constructor.lf`
- `examples/lf/issue_2694_strict_zero_iter_implied_do.lf`
- `test/integration/issue_tests/test_issue_2694_strict_zero_sized_array_literals.f90`


___

### **PR Type**
Bug fix


___

### **Description**
- Treat zero-sized array constructors as size-known in strict mode

- Distinguish between unknown size (-1) and known zero size (0)

- Add test cases for zero-sized arrays and zero-iteration implied-do

- Fix allocatable LHS reallocation validation logic


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Zero-sized array constructors"] -->|Previously treated as| B["Unknown size"]
  A -->|Now treated as| C["Known size 0"]
  C -->|Enables validation| D["Strict mode reallocation check"]
  D -->|Detects| E["Forbidden reallocations"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_issue_2694_strict_zero_sized_array_literals.f90</strong><dd><code>New test for zero-sized array constructor validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

test/integration/issue_tests/test_issue_2694_strict_zero_sized_array_literals.f90

<ul><li>New test program validating strict mode behavior for zero-sized arrays<br> <li> Tests both empty array constructor <code>[integer ::]</code> and zero-iteration <br>implied-do <code>[(i, i=1, 0)]</code><br> <li> Verifies that infer mode passes but strict mode correctly forbids <br>reallocation<br> <li> Includes helper subroutines for reading examples and asserting error <br>messages</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2695/files#diff-df75b32604794af72b2c0420048a453874716d38ec22726324689c70ddaaa7c8">+84/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>issue_2694_strict_zero_sized_array_constructor.lf</strong><dd><code>Example of zero-sized array constructor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/lf/issue_2694_strict_zero_sized_array_constructor.lf

<ul><li>Example demonstrating zero-sized array constructor <code>[integer ::]</code><br> <li> Shows allocatable array assignment with empty constructor followed by <br>reallocation<br> <li> Triggers strict mode validation error for forbidden reallocation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2695/files#diff-9048bb087c0576e85adc98bcc0289508a295ec4325c89630b33c07c5ba3613df">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>issue_2694_strict_zero_iter_implied_do.lf</strong><dd><code>Example of zero-iteration implied-do loop</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

examples/lf/issue_2694_strict_zero_iter_implied_do.lf

<ul><li>Example demonstrating zero-iteration implied-do loop <code>[(i, i=1, 0)]</code><br> <li> Shows allocatable array assignment with zero-iteration loop followed <br>by reallocation<br> <li> Triggers strict mode validation error for forbidden reallocation</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2695/files#diff-cfb257a02a4e2ff88a069c683d96b2f707b938be2283f93072992ce6aac80ec5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic_analyzer_infer_impl_part3.inc</strong><dd><code>Distinguish unknown vs known zero array sizes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc

<ul><li>Changed return value semantics: -1 indicates unknown size, 0 indicates <br>known zero size<br> <li> Modified <code>static_array_literal_size()</code> to return 0 for empty array <br>literals instead of treating as unknown<br> <li> Updated <code>static_array_literal_element_size()</code> to use -1 for unknown <br>instead of 0<br> <li> Fixed <code>find_implied_do_array_size()</code> to distinguish zero-iteration loops <br>(size 0) from unknown sizes<br> <li> Updated validation checks from <code><= 0</code> to <code>< 0</code> to allow zero-sized arrays <br>through validation<br> <li> Modified <code>find_prev_literal_assignment_size()</code> to use -1 for unknown and <br><code>>= 0</code> for known sizes</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2695/files#diff-4a62d5c1122fac082b875ebc5513ecb2d1fd7dae4905a90c9ad3507fcba5ebea">+22/-19</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

