### PR TITLE
fix: remove or use unused node_index in generics codegen (fixes #2746)

### DIFF
--- a/src/codegen/api/codegen_core.f90
+++ b/src/codegen/api/codegen_core.f90
@@ -222,15 +222,15 @@ contains
             code = generate_code_mixed_construct_container(arena, node, &
                                                            node_index)
         type is (template_block_node)
-            code = generate_code_template_block(arena, node, node_index)
+            code = generate_code_template_block(arena, node)
         type is (instantiate_statement_node)
             code = generate_code_instantiate_statement(node)
         type is (trait_block_node)
-            code = generate_code_trait_block(arena, node, node_index)
+            code = generate_code_trait_block(arena, node)
         type is (requirement_block_node)
-            code = generate_code_requirement_block(arena, node, node_index)
+            code = generate_code_requirement_block(arena, node)
         type is (implements_block_node)
-            code = generate_code_implements_block(arena, node, node_index)
+            code = generate_code_implements_block(arena, node)
 
             ! Special nodes
         type is (contains_node)

--- a/src/codegen/decls/codegen_generics.f90
+++ b/src/codegen/decls/codegen_generics.f90
@@ -15,10 +15,9 @@ module codegen_generics
 
 contains
 
-    function generate_code_template_block(arena, node, node_index) result(code)
+    function generate_code_template_block(arena, node) result(code)
         type(ast_arena_t), intent(in) :: arena
         type(template_block_node), intent(in) :: node
-        integer, intent(in) :: node_index
         character(len=:), allocatable :: code
         character(len=:), allocatable :: header
         character(len=:), allocatable :: decl_code
@@ -85,10 +84,9 @@ contains
         end if
     end function generate_code_instantiate_statement
 
-    function generate_code_trait_block(arena, node, node_index) result(code)
+    function generate_code_trait_block(arena, node) result(code)
         type(ast_arena_t), intent(in) :: arena
         type(trait_block_node), intent(in) :: node
-        integer, intent(in) :: node_index
         character(len=:), allocatable :: code
         character(len=:), allocatable :: header
         character(len=:), allocatable :: decl_code
@@ -142,10 +140,9 @@ contains
         code = code // "end trait " // node%name
     end function generate_code_trait_block
 
-    function generate_code_requirement_block(arena, node, node_index) result(code)
+    function generate_code_requirement_block(arena, node) result(code)
         type(ast_arena_t), intent(in) :: arena
         type(requirement_block_node), intent(in) :: node
-        integer, intent(in) :: node_index
         character(len=:), allocatable :: code
         character(len=:), allocatable :: header
         character(len=:), allocatable :: decl_code
@@ -199,10 +196,9 @@ contains
         code = code // "end requirement " // node%name
     end function generate_code_requirement_block
 
-    function generate_code_implements_block(arena, node, node_index) result(code)
+    function generate_code_implements_block(arena, node) result(code)
         type(ast_arena_t), intent(in) :: arena
         type(implements_block_node), intent(in) :: node
-        integer, intent(in) :: node_index
         character(len=:), allocatable :: code
         character(len=:), allocatable :: header
         character(len=:), allocatable :: decl_code


### PR DESCRIPTION
## Summary

Remove the unused `node_index` dummy argument from the generics block codegen routines (template/trait/requirement/implements) and update the dispatcher call sites.

## Verification

CI is the source of truth for this PR (see the Checks tab).