### PR TITLE
polish: drop fortfront facade dependency in parser unit test (fixes #2763)

### DIFF
--- a/test/parser/test_inline_instantiation_consumption.f90
+++ b/test/parser/test_inline_instantiation_consumption.f90
@@ -1,9 +1,8 @@
 program test_inline_instantiation_consumption
-    use lexer_core, only: tokenize_core
+    use lexer_core, only: tokenize_core, token_t
     use parser_inline_instantiation_module, only: consume_inline_instantiation
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_token_views_module, only: token_view_t, build_token_view
-    use fortfront, only: token_t
     implicit none
 
     logical :: all_passed


### PR DESCRIPTION
## Summary

\`test_inline_instantiation_consumption\` was importing \`token_t\` through the \`fortfront\` facade while pulling \`tokenize_core\` from \`lexer_core\`. Switch \`token_t\` to its defining module so the parser-focused unit test depends only on the lexer/parser modules under test.

## Verification

\`\`\`
\$ fpm test test_inline_instantiation_consumption
 === inline instantiation consumption tests ===
 All inline instantiation consumption tests passed!
\`\`\`

## Test plan

- [x] Test compiles and passes with the lighter import