### PR TITLE
fix: add regression tests for check_test_duplication.py (fixes #2704)

### DIFF
--- a/scripts/check_test_duplication.py
+++ b/scripts/check_test_duplication.py
@@ -160,6 +160,12 @@ def _statements_with_newlines(lines: list[str]) -> list[InlineBlock]:
                 idx += 1
                 continue
 
+            if idx > 0:
+                prev_ch = statement[idx - 1]
+                if prev_ch.isalnum() or prev_ch in {"_", "%"}:
+                    idx += 1
+                    continue
+
             j = idx + len("new_line")
             while j < len(statement) and statement[j].isspace():
                 j += 1
@@ -185,6 +191,13 @@ def _statements_with_newlines(lines: list[str]) -> list[InlineBlock]:
                 idx += 1
                 continue
             if j >= len(statement) or statement[j] != quote:
+                idx += 1
+                continue
+
+            j += 1
+            while j < len(statement) and statement[j].isspace():
+                j += 1
+            if j >= len(statement) or statement[j] != ")":
                 idx += 1
                 continue
 

--- a/scripts/test_check_test_duplication.py
+++ b/scripts/test_check_test_duplication.py
@@ -57,6 +57,41 @@ class TestCheckTestDuplication(unittest.TestCase):
         )
         self.assertEqual(blocks, [])
 
+    def test_counts_new_line_case_insensitive(self) -> None:
+        blocks = check_test_duplication._statements_with_newlines(
+            ["source = 'a' // NEW_LINE('A') // 'b' // new_line('a') // 'c'"]
+        )
+        self.assertEqual(len(blocks), 1)
+        self.assertEqual(blocks[0], check_test_duplication.InlineBlock(start_line=1, newline_count=2))
+
+    def test_ignores_new_line_inside_string_literal(self) -> None:
+        blocks = check_test_duplication._statements_with_newlines(
+            ["source = 'new_line(''a'')' // 'b'"]
+        )
+        self.assertEqual(blocks, [])
+
+    def test_ignores_new_line_in_comment(self) -> None:
+        blocks = check_test_duplication._statements_with_newlines(
+            ["source = 'a' ! new_line('a')"]
+        )
+        self.assertEqual(blocks, [])
+
+    def test_ignores_identifier_containing_new_line_substring(self) -> None:
+        blocks = check_test_duplication._statements_with_newlines(
+            ["source = 'a' // foo_new_line('a') // 'b'"]
+        )
+        self.assertEqual(blocks, [])
+        blocks = check_test_duplication._statements_with_newlines(
+            ["source = 'a' // mynew_line('a') // 'b'"]
+        )
+        self.assertEqual(blocks, [])
+
+    def test_ignores_type_bound_new_line_call(self) -> None:
+        blocks = check_test_duplication._statements_with_newlines(
+            ["source = 'a' // foo%new_line('a') // 'b'"]
+        )
+        self.assertEqual(blocks, [])
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
### **User description**
Fixes #2704

Adds regression coverage for `scripts/check_test_duplication.py` and avoids counting `new_line('a')` when it appears as part of a longer identifier (for example `foo_new_line('a')`).

## Verification

Commands (full logs):
- `python3 -m unittest scripts.test_check_test_duplication 2>&1 | tee /tmp/py-test_check_test_duplication.log`
- `python3 scripts/check_test_duplication.py 2>&1 | tee /tmp/check_test_duplication.log`
- `fpm test 2>&1 | tee /tmp/fpm-test.log`

Output excerpts:

```
$ python3 -m unittest scripts.test_check_test_duplication
..........
OK
```

```
$ python3 scripts/check_test_duplication.py
✓ PASS: No end-to-end test violations found
```


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix `new_line()` detection to avoid matching identifiers containing substring

- Add regression tests for various edge cases in test duplication checker

- Prevent false positives from identifiers like `foo_new_line()` or `mynew_line()`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["count_new_line_calls function"] -->|Add identifier boundary check| B["Validate previous character"]
  B -->|Skip if alphanumeric or underscore| C["Avoid false positives"]
  D["Test suite"] -->|Add 4 new test cases| E["Comprehensive edge case coverage"]
  E -->|Case insensitivity, strings, comments, identifiers| F["Improved test reliability"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>check_test_duplication.py</strong><dd><code>Add identifier boundary validation for new_line detection</code></dd></summary>
<hr>

scripts/check_test_duplication.py

<ul><li>Add boundary check before counting <code>new_line()</code> calls to prevent <br>matching as part of longer identifiers<br> <li> Check if previous character is alphanumeric or underscore before <br>treating as valid <code>new_line()</code> call<br> <li> Fixes false positives for identifiers like <code>foo_new_line()</code> or <br><code>mynew_line()</code></ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2705/files#diff-d67e91a175c0476c0f93d6d0c5aeb1b94ee0135770d99eb71bfda59321228ae8">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_check_test_duplication.py</strong><dd><code>Add comprehensive regression tests for edge cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/test_check_test_duplication.py

<ul><li>Add test for case-insensitive <code>new_line()</code> detection with mixed case <br>variants<br> <li> Add test to verify <code>new_line()</code> inside string literals is ignored<br> <li> Add test to verify <code>new_line()</code> in comments is ignored<br> <li> Add test to verify identifiers containing <code>new_line</code> substring are not <br>counted</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2705/files#diff-0ff93368e01bdb9fc3525163844f6adc070f3146e65e5f57525ec82843f913de">+29/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

