### PR TITLE
Reject invalid elemental procedures

### DIFF
--- a/src/parser/declarations/parser_parameter_handling.f90
+++ b/src/parser/declarations/parser_parameter_handling.f90
@@ -137,6 +137,11 @@ contains
                 cycle
             end if
 
+            if (token%kind == TK_OPERATOR .and. token%text == "*") then
+                call append_untyped_parameter(parser, arena, param_indices)
+                cycle
+            end if
+
             if (token%kind == TK_KEYWORD .and. is_type_keyword_token(token)) then
                 call parse_parameter_group(parser, arena, param_indices)
                 cycle

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -15,6 +15,7 @@ use semantic_strict_argument_type_checker, only: &
     validate_strict_argument_types_for_function_reference, &
     validate_strict_argument_types_for_subroutine_call
 use semantic_operating_mode, only: OPERATING_MODE_STRICT
+use semantic_input_mode, only: INPUT_MODE_STANDARD
 use semantic_identifier_context, only: find_program_owner
 use semantic_where_validation, only: validate_where_construct
 use semantic_pure_validation, only: validate_pure_procedure

--- a/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
@@ -7,6 +7,7 @@
             type(mono_type_t), allocatable :: param_types(:)
             character(len=64), allocatable :: param_names(:)
             type(mono_type_t) :: return_type
+            character(len=:), allocatable :: elemental_result_name
             integer :: i
 
             call analyze_function_parameters(arena, expr, param_types, param_names, &
@@ -20,9 +21,19 @@
             call validate_pure_procedure(arena, expr%body_indices, &
                                          expr%prefix_keywords, this%errors)
             ! Enforce ELEMENTAL scalar-dummy restriction (F2008 C1290)
+            if (allocated(expr%result_variable)) then
+                elemental_result_name = expr%result_variable
+            else
+                elemental_result_name = expr%name
+            end if
             call validate_elemental_procedure(arena, expr%param_indices, &
                                               expr%body_indices, &
-                                              expr%prefix_keywords, this%errors)
+                                              expr%prefix_keywords, this%errors, &
+                                              proc_name=expr%name, &
+                                              bind_c_clause=expr%bind_c_clause, &
+                                              result_name=elemental_result_name, &
+                                              require_declared_dummy_intent= &
+                                              this%input_mode == INPUT_MODE_STANDARD)
 
             ! Enforce BIND(C) dummy-argument interoperability (F2003 15.3.2)
             call validate_bind_c_procedure(arena, expr%param_indices, &
@@ -63,7 +74,11 @@
             ! Enforce ELEMENTAL scalar-dummy restriction (F2008 C1290)
             call validate_elemental_procedure(arena, expr%param_indices, &
                                               expr%body_indices, &
-                                              expr%prefix_keywords, this%errors)
+                                              expr%prefix_keywords, this%errors, &
+                                              proc_name=expr%name, &
+                                              bind_c_clause=expr%bind_c_clause, &
+                                              require_declared_dummy_intent= &
+                                              this%input_mode == INPUT_MODE_STANDARD)
 
             ! Enforce BIND(C) dummy-argument interoperability (F2003 15.3.2)
             call validate_bind_c_procedure(arena, expr%param_indices, &

--- a/src/semantic/analyzers/semantic_elemental_validation.f90
+++ b/src/semantic/analyzers/semantic_elemental_validation.f90
@@ -6,8 +6,9 @@ module semantic_elemental_validation
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: identifier_node
     use ast_nodes_data, only: declaration_node, parameter_declaration_node
+    use ast_nodes_misc, only: interface_block_node, module_procedure_node
     use error_handling, only: error_collection_t, ERROR_SEMANTIC
-    use string_utils_mod, only: int_to_string
+    use string_utils_mod, only: int_to_string, to_lower
     implicit none
     private
 
@@ -35,16 +36,36 @@ contains
     ! Validate the dummy arguments of an ELEMENTAL procedure. Non-elemental
     ! procedures are accepted unchanged.
     subroutine validate_elemental_procedure(arena, param_indices, body_indices, &
-            prefix_keywords, errors)
+            prefix_keywords, errors, proc_name, bind_c_clause, result_name, &
+            require_declared_dummy_intent)
         type(ast_arena_t), intent(in) :: arena
         integer, allocatable, intent(in) :: param_indices(:)
         integer, allocatable, intent(in) :: body_indices(:)
         character(len=*), allocatable, intent(in) :: prefix_keywords(:)
         type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in), optional :: proc_name
+        character(len=:), allocatable, intent(in), optional :: bind_c_clause
+        character(len=*), intent(in), optional :: result_name
+        logical, intent(in), optional :: require_declared_dummy_intent
         integer :: i
         character(len=:), allocatable :: dummy_name
+        logical :: check_dummy_intent
 
         if (.not. is_elemental_prefix(prefix_keywords)) return
+        check_dummy_intent = .true.
+        if (present(require_declared_dummy_intent)) then
+            check_dummy_intent = require_declared_dummy_intent
+        end if
+
+        call validate_elemental_bind_c(bind_c_clause, errors)
+        if (present(result_name)) then
+            call validate_elemental_result(arena, body_indices, result_name, &
+                errors)
+        else if (present(proc_name)) then
+            call validate_elemental_result(arena, body_indices, proc_name, &
+                errors)
+        end if
+
         if (.not. allocated(param_indices)) return
 
         do i = 1, size(param_indices)
@@ -57,6 +78,17 @@ contains
             if (.not. allocated(body_indices)) cycle
             if (body_declares_array(arena, body_indices, dummy_name)) then
                 call report_array_dummy(errors, arena, param_indices(i))
+            end if
+            if (body_declares_dummy_procedure(arena, body_indices, dummy_name)) then
+                call report_dummy_procedure(errors, arena, param_indices(i), &
+                    dummy_name)
+            end if
+            if (check_dummy_intent) then
+                if (.not. dummy_has_intent_or_value(arena, param_indices(i), &
+                    body_indices, dummy_name)) then
+                    call report_dummy_intent(errors, arena, param_indices(i), &
+                        dummy_name)
+                end if
             end if
         end do
     end subroutine validate_elemental_procedure
@@ -79,6 +111,22 @@ contains
             is_array = node%is_array
         end select
     end function param_is_array
+
+    function param_has_intent(arena, param_index) result(has_intent)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_index
+        logical :: has_intent
+
+        has_intent = .false.
+        if (.not. arena%has_node_at(param_index)) return
+
+        select type (node => arena%entries(param_index)%node)
+            type is (declaration_node)
+            has_intent = node%has_intent
+            type is (parameter_declaration_node)
+            has_intent = node%intent_type /= 0
+        end select
+    end function param_has_intent
 
     ! Extract the dummy argument name from a parameter node.
     function param_name(arena, param_index) result(name)
@@ -127,23 +175,208 @@ contains
         character(len=*), intent(in) :: dummy_name
         logical :: matches
         integer :: i
+        character(len=:), allocatable :: lowered_dummy
 
         matches = .false.
+        lowered_dummy = to_lower(trim(dummy_name))
         if (allocated(node%var_name)) then
-            if (trim(node%var_name) == trim(dummy_name)) then
+            if (to_lower(trim(node%var_name)) == lowered_dummy) then
                 matches = .true.
                 return
             end if
         end if
         if (allocated(node%var_names)) then
             do i = 1, size(node%var_names)
-                if (trim(node%var_names(i)) == trim(dummy_name)) then
+                if (to_lower(trim(node%var_names(i))) == lowered_dummy) then
                     matches = .true.
                     return
                 end if
             end do
         end if
     end function declaration_names_dummy
+
+    function dummy_has_intent_or_value(arena, param_index, body_indices, &
+            dummy_name) result(has_attr)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_index
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: dummy_name
+        logical :: has_attr
+        integer :: decl_index
+
+        has_attr = param_has_intent(arena, param_index)
+        if (has_attr) return
+
+        decl_index = find_body_declaration(arena, body_indices, dummy_name)
+        if (decl_index <= 0) return
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            has_attr = node%has_intent
+            if (.not. has_attr) has_attr = node%is_value
+        end select
+    end function dummy_has_intent_or_value
+
+    function find_body_declaration(arena, body_indices, name) result(decl_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: name
+        integer :: decl_index
+        integer :: i
+
+        decl_index = 0
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (node => arena%entries(body_indices(i))%node)
+                type is (declaration_node)
+                if (declaration_names_dummy(node, name)) then
+                    decl_index = body_indices(i)
+                    return
+                end if
+            end select
+        end do
+    end function find_body_declaration
+
+    function body_declares_dummy_procedure(arena, body_indices, dummy_name) &
+            result(is_procedure)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: dummy_name
+        logical :: is_procedure
+        integer :: i
+
+        is_procedure = .false.
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            if (node_declares_dummy_procedure(arena, body_indices(i), &
+                dummy_name)) then
+                is_procedure = .true.
+                return
+            end if
+        end do
+    end function body_declares_dummy_procedure
+
+    function node_declares_dummy_procedure(arena, node_index, dummy_name) &
+            result(is_procedure)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: dummy_name
+        logical :: is_procedure
+
+        is_procedure = .false.
+        select type (node => arena%entries(node_index)%node)
+            type is (declaration_node)
+            if (declaration_names_dummy(node, dummy_name)) then
+                is_procedure = declaration_is_procedure(node)
+            end if
+            type is (interface_block_node)
+            is_procedure = interface_declares_name(arena, node, dummy_name)
+        end select
+    end function node_declares_dummy_procedure
+
+    function declaration_is_procedure(node) result(is_procedure)
+        type(declaration_node), intent(in) :: node
+        logical :: is_procedure
+        character(len=:), allocatable :: lowered
+
+        is_procedure = .false.
+        if (.not. allocated(node%type_name)) return
+        lowered = to_lower(trim(node%type_name))
+        if (len(lowered) < 9) return
+        is_procedure = lowered(1:9) == 'procedure'
+    end function declaration_is_procedure
+
+    function interface_declares_name(arena, node, name) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        type(interface_block_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+        logical :: found
+        integer :: i
+
+        found = .false.
+        if (.not. allocated(node%procedure_indices)) return
+        do i = 1, size(node%procedure_indices)
+            if (.not. arena%has_node_at(node%procedure_indices(i))) cycle
+            if (procedure_node_name_matches(arena, node%procedure_indices(i), &
+                name)) then
+                found = .true.
+                return
+            end if
+        end do
+    end function interface_declares_name
+
+    function procedure_node_name_matches(arena, node_index, name) result(matches)
+        use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
+        logical :: matches
+
+        matches = .false.
+        select type (node => arena%entries(node_index)%node)
+            type is (function_def_node)
+            if (allocated(node%name)) matches = names_match(node%name, name)
+            type is (subroutine_def_node)
+            if (allocated(node%name)) matches = names_match(node%name, name)
+            type is (module_procedure_node)
+            matches = module_procedure_names_match(node, name)
+        end select
+    end function procedure_node_name_matches
+
+    function module_procedure_names_match(node, name) result(matches)
+        type(module_procedure_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+        logical :: matches
+        integer :: i
+
+        matches = .false.
+        if (.not. allocated(node%procedure_names)) return
+        do i = 1, size(node%procedure_names)
+            if (names_match(node%procedure_names(i)%s, name)) then
+                matches = .true.
+                return
+            end if
+        end do
+    end function module_procedure_names_match
+
+    function names_match(left, right) result(matches)
+        character(len=*), intent(in) :: left, right
+        logical :: matches
+
+        matches = to_lower(trim(left)) == to_lower(trim(right))
+    end function names_match
+
+    subroutine validate_elemental_bind_c(bind_c_clause, errors)
+        character(len=:), allocatable, intent(in), optional :: bind_c_clause
+        type(error_collection_t), intent(inout) :: errors
+
+        if (.not. present(bind_c_clause)) return
+        if (.not. allocated(bind_c_clause)) return
+        if (len_trim(bind_c_clause) == 0) return
+        call errors%add_error( &
+            message='BIND(C) attribute conflicts with ELEMENTAL attribute', &
+            code=ERROR_SEMANTIC, &
+            component='semantic_elemental_validation', &
+            suggestion='drop BIND(C) or drop the ELEMENTAL prefix')
+    end subroutine validate_elemental_bind_c
+
+    subroutine validate_elemental_result(arena, body_indices, result_name, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: result_name
+        type(error_collection_t), intent(inout) :: errors
+        integer :: decl_index
+
+        if (len_trim(result_name) == 0) return
+        if (.not. allocated(body_indices)) return
+        decl_index = find_body_declaration(arena, body_indices, result_name)
+        if (decl_index <= 0) return
+
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            if (node%is_array) call report_array_result(errors, node)
+            if (node%is_pointer) call report_pointer_result(errors, node)
+        end select
+    end subroutine validate_elemental_result
 
     subroutine report_array_dummy(errors, arena, param_index)
         type(error_collection_t), intent(inout) :: errors
@@ -168,5 +401,80 @@ contains
             suggestion='make the dummy argument scalar, or drop the '// &
             'ELEMENTAL prefix')
     end subroutine report_array_dummy
+
+    subroutine report_dummy_procedure(errors, arena, param_index, dummy_name)
+        type(error_collection_t), intent(inout) :: errors
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_index
+        character(len=*), intent(in) :: dummy_name
+        integer :: line, column
+
+        call source_position(arena, param_index, line, column)
+        call errors%add_error( &
+            message='procedure dummy argument "'//trim(dummy_name)// &
+            '" is not allowed in an ELEMENTAL procedure', &
+            code=ERROR_SEMANTIC, &
+            component='semantic_elemental_validation', &
+            context='line '//int_to_string(line)//', column '// &
+            int_to_string(column), &
+            suggestion='drop the ELEMENTAL prefix or remove the dummy procedure')
+    end subroutine report_dummy_procedure
+
+    subroutine report_dummy_intent(errors, arena, param_index, dummy_name)
+        type(error_collection_t), intent(inout) :: errors
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_index
+        character(len=*), intent(in) :: dummy_name
+        integer :: line, column
+
+        call source_position(arena, param_index, line, column)
+        call errors%add_error( &
+            message='dummy argument "'//trim(dummy_name)// &
+            '" of ELEMENTAL procedure must have INTENT or VALUE', &
+            code=ERROR_SEMANTIC, &
+            component='semantic_elemental_validation', &
+            context='line '//int_to_string(line)//', column '// &
+            int_to_string(column), &
+            suggestion='add INTENT or VALUE, or drop the ELEMENTAL prefix')
+    end subroutine report_dummy_intent
+
+    subroutine report_array_result(errors, node)
+        type(error_collection_t), intent(inout) :: errors
+        type(declaration_node), intent(in) :: node
+
+        call errors%add_error( &
+            message='array result is not allowed in an ELEMENTAL function', &
+            code=ERROR_SEMANTIC, &
+            component='semantic_elemental_validation', &
+            context='line '//int_to_string(node%line)//', column '// &
+            int_to_string(node%column), &
+            suggestion='make the result scalar, or drop the ELEMENTAL prefix')
+    end subroutine report_array_result
+
+    subroutine report_pointer_result(errors, node)
+        type(error_collection_t), intent(inout) :: errors
+        type(declaration_node), intent(in) :: node
+
+        call errors%add_error( &
+            message='pointer result is not allowed in an ELEMENTAL function', &
+            code=ERROR_SEMANTIC, &
+            component='semantic_elemental_validation', &
+            context='line '//int_to_string(node%line)//', column '// &
+            int_to_string(node%column), &
+            suggestion='remove POINTER, or drop the ELEMENTAL prefix')
+    end subroutine report_pointer_result
+
+    subroutine source_position(arena, node_index, line, column)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer, intent(out) :: line, column
+
+        line = 0
+        column = 0
+        if (arena%has_node_at(node_index)) then
+            line = arena%entries(node_index)%node%line
+            column = arena%entries(node_index)%node%column
+        end if
+    end subroutine source_position
 
 end module semantic_elemental_validation

--- a/src/semantic/analyzers/semantic_elemental_validation.f90
+++ b/src/semantic/analyzers/semantic_elemental_validation.f90
@@ -47,7 +47,7 @@ contains
         character(len=:), allocatable, intent(in), optional :: bind_c_clause
         character(len=*), intent(in), optional :: result_name
         logical, intent(in), optional :: require_declared_dummy_intent
-        integer :: i
+        integer :: i, decl_index
         character(len=:), allocatable :: dummy_name
         logical :: check_dummy_intent
 
@@ -75,7 +75,21 @@ contains
             end if
             dummy_name = param_name(arena, param_indices(i))
             if (len_trim(dummy_name) == 0) cycle
+            if (dummy_name == '*') then
+                call report_alternate_return(errors, arena, param_indices(i))
+                cycle
+            end if
             if (.not. allocated(body_indices)) cycle
+            decl_index = find_body_declaration(arena, body_indices, dummy_name)
+            if (decl_index > 0) then
+                select type (node => arena%entries(decl_index)%node)
+                    type is (declaration_node)
+                    if (node%is_allocatable) call report_forbidden_attribute( &
+                        errors, node, 'ALLOCATABLE', 'dummy')
+                    if (node%is_pointer) call report_forbidden_attribute( &
+                        errors, node, 'POINTER', 'dummy')
+                end select
+            end if
             if (body_declares_array(arena, body_indices, dummy_name)) then
                 call report_array_dummy(errors, arena, param_indices(i))
             end if
@@ -374,6 +388,8 @@ contains
         select type (node => arena%entries(decl_index)%node)
             type is (declaration_node)
             if (node%is_array) call report_array_result(errors, node)
+            if (node%is_allocatable) call report_forbidden_attribute( &
+                errors, node, 'ALLOCATABLE', 'result')
             if (node%is_pointer) call report_pointer_result(errors, node)
         end select
     end subroutine validate_elemental_result
@@ -437,6 +453,38 @@ contains
             int_to_string(column), &
             suggestion='add INTENT or VALUE, or drop the ELEMENTAL prefix')
     end subroutine report_dummy_intent
+
+    subroutine report_alternate_return(errors, arena, param_index)
+        type(error_collection_t), intent(inout) :: errors
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_index
+        integer :: line, column
+
+        call source_position(arena, param_index, line, column)
+        call errors%add_error( &
+            message='alternate return is not allowed in an ELEMENTAL procedure', &
+            code=ERROR_SEMANTIC, &
+            component='semantic_elemental_validation', &
+            context='line '//int_to_string(line)//', column '// &
+            int_to_string(column), &
+            suggestion='remove the alternate return, or drop the ELEMENTAL prefix')
+    end subroutine report_alternate_return
+
+    subroutine report_forbidden_attribute(errors, node, attribute, entity)
+        type(error_collection_t), intent(inout) :: errors
+        type(declaration_node), intent(in) :: node
+        character(len=*), intent(in) :: attribute, entity
+
+        call errors%add_error( &
+            message=trim(attribute)//' '//trim(entity)// &
+            ' is not allowed in an ELEMENTAL procedure', &
+            code=ERROR_SEMANTIC, &
+            component='semantic_elemental_validation', &
+            context='line '//int_to_string(node%line)//', column '// &
+            int_to_string(node%column), &
+            suggestion='remove '//trim(attribute)// &
+            ', or drop the ELEMENTAL prefix')
+    end subroutine report_forbidden_attribute
 
     subroutine report_array_result(errors, node)
         type(error_collection_t), intent(inout) :: errors

--- a/test/semantic/test_elemental_validation.f90
+++ b/test/semantic/test_elemental_validation.f90
@@ -20,6 +20,11 @@ program test_elemental_validation
     call test_elemental_scalar_dummy_accepted(all_tests_passed)
     call test_elemental_array_dummy_rejected(all_tests_passed)
     call test_elemental_inline_array_dummy_rejected(all_tests_passed)
+    call test_elemental_dummy_without_intent_rejected(all_tests_passed)
+    call test_elemental_dummy_procedure_rejected(all_tests_passed)
+    call test_elemental_bind_c_rejected(all_tests_passed)
+    call test_elemental_array_result_rejected(all_tests_passed)
+    call test_elemental_pointer_result_rejected(all_tests_passed)
     call test_non_elemental_array_dummy_accepted(all_tests_passed)
     call test_is_elemental_prefix_classification(all_tests_passed)
 
@@ -47,7 +52,8 @@ contains
         errors = create_error_collection()
         allocate (params(1))
         params(1) = push_identifier(arena, 'x', line=1, column=1)
-        decl_idx = push_declaration(arena, 'real', ['x'], line=2, column=1)
+        decl_idx = push_declaration(arena, 'real', ['x'], intent_value='in', &
+            line=2, column=1)
         allocate (body(1))
         body(1) = decl_idx
         prefix = [character(len=16) :: 'elemental']
@@ -121,6 +127,63 @@ contains
         end if
     end subroutine test_elemental_inline_array_dummy_rejected
 
+    subroutine test_elemental_dummy_without_intent_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL dummy without intent/value (rejected)...'
+        source = 'elemental subroutine s(x)'//new_line('a')// &
+            'integer :: x'//new_line('a')// &
+            'end subroutine s'
+        call expect_frontend_error(source, 'INTENT', passed)
+    end subroutine test_elemental_dummy_without_intent_rejected
+
+    subroutine test_elemental_dummy_procedure_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL dummy procedure (rejected)...'
+        source = 'elemental subroutine s(f)'//new_line('a')// &
+            'interface'//new_line('a')// &
+            'pure subroutine f()'//new_line('a')// &
+            'end subroutine f'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'end subroutine s'
+        call expect_frontend_error(source, 'procedure dummy', passed)
+    end subroutine test_elemental_dummy_procedure_rejected
+
+    subroutine test_elemental_bind_c_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL BIND(C) conflict (rejected)...'
+        source = 'elemental subroutine s() bind(c)'//new_line('a')// &
+            'end subroutine s'
+        call expect_frontend_error(source, 'BIND(C)', passed)
+    end subroutine test_elemental_bind_c_rejected
+
+    subroutine test_elemental_array_result_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL array result (rejected)...'
+        source = 'elemental function f()'//new_line('a')// &
+            'integer :: f(2)'//new_line('a')// &
+            'end function f'
+        call expect_frontend_error(source, 'array result', passed)
+    end subroutine test_elemental_array_result_rejected
+
+    subroutine test_elemental_pointer_result_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL pointer result (rejected)...'
+        source = 'elemental function f()'//new_line('a')// &
+            'integer, pointer :: f'//new_line('a')// &
+            'end function f'
+        call expect_frontend_error(source, 'pointer result', passed)
+    end subroutine test_elemental_pointer_result_rejected
+
     subroutine test_non_elemental_array_dummy_accepted(passed)
         logical, intent(inout) :: passed
         type(ast_arena_t) :: arena
@@ -176,5 +239,34 @@ contains
             passed = .false.
         end if
     end subroutine test_is_elemental_prefix_classification
+
+    subroutine expect_frontend_error(source, expected, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (result%success()) then
+            print *, '  FAIL: invalid source was accepted'
+            passed = .false.
+            return
+        end if
+        if (index(result%diagnostic_text, expected) == 0) then
+            print *, '  FAIL: diagnostic missing expected text: ', expected
+            print *, trim(result%diagnostic_text)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_error
 
 end program test_elemental_validation

--- a/test/semantic/test_elemental_validation.f90
+++ b/test/semantic/test_elemental_validation.f90
@@ -21,10 +21,15 @@ program test_elemental_validation
     call test_elemental_array_dummy_rejected(all_tests_passed)
     call test_elemental_inline_array_dummy_rejected(all_tests_passed)
     call test_elemental_dummy_without_intent_rejected(all_tests_passed)
+    call test_elemental_allocatable_dummy_rejected(all_tests_passed)
+    call test_elemental_pointer_dummy_rejected(all_tests_passed)
     call test_elemental_dummy_procedure_rejected(all_tests_passed)
     call test_elemental_bind_c_rejected(all_tests_passed)
     call test_elemental_array_result_rejected(all_tests_passed)
+    call test_elemental_allocatable_result_rejected(all_tests_passed)
     call test_elemental_pointer_result_rejected(all_tests_passed)
+    call test_elemental_alternate_return_rejected(all_tests_passed)
+    call test_elemental_value_dummy_accepted(all_tests_passed)
     call test_non_elemental_array_dummy_accepted(all_tests_passed)
     call test_is_elemental_prefix_classification(all_tests_passed)
 
@@ -138,6 +143,28 @@ contains
         call expect_frontend_error(source, 'INTENT', passed)
     end subroutine test_elemental_dummy_without_intent_rejected
 
+    subroutine test_elemental_allocatable_dummy_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL allocatable dummy (rejected)...'
+        source = 'elemental subroutine s(x)'//new_line('a')// &
+            'integer, allocatable, intent(in) :: x'//new_line('a')// &
+            'end subroutine s'
+        call expect_frontend_error(source, 'ALLOCATABLE dummy', passed)
+    end subroutine test_elemental_allocatable_dummy_rejected
+
+    subroutine test_elemental_pointer_dummy_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL pointer dummy (rejected)...'
+        source = 'elemental subroutine s(x)'//new_line('a')// &
+            'integer, pointer, intent(in) :: x'//new_line('a')// &
+            'end subroutine s'
+        call expect_frontend_error(source, 'POINTER dummy', passed)
+    end subroutine test_elemental_pointer_dummy_rejected
+
     subroutine test_elemental_dummy_procedure_rejected(passed)
         logical, intent(inout) :: passed
         character(len=:), allocatable :: source
@@ -173,6 +200,17 @@ contains
         call expect_frontend_error(source, 'array result', passed)
     end subroutine test_elemental_array_result_rejected
 
+    subroutine test_elemental_allocatable_result_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL allocatable result (rejected)...'
+        source = 'elemental function f()'//new_line('a')// &
+            'integer, allocatable :: f'//new_line('a')// &
+            'end function f'
+        call expect_frontend_error(source, 'ALLOCATABLE result', passed)
+    end subroutine test_elemental_allocatable_result_rejected
+
     subroutine test_elemental_pointer_result_rejected(passed)
         logical, intent(inout) :: passed
         character(len=:), allocatable :: source
@@ -183,6 +221,28 @@ contains
             'end function f'
         call expect_frontend_error(source, 'pointer result', passed)
     end subroutine test_elemental_pointer_result_rejected
+
+    subroutine test_elemental_alternate_return_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL alternate return (rejected)...'
+        source = 'elemental subroutine s(*)'//new_line('a')// &
+            'return 1'//new_line('a')// &
+            'end subroutine s'
+        call expect_frontend_error(source, 'alternate return', passed)
+    end subroutine test_elemental_alternate_return_rejected
+
+    subroutine test_elemental_value_dummy_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ELEMENTAL VALUE dummy (accepted)...'
+        source = 'elemental subroutine s(x)'//new_line('a')// &
+            'integer, value :: x'//new_line('a')// &
+            'end subroutine s'
+        call expect_frontend_success(source, passed)
+    end subroutine test_elemental_value_dummy_accepted
 
     subroutine test_non_elemental_array_dummy_accepted(passed)
         logical, intent(inout) :: passed
@@ -268,5 +328,28 @@ contains
             print *, '  PASS'
         end if
     end subroutine expect_frontend_error
+
+    subroutine expect_frontend_success(source, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (.not. result%success()) then
+            print *, '  FAIL: valid source was rejected'
+            print *, trim(result%diagnostic_text)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_success
 
 end program test_elemental_validation


### PR DESCRIPTION
## Summary
- Enforce the ELEMENTAL procedure constraints in J3 C1279-C1280.
- Reject dummy procedures, alternate returns, BIND(C), array dummies, scalar ALLOCATABLE or POINTER dummies, and missing INTENT/VALUE in standard mode.
- Reject array, ALLOCATABLE, and POINTER results.
- Keep Lazy Fortran intent synthesis valid by applying the missing INTENT/VALUE rule only in standard input mode.

## Verification
### Test fails before fix
```
fo test test_elemental_validation
test_elemental_validation                  FAIL       0.00s
Testing ELEMENTAL allocatable dummy (rejected)...
  FAIL: invalid source was accepted
Testing ELEMENTAL pointer dummy (rejected)...
  FAIL: invalid source was accepted
Testing ELEMENTAL allocatable result (rejected)...
  FAIL: invalid source was accepted
Testing ELEMENTAL alternate return (rejected)...
  FAIL: invalid source was accepted
Testing ELEMENTAL VALUE dummy (accepted)...
  PASS
Summary: 0 passed, 1 failed, 0 skipped (  0.00s)
```

### Test passes after fix
```
fo test test_elemental_validation
test_elemental_validation                  PASS       0.00s
Summary: 1 passed, 0 failed, 0 skipped (  0.00s)
```

```
fo test test_function_prefix_keywords
test_function_prefix_keywords              PASS       0.01s
Summary: 1 passed, 0 failed, 0 skipped (  0.01s)
```

```
fo
Static: OK (1369 modules, 1011 changed, 1011 affected)
Build: OK
Tests: OK
Lint: OK
All stages passed (33.3s)
```
