### PR TITLE
fix: polish: document source text retrieval API conventions (fixes #2650)

### DIFF
--- a/src/ast/arena/README.md
+++ b/src/ast/arena/README.md
@@ -27,6 +27,22 @@ For complete arena allocation design principles, see [AST README](../README.md#k
 - **Safety checks**: `ast_arena_safe.f90` - bounds verification
 - **Source text**: `ast_arena_source_text.f90` - source retrieval for tooling
 
+### Source Text Retrieval API Conventions
+
+The source text retrieval API lives in `src/ast/arena/ast_arena_source_text.f90`.
+Behavioral coverage is in `test/api/test_source_text_retrieval_api.f90`.
+
+- Source text is normalized to LF line endings when stored (`CRLF` becomes
+  `new_line('A')`).
+- Lines and columns are 1-based.
+- Range queries are inclusive on both ends: `(start_line, start_col)` through
+  `(end_line, end_col)`.
+- If the stored source ends with a newline, there is a trailing empty line and
+  `get_source_line` returns `found = .true.` with empty text for that line.
+- An empty range at EOF is treated as found: when the range maps to
+  `start_pos == end_pos == len(source) + 1`, `get_source_range` returns
+  `found = .true.` with empty text.
+
 **Performance**: O(1) allocation, O(1) bulk deallocation, cache-friendly layout
 
 **Stack limits**: Test with `make test-small-stack` to simulate Windows 1-2 MB limits


### PR DESCRIPTION
### **User description**
Summary
- Document source text retrieval conventions for tooling users in `src/ast/arena/README.md`.

Verification
- `fpm test 2>&1 | tee /tmp/fpm-test-issue-2650.log`
- Output excerpt:
  - `=== Source Text Retrieval API Tests ===`
  - `All source text retrieval API tests passed!`
- Test log: `/tmp/fpm-test-issue-2650.log`


___

### **PR Type**
Documentation


___

### **Description**
- Document source text retrieval API conventions and behaviors

- Clarify line ending normalization, 1-based indexing, and range query semantics

- Explain edge cases for EOF and empty ranges


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Source Text Retrieval API"] --> B["Normalization Rules"]
  A --> C["Indexing Conventions"]
  A --> D["Range Query Semantics"]
  A --> E["Edge Cases"]
  B --> B1["CRLF to LF conversion"]
  C --> C1["1-based lines and columns"]
  D --> D1["Inclusive on both ends"]
  E --> E1["Trailing empty lines"]
  E --> E2["Empty range at EOF"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add source text retrieval API conventions documentation</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/ast/arena/README.md

<ul><li>Added new "Source Text Retrieval API Conventions" section documenting <br>API behaviors<br> <li> Documented source text normalization to LF line endings<br> <li> Clarified 1-based indexing for lines and columns<br> <li> Explained inclusive range query semantics and edge cases for EOF <br>handling</ul>


</details>


  </td>
  <td><a href="https://github.com/lazy-fortran/fortfront/pull/2717/files#diff-79ec13b89ad2bb59d24a65ed3f3d483999b7078ef932a06455c17e08ef2f0309">+16/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

