### PR TITLE
fix: align traversal documentation (level-order) (fixes #2735)

### DIFF
--- a/src/ast/README.md
+++ b/src/ast/README.md
@@ -37,7 +37,7 @@ The AST subsystem provides the core data structures and operations for represent
 **Visitor Pattern**
 - Safe traversal via `visit_node_at(arena, index, visitor_callback)`
 - Visitor receives node reference, never copies
-- Supports pre-order, post-order, and level-order traversal
+- Supports pre-order and post-order traversal
 - Type-safe dispatch to node-specific handlers
 
 **Node Type Organization**


### PR DESCRIPTION
## Summary

Align `src/ast/README.md` with the implemented traversal API by removing the stale claim that level-order traversal is supported.

## Verification

Command:

```bash
fpm test 2>&1 | tee /tmp/fpm_test_issue2735.log
```

Excerpt:

```text
All AST traversal tests passed!
STOP 0
```

Log: `/tmp/fpm_test_issue2735.log`
