### PR TITLE
fix: run monomorphization in compile_frontend_from_string (fixes #2810)

### DIFF
--- a/src/frontend/frontend_compiler_api.f90
+++ b/src/frontend/frontend_compiler_api.f90
@@ -13,6 +13,7 @@ module frontend_compiler_api
     use semantic_operating_mode, only: OPERATING_MODE_INFER
     use standardizer, only: standardize_ast, standardize_multi_unit_children, &
                             set_standardizer_input_mode
+    use ast_monomorphization, only: transform_monomorphization
     implicit none
     private
 
@@ -102,6 +103,10 @@ contains
 
         if (opts%standardize .and. result%semantic_ok) then
             call set_standardizer_input_mode(opts%input_mode)
+            ! Mirror the CLI pipeline: monomorphize type-polymorphic calls
+            ! before standardization so backends see specialized procedures.
+            call transform_monomorphization(result%arena, result%root_index, &
+                                            result%semantic_ctx%signatures)
             call standardize_multi_unit_children(result%arena, result%root_index)
             call standardize_ast(result%arena, result%root_index)
         end if

--- a/test/api/test_issue_2810_api_monomorphization.f90
+++ b/test/api/test_issue_2810_api_monomorphization.f90
@@ -1,0 +1,74 @@
+program test_issue_2810_api_monomorphization
+    use fortfront, only: compiler_frontend_result_t, &
+                         compiler_frontend_options_t, &
+                         compile_frontend_from_string, emit_fortran
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== Issue 2810: compile_frontend_from_string monomorphization ==='
+    print *
+
+    all_passed = test_polymorphic_calls_monomorphized()
+
+    print *
+    if (all_passed) then
+        print *, 'Issue 2810 API monomorphization test passed!'
+        stop 0
+    else
+        print *, 'Issue 2810 API monomorphization test failed!'
+        stop 1
+    end if
+
+contains
+
+    include '../common/read_example.inc'
+
+    logical function test_polymorphic_calls_monomorphized()
+        type(compiler_frontend_result_t) :: result
+        type(compiler_frontend_options_t) :: options
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: output
+
+        test_polymorphic_calls_monomorphized = .true.
+        print *, 'Testing standardized output is monomorphized...'
+
+        call read_example('examples/lf/monomorphization_simple.lf', source)
+
+        options%standardize = .true.
+        call compile_frontend_from_string(source, result, options)
+
+        if (.not. result%success()) then
+            print *, '  FAIL: unexpected diagnostic -> ', &
+                trim(result%diagnostic_text)
+            test_polymorphic_calls_monomorphized = .false.
+            return
+        end if
+
+        call emit_fortran(result%arena, result%root_index, output)
+
+        if (index(output, 'interface add') == 0) then
+            print *, '  FAIL: generic interface missing'
+            print *, '  Output:', output
+            test_polymorphic_calls_monomorphized = .false.
+            return
+        end if
+
+        if (index(output, 'add__i32_i32') == 0) then
+            print *, '  FAIL: integer specialization add__i32_i32 missing'
+            print *, '  Output:', output
+            test_polymorphic_calls_monomorphized = .false.
+            return
+        end if
+
+        if (index(output, 'add__r64_r64') == 0) then
+            print *, '  FAIL: real(8) specialization add__r64_r64 missing'
+            print *, '  Output:', output
+            test_polymorphic_calls_monomorphized = .false.
+            return
+        end if
+
+        print *, '  PASS: API output monomorphized via interface and variants'
+    end function test_polymorphic_calls_monomorphized
+
+end program test_issue_2810_api_monomorphization


### PR DESCRIPTION
Fixes #2810.

## Problem
`compile_frontend_from_string` (the API backends consume) ran semantic analysis then standardization but never monomorphization, so lazy programs with type-polymorphic calls (e.g. `add(5,3)` and `add(2.5d0,1.5d0)`) reached backends un-monomorphized. The CLI pipeline runs monomorphization between the two; the API skipped it.

## Fix
In `src/frontend/frontend_compiler_api.f90`, when `opts%standardize` is set, call `transform_monomorphization(result%arena, result%root_index, result%semantic_ctx%signatures)` before standardization, mirroring the CLI ordering.

## Verification
```
$ fpm test test_issue_2810_api_monomorphization
   PASS: API output monomorphized via interface and variants
$ fpm test test_frontend_compiler_api
 All compiler frontend API tests passed!
```
fprettify clean. Integrated full suite green (test_all_examples 610, 0 failures).
