### PR TITLE
fix: name and document unknown static-size sentinel (fixes #2696)

### DIFF
--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -37,6 +37,11 @@ submodule(semantic_analyzer) semantic_analyzer_infer_impl
         type(mono_type_t), allocatable :: param_types(:)
     end type infer_frame_t
 
+    integer, parameter :: UNKNOWN_STATIC_SIZE = -1
+    ! Static size helpers return UNKNOWN_STATIC_SIZE when a size cannot be
+    ! determined. Treat any negative value as unknown and compare with < 0;
+    ! any value >= 0 is a known size, where 0 means known empty.
+
 contains
 
     include 'semantic_analyzer_infer_impl_part1.inc'

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc
@@ -135,7 +135,7 @@
         integer(int64) :: max_arr_size
         integer :: elem_size
 
-        arr_size = -1
+        arr_size = UNKNOWN_STATIC_SIZE
         if (expr_index <= 0 .or. expr_index > arena%size) return
         if (.not. allocated(arena%entries(expr_index)%node)) return
 
@@ -149,11 +149,11 @@
             max_arr_size = int(huge(arr_size), kind=int64)
             do i = 1, size(node%element_indices)
                 if (node%element_indices(i) <= 0) then
-                    arr_size = -1
+                    arr_size = UNKNOWN_STATIC_SIZE
                     return
                 end if
                 if (node%element_indices(i) > arena%size) then
-                    arr_size = -1
+                    arr_size = UNKNOWN_STATIC_SIZE
                     return
                 end if
                 if (.not. &
@@ -162,11 +162,11 @@
                 elem_size = static_array_literal_element_size(arena, &
                                                               node%element_indices(i))
                 if (elem_size < 0) then
-                    arr_size = -1
+                    arr_size = UNKNOWN_STATIC_SIZE
                     return
                 end if
                 if (total_size > max_arr_size - int(elem_size, kind=int64)) then
-                    arr_size = -1
+                    arr_size = UNKNOWN_STATIC_SIZE
                     return
                 end if
                 total_size = total_size + int(elem_size, kind=int64)
@@ -182,7 +182,7 @@
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: expr_index
 
-        elem_size = -1
+        elem_size = UNKNOWN_STATIC_SIZE
         if (expr_index <= 0 .or. expr_index > arena%size) return
         if (.not. allocated(arena%entries(expr_index)%node)) return
 
@@ -216,7 +216,7 @@
         integer(int64) :: total_size
         integer(int64) :: max_implied_size
 
-        implied_size = -1
+        implied_size = UNKNOWN_STATIC_SIZE
         if (do_index <= 0 .or. do_index > arena%size) return
         if (.not. allocated(arena%entries(do_index)%node)) return
 
@@ -265,11 +265,11 @@
                 body_elem_size = static_array_literal_element_size(arena, &
                                                                    loop%body_indices(i))
                 if (body_elem_size < 0) then
-                    implied_size = -1
+                    implied_size = UNKNOWN_STATIC_SIZE
                     return
                 end if
                 if (body_size > max_implied_size - int(body_elem_size, kind=int64)) then
-                    implied_size = -1
+                    implied_size = UNKNOWN_STATIC_SIZE
                     return
                 end if
                 body_size = body_size + int(body_elem_size, kind=int64)
@@ -277,13 +277,13 @@
 
             if (iter_count > 0_int64) then
                 if (body_size > max_implied_size / iter_count) then
-                    implied_size = -1
+                    implied_size = UNKNOWN_STATIC_SIZE
                     return
                 end if
             end if
             total_size = iter_count * body_size
             if (total_size > max_implied_size) then
-                implied_size = -1
+                implied_size = UNKNOWN_STATIC_SIZE
                 return
             end if
             implied_size = int(total_size, kind=kind(implied_size))
@@ -372,7 +372,7 @@
         integer :: pos
         integer :: candidate_size
 
-        prev_size = -1
+        prev_size = UNKNOWN_STATIC_SIZE
         pos = program_body_position(arena, prog_index, current_index)
         if (pos <= 1) return
 
@@ -450,7 +450,7 @@
 
         integer :: lhs_index
 
-        arr_size = -1
+        arr_size = UNKNOWN_STATIC_SIZE
         lhs_index = assignment%target_index
         if (lhs_index <= 0 .or. lhs_index > arena%size) return
         if (.not. allocated(arena%entries(lhs_index)%node)) return


### PR DESCRIPTION
### **User description**
Fixes #2696.

This names and documents the static-size unknown sentinel used by the semantic analyzer static array size helpers, replacing raw -1 literals with a shared constant.

## Verification

CI runs:
- `fpm test`
- `make check-duplication`

Suggested local commands (optional):
- `fpm test 2>&1 | tee /tmp/fpm-test-issue-2696.log`
- `make check-duplication 2>&1 | tee /tmp/make-check-duplication-issue-2696.log`

___

### **PR Type**
Enhancement


___

### **Description**
- Replace raw -1 literals with named constant `UNKNOWN_STATIC_SIZE`

- Add documentation explaining sentinel value semantics

- Improve code maintainability and readability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Raw -1 literals"] -- "Replace with" --> B["UNKNOWN_STATIC_SIZE constant"]
  B -- "Documented in" --> C["semantic_analyzer_infer_impl.f90"]
  C -- "Used throughout" --> D["Static array size helpers"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic_analyzer_infer_impl.f90</strong><dd><code>Define and document unknown static-size sentinel</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_analyzer_infer_impl.f90

<ul><li>Define new module-level parameter <code>UNKNOWN_STATIC_SIZE = -1</code><br> <li> Add comprehensive documentation explaining sentinel value semantics<br> <li> Document that negative values represent unknown sizes and &gt;= 0 <br>represents known sizes</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2714/files#diff-c6ab1fd366e457e6eb128eb0d7c360f60f12c0364136ebd9d8a7c9fd9f8735dd">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>semantic_analyzer_infer_impl_part3.inc</strong><dd><code>Replace magic -1 literals with named constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc

<ul><li>Replace raw -1 literals with <code>UNKNOWN_STATIC_SIZE</code> <br>constant<br> <li> Updates occur in <code>static_array_literal_size()</code> function<br> <li> Updates occur in <code>static_array_literal_element_size()</code> function<br> <li> Updates occur in <code>static_array_literal_implied_size()</code> function<br> <li> Updates occur in <code>find_prev_literal_assignment_size()</code> function<br> <li> Updates occur in <code>assignment_literal_size_if_target_name()</code> function</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2714/files#diff-4a62d5c1122fac082b875ebc5513ecb2d1fd7dae4905a90c9ad3507fcba5ebea">+13/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___
