### PR TITLE
Expose compiler node query API

### DIFF
--- a/src/fortfront_compiler.f90
+++ b/src/fortfront_compiler.f90
@@ -24,19 +24,30 @@ module fortfront_compiler
         get_subroutine_body_info, &
         get_used_modules, get_defined_module, &
         used_module_t, defined_module_t
+    use frontend_compiler_node_queries, only: is_declaration_node, &
+        is_derived_type_node, &
+        get_declaration_var_name, get_declaration_type_name, &
+        get_declaration_has_initializer, &
+        get_declaration_initializer_index, &
+        get_derived_type_name, &
+        get_node_stmt_label, get_goto_label, goto_is_computed, &
+        get_goto_label_list, get_goto_selector_index
     use frontend_compiler_resolution, only: declaration_binding_t, &
-                                            get_scope_bindings, resolve_name_in_scope, &
-                                     resolve_name_at_node, resolve_identifier_binding, &
-                            BINDING_NONE, BINDING_DECLARATION, BINDING_NAMED_CONSTANT, &
-                       BINDING_DUMMY_ARGUMENT, BINDING_DERIVED_TYPE, BINDING_FUNCTION, &
-                                          BINDING_SUBROUTINE, BINDING_FUNCTION_RESULT, &
-                                BINDING_STATEMENT_FUNCTION, BINDING_GENERIC_INTERFACE, &
-                         BINDING_ASSOCIATE_NAME, ASSOCIATION_NONE, ASSOCIATION_DIRECT, &
-                                            ASSOCIATION_HOST, ASSOCIATION_USE
+        get_scope_bindings, resolve_name_in_scope, &
+        resolve_name_at_node, resolve_identifier_binding, &
+        BINDING_NONE, BINDING_DECLARATION, BINDING_NAMED_CONSTANT, &
+        BINDING_DUMMY_ARGUMENT, BINDING_DERIVED_TYPE, BINDING_FUNCTION, &
+        BINDING_SUBROUTINE, BINDING_FUNCTION_RESULT, &
+        BINDING_STATEMENT_FUNCTION, BINDING_GENERIC_INTERFACE, &
+        BINDING_ASSOCIATE_NAME, ASSOCIATION_NONE, ASSOCIATION_DIRECT, &
+        ASSOCIATION_HOST, ASSOCIATION_USE
     use fortfront_semantic, only: INPUT_MODE_LAZY, INPUT_MODE_STANDARD, &
         OPERATING_MODE_INFER, OPERATING_MODE_STRICT
     use fortfront_ast, only: ast_arena_t
+    use fortfront_utils, only: node_exists, get_node_type_at, get_type_for_node
     use fortfront_lexer, only: token_t
+    use type_system_unified, only: mono_type_t, &
+        TINT, TREAL, TCHAR, TLOGICAL, TARRAY, TCOMPLEX, TDOUBLE, TDERIVED
     implicit none
     public
 end module fortfront_compiler

--- a/src/frontend/README.md
+++ b/src/frontend/README.md
@@ -12,6 +12,7 @@ The frontend provides the primary API entry point for transforming lazy Fortran 
 |------|-------------|
 | frontend_compiler_api.f90 | Public compiler-facing API returning AST, semantic context, tokens, and diagnostics without codegen |
 | frontend_compiler_queries.f90 | Safe compiler-facing AST queries for backend consumers |
+| frontend_compiler_node_queries.f90 | Compiler-facing declaration, derived-type, label, and GOTO node metadata queries |
 | frontend_tooling_api.f90 | Public API for tool integration (linters, language servers) |
 | frontend_transformation_pipeline.f90 | Main transformation orchestration: lex → parse → semantic → codegen |
 | frontend_transformation_pipeline_helpers.inc | Private pipeline helpers (option resolution, pre-parse early exit, arena pipeline, leading-comment prepend) included by frontend_transformation_pipeline.f90 |

--- a/src/frontend/frontend_compiler_node_queries.f90
+++ b/src/frontend/frontend_compiler_node_queries.f90
@@ -1,0 +1,207 @@
+module frontend_compiler_node_queries
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_control, only: goto_node
+    use ast_nodes_data, only: declaration_node, derived_type_node
+    implicit none
+    private
+
+    public :: is_declaration_node
+    public :: is_derived_type_node
+    public :: get_declaration_var_name
+    public :: get_declaration_type_name
+    public :: get_declaration_has_initializer
+    public :: get_declaration_initializer_index
+    public :: get_derived_type_name
+    public :: get_node_stmt_label
+    public :: get_goto_label
+    public :: goto_is_computed
+    public :: get_goto_label_list
+    public :: get_goto_selector_index
+
+contains
+
+    logical function is_declaration_node(arena, node_index) result(is_decl)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+
+        is_decl = .false.
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (declaration_node)
+            is_decl = .true.
+        end select
+    end function is_declaration_node
+
+    logical function is_derived_type_node(arena, node_index) result(is_type)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+
+        is_type = .false.
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (derived_type_node)
+            is_type = .true.
+        end select
+    end function is_derived_type_node
+
+    subroutine get_declaration_var_name(arena, decl_index, var_name, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: decl_index
+        character(len=:), allocatable, intent(out) :: var_name
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(var_name)
+        if (.not. arena%has_node_at(decl_index)) then
+            error_msg = 'declaration index does not reference an AST node'
+            return
+        end if
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            if (allocated(node%var_name)) var_name = node%var_name
+            if (len_trim(var_name) == 0 .and. node%is_multi_declaration .and. &
+                allocated(node%var_names)) then
+                if (size(node%var_names) == 1) var_name = node%var_names(1)
+            end if
+            call set_empty(error_msg)
+        class default
+            error_msg = 'AST node is not a declaration'
+        end select
+    end subroutine get_declaration_var_name
+
+    subroutine get_declaration_type_name(arena, decl_index, type_name, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: decl_index
+        character(len=:), allocatable, intent(out) :: type_name
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(type_name)
+        if (.not. arena%has_node_at(decl_index)) then
+            error_msg = 'declaration index does not reference an AST node'
+            return
+        end if
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            if (allocated(node%type_name)) type_name = node%type_name
+            call set_empty(error_msg)
+        class default
+            error_msg = 'AST node is not a declaration'
+        end select
+    end subroutine get_declaration_type_name
+
+    logical function get_declaration_has_initializer(arena, decl_index) &
+            result(has_init)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: decl_index
+
+        has_init = .false.
+        if (.not. arena%has_node_at(decl_index)) return
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            has_init = node%has_initializer
+        end select
+    end function get_declaration_has_initializer
+
+    integer function get_declaration_initializer_index(arena, decl_index) &
+            result(init_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: decl_index
+
+        init_index = 0
+        if (.not. arena%has_node_at(decl_index)) return
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            if (node%has_initializer .and. node%initializer_index > 0) then
+                init_index = node%initializer_index
+            end if
+        end select
+    end function get_declaration_initializer_index
+
+    subroutine get_derived_type_name(arena, type_index, name, error_msg)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: type_index
+        character(len=:), allocatable, intent(out) :: name
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call set_empty(name)
+        if (.not. arena%has_node_at(type_index)) then
+            error_msg = 'derived type index does not reference an AST node'
+            return
+        end if
+        select type (node => arena%entries(type_index)%node)
+            type is (derived_type_node)
+            if (allocated(node%name)) name = node%name
+            call set_empty(error_msg)
+        class default
+            error_msg = 'AST node is not a derived type definition'
+        end select
+    end subroutine get_derived_type_name
+
+    function get_node_stmt_label(arena, node_index) result(label)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: label
+
+        call set_empty(label)
+        if (.not. arena%has_node_at(node_index)) return
+        if (allocated(arena%entries(node_index)%node%stmt_label)) then
+            label = arena%entries(node_index)%node%stmt_label
+        end if
+    end function get_node_stmt_label
+
+    function get_goto_label(arena, node_index) result(label)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: label
+
+        call set_empty(label)
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (goto_node)
+            if (allocated(node%label)) label = node%label
+        end select
+    end function get_goto_label
+
+    logical function goto_is_computed(arena, node_index) result(is_computed)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+
+        is_computed = .false.
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (goto_node)
+            is_computed = node%selector_index /= 0 .or. allocated(node%label_list)
+        end select
+    end function goto_is_computed
+
+    function get_goto_label_list(arena, node_index) result(label_list)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: label_list
+
+        call set_empty(label_list)
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (goto_node)
+            if (allocated(node%label_list)) label_list = node%label_list
+        end select
+    end function get_goto_label_list
+
+    integer function get_goto_selector_index(arena, node_index) result(idx)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+
+        idx = 0
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (goto_node)
+            idx = node%selector_index
+        end select
+    end function get_goto_selector_index
+
+    subroutine set_empty(value)
+        character(len=:), allocatable, intent(out) :: value
+
+        allocate (character(len=0) :: value)
+    end subroutine set_empty
+
+end module frontend_compiler_node_queries

--- a/test/api/test_compiler_node_queries.f90
+++ b/test/api/test_compiler_node_queries.f90
@@ -1,0 +1,186 @@
+program test_compiler_node_queries
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use fortfront_compiler, only: ast_arena_t, &
+        compiler_frontend_options_t, compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD, &
+        is_declaration_node, is_derived_type_node, &
+        get_declaration_var_name, get_declaration_type_name, &
+        get_declaration_has_initializer, get_declaration_initializer_index, &
+        get_declaration_initializer, &
+        get_derived_type_name, &
+        get_node_stmt_label, get_goto_label, goto_is_computed, &
+        get_goto_label_list, get_goto_selector_index
+    implicit none
+
+    call test_declaration_queries()
+    call test_derived_type_name_query()
+    call test_label_and_goto_queries()
+    print *, 'PASS: compiler node queries'
+
+contains
+
+    subroutine test_declaration_queries()
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: name, type_name, error_msg
+        integer :: decl_index
+        integer :: init_index
+
+        call compile_standard( &
+            'program p'//new_line('a')// &
+            '  integer, parameter :: n = 7'//new_line('a')// &
+            '  real :: x'//new_line('a')// &
+            'end program p', result)
+
+        decl_index = find_declaration(result%arena, 'n')
+        call get_declaration_var_name(result%arena, decl_index, name, error_msg)
+        call require_no_error(error_msg)
+        call require_equal(name, 'n', 'declaration name')
+        call get_declaration_type_name(result%arena, decl_index, type_name, &
+            error_msg)
+        call require_no_error(error_msg)
+        call require_equal(type_name, 'integer', 'declaration type')
+        if (.not. get_declaration_has_initializer(result%arena, decl_index)) then
+            call fail('parameter declaration initializer not reported')
+        end if
+        init_index = get_declaration_initializer_index(result%arena, decl_index)
+        if (init_index <= 0) call fail('initializer index not returned')
+        if (init_index /= get_declaration_initializer(result%arena, decl_index)) then
+            call fail('initializer query mismatch')
+        end if
+    end subroutine test_declaration_queries
+
+    subroutine test_derived_type_name_query()
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: name, error_msg
+        integer :: type_index
+
+        call compile_standard( &
+            'program p'//new_line('a')// &
+            '  type :: point_t'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  end type point_t'//new_line('a')// &
+            'end program p', result)
+
+        type_index = find_derived_type(result%arena)
+        call get_derived_type_name(result%arena, type_index, name, error_msg)
+        call require_no_error(error_msg)
+        call require_equal(name, 'point_t', 'derived type name')
+    end subroutine test_derived_type_name_query
+
+    subroutine test_label_and_goto_queries()
+        type(compiler_frontend_result_t) :: result
+        integer :: i
+        integer :: simple_goto
+        integer :: computed_goto
+        logical :: saw_label
+        character(len=:), allocatable :: label
+        character(len=:), allocatable :: label_list
+
+        call compile_standard( &
+            'program p'//new_line('a')// &
+            '  integer :: k'//new_line('a')// &
+            '  k = 1'//new_line('a')// &
+            '  goto 100'//new_line('a')// &
+            '  goto (100, 200), k'//new_line('a')// &
+            '100 continue'//new_line('a')// &
+            '200 continue'//new_line('a')// &
+            'end program p', result)
+
+        simple_goto = 0
+        computed_goto = 0
+        saw_label = .false.
+        do i = 1, result%arena%size
+            label = get_node_stmt_label(result%arena, i)
+            if (trim(label) == '100') saw_label = .true.
+            if (goto_is_computed(result%arena, i)) then
+                computed_goto = i
+            else
+                label = get_goto_label(result%arena, i)
+                if (trim(label) == '100') simple_goto = i
+            end if
+        end do
+
+        if (.not. saw_label) call fail('statement label not exposed')
+        if (simple_goto <= 0) call fail('simple goto label not exposed')
+        if (computed_goto <= 0) call fail('computed goto not exposed')
+        label_list = get_goto_label_list(result%arena, computed_goto)
+        if (index(label_list, '100') <= 0 .or. index(label_list, '200') <= 0) then
+            call fail('computed goto labels not exposed')
+        end if
+        if (get_goto_selector_index(result%arena, computed_goto) <= 0) then
+            call fail('computed goto selector not exposed')
+        end if
+    end subroutine test_label_and_goto_queries
+
+    subroutine compile_standard(source, result)
+        character(len=*), intent(in) :: source
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: options
+
+        options = compiler_frontend_options_t()
+        options%input_mode = INPUT_MODE_STANDARD
+        options%run_semantics = .true.
+        call compile_frontend_from_string(source, result, options)
+        if (result%success()) return
+        write (error_unit, '(A)') 'FAIL: frontend rejected test source'
+        if (allocated(result%error_msg)) write (error_unit, '(A)') result%error_msg
+        error stop 1
+    end subroutine compile_standard
+
+    integer function find_declaration(arena, expected_name) result(index)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: expected_name
+        character(len=:), allocatable :: name, error_msg
+        integer :: i
+
+        index = 0
+        do i = 1, arena%size
+            if (.not. is_declaration_node(arena, i)) cycle
+            call get_declaration_var_name(arena, i, name, error_msg)
+            if (len_trim(error_msg) > 0) cycle
+            if (trim(name) == trim(expected_name)) then
+                index = i
+                return
+            end if
+        end do
+        call fail('declaration not found: '//trim(expected_name))
+    end function find_declaration
+
+    integer function find_derived_type(arena) result(index)
+        type(ast_arena_t), intent(in) :: arena
+        integer :: i
+
+        index = 0
+        do i = 1, arena%size
+            if (is_derived_type_node(arena, i)) then
+                index = i
+                return
+            end if
+        end do
+        call fail('derived type not found')
+    end function find_derived_type
+
+    subroutine require_no_error(error_msg)
+        character(len=*), intent(in) :: error_msg
+
+        if (len_trim(error_msg) == 0) return
+        call fail(error_msg)
+    end subroutine require_no_error
+
+    subroutine require_equal(actual, expected, label)
+        character(len=*), intent(in) :: actual
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: label
+
+        if (trim(actual) == trim(expected)) return
+        call fail(trim(label)//' mismatch')
+    end subroutine require_equal
+
+    subroutine fail(message)
+        character(len=*), intent(in) :: message
+
+        write (error_unit, '(A)') 'FAIL: '//trim(message)
+        error stop 1
+    end subroutine fail
+
+end program test_compiler_node_queries

--- a/test/api/test_compiler_scope_resolution.f90
+++ b/test/api/test_compiler_scope_resolution.f90
@@ -1,13 +1,13 @@
 program test_compiler_scope_resolution
     use, intrinsic :: iso_fortran_env, only: error_unit
     use ast_nodes_core, only: program_node
-    use ast_nodes_data, only: declaration_node, module_node
+    use ast_nodes_data, only: declaration_node
     use ast_nodes_procedure, only: subroutine_def_node
     use fortfront_compiler, only: compiler_frontend_options_t, &
-                             compiler_frontend_result_t, compile_frontend_from_string, &
-                                  INPUT_MODE_STANDARD, declaration_binding_t, &
-                                  resolve_name_in_scope, resolve_name_at_node, &
-                               BINDING_NAMED_CONSTANT, ASSOCIATION_HOST, ASSOCIATION_USE
+        compiler_frontend_result_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD, declaration_binding_t, &
+        resolve_name_in_scope, resolve_name_at_node, &
+        BINDING_NAMED_CONSTANT, ASSOCIATION_HOST, ASSOCIATION_USE
     implicit none
 
     call test_host_parameter()
@@ -40,17 +40,17 @@ contains
         array_decl_index = find_declaration(result, 'a')
         bound_index = first_dimension_index(result, array_decl_index)
         call resolve_name_in_scope(result%arena, subroutine_index, 'n', binding, &
-                                   error_msg)
+            error_msg)
         call require_binding(error_msg, binding, decl_index, BINDING_NAMED_CONSTANT, &
-                             ASSOCIATION_HOST, 'host parameter n')
+            ASSOCIATION_HOST, 'host parameter n')
         call resolve_name_at_node(result%arena, array_decl_index, 'n', binding, &
-                                  error_msg)
+            error_msg)
         call require_binding(error_msg, binding, decl_index, BINDING_NAMED_CONSTANT, &
-                             ASSOCIATION_HOST, 'host parameter n at declaration')
+            ASSOCIATION_HOST, 'host parameter n at declaration')
         call resolve_name_at_node(result%arena, bound_index, 'n', binding, &
-                                  error_msg)
+            error_msg)
         call require_binding(error_msg, binding, decl_index, BINDING_NAMED_CONSTANT, &
-                             ASSOCIATION_HOST, 'host parameter n at bound')
+            ASSOCIATION_HOST, 'host parameter n at bound')
     end subroutine test_host_parameter
 
     subroutine test_use_rename()
@@ -71,9 +71,9 @@ contains
         program_index = find_program(result, 'p')
         decl_index = find_declaration(result, 'remote')
         call resolve_name_in_scope(result%arena, program_index, 'local', binding, &
-                                   error_msg)
+            error_msg)
         call require_binding(error_msg, binding, decl_index, BINDING_NAMED_CONSTANT, &
-                             ASSOCIATION_USE, 'use-renamed local')
+            ASSOCIATION_USE, 'use-renamed local')
         if (trim(binding%module_name) /= 'm') then
             write (error_unit, '(A)') 'FAIL: use binding module_name mismatch'
             error stop 1
@@ -100,7 +100,7 @@ contains
             'end program p', result)
         program_index = find_program(result, 'p')
         call resolve_name_in_scope(result%arena, program_index, 'hidden', binding, &
-                                   error_msg)
+            error_msg)
         if (len_trim(error_msg) > 0) then
             write (error_unit, '(A)') 'FAIL: '//trim(error_msg)
             error stop 1
@@ -127,7 +127,7 @@ contains
     end subroutine compile_standard
 
     subroutine require_binding(error_msg, binding, node_index, kind, association, &
-                               label)
+            label)
         character(len=*), intent(in) :: error_msg
         type(declaration_binding_t), intent(in) :: binding
         integer, intent(in) :: node_index
@@ -166,7 +166,7 @@ contains
         do i = 1, result%arena%size
             if (.not. result%arena%has_node_at(i)) cycle
             select type (node => result%arena%entries(i)%node)
-            type is (program_node)
+                type is (program_node)
                 if (.not. allocated(node%name)) cycle
                 if (trim(node%name) == trim(name)) index = i
             end select
@@ -185,7 +185,7 @@ contains
         do i = 1, result%arena%size
             if (.not. result%arena%has_node_at(i)) cycle
             select type (node => result%arena%entries(i)%node)
-            type is (subroutine_def_node)
+                type is (subroutine_def_node)
                 if (.not. allocated(node%name)) cycle
                 if (trim(node%name) == trim(name)) index = i
             end select
@@ -204,7 +204,7 @@ contains
         do i = 1, result%arena%size
             if (.not. result%arena%has_node_at(i)) cycle
             select type (node => result%arena%entries(i)%node)
-            type is (declaration_node)
+                type is (declaration_node)
                 if (declaration_names(node, name)) index = i
             end select
         end do
@@ -241,7 +241,7 @@ contains
         dim_index = 0
         if (.not. result%arena%has_node_at(decl_index)) return
         select type (node => result%arena%entries(decl_index)%node)
-        type is (declaration_node)
+            type is (declaration_node)
             if (.not. allocated(node%dimension_indices)) return
             if (size(node%dimension_indices) < 1) return
             dim_index = node%dimension_indices(1)


### PR DESCRIPTION
## Summary
- expose declaration, derived-type, label, and GOTO metadata through fortfront_compiler
- add compiler-facing coverage for the new node queries
- keep downstream consumers out of parser-private node modules

## Verification
### Test fails on main
```bash
fo exec test_compiler_node_queries
```
```text
fo build [--------------------] 0/359 0%
fo build [####################] 359/359 100%
fo build tests [####################] 622/622 100%
fo exec: no such target: test_compiler_node_queries
```

### Test passes after fix
```bash
fo exec test_compiler_node_queries
```
```text
fo build [--------------------] 0/360 0%
fo build [####################] 360/360 100%
fo build tests [####################] 623/623 100%
 PASS: compiler node queries
```

```bash
fo
```
```text
Static: OK (1369 modules, 1011 changed, 1011 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed (30.6s)
```

```bash
/home/ert/code/prompts/scripts/check-writing-slop.py src/frontend/README.md
```
```text
PASS: no writing-slop candidates at threshold medium
```