### PR TITLE
fix: deduplicate inline instantiation brace consumption (fixes #2748)

### DIFF
--- a/src/codegen/programs/codegen_program_body.f90
+++ b/src/codegen/programs/codegen_program_body.f90
@@ -229,11 +229,12 @@ contains
         character(len=*), intent(in) :: text
         character(len=:), allocatable :: normalized
         integer :: i, length_text, pos
-        character(len=len(text)) :: buffer
+        character(len=:), allocatable :: buffer
         character(len=1) :: ch
 
         length_text = len(text)
         pos = 0
+        allocate (character(len=length_text) :: buffer)
 
         do i = 1, length_text
             ch = text(i:i)

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -536,7 +536,7 @@ contains
     function is_keyword(word) result(keyword)
         character(len=*), intent(in) :: word
         logical :: keyword
-        character(len=len(word)) :: lower_word
+        character(len=:), allocatable :: lower_word
 
         lower_word = to_lower(word)
 
@@ -582,7 +582,7 @@ contains
     function is_logical_constant(token_text) result(is_constant)
         character(len=*), intent(in) :: token_text
         logical :: is_constant
-        character(len=len(token_text)) :: lower_text
+        character(len=:), allocatable :: lower_text
 
         lower_text = to_lower(token_text)
 

--- a/src/parser/core/parser_inline_instantiation.f90
+++ b/src/parser/core/parser_inline_instantiation.f90
@@ -8,24 +8,20 @@ module parser_inline_instantiation_module
     private
 
     public :: consume_inline_instantiation
-    public :: consume_inline_instantiation_tokens
 
 contains
 
-    subroutine consume_inline_instantiation(parser, inst_text)
+    subroutine consume_inline_instantiation(parser, inst_text, view)
         type(parser_state_t), intent(inout) :: parser
         character(len=:), allocatable, intent(out) :: inst_text
+        type(token_view_t), intent(in), optional :: view
 
-        call consume_inline_instantiation_core(parser, inst_text)
+        if (present(view)) then
+            call consume_inline_instantiation_core(parser, inst_text, view)
+        else
+            call consume_inline_instantiation_core(parser, inst_text)
+        end if
     end subroutine consume_inline_instantiation
-
-    subroutine consume_inline_instantiation_tokens(parser, view, inst_text)
-        type(parser_state_t), intent(inout) :: parser
-        type(token_view_t), intent(in) :: view
-        character(len=:), allocatable, intent(out) :: inst_text
-
-        call consume_inline_instantiation_core(parser, inst_text, view)
-    end subroutine consume_inline_instantiation_tokens
 
     subroutine consume_inline_instantiation_core(parser, inst_text, view)
         type(parser_state_t), intent(inout) :: parser

--- a/src/parser/declarations/parser_parameter_handling.f90
+++ b/src/parser/declarations/parser_parameter_handling.f90
@@ -168,7 +168,7 @@ contains
 
     logical function can_keyword_be_identifier(token) result(can_be_id)
         type(token_t), intent(in) :: token
-        character(len=len(token%text)) :: lower_text
+        character(len=:), allocatable :: lower_text
 
         lower_text = to_lower(token%text)
         can_be_id = lower_text == "stop" .or. lower_text == "pause" .or. &

--- a/src/parser/expressions/parser_expressions.f90
+++ b/src/parser/expressions/parser_expressions.f90
@@ -60,7 +60,7 @@ module parser_expressions_module
                                                        reduce_all_operators, &
                                                        reduce_until_group, &
                                                        push_group_marker
-    use parser_inline_instantiation_module, only: consume_inline_instantiation_tokens
+    use parser_inline_instantiation_module, only: consume_inline_instantiation
     use parser_token_views_module, only: token_view_t, build_token_view, &
                                          view_peek_token, view_lower_token, &
                                          view_consume_token, view_lookahead_token
@@ -892,8 +892,7 @@ contains
                                                             expr_index, op_token)
                 if (expr_index <= 0) exit
             else if (op_token%kind == TK_OPERATOR .and. op_token%text == "{") then
-                call consume_inline_instantiation_tokens(parser, view, &
-                                                         instantiation_text)
+                call consume_inline_instantiation(parser, instantiation_text, view)
                 if (allocated(instantiation_text)) then
                     call append_inline_instantiation_to_name(arena, expr_index, &
                                                              instantiation_text)

--- a/src/parser/procedures/parser_procedure_shared.f90
+++ b/src/parser/procedures/parser_procedure_shared.f90
@@ -96,7 +96,7 @@ contains
         type(parser_state_t), intent(in) :: parser
         type(token_t), intent(in) :: token
         type(token_t) :: lookahead
-        character(len=len(token%text)) :: token_lower
+        character(len=:), allocatable :: token_lower
         character(len=:), allocatable :: next_lower
         integer :: next_index
 

--- a/src/utilities/frontend_utilities.f90
+++ b/src/utilities/frontend_utilities.f90
@@ -36,9 +36,10 @@ contains
     function strip_space_before_comma(text) result(clean)
         character(len=*), intent(in) :: text
         character(len=:), allocatable :: clean
-        character(len=len(text)) :: buffer
+        character(len=:), allocatable :: buffer
         integer :: i, pos
 
+        allocate (character(len=len(text)) :: buffer)
         pos = 0
         do i = 1, len(text)
             if (text(i:i) == ',' .and. pos > 0) then

--- a/test/parser/test_inline_instantiation_consumption.f90
+++ b/test/parser/test_inline_instantiation_consumption.f90
@@ -1,0 +1,107 @@
+program test_inline_instantiation_consumption
+    use lexer_core, only: tokenize_core
+    use parser_inline_instantiation_module, only: consume_inline_instantiation
+    use parser_state_module, only: parser_state_t, create_parser_state
+    use parser_token_views_module, only: token_view_t, build_token_view
+    use fortfront, only: token_t
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    print *, '=== inline instantiation consumption tests ==='
+
+    if (.not. test_balanced_without_view()) all_passed = .false.
+    if (.not. test_balanced_with_view()) all_passed = .false.
+    if (.not. test_unbalanced_reports_error()) all_passed = .false.
+
+    print *
+    if (all_passed) then
+        print *, 'All inline instantiation consumption tests passed!'
+        stop 0
+    end if
+
+    print *, 'Some inline instantiation consumption tests failed!'
+    stop 1
+
+contains
+
+    logical function test_balanced_without_view()
+        type(token_t), allocatable :: tokens(:)
+        type(parser_state_t) :: parser
+        character(len=:), allocatable :: inst_text
+
+        test_balanced_without_view = .true.
+
+        call tokenize_core('{T{U}}', tokens)
+        parser = create_parser_state(tokens)
+
+        call consume_inline_instantiation(parser, inst_text)
+
+        if (.not. allocated(inst_text)) then
+            print *, '  FAIL: Expected allocated instantiation text (no view)'
+            test_balanced_without_view = .false.
+            return
+        end if
+
+        if (inst_text /= '{T{U}}') then
+            print *, '  FAIL: Unexpected instantiation text (no view): ', inst_text
+            test_balanced_without_view = .false.
+            return
+        end if
+    end function test_balanced_without_view
+
+    logical function test_balanced_with_view()
+        type(token_t), allocatable :: tokens(:)
+        type(parser_state_t) :: parser
+        type(token_view_t) :: view
+        character(len=:), allocatable :: inst_text
+
+        test_balanced_with_view = .true.
+
+        call tokenize_core('{T{U}}', tokens)
+        parser = create_parser_state(tokens)
+        call build_token_view(view, parser)
+
+        call consume_inline_instantiation(parser, inst_text, view)
+
+        if (.not. allocated(inst_text)) then
+            print *, '  FAIL: Expected allocated instantiation text (with view)'
+            test_balanced_with_view = .false.
+            return
+        end if
+
+        if (inst_text /= '{T{U}}') then
+            print *, '  FAIL: Unexpected instantiation text (with view): ', inst_text
+            test_balanced_with_view = .false.
+            return
+        end if
+    end function test_balanced_with_view
+
+    logical function test_unbalanced_reports_error()
+        type(token_t), allocatable :: tokens(:)
+        type(parser_state_t) :: parser
+        character(len=:), allocatable :: inst_text
+
+        test_unbalanced_reports_error = .true.
+
+        call tokenize_core('{T{U}', tokens)
+        parser = create_parser_state(tokens)
+
+        call consume_inline_instantiation(parser, inst_text)
+
+        if (allocated(inst_text)) then
+            print *, '  FAIL: Expected instantiation text to be deallocated on error'
+            test_unbalanced_reports_error = .false.
+            return
+        end if
+
+        if (.not. parser%has_errors()) then
+            print *, '  FAIL: Expected an error for unbalanced braces'
+            test_unbalanced_reports_error = .false.
+            return
+        end if
+    end function test_unbalanced_reports_error
+
+end program test_inline_instantiation_consumption


### PR DESCRIPTION
Summary
- Consolidate inline-instantiation brace consumption behind a single `consume_inline_instantiation` entry point (optional `token_view_t`), used by both parser call sites.
- Remove `consume_inline_instantiation_tokens` to prevent drift.
- Add a focused parser unit test covering both view and non-view paths and the unbalanced-braces diagnostic.

Verification
- Command: `fpm test 2>&1 | tee /tmp/fpm-test-issue-2748.log`
- Excerpt:
  - `/tmp/fpm-test-issue-2748.log:5305`: `=== inline instantiation consumption tests ===`
  - `/tmp/fpm-test-issue-2748.log:5307`: `All inline instantiation consumption tests passed!`
- Artifact: `/tmp/fpm-test-issue-2748.log`
