### PR TITLE
fix: parse DO CONCURRENT type-spec index form (refs #2849)

### DIFF
--- a/examples/analysis_only_examples.txt
+++ b/examples/analysis_only_examples.txt
@@ -24,3 +24,4 @@ f90/issue_2497_include_line_standalone.f90
 f90/issue_2737_lfortran_template_instantiate.f90
 f90/issue_2738_lfortran_traits_requirements_implements.f90
 f90/issue_2817_inline_instantiate_caret.f90
+f90/do_concurrent_type_spec.f90  # gfortran-14 does not support type-spec in DO CONCURRENT (#2849)

--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -19,6 +19,7 @@ issue_2153_array_call_scalar_param.lf  # BUG: array variant returns scalar inste
 # Fortran 2018 feature bugs
 issue_2238_select_rank_performance.f90  # BUG: assumed-rank arrays (..) not fully supported (#2238)
 select_rank_simple.f90  # BUG: SELECT RANK requires assumed-rank arrays (..) (#2238)
+do_concurrent_type_spec.f90  # EXTENSION: gfortran-14 rejects type-spec in DO CONCURRENT (#2849)
 
 # ============================================================================
 # EXTENSIONS - gfortran rejects nonstandard syntax; fortfront passes through

--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -19,7 +19,6 @@ issue_2153_array_call_scalar_param.lf  # BUG: array variant returns scalar inste
 # Fortran 2018 feature bugs
 issue_2238_select_rank_performance.f90  # BUG: assumed-rank arrays (..) not fully supported (#2238)
 select_rank_simple.f90  # BUG: SELECT RANK requires assumed-rank arrays (..) (#2238)
-do_concurrent_type_spec.f90  # EXTENSION: gfortran-14 rejects type-spec in DO CONCURRENT (#2849)
 
 # ============================================================================
 # EXTENSIONS - gfortran rejects nonstandard syntax; fortfront passes through

--- a/examples/f90/do_concurrent_type_spec.f90
+++ b/examples/f90/do_concurrent_type_spec.f90
@@ -1,0 +1,5 @@
+program p
+  integer :: n = 4
+  do concurrent (integer :: i = 1:n)
+  end do
+end program

--- a/src/ast/factory/ast_factory_control_part1.inc
+++ b/src/ast/factory/ast_factory_control_part1.inc
@@ -79,9 +79,10 @@
     end function push_if
 
     ! Create do loop node and add to stack
-    function push_do_loop(arena, var_name, start_index, end_index, step_index, &
-                          body_indices, &
-                          loop_label, is_concurrent, line, column, parent_index) &
+function push_do_loop(arena, var_name, start_index, end_index, step_index, &
+                           body_indices, &
+                           loop_label, is_concurrent, line, column, parent_index, &
+                           type_spec) &
         result(loop_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: var_name
@@ -91,6 +92,7 @@
         character(len=*), intent(in), optional :: loop_label
         logical, intent(in), optional :: is_concurrent
         integer, intent(in), optional :: line, column, parent_index
+        character(len=*), intent(in), optional :: type_spec
         integer :: loop_index
         type(do_loop_node) :: loop_node
 
@@ -99,6 +101,7 @@
         loop_node%var_name = var_name
         if (present(loop_label)) loop_node%label = loop_label
         if (present(is_concurrent)) loop_node%is_concurrent = is_concurrent
+        if (present(type_spec) .and. len_trim(type_spec) > 0) loop_node%type_spec = type_spec
 
         ! Set start and end expression indices
         if (start_index > 0 .and. start_index <= arena%size) then

--- a/src/ast/nodes/ast_nodes_loops.f90
+++ b/src/ast/nodes/ast_nodes_loops.f90
@@ -18,6 +18,7 @@ module ast_nodes_loops
     type, extends(ast_node) :: do_loop_node
         character(len=:), allocatable :: var_name ! Loop variable
         character(len=:), allocatable :: label ! Loop label (optional)
+        character(len=:), allocatable :: type_spec ! Type spec for DO CONCURRENT index (optional)
         integer :: start_expr_index = 0 ! Start expression arena index
         integer :: end_expr_index = 0 ! End expression arena index
         integer :: step_expr_index = 0 ! Step expression arena &
@@ -101,6 +102,8 @@ contains
         lhs%var_name = rhs%var_name
         if (allocated(lhs%label)) deallocate (lhs%label)
         if (allocated(rhs%label)) lhs%label = rhs%label
+        if (allocated(lhs%type_spec)) deallocate (lhs%type_spec)
+        if (allocated(rhs%type_spec)) lhs%type_spec = rhs%type_spec
         lhs%start_expr_index = rhs%start_expr_index
         lhs%end_expr_index = rhs%end_expr_index
         lhs%step_expr_index = rhs%step_expr_index

--- a/src/codegen/statements/codegen_control_flow.f90
+++ b/src/codegen/statements/codegen_control_flow.f90
@@ -181,7 +181,7 @@ contains
         integer, intent(in) :: node_index
         character(len=:), allocatable :: code
         character(len=:), allocatable :: var_code, start_code, end_code, step_code
-        character(len=:), allocatable :: body_code, end_keyword
+        character(len=:), allocatable :: body_code, end_keyword, index_code
         integer :: indent_level
 
         indent_level = 0
@@ -217,14 +217,18 @@ contains
 
         ! Generate do statement with optional label
         if (node%is_concurrent) then
-            ! DO CONCURRENT syntax: do concurrent (var = start:end[:step])
+            ! DO CONCURRENT syntax: do concurrent ([type-spec ::] var = start:end[:step])
+            index_code = var_code
+            if (allocated(node%type_spec) .and. len_trim(node%type_spec) > 0) then
+                index_code = trim(node%type_spec)//" :: "//var_code
+            end if
             if (allocated(node%label)) then
                 code = trim(adjustl(node%label))//": do concurrent ("// &
-                    var_code// &
+                    index_code// &
                     " = "//start_code//":"//end_code
                 end_keyword = "end do "//trim(adjustl(node%label))
             else
-                code = "do concurrent ("//var_code//" = "//start_code//":"// &
+                code = "do concurrent ("//index_code//" = "//start_code//":"// &
                     end_code
                 end_keyword = "end do"
             end if

--- a/src/parser/control_flow/parser_do_constructs.f90
+++ b/src/parser/control_flow/parser_do_constructs.f90
@@ -20,6 +20,7 @@ module parser_do_constructs_module
 
     type :: do_loop_control_t
         character(len=:), allocatable :: var_name
+        character(len=:), allocatable :: type_spec
         integer :: start_index = 0
         integer :: end_index = 0
         integer :: step_index = 0

--- a/src/parser/control_flow/parser_do_constructs_part1.inc
+++ b/src/parser/control_flow/parser_do_constructs_part1.inc
@@ -25,9 +25,65 @@
     logical function next_tokens_form_control(parser, start_pos) result(is_control)
         type(parser_state_t), intent(in) :: parser
         integer, intent(in) :: start_pos
-        integer :: idx
+        integer :: idx, paren_depth
 
         idx = start_pos
+        do while (idx <= size(parser%tokens))
+            select case (parser%tokens(idx)%kind)
+            case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
+                idx = idx + 1
+                cycle
+            case default
+                exit
+            end select
+        end do
+
+        if (idx > size(parser%tokens)) then
+            is_control = .false.
+            return
+        end if
+
+        ! Skip optional type-spec prefix: type-name [ (params) ] ::
+        if (parser%tokens(idx)%kind == TK_KEYWORD) then
+            select case (trim(to_lower(parser%tokens(idx)%text)))
+            case ("integer", "real", "logical", "character", "complex", "double")
+                idx = idx + 1
+                ! Skip "precision" after "double"
+                if (idx <= size(parser%tokens)) then
+                    if (parser%tokens(idx)%kind == TK_KEYWORD .and. &
+                        trim(to_lower(parser%tokens(idx)%text)) == "precision") then
+                        idx = idx + 1
+                    end if
+                end if
+                ! Skip parenthesized kind spec
+                if (idx <= size(parser%tokens)) then
+                    if (parser%tokens(idx)%kind == TK_OPERATOR .and. &
+                        parser%tokens(idx)%text == "(") then
+                        paren_depth = 1
+                        idx = idx + 1
+                        do while (idx <= size(parser%tokens) .and. paren_depth > 0)
+                            if (parser%tokens(idx)%kind == TK_OPERATOR) then
+                                if (parser%tokens(idx)%text == "(") then
+                                    paren_depth = paren_depth + 1
+                                else if (parser%tokens(idx)%text == ")") then
+                                    paren_depth = paren_depth - 1
+                                end if
+                            end if
+                            idx = idx + 1
+                        end do
+                    end if
+                end if
+                ! Skip ::
+                if (idx <= size(parser%tokens)) then
+                    if (parser%tokens(idx)%kind == TK_OPERATOR .and. &
+                        parser%tokens(idx)%text == "::") then
+                        idx = idx + 1
+                    end if
+                end if
+            end select
+        end if
+
+        ! Skip whitespace after type-spec
         do while (idx <= size(parser%tokens))
             select case (parser%tokens(idx)%kind)
             case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
@@ -124,13 +180,61 @@
         type(ast_arena_t), intent(inout) :: arena
         type(do_loop_control_t), intent(out) :: control
         type(token_t) :: tok
+        character(len=:), allocatable :: type_spec_str
+        integer :: saved_pos
 
         success = .false.
         control%step_index = 0
+        type_spec_str = ""
 
+        saved_pos = parser%current_token
+
+        ! Check for optional type-spec: integer, real, logical, character, complex, double
+        tok = parser%peek()
+        if (tok%kind == TK_KEYWORD) then
+            select case (trim(to_lower(tok%text)))
+            case ("integer", "real", "logical", "character", "complex", "double")
+                tok = parser%consume()
+                type_spec_str = trim(tok%text)
+
+                ! Handle "double precision"
+                if (trim(to_lower(tok%text)) == "double") then
+                    tok = parser%peek()
+                    if (tok%kind == TK_KEYWORD .and. &
+                        trim(to_lower(tok%text)) == "precision") then
+                        tok = parser%consume()
+                        type_spec_str = "double precision"
+                    end if
+                end if
+
+                ! Handle kind parameters: type(kind) or type(param)
+                tok = parser%peek()
+                if (tok%kind == TK_OPERATOR .and. tok%text == "(") then
+                    type_spec_str = trim(type_spec_str) // parse_type_spec_parens(parser)
+                end if
+
+                ! Expect ::
+                tok = parser%peek()
+                if (tok%kind == TK_OPERATOR .and. tok%text == "::") then
+                    tok = parser%consume()
+                else
+                    ! Not a type-spec form, restore position
+                    parser%current_token = saved_pos
+                    type_spec_str = ""
+                end if
+            end select
+        end if
+
+        ! Parse variable name
         tok = parser%consume()
-        if (tok%kind /= TK_IDENTIFIER) return
+        if (tok%kind /= TK_IDENTIFIER) then
+            if (len_trim(type_spec_str) > 0) then
+                parser%current_token = saved_pos
+            end if
+            return
+        end if
         control%var_name = tok%text
+        if (len_trim(type_spec_str) > 0) control%type_spec = type_spec_str
 
         tok = parser%consume()
         if (tok%kind /= TK_OPERATOR .or. tok%text /= "=") return
@@ -156,6 +260,38 @@
         if (control%step_index < 0) control%step_index = 0
         success = control%start_index > 0 .and. control%end_index > 0
     end function parse_concurrent_control
+
+    ! Parse parenthesized type parameters: (kind=8) or (8) etc.
+    ! Returns the full parenthesized string including parentheses
+    function parse_type_spec_parens(parser) result(parens_str)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=:), allocatable :: parens_str
+        type(token_t) :: tok
+        integer :: depth
+        character(len=256) :: buf
+
+        buf = ""
+        depth = 0
+
+        do while (.not. parser%is_at_end())
+            tok = parser%consume()
+            if (tok%kind == TK_OPERATOR) then
+                if (tok%text == "(") then
+                    depth = depth + 1
+                else if (tok%text == ")") then
+                    depth = depth - 1
+                    if (depth == 0) then
+                        buf = trim(buf) // tok%text
+                        exit
+                    end if
+                end if
+            end if
+            if (len_trim(buf) > 0 .and. tok%kind /= TK_OPERATOR) buf = trim(buf) // " "
+            buf = trim(buf) // tok%text
+        end do
+
+        parens_str = trim(buf)
+    end function parse_type_spec_parens
 
     logical function parse_concurrent_control_list(parser, arena, controls) &
         result(success)
@@ -384,7 +520,7 @@
         integer :: loop_index
 
         type(token_t) :: do_token, var_token, comma_token, label_token
-        character(len=:), allocatable :: var_name, loop_label
+        character(len=:), allocatable :: var_name, loop_label, type_spec
         type(do_loop_control_t), allocatable :: controls(:)
         type(do_loop_control_t) :: control
         integer :: start_index, end_index, step_index
@@ -398,6 +534,7 @@
         step_index = 0  ! Initialize to 0 (no step)
         loop_index = 0  ! Initialize to 0 (failure) in case of early return
         is_concurrent = .false.
+        type_spec = ""
 
         ! Starting to parse do loop
 
@@ -483,6 +620,7 @@
         start_index = control%start_index
         end_index = control%end_index
         step_index = control%step_index
+        if (allocated(control%type_spec)) type_spec = control%type_spec
 
         if (start_index <= 0 .or. end_index <= 0) then
             loop_index = 0
@@ -508,14 +646,16 @@
                                               body_indices=[integer ::], &
                                               loop_label=loop_label, &
                                               is_concurrent=is_concurrent, &
-                                              line=line, column=column)
+                                              line=line, column=column, &
+                                              type_spec=type_spec)
                 else
                     loop_index = push_do_loop(arena, var_name, start_index, &
                                               end_index, &
                                               step_index=step_index, &
                                               body_indices=[integer ::], &
                                               is_concurrent=is_concurrent, &
-                                              line=line, column=column)
+                                              line=line, column=column, &
+                                              type_spec=type_spec)
                 end if
             else
                 if (control_count == 1 .and. allocated(loop_label)) then
@@ -524,13 +664,15 @@
                                               body_indices=[integer ::], &
                                               loop_label=loop_label, &
                                               is_concurrent=is_concurrent, &
-                                              line=line, column=column)
+                                              line=line, column=column, &
+                                              type_spec=type_spec)
                 else
                     loop_index = push_do_loop(arena, var_name, start_index, &
                                               end_index, &
                                               body_indices=[integer ::], &
                                               is_concurrent=is_concurrent, &
-                                              line=line, column=column)
+                                              line=line, column=column, &
+                                              type_spec=type_spec)
                 end if
             end if
 
@@ -806,13 +948,16 @@
             block
                 integer :: idx, outer_index, outer_step
                 integer :: outer_start, outer_end
-                character(len=:), allocatable :: outer_name
+                character(len=:), allocatable :: outer_name, outer_type_spec
 
                 do idx = control_count - 1, 1, -1
                     outer_name = controls(idx)%var_name
                     outer_start = controls(idx)%start_index
                     outer_end = controls(idx)%end_index
                     outer_step = controls(idx)%step_index
+                    outer_type_spec = ""
+                    if (allocated(controls(idx)%type_spec)) &
+                        outer_type_spec = controls(idx)%type_spec
 
                     if (outer_start <= 0 .or. outer_end <= 0) then
                         loop_index = 0
@@ -827,14 +972,16 @@
                                                        step_index=outer_step, &
                                                        body_indices=[loop_index], &
                                                        loop_label=loop_label, &
-                                                       line=line, column=column)
+                                                       line=line, column=column, &
+                                                       type_spec=outer_type_spec)
                         else
                             outer_index = push_do_loop(arena, outer_name, &
                                                        outer_start, &
                                                        outer_end, &
                                                        step_index=outer_step, &
                                                        body_indices=[loop_index], &
-                                                       line=line, column=column)
+                                                       line=line, column=column, &
+                                                       type_spec=outer_type_spec)
                         end if
                     else
                         if (idx == 1 .and. allocated(loop_label)) then
@@ -843,13 +990,15 @@
                                                        outer_end, &
                                                        body_indices=[loop_index], &
                                                        loop_label=loop_label, &
-                                                       line=line, column=column)
+                                                       line=line, column=column, &
+                                                       type_spec=outer_type_spec)
                         else
                             outer_index = push_do_loop(arena, outer_name, &
                                                        outer_start, &
                                                        outer_end, &
                                                        body_indices=[loop_index], &
-                                                       line=line, column=column)
+                                                       line=line, column=column, &
+                                                       type_spec=outer_type_spec)
                         end if
                     end if
 

--- a/test/parser/test_do_concurrent_type_spec_issue_2849.f90
+++ b/test/parser/test_do_concurrent_type_spec_issue_2849.f90
@@ -1,0 +1,134 @@
+program test_do_concurrent_type_spec_issue_2849
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+
+    character(len=:), allocatable :: source, output, error_msg
+
+    print *, "Testing DO CONCURRENT type-spec index form (Issue #2849)"
+
+    ! Test 1: Basic integer type-spec
+    call read_example('examples/f90/do_concurrent_type_spec.f90', source)
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) then
+            print *, 'ERROR: parse failed for basic type-spec form'
+            print *, 'Error: ', trim(error_msg)
+            print *, 'Source:'
+            print *, trim(source)
+            stop 1
+        end if
+    end if
+
+    if (index(output, 'do concurrent') == 0) then
+        print *, 'ERROR: DO CONCURRENT missing from output'
+        print *, 'Output:'
+        print *, trim(output)
+        stop 1
+    end if
+
+    if (index(output, 'integer :: i') == 0) then
+        print *, 'ERROR: type-spec "integer :: i" missing from DO CONCURRENT output'
+        print *, 'Output:'
+        print *, trim(output)
+        stop 1
+    end if
+
+    ! Test 2: Real type-spec with kind parameter
+    source = "program p2"&
+         // new_line('a') &
+         // "  integer :: n = 10"&
+         // new_line('a') &
+         // "  real(8) :: arr(10)"&
+         // new_line('a') &
+         // "  do concurrent (real(8) :: x = 0.0d0:1.0d0:0.1d0)"&
+         // new_line('a') &
+         // "    arr(1) = x"&
+         // new_line('a') &
+         // "  end do"&
+         // new_line('a') &
+         // "end program p2"
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) then
+            print *, 'ERROR: parse failed for real(8) type-spec form'
+            print *, 'Error: ', trim(error_msg)
+            stop 1
+        end if
+    end if
+
+    if (index(output, 'do concurrent') == 0) then
+        print *, 'ERROR: DO CONCURRENT missing from real(8) output'
+        print *, 'Output:'
+        print *, trim(output)
+        stop 1
+    end if
+
+    if (index(output, 'real(8)') == 0) then
+        print *, 'ERROR: type-spec "real(8)" missing from DO CONCURRENT output'
+        print *, 'Output:'
+        print *, trim(output)
+        stop 1
+    end if
+
+    ! Test 3: Multi-index with type-spec on inner loop
+    source = "program p3"&
+         // new_line('a') &
+         // "  integer :: n = 5, m = 3"&
+         // new_line('a') &
+         // "  do concurrent (i = 1:n, integer :: j = 1:m)"&
+         // new_line('a') &
+         // "  end do"&
+         // new_line('a') &
+         // "end program p3"
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) then
+            print *, 'ERROR: parse failed for mixed type-spec form'
+            print *, 'Error: ', trim(error_msg)
+            stop 1
+        end if
+    end if
+
+    if (index(output, 'do concurrent') == 0) then
+        print *, 'ERROR: DO CONCURRENT missing from mixed type-spec output'
+        print *, 'Output:'
+        print *, trim(output)
+        stop 1
+    end if
+
+    ! Test 4: Logical type-spec
+    source = "program p4"&
+         // new_line('a') &
+         // "  do concurrent (logical :: f = .true.:.false.)"&
+         // new_line('a') &
+         // "  end do"&
+         // new_line('a') &
+         // "end program p4"
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (allocated(error_msg)) then
+        if (len_trim(error_msg) > 0) then
+            print *, 'ERROR: parse failed for logical type-spec form'
+            print *, 'Error: ', trim(error_msg)
+            stop 1
+        end if
+    end if
+
+    if (index(output, 'do concurrent') == 0) then
+        print *, 'ERROR: DO CONCURRENT missing from logical type-spec output'
+        print *, 'Output:'
+        print *, trim(output)
+        stop 1
+    end if
+
+    print *, 'PASS: DO CONCURRENT type-spec index form parsed correctly'
+    stop 0
+
+contains
+
+    include '../common/read_example.inc'
+end program test_do_concurrent_type_spec_issue_2849


### PR DESCRIPTION
## Requirements

- REQ-001: Parse F2018 R1125 type-spec form `do concurrent (type-spec :: var = start:end[:step])` — **satisfied**
- REQ-002: Store type-spec in AST node for code generation — **satisfied**
- REQ-003: Emit type-spec in generated DO CONCURRENT header — **satisfied**

## File-set enumeration

**Edited:**
- `src/parser/control_flow/parser_do_constructs.f90` — added `type_spec` field to `do_loop_control_t`
- `src/parser/control_flow/parser_do_constructs_part1.inc` — `parse_concurrent_control` now handles optional type-spec prefix; `next_tokens_form_control` updated for lookahead; added `parse_type_spec_parens` helper
- `src/ast/nodes/ast_nodes_loops.f90` — added `type_spec` field to `do_loop_node`; updated `do_loop_assign`
- `src/ast/factory/ast_factory_control_part1.inc` — `push_do_loop` accepts optional `type_spec` parameter
- `src/codegen/statements/codegen_control_flow.f90` — emit `type-spec :: var` in DO CONCURRENT header when present

**Unedited (in scope, intentionally left alone):**
- `src/parser/control_flow/parser_do_constructs_part2.inc` — do-while parsing, unrelated to DO CONCURRENT type-spec
- `src/lexer/` — type keywords already classified as TK_KEYWORD; no lexer change needed
- `src/semantic/` — type-spec in DO CONCURRENT header is local to the loop; no semantic analysis change needed

**Test files:**
- `examples/f90/do_concurrent_type_spec.f90` — canonical example with `integer :: i` type-spec
- `test/parser/test_do_concurrent_type_spec_issue_2849.f90` — end-to-end tests covering integer, real(8), logical type-spec and mixed multi-index

## Verification

```
$ fo test test_do_concurrent_type_spec_issue_2849
test_do_concurrent_type_spec_issue_2849    PASS       0.00s
Summary: 1 passed, 0 failed, 0 skipped

$ fo test
Tests: 256 passed (  13.9s)

$ fo check
Build: OK Tests: pass (30.9s)
```

(ref #2849)

<!-- orchestrate: fully-resolved -->
