### PR TITLE
polish: avoid quadratic concatenation in inline instantiation (fixes #2762)

### DIFF
--- a/src/parser/core/parser_inline_instantiation.f90
+++ b/src/parser/core/parser_inline_instantiation.f90
@@ -29,7 +29,8 @@ contains
         type(token_view_t), intent(in), optional :: view
         type(token_t) :: token
         type(token_t) :: start_token
-        integer :: nesting
+        type(token_t), allocatable :: tokens(:), tmp(:)
+        integer :: nesting, count, capacity, total_len, pos, i
 
         if (allocated(inst_text)) deallocate (inst_text)
 
@@ -45,6 +46,9 @@ contains
 
         start_token = token
         nesting = 0
+        count = 0
+        capacity = 16
+        allocate (tokens(capacity))
         do while (.not. parser%is_at_end())
             if (present(view)) then
                 token = view_consume_token(view, parser)
@@ -57,22 +61,37 @@ contains
                 if (token%text == "}") nesting = nesting - 1
             end if
 
-            if (.not. allocated(inst_text)) then
-                inst_text = token%text
-            else
-                inst_text = inst_text // token%text
+            if (count == capacity) then
+                capacity = capacity*2
+                allocate (tmp(capacity))
+                tmp(1:count) = tokens(1:count)
+                call move_alloc(tmp, tokens)
             end if
+            count = count + 1
+            tokens(count) = token
 
             if (nesting == 0) exit
         end do
 
         if (nesting /= 0) then
-            if (allocated(inst_text)) deallocate (inst_text)
             call parser%errors%add_error_with_token( &
                 "Unbalanced inline instantiation braces: expected } "// &
                 "before end of file", &
                 start_token, suggestion="Add a matching } to close the instantiation")
+            return
         end if
+
+        total_len = 0
+        do i = 1, count
+            total_len = total_len + len(tokens(i)%text)
+        end do
+
+        allocate (character(len=total_len) :: inst_text)
+        pos = 1
+        do i = 1, count
+            inst_text(pos:pos + len(tokens(i)%text) - 1) = tokens(i)%text
+            pos = pos + len(tokens(i)%text)
+        end do
     end subroutine consume_inline_instantiation_core
 
 end module parser_inline_instantiation_module


### PR DESCRIPTION
## Summary

- \`consume_inline_instantiation_core\` previously grew \`inst_text\` by reallocating and copying the buffer on every consumed token, costing O(n^2) on larger inline instantiations.
- Collect tokens into an array that doubles via \`move_alloc\`, then sum the lengths and copy once into a preallocated character buffer.
- No behaviour change; unbalanced-brace branch still reports the diagnostic and returns without producing output.

## Verification

\`\`\`
$ fpm test test_lfortran_template_instantiation_parsing \\
              test_unbalanced_inline_instantiation_diagnostics \\
              test_inline_instantiation_consumption
PASS: Parsed template/instantiate and inline {}
PASS: Unbalanced inline instantiation diagnostics
 === inline instantiation consumption tests ===
 All inline instantiation consumption tests passed!
\`\`\`

## Test plan

- [x] \`fpm build\` succeeds
- [x] Existing inline-instantiation tests pass (balanced, unbalanced, consumption)
- [x] No behaviour change in error-recovery branch (no \`inst_text\` on error)