### PR TITLE
fix: polish: avoid full-arena scans in strict allocatable LHS (fixes #2690)

### DIFF
--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -15,6 +15,7 @@ submodule(semantic_analyzer) semantic_analyzer_infer_impl
         validate_strict_argument_types_for_function_reference, &
         validate_strict_argument_types_for_subroutine_call
     use semantic_operating_mode, only: OPERATING_MODE_STRICT
+    use semantic_identifier_context, only: find_program_owner
     use semantic_type_lookup_wrapper, only: set_semantic_context_for_lookup, &
                                             clear_semantic_context_for_lookup, &
                                             get_type_with_stored_context

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc
@@ -36,7 +36,6 @@
     subroutine validate_strict_allocatable_lhs_reallocation(ctx, arena, &
                                                             assignment, &
                                                             assignment_index)
-        use semantic_identifier_context, only: find_program_owner
         type(semantic_context_t), intent(inout) :: ctx
         type(ast_arena_t), intent(inout) :: arena
         type(assignment_node), intent(in) :: assignment


### PR DESCRIPTION
### **User description**
## Summary

Replace the strict-mode allocatable LHS reallocation check's full-arena scan with an O(parent-depth) lookup via `find_program_owner()`.

## Verification

- `fpm test 2>&1 | tee /tmp/fpm-test-issue-2690.log`

Excerpt (from `/tmp/fpm-test-issue-2690.log`):

```
 All fortfront API arena tests passed!
STOP 0
...
 All function parameter parsing tests passed!
STOP 0
```


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Replace full-arena scan with O(parent-depth) lookup in strict allocatable LHS check

- Remove inefficient `find_containing_program_index()` function

- Use existing `find_program_owner()` from semantic_identifier_context module

- Improves performance for strict mode allocatable array reallocation validation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["validate_strict_allocatable_lhs_reallocation"] -->|old: full-arena scan| B["find_containing_program_index"]
  A -->|new: O(parent-depth)| C["find_program_owner"]
  B -->|removed| D["Inefficient iteration"]
  C -->|reuses| E["semantic_identifier_context module"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Performance optimization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>semantic_analyzer_infer_impl_part3.inc</strong><dd><code>Replace full-arena scan with efficient parent lookup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc

<ul><li>Added import of <code>find_program_owner</code> from <code>semantic_identifier_context</code> <br>module<br> <li> Replaced call to <code>find_containing_program_index()</code> with <br><code>find_program_owner()</code> for finding program owner<br> <li> Removed inefficient <code>find_containing_program_index()</code> function that <br>performed full-arena iteration<br> <li> Maintains same validation logic with improved algorithmic complexity</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2716/files#diff-4a62d5c1122fac082b875ebc5513ecb2d1fd7dae4905a90c9ad3507fcba5ebea">+2/-29</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

