### PR TITLE
fix: resolve lazy dummy type_name from cached kind, not stale arena (fixes #2812)

### DIFF
--- a/examples/lf/issue_2812_lazy_toplevel_function.lf
+++ b/examples/lf/issue_2812_lazy_toplevel_function.lf
@@ -1,0 +1,6 @@
+function add(a, b)
+    add = a + b
+end function
+
+x = add(5, 3)
+print *, x

--- a/src/standardizers/standardizer_function_parameters.f90
+++ b/src/standardizers/standardizer_function_parameters.f90
@@ -4,6 +4,7 @@ module standardizer_function_parameters
     use ast_nodes_data, only: INTENT_IN, INTENT_INOUT, INTENT_OUT
     use ast_nodes_procedure, only: function_def_node
     use type_system_unified, only: TINT
+    use type_string_utils, only: mono_type_cached_string => mono_type_to_string
     use standardizer_function_param_scanner, only: analyze_parameter_usage
     use standardizer_function_parameter_builders, only: &
         add_missing_parameter_declarations_ext, &
@@ -144,7 +145,11 @@ contains
         if (metadata%is_unsigned(slot)) then
             inferred_text = "integer"
         else
-            inferred_text = param%inferred_type%to_string()
+            ! Use cached-field formatter: the type-bound to_string dereferences
+            ! the type arena, which may be stale after reset_type_system, yielding
+            ! garbage. The cached kind/size/is_unsigned survive on the AST node.
+            inferred_text = mono_type_cached_string(param%inferred_type, &
+                                                    fallback="")
         end if
         call apply_function_type(metadata, slot, .false., "", .false., 0, &
                                  param%inferred_type%kind > 0, inferred_text, &
@@ -175,7 +180,8 @@ contains
         if (metadata%is_unsigned(slot)) then
             inferred_text = "integer"
         else
-            inferred_text = param%inferred_type%to_string()
+            inferred_text = mono_type_cached_string(param%inferred_type, &
+                                                    fallback="")
         end if
         call apply_function_type(metadata, slot, has_explicit_type, &
                                  explicit_type, &
@@ -208,7 +214,8 @@ contains
         if (metadata%is_unsigned(slot)) then
             inferred_text = "integer"
         else
-            inferred_text = param%inferred_type%to_string()
+            inferred_text = mono_type_cached_string(param%inferred_type, &
+                                                    fallback="")
         end if
         call apply_function_type(metadata, slot, has_explicit_type, &
                                  explicit_type, &

--- a/test/standardizer/test_issue_2812_lazy_dummy_type.f90
+++ b/test/standardizer/test_issue_2812_lazy_dummy_type.f90
@@ -1,0 +1,149 @@
+program test_issue_2812_lazy_dummy_type
+    ! Issue #2812: the lazy standardizer synthesized a dummy intent-restatement
+    ! declaration_node whose type_name was read from a stale type arena via the
+    ! type-bound to_string. The bytes were uninitialized garbage, so AST
+    ! consumers (e.g. the ffc backend) saw a nondeterministic, unresolved type.
+    !
+    ! The standardized AST must carry a concrete, ASCII-clean type_name for the
+    ! inferred kind. The dummies a, b are inferred integer from add(5, 3).
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use fortfront, only: lex_source, parse_tokens, create_ast_arena, &
+                         ast_arena_t, token_t
+    use semantic_api, only: semantic_context_t, create_semantic_context, &
+                            analyze_program
+    use standardizer, only: standardize_ast
+    use ast_nodes_data, only: declaration_node
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    integer :: iter
+    integer, parameter :: n_iterations = 20
+
+    call read_example('examples/lf/issue_2812_lazy_toplevel_function.lf', &
+        & source_code)
+
+    do iter = 1, n_iterations
+        call run_and_check(source_code, iter)
+    end do
+
+    print *, 'PASS: Issue #2812 lazy dummy type concrete and deterministic'
+
+contains
+
+    include '../common/read_example.inc'
+
+    subroutine run_and_check(source_code, iter)
+        character(len=*), intent(in) :: source_code
+        integer, intent(in) :: iter
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        type(semantic_context_t) :: ctx
+        character(len=:), allocatable :: err
+        integer :: prog_index
+        logical :: found_a, found_b
+
+        call lex_source(source_code, tokens, err)
+        call assert_no_error(err, 'lex')
+        arena = create_ast_arena()
+        call parse_tokens(tokens, arena, prog_index, err)
+        call assert_no_error(err, 'parse')
+        call create_semantic_context(ctx)
+        call analyze_program(ctx, arena, prog_index)
+        call standardize_ast(arena, prog_index)
+
+        found_a = .false.
+        found_b = .false.
+        call inspect_declarations(arena, iter, found_a, found_b)
+
+        if (.not. found_a) then
+            write (error_unit, '(A,I0)') &
+                'FAIL: dummy declaration for a missing at iteration ', iter
+            error stop 1
+        end if
+        if (.not. found_b) then
+            write (error_unit, '(A,I0)') &
+                'FAIL: dummy declaration for b missing at iteration ', iter
+            error stop 1
+        end if
+    end subroutine run_and_check
+
+    subroutine inspect_declarations(arena, iter, found_a, found_b)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: iter
+        logical, intent(inout) :: found_a, found_b
+        integer :: i
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+            type is (declaration_node)
+                call check_declaration(node, iter)
+                if (trim(node%var_name) == 'a') then
+                    call assert_integer_type(node%type_name, 'a', iter)
+                    found_a = .true.
+                else if (trim(node%var_name) == 'b') then
+                    call assert_integer_type(node%type_name, 'b', iter)
+                    found_b = .true.
+                end if
+            end select
+        end do
+    end subroutine inspect_declarations
+
+    subroutine check_declaration(node, iter)
+        type(declaration_node), intent(in) :: node
+        integer, intent(in) :: iter
+
+        ! Guarantee: no declaration_node may carry an unallocated type_name.
+        if (.not. allocated(node%type_name)) then
+            write (error_unit, '(A,A,A,I0)') &
+                'FAIL: unallocated type_name for ', trim(node%var_name), &
+                ' at iteration ', iter
+            error stop 1
+        end if
+        call assert_ascii_clean(node%type_name, node%var_name, iter)
+    end subroutine check_declaration
+
+    subroutine assert_integer_type(type_name, var, iter)
+        character(len=*), intent(in) :: type_name
+        character(len=*), intent(in) :: var
+        integer, intent(in) :: iter
+
+        if (trim(type_name) /= 'integer') then
+            write (error_unit, '(A,A,A,A,A,I0)') &
+                'FAIL: dummy ', trim(var), ' type_name not integer (got [', &
+                trim(type_name), ']) at iteration ', iter
+            error stop 1
+        end if
+    end subroutine assert_integer_type
+
+    subroutine assert_ascii_clean(text, var, iter)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: var
+        integer, intent(in) :: iter
+        integer :: i, code
+
+        do i = 1, len(text)
+            code = iachar(text(i:i))
+            if (code == 9 .or. code == 32) cycle
+            if (code < 32 .or. code > 126) then
+                write (error_unit, '(A,A,A,I0,A,I0)') &
+                    'FAIL: non-ASCII byte in type_name of ', trim(var), &
+                    ' code=', code, ' at iteration ', iter
+                error stop 1
+            end if
+        end do
+    end subroutine assert_ascii_clean
+
+    subroutine assert_no_error(message, phase)
+        character(len=:), allocatable, intent(in) :: message
+        character(len=*), intent(in) :: phase
+
+        if (.not. allocated(message)) return
+        if (len_trim(message) == 0) return
+
+        write (error_unit, '(A,A,A,A)') 'FAIL: ', phase, ' error: ', &
+            trim(message)
+        error stop 1
+    end subroutine assert_no_error
+
+end program test_issue_2812_lazy_dummy_type


### PR DESCRIPTION
Fixes #2812.

## Problem
The lazy standardizer derived dummy-parameter type strings via the type-bound `mono_type_t%to_string()`, which dereferences the type-system arena. After `reset_type_system` runs between passes, that handle is stale, so `to_string` returned uninitialized bytes. The garbage flowed into the synthesized dummy `declaration_node%type_name` (reported at line 1, col 1), giving backends a nondeterministic, unresolved type.

## Fix
Replace the three `to_string()` call sites in metadata population with `type_string_utils::mono_type_to_string(param%inferred_type, fallback="")`, which formats from cached node fields (kind, size, is_unsigned) and never touches the arena. Integer-inferred dummies get a concrete `integer`; a genuine type variable yields "" and is resolved downstream, so no declaration is ever pushed with a garbage type_name.

## Verification
Before (fix reverted): test aborts on non-ASCII byte (code=128) in dummy type_name at iteration 1.
After:
```
$ fpm test test_issue_2812_lazy_dummy_type
 PASS: Issue #2812 lazy dummy type concrete and deterministic
```
Determinism loop (20 iterations) yields identical output. CLI emits `integer, intent(in) :: a`/`:: b`. test_all_examples 610, 0 failures.
