### PR TITLE
cleanup: drop misleading 'stub for now' on compose_substitutions (fixes #2772)

### DIFF
--- a/src/semantic/types/type_system_unified.f90
+++ b/src/semantic/types/type_system_unified.f90
@@ -276,7 +276,8 @@ contains
         fun_type = create_mono_type(TFUN, args=args)
     end function create_fun_type
 
-    ! Compose substitutions (stub for now)
+    ! (s1 . s2)(x) = s1(s2(x)): map every var in s2 to s1 applied to its
+    ! image, then carry over any s1-only bindings.
     function compose_substitutions(s1, s2) result(composed)
         type(substitution_t), intent(in) :: s1, s2
         type(substitution_t) :: composed

--- a/test/semantic/test_compose_substitutions.f90
+++ b/test/semantic/test_compose_substitutions.f90
@@ -1,0 +1,56 @@
+program test_compose_substitutions
+    use type_system_unified, only: substitution_t, compose_substitutions, &
+                                   type_var_t, mono_type_t, &
+                                   create_type_var, create_mono_type, TINT
+    implicit none
+
+    type(type_var_t) :: a, b
+    type(mono_type_t) :: int_type, applied
+    type(substitution_t) :: s1, s2, composed
+    logical :: ok
+
+    ok = .true.
+
+    int_type = create_mono_type(TINT)
+    a = create_type_var(1, "a")
+    b = create_type_var(2, "b")
+
+    ! s2 maps b -> a (as a mono_type wrapping the type var)
+    call s2%add(b, var_to_mono(a))
+
+    ! s1 maps a -> int
+    call s1%add(a, int_type)
+
+    ! Composing s1 . s2 should give b -> int and a -> int
+    composed = compose_substitutions(s1, s2)
+
+    if (composed%count /= 2) then
+        print *, "FAIL: composed has ", composed%count, " bindings, expected 2"
+        ok = .false.
+    end if
+
+    call composed%apply(var_to_mono(b), applied)
+    if (applied%kind /= TINT) then
+        print *, "FAIL: composed(b) kind=", applied%kind, " expected TINT=", TINT
+        ok = .false.
+    else
+        print *, "PASS: composed(b) -> int"
+    end if
+
+    call composed%apply(var_to_mono(a), applied)
+    if (applied%kind /= TINT) then
+        print *, "FAIL: composed(a) kind=", applied%kind, " expected TINT=", TINT
+        ok = .false.
+    else
+        print *, "PASS: composed(a) -> int"
+    end if
+
+    if (.not. ok) error stop 1
+    print *, "=== compose_substitutions tests passed ==="
+contains
+    function var_to_mono(v) result(mt)
+        type(type_var_t), intent(in) :: v
+        type(mono_type_t) :: mt
+        mt = create_mono_type(1, var=v)  ! TVAR = 1
+    end function var_to_mono
+end program test_compose_substitutions


### PR DESCRIPTION
## Summary

\`compose_substitutions\` in \`type_system_unified.f90\` is labelled 'stub for now', but the implementation is the standard Robinson composition: every var in \`s2\` is rebound to \`s1\`-applied image, then any \`s1\`-only bindings carry over. It is already called by \`semantic_analyzer_type_ops_impl.f90:69\` to chain unifier results, so removal is not on the table.

- Replace the misleading header with a one-line note on what the function computes.
- Add a small unit test that constructs \`s1 = {a -> int}\` and \`s2 = {b -> a}\` and asserts the composition resolves both \`a\` and \`b\` to \`int\`.

## Verification

\`\`\`
\$ fpm test test_compose_substitutions
 PASS: composed(b) -> int
 PASS: composed(a) -> int
 === compose_substitutions tests passed ===
\`\`\`

## Test plan

- [x] No remaining 'stub' comments around compose_substitutions
- [x] Unit test added and passing