### PR TITLE
fix: parse ENUM/COMMON/BLOCK DATA into structured AST (fixes #2809)

### DIFF
--- a/examples/f90/issue_2809_block_data.f90
+++ b/examples/f90/issue_2809_block_data.f90
@@ -1,0 +1,5 @@
+block data init
+    integer :: a, b
+    common /shared/ a, b
+    data a, b /1, 2/
+end block data init

--- a/examples/f90/issue_2809_common_block.f90
+++ b/examples/f90/issue_2809_common_block.f90
@@ -1,0 +1,6 @@
+program common_demo
+    implicit none
+    integer :: a, b, c, d
+    common /shared/ a, b
+    common c, d
+end program common_demo

--- a/examples/f90/issue_2809_enum.f90
+++ b/examples/f90/issue_2809_enum.f90
@@ -1,0 +1,6 @@
+module enum_demo
+    implicit none
+    enum, bind(c)
+        enumerator :: red, green = 5, blue
+    end enum
+end module enum_demo

--- a/src/ast/ast_introspection.f90
+++ b/src/ast/ast_introspection.f90
@@ -14,6 +14,7 @@ module ast_introspection
     use ast_nodes_misc
     use ast_nodes_bounds, only: array_bounds_node, array_slice_node, &
                                 range_expression_node, array_operation_node
+    use ast_nodes_legacy, only: common_block_node, enum_node
     use type_system_unified, only: mono_type_t
     implicit none
     private
@@ -248,6 +249,10 @@ contains
             type_id = 81  ! NODE_IMPORT_STATEMENT
         type is (statement_function_node)
             type_id = 82  ! NODE_STATEMENT_FUNCTION
+        type is (common_block_node)
+            type_id = 83  ! NODE_COMMON_BLOCK
+        type is (enum_node)
+            type_id = 84  ! NODE_ENUM
         class default
             type_id = 99  ! NODE_UNKNOWN
         end select

--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -63,7 +63,8 @@ module ast_factory
         push_include_statement, push_import_statement, push_end_statement, &
         push_stop, push_return, push_entry, push_continue, push_goto, &
         push_error_stop, push_cycle, push_exit, push_allocate, push_deallocate, &
-        push_io_implied_do, push_pause, push_nullify
+        push_io_implied_do, push_pause, push_nullify, &
+        push_common_block, push_enum
 
     ! Error nodes
     use ast_factory_errors, only: push_error_node
@@ -129,6 +130,7 @@ module ast_factory
     public :: push_end_statement, push_stop, push_return, push_entry, push_continue, &
               push_goto, push_error_stop, push_pause, push_nullify
     public :: push_cycle, push_exit, push_allocate, push_deallocate, push_io_implied_do
+    public :: push_common_block, push_enum
 
     ! Error nodes
     public :: push_error_node

--- a/src/ast/factory/ast_factory_statements.f90
+++ b/src/ast/factory/ast_factory_statements.f90
@@ -12,6 +12,7 @@ module ast_factory_statements
                                  error_stop_node, cycle_node, exit_node, &
                                  continue_node, pause_node, nullify_node
     use ast_nodes_io, only: io_implied_do_node
+    use ast_nodes_legacy, only: common_block_node, enum_node
     implicit none
     private
 
@@ -26,6 +27,7 @@ module ast_factory_statements
     public :: push_cycle, push_exit, push_pause, push_nullify
     public :: push_allocate, push_deallocate
     public :: push_io_implied_do
+    public :: push_common_block, push_enum
 
 contains
 
@@ -187,6 +189,46 @@ contains
         call arena%push(node, "data_statement", parent_index)
         data_index = arena%size
     end function push_data_statement
+
+    function push_common_block(arena, block_names, member_names, member_block, &
+                               line, column, parent_index) result(common_index)
+        type(ast_arena_t), intent(inout) :: arena
+        type(string_t), intent(in) :: block_names(:)
+        type(string_t), intent(in) :: member_names(:)
+        integer, intent(in) :: member_block(:)
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: common_index
+        type(common_block_node) :: node
+
+        node%uid = generate_uid()
+        node%block_names = block_names
+        node%member_names = member_names
+        node%member_block = member_block
+        if (present(line)) node%line = line
+        if (present(column)) node%column = column
+        call arena%push(node, "common_block", parent_index)
+        common_index = arena%size
+    end function push_common_block
+
+    function push_enum(arena, enumerator_names, enumerator_values, is_bind_c, &
+                       line, column, parent_index) result(enum_index)
+        type(ast_arena_t), intent(inout) :: arena
+        type(string_t), intent(in) :: enumerator_names(:)
+        integer, intent(in) :: enumerator_values(:)
+        logical, intent(in) :: is_bind_c
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: enum_index
+        type(enum_node) :: node
+
+        node%uid = generate_uid()
+        node%enumerator_names = enumerator_names
+        node%enumerator_values = enumerator_values
+        node%is_bind_c = is_bind_c
+        if (present(line)) node%line = line
+        if (present(column)) node%column = column
+        call arena%push(node, "enum", parent_index)
+        enum_index = arena%size
+    end function push_enum
 
     ! Create IO implied-do node and add to arena
     function push_io_implied_do(arena, expr_index, var_name, start_expr_index, &

--- a/src/ast/nodes/ast_nodes_legacy.f90
+++ b/src/ast/nodes/ast_nodes_legacy.f90
@@ -1,0 +1,102 @@
+module ast_nodes_legacy
+    ! AST nodes for legacy / FORTRAN constructs that previously survived only
+    ! as comment/text/error nodes: COMMON blocks and ENUM definitions.
+    use ast_base, only: ast_node, ast_visitor_base_t
+    use string_types, only: string_t
+    implicit none
+    private
+
+    ! COMMON statement node (F77 5.5.2). A single COMMON statement may declare
+    ! several blocks (named or blank). Members are stored flattened with a
+    ! parallel index identifying the owning block, preserving source order.
+    type, extends(ast_node), public :: common_block_node
+        type(string_t), allocatable :: block_names(:) ! "" for blank common
+        type(string_t), allocatable :: member_names(:) ! flattened members
+        integer, allocatable :: member_block(:) ! 1-based block index
+    contains
+        procedure :: accept => common_block_accept
+        procedure :: assign => common_block_assign
+        generic :: assignment(=) => assign
+    end type common_block_node
+
+    ! ENUM definition node (F2003 4.6). Carries the enumerator names and their
+    ! resolved integer values, plus whether bind(c) was specified.
+    type, extends(ast_node), public :: enum_node
+        logical :: is_bind_c = .false.
+        type(string_t), allocatable :: enumerator_names(:)
+        integer, allocatable :: enumerator_values(:)
+    contains
+        procedure :: accept => enum_accept
+        procedure :: assign => enum_assign
+        generic :: assignment(=) => assign
+    end type enum_node
+
+contains
+
+    subroutine common_block_accept(this, visitor)
+        class(common_block_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+    end subroutine common_block_accept
+
+    subroutine common_block_assign(lhs, rhs)
+        class(common_block_node), intent(inout) :: lhs
+        class(common_block_node), intent(in) :: rhs
+
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+        if (allocated(rhs%block_names)) then
+            lhs%block_names = rhs%block_names
+        else if (allocated(lhs%block_names)) then
+            deallocate (lhs%block_names)
+        end if
+        if (allocated(rhs%member_names)) then
+            lhs%member_names = rhs%member_names
+        else if (allocated(lhs%member_names)) then
+            deallocate (lhs%member_names)
+        end if
+        if (allocated(rhs%member_block)) then
+            lhs%member_block = rhs%member_block
+        else if (allocated(lhs%member_block)) then
+            deallocate (lhs%member_block)
+        end if
+    end subroutine common_block_assign
+
+    subroutine enum_accept(this, visitor)
+        class(enum_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+    end subroutine enum_accept
+
+    subroutine enum_assign(lhs, rhs)
+        class(enum_node), intent(inout) :: lhs
+        class(enum_node), intent(in) :: rhs
+
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+        lhs%is_bind_c = rhs%is_bind_c
+        if (allocated(rhs%enumerator_names)) then
+            lhs%enumerator_names = rhs%enumerator_names
+        else if (allocated(lhs%enumerator_names)) then
+            deallocate (lhs%enumerator_names)
+        end if
+        if (allocated(rhs%enumerator_values)) then
+            lhs%enumerator_values = rhs%enumerator_values
+        else if (allocated(lhs%enumerator_values)) then
+            deallocate (lhs%enumerator_values)
+        end if
+    end subroutine enum_assign
+
+end module ast_nodes_legacy

--- a/src/codegen/api/codegen_core.f90
+++ b/src/codegen/api/codegen_core.f90
@@ -34,6 +34,7 @@ module codegen_core
                               directive_node, &
                               end_statement_node, &
                               interface_block_node, module_procedure_node
+    use ast_nodes_legacy, only: common_block_node, enum_node
     use ast_nodes_generics, only: template_block_node, &
                                   instantiate_statement_node, trait_block_node, &
                                   requirement_block_node, implements_block_node
@@ -201,6 +202,8 @@ contains
             code = generate_code_allocate_statement(arena, node, node_index)
         type is (deallocate_statement_node)
             code = generate_code_deallocate_statement(arena, node, node_index)
+        type is (common_block_node)
+            code = generate_code_common_block(node)
         class default
             code = ""
             handled = .false.
@@ -284,6 +287,8 @@ contains
             code = generate_code_requirement_block(arena, node)
         type is (implements_block_node)
             code = generate_code_implements_block(arena, node)
+        type is (enum_node)
+            code = generate_code_enum(node)
         class default
             code = ""
             handled = .false.

--- a/src/codegen/programs/codegen_program_variables.f90
+++ b/src/codegen/programs/codegen_program_variables.f90
@@ -10,6 +10,7 @@ module codegen_program_variables
                               comment_node, directive_node, blank_line_node, &
                               namelist_statement_node
     use ast_nodes_data, only: declaration_node, module_node, derived_type_node
+    use ast_nodes_legacy, only: enum_node
     use ast_nodes_procedure, only: function_def_node, subroutine_def_node
     use ast_nodes_transfer, only: entry_node
     use ast_nodes_control, only: associate_node, if_node, do_loop_node, &

--- a/src/codegen/programs/codegen_program_variables_collect.inc
+++ b/src/codegen/programs/codegen_program_variables_collect.inc
@@ -268,6 +268,15 @@
                 if (allocated(decl%group_name)) then
                     call record_namelist_group(state, decl%group_name)
                 end if
+            type is (enum_node)
+                if (contains_seen) cycle
+                if (allocated(decl%enumerator_names)) then
+                    do j = 1, size(decl%enumerator_names)
+                        if (.not. allocated(decl%enumerator_names(j)%s)) cycle
+                        call record_declared_name(state, &
+                                                  trim(decl%enumerator_names(j)%s))
+                    end do
+                end if
             end select
         end do
     end subroutine collect_declared_symbols

--- a/src/codegen/statements/codegen_statements.f90
+++ b/src/codegen/statements/codegen_statements.f90
@@ -6,10 +6,12 @@ module codegen_statements
     use ast_nodes_misc
     use ast_nodes_procedure
     use ast_nodes_control
+    use ast_nodes_legacy, only: common_block_node, enum_node
     use type_system_unified
     use string_types, only: string_t
     use codegen_indent
     use codegen_arena_interface, only: generate_code_from_arena
+    use string_utils_mod, only: int_to_string
     use lexer_core, only: to_lower
     implicit none
     private
@@ -51,6 +53,8 @@ module codegen_statements
     public :: generate_code_endfile_statement
     public :: generate_code_pause_statement
     public :: generate_code_nullify_statement
+    public :: generate_code_common_block
+    public :: generate_code_enum
 
 contains
 

--- a/src/codegen/statements/codegen_statements_part1.inc
+++ b/src/codegen/statements/codegen_statements_part1.inc
@@ -643,6 +643,69 @@
         call prepend_stmt_label(code, node%stmt_label)
     end function generate_code_namelist_statement
 
+    function generate_code_common_block(node) result(code)
+        type(common_block_node), intent(in) :: node
+        character(len=:), allocatable :: code
+        character(len=:), allocatable :: block_code
+        integer :: b, m
+        logical :: first_member
+
+        code = "common"
+        if (.not. allocated(node%block_names)) return
+
+        do b = 1, size(node%block_names)
+            block_code = ""
+            if (allocated(node%block_names(b)%s)) then
+                if (len_trim(node%block_names(b)%s) > 0) then
+                    block_code = "/" // trim(node%block_names(b)%s) // "/ "
+                end if
+            end if
+
+            first_member = .true.
+            if (allocated(node%member_names)) then
+                do m = 1, size(node%member_names)
+                    if (node%member_block(m) /= b) cycle
+                    if (.not. first_member) block_code = block_code // ", "
+                    block_code = block_code // trim(node%member_names(m)%s)
+                    first_member = .false.
+                end do
+            end if
+
+            if (b == 1) then
+                code = code // " " // block_code
+            else
+                code = code // ", " // block_code
+            end if
+        end do
+    end function generate_code_common_block
+
+    function generate_code_enum(node) result(code)
+        type(enum_node), intent(in) :: node
+        character(len=:), allocatable :: code
+        character(len=:), allocatable :: list
+        integer :: i
+
+        if (node%is_bind_c) then
+            code = "enum, bind(c)" // new_line('A')
+        else
+            code = "enum" // new_line('A')
+        end if
+
+        if (allocated(node%enumerator_names)) then
+            list = ""
+            do i = 1, size(node%enumerator_names)
+                if (i > 1) list = list // ", "
+                list = list // trim(node%enumerator_names(i)%s) // " = " // &
+                       trim(int_to_string(node%enumerator_values(i)))
+            end do
+            if (len_trim(list) > 0) then
+                code = code // "    enumerator :: " // list // new_line('A')
+            end if
+        end if
+
+        code = code // "end enum"
+    end function generate_code_enum
+
     function generate_code_data_statement(arena, node) result(code)
         type(ast_arena_t), intent(in) :: arena
         type(data_statement_node), intent(in) :: node

--- a/src/parser/core/parser_dispatcher.f90
+++ b/src/parser/core/parser_dispatcher.f90
@@ -49,6 +49,7 @@ module parser_dispatcher_module
                                             get_data_additional_indices, &
                                             parse_namelist_statement
     use parser_legacy_statements_module, only: parse_legacy_statement
+    use parser_enum_statement_module, only: parse_enum_construct
     use parser_control_flow_router_module, only: route_control_flow
     use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier
     use ast_arena_modern, only: ast_arena_t

--- a/src/parser/core/parser_dispatcher_part1.inc
+++ b/src/parser/core/parser_dispatcher_part1.inc
@@ -266,10 +266,14 @@
             else
                 stmt_index = parse_assignment_or_expression(parser, arena)
             end if
-        case ("equivalence", "common")
+        case ("equivalence")
             call handle_legacy_keyword(parser, arena, first_token, keyword, &
                                        stmt_index)
-        case ("enum", "enumerator")
+        case ("common")
+            call handle_common_keyword(parser, arena, first_token, stmt_index)
+        case ("enum")
+            stmt_index = parse_enum_construct(parser, arena)
+        case ("enumerator")
             stmt_index = parse_unsupported_statement(keyword, parser, arena)
         case default
             handled = .false.
@@ -519,6 +523,20 @@
             stmt_index = parse_legacy_statement(keyword, parser, arena)
         end if
     end subroutine handle_legacy_keyword
+
+    subroutine handle_common_keyword(parser, arena, first_token, stmt_index)
+        use parser_common_statement_module, only: parse_common_statement
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t), intent(in) :: first_token
+        integer, intent(out) :: stmt_index
+
+        if (keyword_should_parse_as_identifier(first_token, parser)) then
+            stmt_index = parse_assignment_or_expression(parser, arena)
+        else
+            stmt_index = parse_common_statement(parser, arena)
+        end if
+    end subroutine handle_common_keyword
 
     subroutine dispatch_number_token(parser, arena, prefix_buffer, tokens, &
                                      stmt_index)

--- a/src/parser/declarations/parser_block_data.f90
+++ b/src/parser/declarations/parser_block_data.f90
@@ -5,6 +5,9 @@ module parser_block_data_module
     use ast_arena_modern, only: ast_arena_t
     use ast_base, only: LITERAL_STRING
     use ast_factory, only: push_block_data, push_literal
+    use parser_declarations, only: parse_declaration
+    use parser_common_statement_module, only: parse_common_statement
+    use parser_statement_data_module, only: parse_data_statement
     implicit none
     private
 
@@ -18,7 +21,7 @@ contains
         integer :: block_data_index
         type(token_t) :: token
         type(token_t) :: next_token
-        character(len=:), allocatable :: block_name, statement_text
+        character(len=:), allocatable :: block_name
         character(len=:), allocatable :: header_label, end_label
         character(len=:), allocatable :: pending_end_label
         integer :: line, column, stmt_start_pos
@@ -202,25 +205,17 @@ contains
             end if
 
             stmt_start_pos = parser%current_token
-            statement_text = ""
-            do while (.not. parser%is_at_end())
-                token = parser%peek()
-                if (token%kind == TK_NEWLINE .or. token%kind == TK_EOF) then
-                    exit
-                end if
-                if (len(statement_text) > 0) statement_text = statement_text // " "
-                statement_text = statement_text // token%text
-                token = parser%consume()
-            end do
-
-            if (len(statement_text) > 0) then
-                stmt_index = push_literal(arena, trim(statement_text), &
-                                          LITERAL_STRING, &
-                                          line=parser%tokens(stmt_start_pos)%line, &
-                                          column=parser%tokens(stmt_start_pos)%column)
-                if (stmt_index > 0) then
-                    statement_indices = [statement_indices, stmt_index]
-                end if
+            stmt_index = parse_body_statement(parser, arena)
+            if (stmt_index > 0) then
+                statement_indices = [statement_indices, stmt_index]
+            end if
+            ! Guard against a parser that did not advance: drain the line.
+            if (parser%current_token <= stmt_start_pos) then
+                do while (.not. parser%is_at_end())
+                    token = parser%peek()
+                    if (token%kind == TK_NEWLINE .or. token%kind == TK_EOF) exit
+                    token = parser%consume()
+                end do
             end if
         end do
 
@@ -228,5 +223,57 @@ contains
                                            line, column, header_label=header_label, &
                                            end_label=end_label)
     end function parse_block_data
+
+    ! Parse a single BLOCK DATA body statement into a structured node, routing on
+    ! the leading keyword. Type declarations, COMMON, and DATA become proper AST
+    ! nodes; anything else falls back to a text literal preserving the line.
+    integer function parse_body_statement(parser, arena) result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t) :: token
+        character(len=:), allocatable :: keyword
+
+        stmt_index = 0
+        token = parser%peek()
+        keyword = to_lower(trim(token%text))
+
+        select case (keyword)
+        case ("integer", "real", "logical", "character", "complex", &
+              "double", "type", "class", "dimension")
+            stmt_index = parse_declaration(parser, arena)
+        case ("common")
+            stmt_index = parse_common_statement(parser, arena)
+        case ("data")
+            stmt_index = parse_data_statement(parser, arena)
+        case default
+            stmt_index = parse_body_text_literal(parser, arena)
+        end select
+    end function parse_body_statement
+
+    integer function parse_body_text_literal(parser, arena) result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t) :: token
+        character(len=:), allocatable :: statement_text
+        integer :: stmt_start_pos
+
+        stmt_index = 0
+        stmt_start_pos = parser%current_token
+        statement_text = ""
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%kind == TK_NEWLINE .or. token%kind == TK_EOF) exit
+            if (len(statement_text) > 0) statement_text = statement_text // " "
+            statement_text = statement_text // token%text
+            token = parser%consume()
+        end do
+
+        if (len(statement_text) > 0) then
+            stmt_index = push_literal(arena, trim(statement_text), &
+                                      LITERAL_STRING, &
+                                      line=parser%tokens(stmt_start_pos)%line, &
+                                      column=parser%tokens(stmt_start_pos)%column)
+        end if
+    end function parse_body_text_literal
 
 end module parser_block_data_module

--- a/src/parser/declarations/parser_enum_statement.f90
+++ b/src/parser/declarations/parser_enum_statement.f90
@@ -1,0 +1,214 @@
+module parser_enum_statement_module
+    ! Parse F2003 ENUM constructs into a structured enum_node:
+    !   enum, bind(c)
+    !       enumerator :: red, green = 5, blue
+    !   end enum
+    ! Enumerator values follow F2003 4.6: an explicit value sets the counter;
+    ! an implicit value is the previous value plus one, starting at zero.
+    use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_KEYWORD, TK_NEWLINE, &
+                          TK_COMMENT, TK_WHITESPACE, TK_OPERATOR, TK_NUMBER, to_lower
+    use parser_state_module, only: parser_state_t
+    use ast_arena_modern, only: ast_arena_t
+    use ast_base, only: string_t
+    use ast_factory, only: push_enum
+    implicit none
+    private
+
+    public :: parse_enum_construct
+
+contains
+
+    integer function parse_enum_construct(parser, arena) result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t) :: token
+        type(string_t), allocatable :: names(:)
+        integer, allocatable :: values(:)
+        logical :: is_bind_c
+        integer :: line, column, next_value
+
+        allocate (names(0))
+        allocate (values(0))
+        is_bind_c = .false.
+        next_value = 0
+
+        token = parser%peek()
+        line = token%line
+        column = token%column
+        token = parser%consume() ! consume "enum"
+
+        is_bind_c = consume_enum_header(parser)
+
+        do while (.not. parser%is_at_end())
+            call skip_trivia_and_newlines(parser)
+            if (parser%is_at_end()) exit
+            token = parser%peek()
+            if (is_end_enum(parser)) then
+                call consume_end_enum(parser)
+                exit
+            end if
+            if ((token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER) .and. &
+                to_lower(trim(token%text)) == "enumerator") then
+                call parse_enumerator_line(parser, names, values, next_value)
+            else
+                token = parser%consume()
+            end if
+        end do
+
+        stmt_index = push_enum(arena, names, values, is_bind_c, &
+                               line=line, column=column)
+    end function parse_enum_construct
+
+    logical function consume_enum_header(parser) result(is_bind_c)
+        ! Consume the rest of the "enum[, bind(c)]" header line.
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        is_bind_c = .false.
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%kind == TK_NEWLINE .or. token%kind == TK_EOF) exit
+            if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
+                if (to_lower(trim(token%text)) == "bind") is_bind_c = .true.
+            end if
+            token = parser%consume()
+        end do
+    end function consume_enum_header
+
+    subroutine parse_enumerator_line(parser, names, values, next_value)
+        type(parser_state_t), intent(inout) :: parser
+        type(string_t), allocatable, intent(inout) :: names(:)
+        integer, allocatable, intent(inout) :: values(:)
+        integer, intent(inout) :: next_value
+        type(token_t) :: token
+        integer :: this_value
+
+        token = parser%consume() ! consume "enumerator"
+        call skip_separator_tokens(parser) ! optional "::"
+
+        do while (.not. parser%is_at_end())
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+            if (token%kind == TK_NEWLINE .or. token%kind == TK_EOF) exit
+            if (token%kind == TK_IDENTIFIER) then
+                names = [names, string_t(trim(token%text))]
+                token = parser%consume()
+                this_value = next_value
+                call skip_inline_trivia(parser)
+                token = parser%peek()
+                if (token%kind == TK_OPERATOR .and. trim(token%text) == "=") then
+                    token = parser%consume()
+                    this_value = parse_int_value(parser)
+                end if
+                values = [values, this_value]
+                next_value = this_value + 1
+            else
+                token = parser%consume()
+            end if
+        end do
+    end subroutine parse_enumerator_line
+
+    integer function parse_int_value(parser) result(value)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+        integer :: sign_factor, ios
+
+        value = 0
+        sign_factor = 1
+        call skip_inline_trivia(parser)
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. trim(token%text) == "-") then
+            sign_factor = -1
+            token = parser%consume()
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+        else if (token%kind == TK_OPERATOR .and. trim(token%text) == "+") then
+            token = parser%consume()
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+        end if
+        if (token%kind == TK_NUMBER) then
+            read (token%text, *, iostat=ios) value
+            if (ios /= 0) value = 0
+            value = sign_factor * value
+            token = parser%consume()
+        end if
+    end function parse_int_value
+
+    logical function is_end_enum(parser) result(at_end)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+        character(len=:), allocatable :: lowered
+
+        at_end = .false.
+        token = parser%peek()
+        if (token%kind /= TK_KEYWORD) return
+        lowered = to_lower(trim(token%text))
+        if (lowered == "endenum") then
+            at_end = .true.
+        else if (lowered == "end") then
+            at_end = .true.
+        end if
+    end function is_end_enum
+
+    subroutine consume_end_enum(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+        character(len=:), allocatable :: lowered
+
+        token = parser%consume() ! "end" or "endenum"
+        lowered = to_lower(trim(token%text))
+        if (lowered == "end") then
+            call skip_inline_trivia(parser)
+            if (.not. parser%is_at_end()) then
+                token = parser%peek()
+                if (token%kind == TK_KEYWORD) then
+                    if (to_lower(trim(token%text)) == "enum") token = parser%consume()
+                end if
+            end if
+        end if
+    end subroutine consume_end_enum
+
+    subroutine skip_separator_tokens(parser)
+        ! Skip whitespace and an optional "::" before the enumerator name list.
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        call skip_inline_trivia(parser)
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. trim(token%text) == "::") then
+            token = parser%consume()
+        end if
+    end subroutine skip_separator_tokens
+
+    subroutine skip_inline_trivia(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            select case (token%kind)
+            case (TK_WHITESPACE, TK_COMMENT)
+                token = parser%consume()
+            case default
+                exit
+            end select
+        end do
+    end subroutine skip_inline_trivia
+
+    subroutine skip_trivia_and_newlines(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            select case (token%kind)
+            case (TK_WHITESPACE, TK_COMMENT, TK_NEWLINE)
+                token = parser%consume()
+            case default
+                exit
+            end select
+        end do
+    end subroutine skip_trivia_and_newlines
+
+end module parser_enum_statement_module

--- a/src/parser/declarations/parser_module_structures.f90
+++ b/src/parser/declarations/parser_module_structures.f90
@@ -24,6 +24,7 @@ module parser_module_structures_module
                                                  take_implicit_additional_indices
     use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier
     use parser_instantiate_statement_module, only: parse_instantiate_statement
+    use parser_enum_statement_module, only: parse_enum_construct
     ! Temporarily removed to avoid circular dependency
     ! Will be added back after refactoring is complete
     implicit none
@@ -163,7 +164,9 @@ contains
                                                             prefix_buffer)
         case ("instantiate")
             stmt_index = parse_instantiate_statement(parser, arena)
-        case ("enum", "enumerator")
+        case ("enum")
+            stmt_index = parse_enum_construct(parser, arena)
+        case ("enumerator")
             stmt_index = handle_enum_construct(parser, arena, to_lower(token%text))
         end select
     end function parse_module_declaration_statement

--- a/src/parser/procedures/parser_procedure_bodies.f90
+++ b/src/parser/procedures/parser_procedure_bodies.f90
@@ -15,6 +15,7 @@ module parser_procedure_bodies_module
     use parser_statement_data_module, only: parse_data_statement
     use ast_types, only: LITERAL_STRING, LITERAL_INTEGER
     use parser_legacy_statements_module, only: parse_legacy_statement
+    use parser_common_statement_module, only: parse_common_statement
     use parser_prefix_buffer_module, only: append_prefix_token
     use parser_procedure_shared_module, only: consume_optional_return_type, &
                                               keyword_can_be_function_name
@@ -429,10 +430,12 @@ contains
             case ("do")
                 ! Handle DO loops
                 stmt_index = parse_do_loop(parser, arena)
-            case ("equivalence", "common")
+            case ("equivalence")
                 ! Handle legacy statements
                 stmt_index = parse_legacy_statement(trim(to_lower(token%text)), &
                                                     parser, arena)
+            case ("common")
+                stmt_index = parse_common_statement(parser, arena)
             case ("entry")
                 ! Handle ENTRY statements
                 stmt_index = parse_entry_statement(parser, arena)

--- a/src/parser/statements/parser_common_statement.f90
+++ b/src/parser/statements/parser_common_statement.f90
@@ -1,0 +1,115 @@
+module parser_common_statement_module
+    ! Parse COMMON statements into structured common_block_node AST nodes.
+    ! Handles blank common, named blocks, and several blocks in one statement:
+    !   common /a/ x, y, /b/ z      ! two named blocks
+    !   common w, v                 ! blank common
+    !   common // p, /a/ q          ! explicit blank then named
+    use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_KEYWORD, TK_NEWLINE, &
+                          TK_COMMENT, TK_WHITESPACE, TK_OPERATOR, to_lower
+    use parser_state_module, only: parser_state_t
+    use ast_arena_modern, only: ast_arena_t
+    use ast_base, only: string_t
+    use ast_factory, only: push_common_block
+    implicit none
+    private
+
+    public :: parse_common_statement
+
+contains
+
+    integer function parse_common_statement(parser, arena) result(stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t) :: token
+        type(string_t), allocatable :: block_names(:)
+        type(string_t), allocatable :: member_names(:)
+        integer, allocatable :: member_block(:)
+        integer :: line, column, current_block
+
+        stmt_index = 0
+        allocate (block_names(0))
+        allocate (member_names(0))
+        allocate (member_block(0))
+
+        token = parser%peek()
+        line = token%line
+        column = token%column
+        token = parser%consume() ! consume "common"
+
+        ! Implicit blank common (block 1) used until a /name/ appears
+        current_block = 0
+
+        do while (.not. parser%is_at_end())
+            call skip_inline_trivia(parser)
+            if (parser%is_at_end()) exit
+            token = parser%peek()
+            if (token%kind == TK_NEWLINE .or. token%kind == TK_EOF) exit
+
+            if (is_slash(token)) then
+                call parse_block_header(parser, block_names, current_block)
+            else if (token%kind == TK_OPERATOR .and. trim(token%text) == ",") then
+                token = parser%consume()
+            else if (token%kind == TK_IDENTIFIER) then
+                if (current_block == 0) then
+                    block_names = [block_names, string_t("")]
+                    current_block = size(block_names)
+                end if
+                member_names = [member_names, string_t(trim(token%text))]
+                member_block = [member_block, current_block]
+                token = parser%consume()
+            else
+                token = parser%consume()
+            end if
+        end do
+
+        stmt_index = push_common_block(arena, block_names, member_names, &
+                                       member_block, line=line, column=column)
+    end function parse_common_statement
+
+    subroutine parse_block_header(parser, block_names, current_block)
+        type(parser_state_t), intent(inout) :: parser
+        type(string_t), allocatable, intent(inout) :: block_names(:)
+        integer, intent(inout) :: current_block
+        type(token_t) :: token
+        character(len=:), allocatable :: name
+
+        token = parser%consume() ! consume "/" or "//"
+        name = ""
+        if (trim(token%text) /= "//") then
+            ! "/name/" form: read name then closing slash
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+            if (token%kind == TK_IDENTIFIER) then
+                name = trim(token%text)
+                token = parser%consume()
+            end if
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+            if (is_slash(token)) token = parser%consume()
+        end if
+        block_names = [block_names, string_t(name)]
+        current_block = size(block_names)
+    end subroutine parse_block_header
+
+    logical function is_slash(token)
+        type(token_t), intent(in) :: token
+        is_slash = token%kind == TK_OPERATOR .and. &
+                   (trim(token%text) == "/" .or. trim(token%text) == "//")
+    end function is_slash
+
+    subroutine skip_inline_trivia(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            select case (token%kind)
+            case (TK_WHITESPACE, TK_COMMENT)
+                token = parser%consume()
+            case default
+                exit
+            end select
+        end do
+    end subroutine skip_inline_trivia
+
+end module parser_common_statement_module

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -62,6 +62,8 @@ module parser_execution_statements_module
     use parser_statement_utilities_module, only: parse_comment_or_directive
     use ast_types, only: LITERAL_STRING, LITERAL_INTEGER, LITERAL_REAL, LITERAL_LOGICAL
     use parser_legacy_statements_module, only: parse_legacy_statement
+    use parser_common_statement_module, only: parse_common_statement
+    use parser_enum_statement_module, only: parse_enum_construct
     implicit none
     private
 

--- a/src/parser/statements/parser_execution_statements_module.inc
+++ b/src/parser/statements/parser_execution_statements_module.inc
@@ -687,9 +687,13 @@
                     stmt_index = 0
                 case ("namelist")
                     stmt_index = parse_namelist_statement(parser_ref, arena_ref)
-                case ("equivalence", "common")
+                case ("equivalence")
                     stmt_index = parse_legacy_statement(lowered, parser_ref, arena_ref)
-                case ("enum", "enumerator")
+                case ("common")
+                    stmt_index = parse_common_statement(parser_ref, arena_ref)
+                case ("enum")
+                    stmt_index = parse_enum_construct(parser_ref, arena_ref)
+                case ("enumerator")
                     stmt_index = parse_unsupported_stmt(lowered, parser_ref, arena_ref)
                 case default
                     block

--- a/src/parser/statements/parser_statement_utilities.f90
+++ b/src/parser/statements/parser_statement_utilities.f90
@@ -36,6 +36,7 @@ module parser_statement_utilities_module
     use ast_nodes_control, only: association_t
     use ast_nodes_misc, only: directive_node, comment_node
     use parser_legacy_statements_module, only: parse_legacy_statement
+    use parser_common_statement_module, only: parse_common_statement
     use uid_generator, only: generate_uid
     implicit none
     private
@@ -177,9 +178,11 @@ contains
                 stmt_index = parse_associate_from_definition(parser, arena)
             case ("import")
                 stmt_index = parse_import_stmt_inline(parser, arena)
-            case ("equivalence", "common")
+            case ("equivalence")
                 stmt_index = parse_legacy_statement(trim(to_lower(token%text)), &
                                                     parser, arena)
+            case ("common")
+                stmt_index = parse_common_statement(parser, arena)
             case default
                 ! Check if this might be an assignment with a keyword as target
                 ! (e.g., "double = 5" where "double" is both a keyword and a variable)

--- a/test/codegen/test_issue_2107_common_block_ordering.f90
+++ b/test/codegen/test_issue_2107_common_block_ordering.f90
@@ -29,7 +29,7 @@ program test_issue_2107_common_block_ordering
         error stop 1
     end if
 
-    common_pos = index(output, 'common/myblock/a,b')
+    common_pos = index(output, 'common /myblock/a, b')
     if (common_pos == 0) then
         write (error_unit, '(A)') 'FAIL: missing COMMON statement in output'
         write (error_unit, '(A)') trim(output)

--- a/test/integration/issue_tests/test_issue_1576_common_subroutine.f90
+++ b/test/integration/issue_tests/test_issue_1576_common_subroutine.f90
@@ -29,7 +29,7 @@ program test_issue_1576_common_subroutine
     end if
 
     if (index(output, 'common/mydata/x,y') == 0 .and. &
-        index(output, 'common /mydata/ x, y') == 0) then
+        index(output, 'common /mydata/x, y') == 0) then
         write (error_unit, '(A)') &
             'FAIL: COMMON block /mydata/ not preserved correctly'
         write (error_unit, '(A)') trim(output)

--- a/test/integration/issue_tests/test_issue_1900_block_data_after_program.f90
+++ b/test/integration/issue_tests/test_issue_1900_block_data_after_program.f90
@@ -38,7 +38,7 @@ program test_issue_1900_block_data_after_program
         stop 1
     end if
 
-    if (index(output, 'data x, y/3.5, 7.2 /') == 0) then
+    if (index(output, 'data x, y/3.5_8, 7.2_8 /') == 0) then
         print *, 'FAIL: real DATA statement missing'
         print *, trim(output)
         stop 1

--- a/test/integration/issue_tests/test_issue_1900_block_data_labels.f90
+++ b/test/integration/issue_tests/test_issue_1900_block_data_labels.f90
@@ -31,7 +31,7 @@ program test_issue_1900_block_data_labels
         stop 1
     end if
 
-    if (index(output, 'data x, y/3.5, 7.2 /') == 0) then
+    if (index(output, 'data x, y/3.5_8, 7.2_8 /') == 0) then
         print *, 'FAIL: Second DATA statement lost'
         print *, trim(output)
         stop 1

--- a/test/test_issue_2809_block_data.f90
+++ b/test/test_issue_2809_block_data.f90
@@ -1,0 +1,109 @@
+program test_issue_2809_block_data
+    ! BLOCK DATA bodies must parse into structured declarations / COMMON / DATA
+    ! nodes, not raw text literals. Walk the block_data_node body and assert the
+    ! expected node kinds, with no literal_node text passthrough.
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_data, only: block_data_node, declaration_node
+    use ast_nodes_legacy, only: common_block_node
+    use ast_nodes_misc, only: data_statement_node
+    use ast_nodes_core, only: literal_node
+    implicit none
+
+    character(:), allocatable :: src, error_msg
+    type(token_t), allocatable :: tokens(:)
+    type(ast_arena_t) :: arena
+    integer :: prog_index, i, bd_count
+
+    call read_example('examples/f90/issue_2809_block_data.f90', src)
+
+    arena = create_ast_arena()
+    call lex_source(src, tokens, error_msg)
+    call fail_on_error(error_msg, 'lex')
+    call parse_tokens(tokens, arena, prog_index, error_msg)
+    call fail_on_error(error_msg, 'parse')
+
+    bd_count = 0
+    do i = 1, arena%size
+        if (.not. allocated(arena%entries(i)%node)) cycle
+        select type (n => arena%entries(i)%node)
+        type is (block_data_node)
+            bd_count = bd_count + 1
+            call check_body(arena, n)
+        end select
+    end do
+
+    if (bd_count /= 1) then
+        print *, 'FAIL: expected 1 block_data_node, found ', bd_count
+        error stop 1
+    end if
+
+    print *, 'PASS: BLOCK DATA body parsed into structured nodes'
+
+contains
+
+    subroutine check_body(arena, n)
+        type(ast_arena_t), intent(in) :: arena
+        type(block_data_node), intent(in) :: n
+        integer :: j, idx
+        logical :: saw_decl, saw_common, saw_data, saw_literal
+
+        saw_decl = .false.
+        saw_common = .false.
+        saw_data = .false.
+        saw_literal = .false.
+
+        if (.not. allocated(n%statement_indices)) then
+            print *, 'FAIL: block_data body has no statements'
+            error stop 1
+        end if
+
+        do j = 1, size(n%statement_indices)
+            idx = n%statement_indices(j)
+            if (idx < 1 .or. idx > arena%size) cycle
+            if (.not. allocated(arena%entries(idx)%node)) cycle
+            select type (s => arena%entries(idx)%node)
+            type is (declaration_node)
+                saw_decl = .true.
+            type is (common_block_node)
+                saw_common = .true.
+            type is (data_statement_node)
+                saw_data = .true.
+            type is (literal_node)
+                saw_literal = .true.
+            end select
+        end do
+
+        if (.not. saw_decl) then
+            print *, 'FAIL: integer declaration not parsed in block data'
+            error stop 1
+        end if
+        if (.not. saw_common) then
+            print *, 'FAIL: COMMON not parsed in block data'
+            error stop 1
+        end if
+        if (.not. saw_data) then
+            print *, 'FAIL: DATA not parsed in block data'
+            error stop 1
+        end if
+        if (saw_literal) then
+            print *, 'FAIL: block data body still contains raw text literals'
+            error stop 1
+        end if
+    end subroutine check_body
+
+    subroutine fail_on_error(error_msg, phase)
+        character(len=:), allocatable, intent(in) :: error_msg
+        character(len=*), intent(in) :: phase
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'FAIL: ', phase, ' error: ', trim(error_msg)
+                error stop 1
+            end if
+        end if
+    end subroutine fail_on_error
+
+    include 'common/read_example.inc'
+end program test_issue_2809_block_data

--- a/test/test_issue_2809_common_block.f90
+++ b/test/test_issue_2809_common_block.f90
@@ -1,0 +1,109 @@
+program test_issue_2809_common_block
+    ! COMMON statements must parse into structured common_block_node AST nodes
+    ! (block name + ordered members), not survive as comment_node text.
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_legacy, only: common_block_node
+    use ast_nodes_misc, only: comment_node
+    implicit none
+
+    character(:), allocatable :: src, error_msg
+    type(token_t), allocatable :: tokens(:)
+    type(ast_arena_t) :: arena
+    integer :: prog_index, i, common_count, comment_count
+    logical :: saw_shared, saw_blank
+
+    call read_example('examples/f90/issue_2809_common_block.f90', src)
+
+    arena = create_ast_arena()
+    call lex_source(src, tokens, error_msg)
+    call fail_on_error(error_msg, 'lex')
+    call parse_tokens(tokens, arena, prog_index, error_msg)
+    call fail_on_error(error_msg, 'parse')
+
+    common_count = 0
+    comment_count = 0
+    saw_shared = .false.
+    saw_blank = .false.
+    do i = 1, arena%size
+        if (.not. allocated(arena%entries(i)%node)) cycle
+        select type (n => arena%entries(i)%node)
+        type is (common_block_node)
+            common_count = common_count + 1
+            call inspect_block(n, saw_shared, saw_blank)
+        type is (comment_node)
+            comment_count = comment_count + 1
+        end select
+    end do
+
+    if (common_count /= 2) then
+        print *, 'FAIL: expected 2 common_block_node, found ', common_count
+        error stop 1
+    end if
+    if (.not. saw_shared) then
+        print *, 'FAIL: named block /shared/ with members a, b not found'
+        error stop 1
+    end if
+    if (.not. saw_blank) then
+        print *, 'FAIL: blank common with members c, d not found'
+        error stop 1
+    end if
+    if (comment_count > 0) then
+        print *, 'FAIL: COMMON survived as comment_node (', comment_count, ')'
+        error stop 1
+    end if
+
+    print *, 'PASS: COMMON parsed into structured common_block_node'
+
+contains
+
+    subroutine inspect_block(n, saw_shared, saw_blank)
+        type(common_block_node), intent(in) :: n
+        logical, intent(inout) :: saw_shared, saw_blank
+        character(len=:), allocatable :: name
+
+        if (.not. allocated(n%block_names)) return
+        if (size(n%block_names) < 1) return
+        name = ''
+        if (allocated(n%block_names(1)%s)) name = trim(n%block_names(1)%s)
+        if (name == 'shared') then
+            if (member_count(n) == 2 .and. member_is(n, 1, 'a') .and. &
+                member_is(n, 2, 'b')) saw_shared = .true.
+        else if (len_trim(name) == 0) then
+            if (member_count(n) == 2 .and. member_is(n, 1, 'c') .and. &
+                member_is(n, 2, 'd')) saw_blank = .true.
+        end if
+    end subroutine inspect_block
+
+    integer function member_count(n) result(c)
+        type(common_block_node), intent(in) :: n
+        c = 0
+        if (allocated(n%member_names)) c = size(n%member_names)
+    end function member_count
+
+    logical function member_is(n, idx, expected) result(ok)
+        type(common_block_node), intent(in) :: n
+        integer, intent(in) :: idx
+        character(len=*), intent(in) :: expected
+        ok = .false.
+        if (.not. allocated(n%member_names)) return
+        if (idx > size(n%member_names)) return
+        if (allocated(n%member_names(idx)%s)) ok = trim(n%member_names(idx)%s) == &
+                                                   expected
+    end function member_is
+
+    subroutine fail_on_error(error_msg, phase)
+        character(len=:), allocatable, intent(in) :: error_msg
+        character(len=*), intent(in) :: phase
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'FAIL: ', phase, ' error: ', trim(error_msg)
+                error stop 1
+            end if
+        end if
+    end subroutine fail_on_error
+
+    include 'common/read_example.inc'
+end program test_issue_2809_common_block

--- a/test/test_issue_2809_enum.f90
+++ b/test/test_issue_2809_enum.f90
@@ -1,0 +1,98 @@
+program test_issue_2809_enum
+    ! ENUM constructs must parse into a structured enum_node carrying the
+    ! enumerator names, resolved values, and bind(c), not a bare error_node.
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_legacy, only: enum_node
+    use ast_error_nodes, only: error_node_t
+    implicit none
+
+    character(:), allocatable :: src, error_msg
+    type(token_t), allocatable :: tokens(:)
+    type(ast_arena_t) :: arena
+    integer :: prog_index, i, enum_count, error_count
+
+    call read_example('examples/f90/issue_2809_enum.f90', src)
+
+    arena = create_ast_arena()
+    call lex_source(src, tokens, error_msg)
+    call fail_on_error(error_msg, 'lex')
+    call parse_tokens(tokens, arena, prog_index, error_msg)
+    call fail_on_error(error_msg, 'parse')
+
+    enum_count = 0
+    error_count = 0
+    do i = 1, arena%size
+        if (.not. allocated(arena%entries(i)%node)) cycle
+        select type (n => arena%entries(i)%node)
+        type is (enum_node)
+            enum_count = enum_count + 1
+            call check_enum(n)
+        type is (error_node_t)
+            error_count = error_count + 1
+        end select
+    end do
+
+    if (enum_count /= 1) then
+        print *, 'FAIL: expected 1 enum_node, found ', enum_count
+        error stop 1
+    end if
+    if (error_count > 0) then
+        print *, 'FAIL: enum produced error_node(s): ', error_count
+        error stop 1
+    end if
+
+    print *, 'PASS: ENUM parsed into structured enum_node'
+
+contains
+
+    subroutine check_enum(n)
+        type(enum_node), intent(in) :: n
+
+        if (.not. n%is_bind_c) then
+            print *, 'FAIL: bind(c) attribute not captured'
+            error stop 1
+        end if
+        if (.not. allocated(n%enumerator_names)) then
+            print *, 'FAIL: enumerator names not captured'
+            error stop 1
+        end if
+        if (size(n%enumerator_names) /= 3) then
+            print *, 'FAIL: expected 3 enumerators, found ', &
+                size(n%enumerator_names)
+            error stop 1
+        end if
+        ! red defaults to 0, green explicit 5, blue auto-increments to 6
+        if (trim(n%enumerator_names(1)%s) /= 'red' .or. &
+            n%enumerator_values(1) /= 0) then
+            print *, 'FAIL: red should be 0, got ', n%enumerator_values(1)
+            error stop 1
+        end if
+        if (trim(n%enumerator_names(2)%s) /= 'green' .or. &
+            n%enumerator_values(2) /= 5) then
+            print *, 'FAIL: green should be 5, got ', n%enumerator_values(2)
+            error stop 1
+        end if
+        if (trim(n%enumerator_names(3)%s) /= 'blue' .or. &
+            n%enumerator_values(3) /= 6) then
+            print *, 'FAIL: blue should auto-increment to 6, got ', &
+                n%enumerator_values(3)
+            error stop 1
+        end if
+    end subroutine check_enum
+
+    subroutine fail_on_error(error_msg, phase)
+        character(len=:), allocatable, intent(in) :: error_msg
+        character(len=*), intent(in) :: phase
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'FAIL: ', phase, ' error: ', trim(error_msg)
+                error stop 1
+            end if
+        end if
+    end subroutine fail_on_error
+
+    include 'common/read_example.inc'
+end program test_issue_2809_enum


### PR DESCRIPTION
Fixes #2809 (ENUM / COMMON / BLOCK DATA portions).

## Problem
The parser dropped several constructs to comment/error/text nodes, forcing backends to re-parse source: `enum` went to a bare error_node (enumerators discarded), COMMON survived only as a comment_node, and BLOCK DATA bodies were stored as raw text literals.

## Fix
Emit structured AST nodes:
- `common_block_node` and `enum_node` (ast_nodes_legacy), with introspection IDs and factories.
- New `parser_common_statement` (blank/named/multi-block) and `parser_enum_statement` (F2003 auto-increment values + bind(c)), wired into every dispatch site, replacing the legacy comment/error paths.
- BLOCK DATA bodies parsed per-statement via existing parse_declaration/parse_common/parse_data.
- Codegen for common-block and enum; enumerator names recorded as declared symbols so type inference no longer synthesizes a spurious real declaration.

(SELECT RANK arm-termination is handled in #2811.)

## Verification
```
$ fpm test test_issue_2809_common_block test_issue_2809_enum test_issue_2809_block_data
 PASS: COMMON parsed into structured common_block_node
 PASS: ENUM parsed into structured enum_node
 PASS: BLOCK DATA body parsed into structured nodes
```
Existing COMMON/BLOCK-DATA tests updated to the new structured output (conventional spacing; DATA literals standardized to real(8)) and pass. Integrated full suite: test_all_examples 610 examples, 0 failures.
