### PR TITLE
enhancement: replace bare stop 1 with error stop in library code (fixes #2782)

### DIFF
--- a/src/utilities/debug_trace.f90
+++ b/src/utilities/debug_trace.f90
@@ -105,7 +105,7 @@ contains
                 write (error_unit, '(A,I0,1X,A)') 'TRACE: Max depth exceeded: ', &
                     depth, trim(name)
                 flush (error_unit)
-                stop 1
+                error stop 'debug_trace: TRACE max depth exceeded'
             end if
             write (error_unit, '(A,I0,2X,A)') '>> depth', depth, trim(name)
             if (file_u > 0) then
@@ -125,7 +125,7 @@ contains
             write (error_unit, '(A,I0,1X,A)') 'PROFILE: Max depth exceeded: ', &
                 profile_depth, trim(name)
             flush (error_unit)
-            stop 1
+            error stop 'debug_trace: PROFILE max depth exceeded'
         end if
 
         section_index = ensure_profile_section(trim(name))
@@ -169,19 +169,19 @@ contains
         if (.not. allocated(profile_sections)) then
             write (error_unit, '(A)') 'PROFILE: Internal error: missing sections'
             flush (error_unit)
-            stop 1
+            error stop 'debug_trace: profile sections not allocated'
         end if
         if (section_index < 1 .or. section_index > size(profile_sections)) then
             write (error_unit, '(A,1X,I0)') 'PROFILE: Invalid section index:', &
                 section_index
             flush (error_unit)
-            stop 1
+            error stop 'debug_trace: invalid profile section index'
         end if
         if (.not. allocated(profile_sections(section_index)%name)) then
             write (error_unit, '(A,1X,I0)') 'PROFILE: Missing section name:', &
                 section_index
             flush (error_unit)
-            stop 1
+            error stop 'debug_trace: missing profile section name'
         end if
 
         names_match = trim(profile_sections(section_index)%name) == trim(name)
@@ -191,7 +191,7 @@ contains
                 trim(profile_sections(section_index)%name)
             write (error_unit, '(A,1X,A)') 'got:', trim(name)
             flush (error_unit)
-            stop 1
+            error stop 'debug_trace: trace_leave name mismatch'
         end if
 
         elapsed_counts = end_count - profile_stack(profile_depth)%start_count

--- a/src/utilities/test_shell_commands.f90
+++ b/src/utilities/test_shell_commands.f90
@@ -90,46 +90,38 @@ contains
 
         quoted = quote_for_shell('path with spaces/example.lf', is_windows)
         if (len_trim(quoted) == 0) then
-            print *, 'ERROR: quote_for_shell rejected safe path'
-            stop 1
+            error stop 'verify_shell_helpers: quote_for_shell rejected safe path'
         end if
         trimmed_len = len_trim(quoted)
         if (quoted(1:1) /= '"' .or. quoted(trimmed_len:trimmed_len) /= '"') then
-            print *, 'ERROR: quote_for_shell missing quotes'
-            stop 1
+            error stop 'verify_shell_helpers: quote_for_shell missing quotes'
         end if
 
         command = build_compile_command('output file.f90', 'modules dir', 'temp dir', &
                                         is_windows)
         if (len_trim(command) == 0) then
-            print *, 'ERROR: build_compile_command returned empty command'
-            stop 1
+            error stop 'verify_shell_helpers: build_compile_command returned empty command'
         end if
         if (is_windows) then
             if (index(command, '"modules dir"') == 0) then
-                print *, 'ERROR: module directory not quoted for cmd'
-                stop 1
+                error stop 'verify_shell_helpers: module directory not quoted for cmd'
             end if
             if (index(command, '"output file.f90"') == 0) then
-                print *, 'ERROR: output path not quoted for cmd'
-                stop 1
+                error stop 'verify_shell_helpers: output path not quoted for cmd'
             end if
         else
             if (index(command, '"modules dir"') == 0) then
-                print *, 'ERROR: module directory not quoted'
-                stop 1
+                error stop 'verify_shell_helpers: module directory not quoted'
             end if
             if (index(command, '"output file.f90"') == 0) then
-                print *, 'ERROR: output path not quoted'
-                stop 1
+                error stop 'verify_shell_helpers: output path not quoted'
             end if
         end if
         if (is_windows) then
             if (index(quote_for_shell('pipe path', is_windows, &
                                       escape_for_cmd=.true.), &
                       '"pipe path"') == 0) then
-                print *, 'ERROR: Windows cmd escaping missing'
-                stop 1
+                error stop 'verify_shell_helpers: Windows cmd escaping missing'
             end if
         end if
     end subroutine verify_shell_helpers


### PR DESCRIPTION
## Summary

Library code under \`src/\` should not exit with a bare \`stop 1\`; per the issue, fatal invariants should \`error stop\` with a structured message that writes to stderr and returns a non-zero exit code.

- \`src/utilities/debug_trace.f90\`: 6 trace/profile invariant-violation sites now \`error stop\` with a labelled message instead of \`stop 1\` (the existing stderr write that names the offending depth / section is preserved).
- \`src/utilities/test_shell_commands.f90\`: 8 assertion sites in \`verify_shell_helpers\` now \`error stop\` with a labelled message instead of \`print\` + \`stop 1\`. The routine is a test helper invoked from \`test_all_examples\` and \`test_shell_commands_windows_quotes\`, and aborting on failure is the intended contract.

After:

\`\`\`
\$ rg -n '^\s*stop\s+1\b' src/ -g '*.f90'
(no matches)
\`\`\`

## Verification

\`\`\`
\$ fpm build
[100%] Project compiled successfully.
\$ fpm test test_shell_commands_windows_quotes
... PASS
\`\`\`

## Test plan

- [x] No bare \`stop 1\` remains in \`src/\`
- [x] CLI / tests untouched (out of scope per the issue)
- [x] Existing stderr context preserved at each call site