### PR TITLE
docs: fix stale test-dedup status and missing README file-index entries

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,28 +310,14 @@ end program
 
 **Issue #1975 - Test Deduplication Migration**
 
-**Current Status** (as of 2025-10-28):
-- Total end-to-end violations: 41 tests with >15 inline lines
-- Total warnings: 69 tests with 6-15 inline lines (review needed)
-- Migrated: 1 test (test_close_in_control_flow.f90 - 51 lines → 5 example files)
+**Status: complete.** The end-to-end test deduplication is done: `make check-duplication` reports 0 violations and 0 warnings. End-to-end tests reference `examples/`; unit tests keep small inline inputs as described above.
 
 **CI Enforcement** (ACTIVE):
-- ✅ Check script: `scripts/check_test_duplication.py`
-- ✅ Make target: `make check-duplication`
-- ✅ CI workflow: Non-blocking check in `.github/workflows/ci.yml`
-- Status: WARNING mode (provides visibility, does not block PRs during migration)
+- Check script: `scripts/check_test_duplication.py`
+- Make target: `make check-duplication`
+- CI workflow: `.github/workflows/ci.yml`
 
-**Enforcement Plan**:
-1. ✅ CI check warns on new inline code (prevents regression awareness)
-2. 🔄 Gradual migration: Top violators first (41 end-to-end tests remaining)
-3. 📋 Review warnings: 69 integration tests need case-by-case evaluation
-4. 🎯 Future: Switch CI check to blocking mode once violations < 10
-
-**Migration Priority**:
-- P0: ✅ CI enforcement (completed - provides visibility)
-- P1: 🔄 Top 20 end-to-end tests (addresses ~50% of problem)
-- P2: 📋 Review 69 integration test warnings
-- P3: ⬜ All remaining files (complete zero-duplication compliance)
+Keep it at zero: new end-to-end tests must use `read_example()` rather than inline full programs.
 
 **How to Check Status**:
 ```bash

--- a/app/README.md
+++ b/app/README.md
@@ -10,6 +10,7 @@ This directory contains the CLI (command-line interface) application for fortfro
 |------|-------------|
 | fortfront.f90 | Main CLI application: argument parsing, file I/O, transformation orchestration |
 | debug_ast.f90 | Debug utilities for printing AST structure (development tool) |
+| frontend_probe.f90 | Frontend conformance probe: exercises the frontend API from a Fortran program |
 
 ## Key Concepts
 

--- a/src/semantic/README.md
+++ b/src/semantic/README.md
@@ -17,6 +17,8 @@ The semantic analysis subsystem performs type inference, scope resolution, and v
 | scope_manager.f90 | Scope stack management, symbol table, variable declarations |
 | semantic_inference_helpers.f90 | Type inference helper functions |
 | semantic_input_mode.f90 | Input mode enum (lazy vs standard Fortran) |
+| semantic_operating_mode.f90 | Operating mode selection (strict vs infer) |
+| symbol_table_api.f90 | Public API for the symbol table |
 | semantic_unsigned_integer_mix_diagnostics.f90 | Shared diagnostics for signed/unsigned integer mixing |
 | type_hierarchy.f90 | Type hierarchy and subtype relationships |
 | constant_transformation.f90 | Constant folding and compile-time evaluation |


### PR DESCRIPTION
Trivial, verified-safe documentation fixes found during the repo-wide quality audit.

## Changes
- **CLAUDE.md**: the test-deduplication migration (issue #1975) is complete - `make check-duplication` reports 0 violations and 0 warnings. Replaced the stale "as of 2025-10-28 ... 41 violations remaining" in-progress status (and the obsolete enforcement plan/priority lists) with the completed state.
- **app/README.md**: added `frontend_probe.f90` to the file index (was undocumented).
- **src/semantic/README.md**: added `semantic_operating_mode.f90` and `symbol_table_api.f90` to the file index (were undocumented).

## Verification
- `make check-duplication` -> 0 violations, 0 warnings (confirms the CLAUDE.md status correction).
- File indexes now match the actual directory contents (`ls app`, `ls src/semantic`).
- Docs-only; no source/build impact.

Audit false positives were excluded (e.g. `stdout_sanitizer.c` and the `.inc` part-files do exist, so those READMEs were already correct). Remaining audit findings are filed as #2828-#2832.
