### PR TITLE
fix: deduplicate inline instantiation token consumption (fixes #2742)

### DIFF
--- a/src/parser/core/README.md
+++ b/src/parser/core/README.md
@@ -16,6 +16,7 @@ The parser core provides the fundamental infrastructure for parsing operations: 
 | parser_utilities.f90 | General parsing utilities: lookahead, backtracking, synchronization |
 | parser_utils.f90 | Low-level parser utilities: token matching, consumption |
 | parser_token_views.f90 | Token stream view abstraction for lookahead |
+| parser_inline_instantiation.f90 | Shared helpers for consuming inline instantiation braces |
 | parser_implicit_shared.f90 | Shared implicit typing utilities |
 | parser_import_resolution.f90 | Import statement resolution and dependency tracking |
 | mixed_construct_detector.f90 | Detect mixed lazy/standard Fortran constructs |

--- a/src/parser/core/parser_inline_instantiation.f90
+++ b/src/parser/core/parser_inline_instantiation.f90
@@ -1,0 +1,82 @@
+module parser_inline_instantiation_module
+    use lexer_core, only: token_t
+    use lexer_token_types, only: TK_OPERATOR
+    use parser_state_module, only: parser_state_t
+    use parser_token_views_module, only: token_view_t, view_peek_token, &
+                                         view_consume_token
+    implicit none
+    private
+
+    public :: consume_inline_instantiation
+    public :: consume_inline_instantiation_tokens
+
+contains
+
+    subroutine consume_inline_instantiation(parser, inst_text)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=:), allocatable, intent(out) :: inst_text
+
+        call consume_inline_instantiation_core(parser, inst_text)
+    end subroutine consume_inline_instantiation
+
+    subroutine consume_inline_instantiation_tokens(parser, view, inst_text)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_view_t), intent(in) :: view
+        character(len=:), allocatable, intent(out) :: inst_text
+
+        call consume_inline_instantiation_core(parser, inst_text, view)
+    end subroutine consume_inline_instantiation_tokens
+
+    subroutine consume_inline_instantiation_core(parser, inst_text, view)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=:), allocatable, intent(out) :: inst_text
+        type(token_view_t), intent(in), optional :: view
+        type(token_t) :: token
+        type(token_t) :: start_token
+        integer :: nesting
+
+        if (allocated(inst_text)) deallocate (inst_text)
+
+        if (present(view)) then
+            token = view_peek_token(view, parser)
+        else
+            token = parser%peek()
+        end if
+
+        if (.not. (token%kind == TK_OPERATOR .and. token%text == "{")) then
+            return
+        end if
+
+        start_token = token
+        nesting = 0
+        do while (.not. parser%is_at_end())
+            if (present(view)) then
+                token = view_consume_token(view, parser)
+            else
+                token = parser%consume()
+            end if
+
+            if (token%kind == TK_OPERATOR) then
+                if (token%text == "{") nesting = nesting + 1
+                if (token%text == "}") nesting = nesting - 1
+            end if
+
+            if (.not. allocated(inst_text)) then
+                inst_text = token%text
+            else
+                inst_text = inst_text // token%text
+            end if
+
+            if (nesting == 0) exit
+        end do
+
+        if (nesting /= 0) then
+            if (allocated(inst_text)) deallocate (inst_text)
+            call parser%errors%add_error_with_token( &
+                "Unbalanced inline instantiation braces: expected } "// &
+                "before end of file", &
+                start_token, suggestion="Add a matching } to close the instantiation")
+        end if
+    end subroutine consume_inline_instantiation_core
+
+end module parser_inline_instantiation_module

--- a/src/parser/expressions/parser_expressions.f90
+++ b/src/parser/expressions/parser_expressions.f90
@@ -60,6 +60,7 @@ module parser_expressions_module
                                                        reduce_all_operators, &
                                                        reduce_until_group, &
                                                        push_group_marker
+    use parser_inline_instantiation_module, only: consume_inline_instantiation_tokens
     use parser_token_views_module, only: token_view_t, build_token_view, &
                                          view_peek_token, view_lower_token, &
                                          view_consume_token, view_lookahead_token
@@ -909,47 +910,6 @@ contains
             end if
         end do
     end function parse_postfix_ops
-
-    subroutine consume_inline_instantiation_tokens(parser, view, inst_text)
-        type(parser_state_t), intent(inout) :: parser
-        type(token_view_t), intent(in) :: view
-        character(len=:), allocatable, intent(out) :: inst_text
-        type(token_t) :: token
-        type(token_t) :: start_token
-        integer :: nesting
-
-        if (allocated(inst_text)) deallocate (inst_text)
-        token = view_peek_token(view, parser)
-        if (.not. (token%kind == TK_OPERATOR .and. token%text == "{")) then
-            return
-        end if
-
-        start_token = token
-        nesting = 0
-        do while (.not. parser%is_at_end())
-            token = view_consume_token(view, parser)
-            if (token%kind == TK_OPERATOR) then
-                if (token%text == "{") nesting = nesting + 1
-                if (token%text == "}") nesting = nesting - 1
-            end if
-
-            if (.not. allocated(inst_text)) then
-                inst_text = token%text
-            else
-                inst_text = inst_text // token%text
-            end if
-
-            if (nesting == 0) exit
-        end do
-
-        if (nesting /= 0) then
-            if (allocated(inst_text)) deallocate (inst_text)
-            call parser%errors%add_error_with_token( &
-                "Unbalanced inline instantiation braces: expected } "// &
-                "before end of file", &
-                start_token, suggestion="Add a matching } to close the instantiation")
-        end if
-    end subroutine consume_inline_instantiation_tokens
 
     subroutine append_inline_instantiation_to_name(arena, expr_index, inst_text)
         use ast_nodes_core, only: identifier_node, component_access_node

--- a/src/parser/procedures/parser_call.f90
+++ b/src/parser/procedures/parser_call.f90
@@ -2,6 +2,7 @@ module parser_call_module
     ! Shared call-statement parser used across control-flow helpers
     use lexer_core, only: token_t
     use lexer_token_types, only: TK_IDENTIFIER, TK_OPERATOR, TK_KEYWORD
+    use parser_inline_instantiation_module, only: consume_inline_instantiation
     use parser_state_module, only: parser_state_t
     use parser_expressions_module, only: parse_range
     use ast_arena_modern, only: ast_arena_t
@@ -13,45 +14,6 @@ module parser_call_module
     public :: parse_call_statement
 
 contains
-
-    subroutine consume_inline_instantiation(parser, inst_text)
-        type(parser_state_t), intent(inout) :: parser
-        character(len=:), allocatable, intent(out) :: inst_text
-        type(token_t) :: token
-        type(token_t) :: start_token
-        integer :: nesting
-
-        if (allocated(inst_text)) deallocate (inst_text)
-        token = parser%peek()
-        if (.not. (token%kind == TK_OPERATOR .and. token%text == "{")) then
-            return
-        end if
-
-        start_token = token
-        nesting = 0
-        do while (.not. parser%is_at_end())
-            token = parser%consume()
-            if (token%kind == TK_OPERATOR) then
-                if (token%text == "{") nesting = nesting + 1
-                if (token%text == "}") nesting = nesting - 1
-            end if
-
-            if (.not. allocated(inst_text)) then
-                inst_text = token%text
-            else
-                inst_text = inst_text // token%text
-            end if
-            if (nesting == 0) exit
-        end do
-
-        if (nesting /= 0) then
-            if (allocated(inst_text)) deallocate (inst_text)
-            call parser%errors%add_error_with_token( &
-                "Unbalanced inline instantiation braces: expected } "// &
-                "before end of file", &
-                start_token, suggestion="Add a matching } to close the instantiation")
-        end if
-    end subroutine consume_inline_instantiation
 
     subroutine parse_call_arguments(parser, arena, arg_indices)
         use ast_nodes_core, only: assignment_node


### PR DESCRIPTION
Summary
- Deduplicate inline `{...}` instantiation consumption by introducing a shared helper used by both call parsing and expression postfix parsing.

Verification
- `fpm test 2>&1 | tee /tmp/fpm-test-issue-2742.log`
  - `PASS: Parsed template/instantiate and inline {}`
  - `PASS: Unbalanced inline instantiation diagnostics`
- `make check-duplication 2>&1 | tee /tmp/check-duplication-issue-2742.log`
  - `✓ PASS: No end-to-end test violations found`
