### PR TITLE
fix: parse DIMENSION statement as specification statement (refs #2848)

### DIFF
--- a/examples/f90/issue_2848_dimension_statement.f90
+++ b/examples/f90/issue_2848_dimension_statement.f90
@@ -1,0 +1,4 @@
+dimension a(5)
+i = 0
+a(1) = 1.0
+end

--- a/src/parser/core/parser_dispatcher.f90
+++ b/src/parser/core/parser_dispatcher.f90
@@ -49,6 +49,7 @@ module parser_dispatcher_module
         get_data_additional_indices, &
         parse_namelist_statement
     use parser_legacy_statements_module, only: parse_legacy_statement
+    use parser_dimension_statements_module, only: parse_dimension_statement
     use parser_enum_statement_module, only: parse_enum_construct
     use parser_control_flow_router_module, only: route_control_flow
     use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier

--- a/src/parser/core/parser_dispatcher_part1.inc
+++ b/src/parser/core/parser_dispatcher_part1.inc
@@ -285,6 +285,8 @@
                                        stmt_index)
         case ("common")
             call handle_common_keyword(parser, arena, first_token, stmt_index)
+        case ("dimension")
+            call handle_dimension_keyword(parser, arena, first_token, stmt_index)
         case ("enum")
             stmt_index = parse_enum_construct(parser, arena)
         case ("enumerator")
@@ -551,6 +553,19 @@
             stmt_index = parse_common_statement(parser, arena)
         end if
     end subroutine handle_common_keyword
+
+    subroutine handle_dimension_keyword(parser, arena, first_token, stmt_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t), intent(in) :: first_token
+        integer, intent(out) :: stmt_index
+
+        if (keyword_should_parse_as_identifier(first_token, parser)) then
+            stmt_index = parse_assignment_or_expression(parser, arena)
+        else
+            stmt_index = parse_dimension_statement(parser, arena)
+        end if
+    end subroutine handle_dimension_keyword
 
     subroutine dispatch_number_token(parser, arena, prefix_buffer, tokens, &
                                      stmt_index)

--- a/src/parser/declarations/parser_dimension_statements_module.f90
+++ b/src/parser/declarations/parser_dimension_statements_module.f90
@@ -21,16 +21,16 @@ module parser_dimension_statements_module
 
         contains
 
-            logical function parse_dimension_statement(parser, arena) result(success)
+            integer function parse_dimension_statement(parser, arena) result(decl_index)
                 type(parser_state_t), intent(inout) :: parser
                 type(ast_arena_t), intent(inout) :: arena
                 type(token_t) :: token
                 character(len=:), allocatable :: var_name
                 character(len=:), allocatable :: lowered_keyword
                 integer, allocatable :: dimension_indices(:)
-                logical :: applied
+                integer :: applied_index
 
-                success = .false.
+                decl_index = 0
                 if (parser%is_at_end()) return
 
                 call skip_trivia(parser)
@@ -76,9 +76,9 @@ module parser_dimension_statements_module
                     token = parser%consume()
 
                     call parse_array_dimensions(parser, arena, dimension_indices)
-                    applied = apply_dimension_to_variable(arena, var_name, dimension_indices)
+                    applied_index = apply_dimension_to_variable(arena, var_name, dimension_indices)
                     if (allocated(dimension_indices)) deallocate (dimension_indices)
-                    success = success .or. applied
+                    if (applied_index > 0 .and. decl_index == 0) decl_index = applied_index
 
                     call skip_trivia(parser)
                     if (parser%is_at_end()) exit
@@ -107,18 +107,18 @@ module parser_dimension_statements_module
 
             logical function token_is_identifier(token) result(is_ident)
                 type(token_t), intent(in) :: token
-                is_ident = (token%kind == TK_IDENTIFIER)
+                is_ident = (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD)
             end function token_is_identifier
 
-            logical function apply_dimension_to_variable(arena, name, dimension_indices) &
-                    result(applied)
+            integer function apply_dimension_to_variable(arena, name, dimension_indices) &
+                    result(idx_result)
                 type(ast_arena_t), intent(inout) :: arena
                 character(len=*), intent(in) :: name
                 integer, intent(in) :: dimension_indices(:)
                 character(len=:), allocatable :: target
                 integer :: idx
 
-                applied = .false.
+                idx_result = 0
                 target = adjustl(trim(name))
 
                 do idx = arena%size, 1, -1
@@ -128,19 +128,44 @@ module parser_dimension_statements_module
                         if (decl%is_multi_declaration .and. allocated(decl%var_names)) then
                             if (apply_dimension_multi(arena, idx, decl, target, &
                                 dimension_indices)) then
-                                applied = .true.
+                                idx_result = idx
                                 return
                             end if
                         end if
                         if (trim(decl%var_name) == target) then
                             call apply_dimension_single(arena, idx, decl, target, &
                                 dimension_indices)
-                            applied = .true.
+                            idx_result = idx
                             return
                         end if
                     end select
                 end do
+
+                idx_result = create_dimension_declaration(arena, name, dimension_indices)
             end function apply_dimension_to_variable
+
+            integer function create_dimension_declaration(arena, name, dimension_indices) &
+                    result(new_index)
+                type(ast_arena_t), intent(inout) :: arena
+                character(len=*), intent(in) :: name
+                integer, intent(in) :: dimension_indices(:)
+                type(declaration_node) :: decl
+
+                decl%type_name = ""
+                decl%var_name = adjustl(trim(name))
+                decl%is_multi_declaration = .false.
+                decl%is_array = .true.
+                if (size(dimension_indices) > 0) then
+                    allocate (decl%dimension_indices(size(dimension_indices)))
+                    decl%dimension_indices = dimension_indices
+                else
+                    allocate (decl%dimension_indices(0))
+                end if
+
+                call arena%push(decl, "declaration", 0)
+                new_index = arena%size
+                call register_type_annotation(new_index, "", [adjustl(trim(name))])
+            end function create_dimension_declaration
 
             subroutine apply_dimension_single(arena, decl_index, decl, target, &
                     dimension_indices)

--- a/src/parser/statements/parser_execution_statements_module.inc
+++ b/src/parser/statements/parser_execution_statements_module.inc
@@ -704,11 +704,9 @@
                 case ("dimension")
                     block
                         type(token_t) :: ignored_token
-                        logical :: success
                         ignored_token = parser_ref%consume()
-                        success = parse_dimension_statement(parser_ref, arena_ref)
+                        stmt_index = parse_dimension_statement(parser_ref, arena_ref)
                     end block
-                    stmt_index = 0
                 case ("parameter")
                     block
                         use parser_parameter_statements_module, only: &

--- a/src/parser/statements/parser_statement_core.f90
+++ b/src/parser/statements/parser_statement_core.f90
@@ -198,11 +198,7 @@ contains
             if (stmt_index /= 0) return
 
             if (lowered == "dimension") then
-                if (parse_dimension_statement(parser, arena)) then
-                    stmt_index = STATEMENT_NO_NODE
-                else
-                    stmt_index = 0
-                end if
+                stmt_index = parse_dimension_statement(parser, arena)
             end if
 
             if (lowered == "parameter") then

--- a/test/test_issue_2848_dimension_statement.f90
+++ b/test/test_issue_2848_dimension_statement.f90
@@ -1,0 +1,94 @@
+program test_issue_2848_dimension_statement
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    character(len=:), allocatable :: source, output, error_msg
+
+    call read_example('examples/f90/issue_2848_dimension_statement.f90', source)
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: unexpected error:", trim(error_msg)
+        error stop 1
+    end if
+
+    ! The DIMENSION statement should create a proper array declaration
+    ! Check that 'dimension' is NOT declared as a variable
+    if (index(output, 'dimension') > 0) then
+        ! 'dimension' should only appear in the dimension attribute, not as a var name
+        if (index(output, ':: dimension') > 0 .or. &
+            index(output, 'real') > 0 .and. index(output, 'dimension') > 0) then
+            ! Check more carefully - dimension should appear as attribute, not variable
+            block
+                character(len=:), allocatable :: lower_output
+                integer :: dim_pos, decl_pos
+                lower_output = tolower(output)
+                dim_pos = index(lower_output, 'dimension(')
+                decl_pos = index(lower_output, ':: dimension')
+                if (decl_pos > 0 .and. (dim_pos == 0 .or. decl_pos < dim_pos)) then
+                    print *, "FAIL: 'dimension' parsed as variable instead of statement"
+                    print *, "Output:"
+                    print *, trim(output)
+                    error stop 1
+                end if
+            end block
+        end if
+    end if
+
+    ! Check that array 'a' has a proper declaration with dimension
+    if (index(output, 'a(5)') <= 0 .and. index(output, 'a (5)') <= 0) then
+        print *, "FAIL: array 'a' dimension not preserved"
+        print *, "Output:"
+        print *, trim(output)
+        error stop 1
+    end if
+
+    ! Check that 'a' is declared as an array, not as allocatable with unknown shape
+    if (index(output, 'a(:)') > 0) then
+        print *, &
+            "FAIL: array a should have explicit dimension, not allocatable shape"
+        print *, "Output:"
+        print *, trim(output)
+        error stop 1
+    end if
+
+    print *, "PASS: DIMENSION statement creates proper array declaration"
+
+contains
+
+    subroutine read_example(filepath, content)
+        character(len=*), intent(in) :: filepath
+        character(len=:), allocatable, intent(out) :: content
+        integer :: unit_num, ios
+        integer :: file_size
+
+        open (newunit=unit_num, file=filepath, status='old', action='read', &
+            iostat=ios)
+        if (ios /= 0) then
+            print *, "FAIL: could not open example file:", trim(filepath)
+            error stop 1
+        end if
+
+        inquire (unit=unit_num, size=file_size)
+        allocate (character(len=file_size) :: content)
+
+        read (unit_num, '(A)') content
+        close (unit_num)
+    end subroutine read_example
+
+    function tolower(s) result(lower)
+        character(len=*), intent(in) :: s
+        character(len=len(s)) :: lower
+        integer :: i, code_val
+
+        lower = s
+        do i = 1, len(s)
+            code_val = ichar(lower(i:i))
+            if (code_val >= ichar('A') .and. code_val <= ichar('Z')) then
+                lower(i:i) = char(code_val + ichar('a') - ichar('A'))
+            end if
+        end do
+    end function tolower
+
+end program test_issue_2848_dimension_statement


### PR DESCRIPTION
## Requirements

- [x] REQ-001: DIMENSION statement parsed as specification statement, not bare identifier
- [x] REQ-002: DIMENSION creates proper array declaration node in AST
- [x] REQ-003: Variable named "dimension" with assignment still works (disambiguation)

## File Set

### Edited:
- `src/parser/core/parser_dispatcher.f90` - import parse_dimension_statement
- `src/parser/core/parser_dispatcher_part1.inc` - add dimension case + handler
- `src/parser/declarations/parser_dimension_statements_module.f90` - return decl index, create decl when no existing decl found
- `src/parser/statements/parser_execution_statements_module.inc` - wire decl index return
- `src/parser/statements/parser_statement_core.f90` - wire decl index return

### Created:
- `examples/f90/issue_2848_dimension_statement.f90` - canonical test input
- `test/test_issue_2848_dimension_statement.f90` - end-to-end test

## Verification

```
$ fo exec test_issue_2848_dimension_statement
 PASS: DIMENSION statement creates proper array declaration

$ fo exec fortfront < examples/f90/issue_2848_dimension_statement.f90
program main
    implicit none
    real :: a(5)
    integer :: i
    i = 0
    a(1) = 1.0_8
end program main

$ fo
Tests: OK
Lint: OK
All stages passed
```

(ref #2848)
<!-- orchestrate: fully-resolved -->