### PR TITLE
fix: terminate SELECT TYPE/RANK guard bodies at end select (fixes #2811)

### DIFF
--- a/examples/f90/issue_2811_select_rank_trailing.f90
+++ b/examples/f90/issue_2811_select_rank_trailing.f90
@@ -1,0 +1,17 @@
+! Issue #2811: a statement after end select must be a sibling of the
+! select rank construct, not absorbed into the rank default arm body.
+program issue_2811_select_rank_trailing
+    implicit none
+    integer :: arr(3)
+    integer :: i
+
+    i = 0
+    arr = 0
+    select rank (arr)
+    rank (1)
+        i = 1
+    rank default
+        i = 2
+    end select
+    print *, i
+end program issue_2811_select_rank_trailing

--- a/examples/f90/issue_2811_select_rank_trailing.f90
+++ b/examples/f90/issue_2811_select_rank_trailing.f90
@@ -2,16 +2,25 @@
 ! select rank construct, not absorbed into the rank default arm body.
 program issue_2811_select_rank_trailing
     implicit none
-    integer :: arr(3)
-    integer :: i
+    integer :: a1(3)
 
-    i = 0
-    arr = 0
-    select rank (arr)
-    rank (1)
-        i = 1
-    rank default
-        i = 2
-    end select
-    print *, i
+    a1 = 0
+    call probe(a1)
+
+contains
+
+    subroutine probe(arr)
+        integer :: arr(..)
+        integer :: i
+
+        i = 0
+        select rank (arr)
+        rank (1)
+            i = 1
+        rank default
+            i = 2
+        end select
+        print *, i
+    end subroutine probe
+
 end program issue_2811_select_rank_trailing

--- a/examples/f90/issue_2811_select_type_trailing.f90
+++ b/examples/f90/issue_2811_select_type_trailing.f90
@@ -1,0 +1,17 @@
+! Issue #2811: a statement after end select must be a sibling of the
+! select type construct, not absorbed into the last guard arm body.
+program issue_2811_select_type_trailing
+    implicit none
+    class(*), allocatable :: x
+    integer :: i
+
+    i = 0
+    allocate (integer :: x)
+    select type (x)
+    type is (integer)
+        i = 1
+    class default
+        i = 2
+    end select
+    print *, i
+end program issue_2811_select_type_trailing

--- a/src/parser/control_flow/parser_select_constructs.f90
+++ b/src/parser/control_flow/parser_select_constructs.f90
@@ -434,6 +434,62 @@ contains
         end if
     end function parse_select_type_selector
 
+    ! Consume an optional kind selector following a guard type name, e.g. the
+    ! "(8)" in "type is (real(8))". Returns the parenthesized text (including
+    ! the parentheses) so the caller can fold it into the type name; returns an
+    ! empty string when no kind selector is present. Leaves the parser position
+    ! unchanged in that case.
+    subroutine consume_guard_kind_suffix(parser, kind_suffix)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=:), allocatable, intent(out) :: kind_suffix
+
+        type(token_t) :: tok
+        integer :: depth, saved_pos
+
+        kind_suffix = ""
+        saved_pos = parser%current_token
+
+        tok = parser%peek()
+        do while (tok%kind == TK_WHITESPACE .or. tok%kind == TK_COMMENT .or. &
+                  tok%kind == TK_NEWLINE)
+            tok = parser%consume()
+            if (parser%is_at_end()) then
+                parser%current_token = saved_pos
+                return
+            end if
+            tok = parser%peek()
+        end do
+
+        if (tok%kind /= TK_OPERATOR .or. tok%text /= "(") then
+            parser%current_token = saved_pos
+            return
+        end if
+
+        depth = 0
+        do while (.not. parser%is_at_end())
+            tok = parser%consume()
+            select case (tok%kind)
+            case (TK_WHITESPACE, TK_COMMENT, TK_NEWLINE)
+                ! drop layout inside the selector
+            case default
+                if (tok%kind == TK_OPERATOR .and. tok%text == "(") then
+                    depth = depth + 1
+                    kind_suffix = kind_suffix // "("
+                else if (tok%kind == TK_OPERATOR .and. tok%text == ")") then
+                    depth = depth - 1
+                    kind_suffix = kind_suffix // ")"
+                    if (depth == 0) return
+                else
+                    kind_suffix = kind_suffix // tok%text
+                end if
+            end select
+        end do
+
+        ! Unbalanced parentheses: restore and report no suffix
+        parser%current_token = saved_pos
+        kind_suffix = ""
+    end subroutine consume_guard_kind_suffix
+
     recursive function parse_select_type(parser, arena) result(select_index)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
@@ -445,7 +501,7 @@ contains
         integer, allocatable :: guard_indices(:)
         integer :: line, column
         character(len=:), allocatable :: guard_keyword
-        character(len=20), dimension(3) :: end_keywords
+        character(len=20), dimension(4) :: end_keywords
         type(statement_callbacks_t) :: callbacks
 
         ! Consume select
@@ -488,6 +544,11 @@ contains
         end_keywords(1) = "type"
         end_keywords(2) = "class"
         end_keywords(3) = "contains"
+        ! "end select" specifically (matched as end followed by select) terminates
+        ! a guard body so a trailing statement after end select is a sibling of
+        ! the select node, not absorbed into the last arm. A bare end or
+        ! end if/end do inside an arm is not matched.
+        end_keywords(4) = "end select"
 
         callbacks = null_statement_callbacks()
         callbacks%parse_select_case => parse_select_case
@@ -652,11 +713,26 @@ contains
 
                             name_line = type_name_token%line
                             name_column = type_name_token%column
-                            type_name_index = push_identifier(arena, &
-                                                              type_name_token%text, &
-                                                              line=name_line, &
-                                                              column=name_column)
-                            type_name_token = parser%consume()
+                            block
+                                character(len=:), allocatable :: full_type_name
+                                character(len=:), allocatable :: kind_suffix
+
+                                full_type_name = type_name_token%text
+                                type_name_token = parser%consume()
+
+                                ! Capture an optional kind selector, e.g. real(8)
+                                ! or real(kind=8), so real and real(8) become
+                                ! distinct guards instead of colliding.
+                                call consume_guard_kind_suffix(parser, kind_suffix)
+                                if (len(kind_suffix) > 0) then
+                                    full_type_name = full_type_name // kind_suffix
+                                end if
+
+                                type_name_index = push_identifier(arena, &
+                                                                  full_type_name, &
+                                                                  line=name_line, &
+                                                                  column=name_column)
+                            end block
 
                             ! Expect )
                             next_token = parser%peek()
@@ -818,10 +894,12 @@ contains
         default_index = 0
 
         end_keywords(1) = "rank"
-        ! Note: end is NOT included because parse_statement_body would stop at
-        ! ANY end keyword (end if, end do, etc.), not just end select.
-        ! We handle end select detection in the main loop below.
-        end_keywords(2) = ""
+        ! "end select" specifically (matched as end followed by select) terminates
+        ! a rank body so a trailing statement after end select is a sibling of
+        ! the select node, not absorbed into the last arm. A bare end or
+        ! end if/end do inside an arm is not matched (check_end_keyword_match
+        ! requires the select suffix), which is why a plain "end" stays excluded.
+        end_keywords(2) = "end select"
 
         callbacks = null_statement_callbacks()
         callbacks%parse_select_rank => parse_select_rank

--- a/test/test_issue_2811_select_trailing.f90
+++ b/test/test_issue_2811_select_trailing.f90
@@ -1,0 +1,84 @@
+program test_issue_2811_select_trailing
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use frontend_core, only: lex_source, emit_fortran
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    implicit none
+
+    call verify_trailing_is_sibling( &
+        'examples/f90/issue_2811_select_type_trailing.f90', 'SELECT TYPE')
+    call verify_trailing_is_sibling( &
+        'examples/f90/issue_2811_select_rank_trailing.f90', 'SELECT RANK')
+
+    print *, ""
+    print *, "Issue 2811 select-trailing tests completed."
+
+contains
+
+    include 'common/read_example.inc'
+
+    subroutine verify_trailing_is_sibling(example_path, label)
+        character(len=*), intent(in) :: example_path
+        character(len=*), intent(in) :: label
+        character(:), allocatable :: input_code
+        character(:), allocatable :: output_code
+        character(:), allocatable :: error_msg
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+        integer :: end_select_pos, print_pos
+
+        call read_example(example_path, input_code)
+
+        arena = create_ast_arena()
+        call lex_source(input_code, tokens, error_msg)
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                write (error_unit, '(A)') label // ' lexing error: ' // &
+                    trim(error_msg)
+                error stop 1
+            end if
+        end if
+
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                write (error_unit, '(A)') label // ' parsing error: ' // &
+                    trim(error_msg)
+                error stop 1
+            end if
+        end if
+
+        call emit_fortran(arena, prog_index, output_code)
+
+        print_pos = index(output_code, 'print *, i')
+        end_select_pos = index(output_code, 'end select')
+
+        if (print_pos == 0) then
+            write (error_unit, '(A)') label // &
+                ' FAIL: trailing print missing from emitted code'
+            write (error_unit, '(A)') trim(output_code)
+            error stop 1
+        end if
+        if (end_select_pos == 0) then
+            write (error_unit, '(A)') label // &
+                ' FAIL: end select missing from emitted code'
+            write (error_unit, '(A)') trim(output_code)
+            error stop 1
+        end if
+
+        ! Trailing statement is a sibling of the select node only if it is
+        ! emitted after the construct closes. Absorption into the last arm
+        ! would place the print before end select.
+        if (print_pos < end_select_pos) then
+            write (error_unit, '(A)') label // &
+                ' FAIL: trailing print absorbed into last arm (before end select)'
+            write (error_unit, '(A)') trim(output_code)
+            error stop 1
+        end if
+
+        print *, '[PASS] ' // label // ': trailing statement is a sibling'
+    end subroutine verify_trailing_is_sibling
+
+end program test_issue_2811_select_trailing


### PR DESCRIPTION
Fixes #2811.

## Problem
The `end_keywords` arrays passed to `parse_statement_body` for SELECT TYPE / SELECT RANK guard arms omitted the construct terminator, so the source-last guard/default arm absorbed every statement after `end select`. Separately, `type is (real(8))` failed to parse (the kind suffix was not consumed), so a real8 guard was dropped and could not be distinguished from `type is (real)`.

## Fix
- Add `end select` as a guard-body terminator for SELECT TYPE (end_keywords grown to dimension(4)) and SELECT RANK (empty slot replaced). A trailing statement now parses as a sibling of the select node.
- New helper consumes an optional balanced kind selector after a guard type name so `type is (real)` and `type is (real(8))` are distinct, round-tripping guards.
- Examples corrected to valid F2003 (SELECT RANK selector is an assumed-rank dummy).

## Verification
Before (fix reverted): trailing `print *, i` emitted inside `class default`, before `end select`; runtime STOP 1.
After:
```
$ fpm test test_issue_2811_select_trailing
 [PASS] SELECT TYPE: trailing statement is a sibling
 [PASS] SELECT RANK: trailing statement is a sibling
```
Round-trip of both examples emits `print *, i` after `end select` and compiles (gfortran -fsyntax-only rc=0). Regression: test_issue_1623_select_type, test_issue_2559_select_type_case_variations, nested control-flow/select-case tests all pass. Integrated full suite: test_all_examples 610 examples, 0 failures.
