### PR TITLE
cleanup: clarify bounds-node accept stubs are deferred-interface no-ops (fixes #2774)

### DIFF
--- a/src/ast/nodes/ast_nodes_bounds.f90
+++ b/src/ast/nodes/ast_nodes_bounds.f90
@@ -238,32 +238,32 @@ contains
         class(array_bounds_node), intent(in) :: this
         class(ast_visitor_base_t), intent(inout) :: visitor
 
-        ! Visitor pattern stub - would need full implementation
-        ! For now, just validate the visitor is not null
+        ! Bounds nodes do not have a visit hook on ast_visitor_t; the
+        ! deferred accept on ast_node is satisfied by this no-op.
     end subroutine array_bounds_accept
 
     subroutine array_slice_accept(this, visitor)
         class(array_slice_node), intent(in) :: this
         class(ast_visitor_base_t), intent(inout) :: visitor
 
-        ! Visitor pattern stub - would need full implementation
-        ! For now, just validate the visitor is not null
+        ! Bounds nodes do not have a visit hook on ast_visitor_t; the
+        ! deferred accept on ast_node is satisfied by this no-op.
     end subroutine array_slice_accept
 
     subroutine range_expression_accept(this, visitor)
         class(range_expression_node), intent(in) :: this
         class(ast_visitor_base_t), intent(inout) :: visitor
 
-        ! Visitor pattern stub - would need full implementation
-        ! For now, just validate the visitor is not null
+        ! Bounds nodes do not have a visit hook on ast_visitor_t; the
+        ! deferred accept on ast_node is satisfied by this no-op.
     end subroutine range_expression_accept
 
     subroutine array_operation_accept(this, visitor)
         class(array_operation_node), intent(in) :: this
         class(ast_visitor_base_t), intent(inout) :: visitor
 
-        ! Visitor pattern stub - would need full implementation
-        ! For now, just validate the visitor is not null
+        ! Bounds nodes do not have a visit hook on ast_visitor_t; the
+        ! deferred accept on ast_node is satisfied by this no-op.
     end subroutine array_operation_accept
 
 end module ast_nodes_bounds


### PR DESCRIPTION
## Summary

The four \`array_bounds_*_accept\` procedures in \`src/ast/nodes/ast_nodes_bounds.f90\` looked like dead stubs ('would need full implementation'), but they actually satisfy the \`procedure(visit_interface), deferred :: accept\` binding on \`ast_node\`. Bounds nodes have no \`visit_array_bounds\` / \`visit_array_slice\` / \`visit_range_expression\` / \`visit_array_operation\` hook on \`ast_visitor_t\`, so a no-op is the correct dispatch.

The to_json stubs cited in the issue were already removed by #2771.

Replace the misleading comments with an accurate one-line explanation. No behaviour change.

## Verification

\`\`\`
\$ fpm build
[100%] Project compiled successfully.
\`\`\`

## Test plan

- [x] No empty-body methods misrepresented as TODO
- [x] All tests pass (no observable change)
- [x] Visitor pattern remains consistent: every ast_node descendant still provides an \`accept\` to satisfy the deferred binding