### PR TITLE
Expose structured compiler diagnostics

### DIFF
--- a/src/error_handling.f90
+++ b/src/error_handling.f90
@@ -24,6 +24,10 @@ module error_handling
         character(len=:), allocatable :: error_message
         integer :: error_code = 0
         integer :: severity = ERROR_INFO
+        integer :: line = 0
+        integer :: column = 0
+        integer :: end_line = 0
+        integer :: end_column = 0
         character(len=:), allocatable :: component
         character(len=:), allocatable :: context
         character(len=:), allocatable :: suggestion
@@ -189,6 +193,10 @@ contains
         this%success = .true.
         this%error_code = 0
         this%severity = ERROR_INFO
+        this%line = 0
+        this%column = 0
+        this%end_line = 0
+        this%end_column = 0
         if (allocated(this%error_message)) deallocate (this%error_message)
         if (allocated(this%component)) deallocate (this%component)
         if (allocated(this%context)) deallocate (this%context)
@@ -208,6 +216,10 @@ contains
         ! Combine error codes (if both present, use the more severe one)
         if (this%severity >= other%severity) then
             combined%error_code = this%error_code
+            combined%line = this%line
+            combined%column = this%column
+            combined%end_line = this%end_line
+            combined%end_column = this%end_column
             if (allocated(this%error_message)) combined%error_message = &
                 this%error_message
             if (allocated(this%component)) combined%component = this%component
@@ -215,6 +227,10 @@ contains
             if (allocated(this%suggestion)) combined%suggestion = this%suggestion
         else
             combined%error_code = other%error_code
+            combined%line = other%line
+            combined%column = other%column
+            combined%end_line = other%end_line
+            combined%end_column = other%end_column
             if (allocated(other%error_message)) combined%error_message = &
                 other%error_message
             if (allocated(other%component)) combined%component = other%component
@@ -230,6 +246,10 @@ contains
         lhs%success = rhs%success
         lhs%error_code = rhs%error_code
         lhs%severity = rhs%severity
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%end_line = rhs%end_line
+        lhs%end_column = rhs%end_column
 
         if (allocated(rhs%error_message)) lhs%error_message = rhs%error_message
         if (allocated(rhs%component)) lhs%component = rhs%component
@@ -244,14 +264,19 @@ contains
         res%severity = ERROR_INFO
     end function success_result
 
-    function create_error_result(message, code, component, context, suggestion) &
-            result(res)
+    function create_error_result(message, code, component, context, suggestion, &
+            line, column, end_line, end_column) result(res)
         character(len=*), intent(in) :: message
         integer, intent(in), optional :: code
         character(len=*), intent(in), optional :: component, context, suggestion
+        integer, intent(in), optional :: line, column, end_line, end_column
         type(result_t) :: res
 
         call res%set_error(message, code, component, context, suggestion)
+        if (present(line)) res%line = line
+        if (present(column)) res%column = column
+        if (present(end_line)) res%end_line = end_line
+        if (present(end_column)) res%end_column = end_column
     end function create_error_result
 
     function warning_result(message, code, component, context, suggestion) result(res)
@@ -286,11 +311,13 @@ contains
         collection%count = 0
     end function create_error_collection
 
-    subroutine add_error(this, message, code, severity, component, context, suggestion)
+    subroutine add_error(this, message, code, severity, component, context, &
+            suggestion, line, column, end_line, end_column)
         class(error_collection_t), intent(inout) :: this
         character(len=*), intent(in) :: message
         integer, intent(in), optional :: code, severity
         character(len=*), intent(in), optional :: component, context, suggestion
+        integer, intent(in), optional :: line, column, end_line, end_column
 
         type(result_t) :: error_result
         integer :: sev
@@ -308,6 +335,11 @@ contains
             error_result = create_error_result(message, code, component, context, &
                 suggestion)
         end select
+
+        if (present(line)) error_result%line = line
+        if (present(column)) error_result%column = column
+        if (present(end_line)) error_result%end_line = end_line
+        if (present(end_column)) error_result%end_column = end_column
 
         call this%add_result(error_result)
     end subroutine add_error

--- a/src/error_reporting.f90
+++ b/src/error_reporting.f90
@@ -14,6 +14,8 @@ module error_reporting
     type, public :: error_context_t
         integer :: line = 0
         integer :: column = 0
+        integer :: end_line = 0
+        integer :: end_column = 0
         character(len=:), allocatable :: filename
         character(len=:), allocatable :: source_line
     end type error_context_t
@@ -48,13 +50,19 @@ module error_reporting
 contains
 
     ! Create error context from line/column information
-    function create_error_context(line, column, filename, source_line) result(context)
+    function create_error_context(line, column, filename, source_line, end_line, &
+            end_column) result(context)
         integer, intent(in) :: line, column
         character(len=*), intent(in), optional :: filename, source_line
+        integer, intent(in), optional :: end_line, end_column
         type(error_context_t) :: context
 
         context%line = line
         context%column = column
+        context%end_line = line
+        context%end_column = column + 1
+        if (present(end_line)) context%end_line = end_line
+        if (present(end_column)) context%end_column = end_column
 
         if (present(filename)) then
             context%filename = filename
@@ -75,6 +83,11 @@ contains
 
         context%line = token%line
         context%column = token%column
+        context%end_line = token%line
+        context%end_column = token%column + 1
+        if (allocated(token%text)) then
+            context%end_column = token%column + max(len(token%text), 1)
+        end if
 
         if (present(filename)) then
             context%filename = filename

--- a/src/fortfront_compiler.f90
+++ b/src/fortfront_compiler.f90
@@ -30,6 +30,10 @@ module fortfront_compiler
         query_array_slice, query_array_bounds, query_range_expression, &
         query_component_access, query_array_literal, &
         query_pointer_assignment, query_nullify
+    use frontend_compiler_diagnostics, only: compiler_diagnostic_t, &
+        get_compiler_diagnostics, &
+        DIAGNOSTIC_PHASE_PARSER, DIAGNOSTIC_PHASE_SEMANTIC, &
+        DIAGNOSTIC_CODE_PARSER, DIAGNOSTIC_CODE_SEMANTIC
     use frontend_compiler_node_queries, only: is_declaration_node, &
         is_derived_type_node, &
         get_declaration_var_name, get_declaration_type_name, &
@@ -50,6 +54,8 @@ module fortfront_compiler
     use fortfront_semantic, only: INPUT_MODE_LAZY, INPUT_MODE_STANDARD, &
         OPERATING_MODE_INFER, OPERATING_MODE_STRICT
     use fortfront_ast, only: ast_arena_t
+    use fortfront_types, only: DIAGNOSTIC_ERROR, DIAGNOSTIC_WARNING, &
+        DIAGNOSTIC_INFO
     use fortfront_utils, only: node_exists, get_node_type_at, get_type_for_node
     use fortfront_lexer, only: token_t
     use type_system_unified, only: mono_type_t, &

--- a/src/frontend/frontend_compiler_api.f90
+++ b/src/frontend/frontend_compiler_api.f90
@@ -5,6 +5,7 @@ module frontend_compiler_api
     use ast_arena_source_text, only: set_source_text
     use frontend_core, only: lex_source
     use frontend_parsing, only: parse_tokens
+    use error_reporting, only: error_record_t
     use frontend_tooling_api, only: read_file_contents, message_has_error
     use frontend_transformation_semantics, only: get_detailed_semantic_errors
     use semantic_analyzer, only: semantic_context_t, create_semantic_context, &
@@ -38,6 +39,7 @@ module frontend_compiler_api
         character(len=:), allocatable :: error_msg
         character(len=:), allocatable :: diagnostic_text
         type(token_t), allocatable :: tokens(:)
+        type(error_record_t), allocatable :: parser_errors(:)
     contains
         procedure :: success => compiler_frontend_success
     end type compiler_frontend_result_t
@@ -75,7 +77,7 @@ contains
 
         parse_error = ''
         call parse_tokens(local_tokens, result%arena, result%root_index, &
-            parse_error)
+            parse_error, result%parser_errors)
         if (len_trim(parse_error) > 0) then
             call set_result_error(result, parse_error)
             if (allocated(local_tokens)) deallocate (local_tokens)
@@ -176,6 +178,7 @@ contains
         call allocate_empty(result%source_path)
         call allocate_empty(result%error_msg)
         call allocate_empty(result%diagnostic_text)
+        allocate (result%parser_errors(0))
     end subroutine initialize_result
 
     subroutine set_result_error(result, message)

--- a/src/frontend/frontend_compiler_diagnostics.f90
+++ b/src/frontend/frontend_compiler_diagnostics.f90
@@ -1,0 +1,161 @@
+module frontend_compiler_diagnostics
+    use frontend_compiler_api, only: compiler_frontend_result_t
+    use fortfront_types, only: source_range_t, DIAGNOSTIC_ERROR, &
+        DIAGNOSTIC_WARNING, DIAGNOSTIC_INFO
+    use error_reporting, only: PARSER_ERROR_WARNING => ERROR_WARNING, &
+        PARSER_ERROR_ERROR => ERROR_ERROR, PARSER_ERROR_FATAL => ERROR_FATAL
+    use error_handling, only: ERROR_PARSER, ERROR_SEMANTIC, &
+        SEMANTIC_ERROR_WARNING => ERROR_WARNING, &
+        SEMANTIC_ERROR_ERROR => ERROR_ERROR, &
+        SEMANTIC_ERROR_CRITICAL => ERROR_CRITICAL
+    implicit none
+    private
+
+    integer, parameter, public :: DIAGNOSTIC_PHASE_PARSER = 1
+    integer, parameter, public :: DIAGNOSTIC_PHASE_SEMANTIC = 2
+    integer, parameter, public :: DIAGNOSTIC_CODE_PARSER = ERROR_PARSER
+    integer, parameter, public :: DIAGNOSTIC_CODE_SEMANTIC = ERROR_SEMANTIC
+
+    type, public :: compiler_diagnostic_t
+        integer :: phase = 0
+        integer :: code = 0
+        integer :: severity = DIAGNOSTIC_INFO
+        type(source_range_t) :: span
+        character(len=:), allocatable :: message
+        character(len=:), allocatable :: category
+    end type compiler_diagnostic_t
+
+    public :: get_compiler_diagnostics
+
+contains
+
+    function get_compiler_diagnostics(result) result(diagnostics)
+        type(compiler_frontend_result_t), intent(in) :: result
+        type(compiler_diagnostic_t), allocatable :: diagnostics(:)
+        integer :: count, output_index
+
+        count = result%semantic_ctx%errors%count
+        if (allocated(result%parser_errors)) then
+            count = count + size(result%parser_errors)
+        end if
+        allocate (diagnostics(count))
+        output_index = 0
+        call fill_parser_diagnostics(result, diagnostics, output_index)
+        call fill_semantic_diagnostics(result, diagnostics, output_index)
+    end function get_compiler_diagnostics
+
+    subroutine fill_parser_diagnostics(result, diagnostics, output_index)
+        type(compiler_frontend_result_t), intent(in) :: result
+        type(compiler_diagnostic_t), intent(inout) :: diagnostics(:)
+        integer, intent(inout) :: output_index
+        integer :: i
+
+        if (.not. allocated(result%parser_errors)) return
+        do i = 1, size(result%parser_errors)
+            output_index = output_index + 1
+            diagnostics(output_index)%phase = DIAGNOSTIC_PHASE_PARSER
+            diagnostics(output_index)%code = DIAGNOSTIC_CODE_PARSER
+            diagnostics(output_index)%severity = parser_severity( &
+                result%parser_errors(i)%severity)
+            call set_span(diagnostics(output_index)%span, &
+                result%parser_errors(i)%context%line, &
+                result%parser_errors(i)%context%column, &
+                result%parser_errors(i)%context%end_line, &
+                result%parser_errors(i)%context%end_column)
+            if (allocated(result%parser_errors(i)%message)) then
+                diagnostics(output_index)%message = result%parser_errors(i)%message
+            else
+                diagnostics(output_index)%message = ''
+            end if
+            diagnostics(output_index)%category = 'parser'
+        end do
+    end subroutine fill_parser_diagnostics
+
+    subroutine fill_semantic_diagnostics(result, diagnostics, output_index)
+        type(compiler_frontend_result_t), intent(in) :: result
+        type(compiler_diagnostic_t), intent(inout) :: diagnostics(:)
+        integer, intent(inout) :: output_index
+        integer :: i
+
+        do i = 1, result%semantic_ctx%errors%count
+            output_index = output_index + 1
+            call fill_semantic_identity(result, i, diagnostics(output_index))
+            call set_span(diagnostics(output_index)%span, &
+                result%semantic_ctx%errors%errors(i)%line, &
+                result%semantic_ctx%errors%errors(i)%column, &
+                result%semantic_ctx%errors%errors(i)%end_line, &
+                result%semantic_ctx%errors%errors(i)%end_column)
+            if (allocated( &
+                result%semantic_ctx%errors%errors(i)%error_message)) then
+                diagnostics(output_index)%message = &
+                    result%semantic_ctx%errors%errors(i)%error_message
+            else
+                diagnostics(output_index)%message = ''
+            end if
+            if (allocated(result%semantic_ctx%errors%errors(i)%component)) then
+                diagnostics(output_index)%category = &
+                    result%semantic_ctx%errors%errors(i)%component
+            else
+                diagnostics(output_index)%category = 'semantic'
+            end if
+        end do
+    end subroutine fill_semantic_diagnostics
+
+    subroutine fill_semantic_identity(result, index, diagnostic)
+        type(compiler_frontend_result_t), intent(in) :: result
+        integer, intent(in) :: index
+        type(compiler_diagnostic_t), intent(inout) :: diagnostic
+
+        diagnostic%phase = DIAGNOSTIC_PHASE_SEMANTIC
+        diagnostic%code = result%semantic_ctx%errors%errors(index)%error_code
+        if (diagnostic%code == 0) diagnostic%code = DIAGNOSTIC_CODE_SEMANTIC
+        diagnostic%severity = semantic_severity( &
+            result%semantic_ctx%errors%errors(index)%severity)
+    end subroutine fill_semantic_identity
+
+    subroutine set_span(span, line, column, end_line, end_column)
+        type(source_range_t), intent(out) :: span
+        integer, intent(in) :: line, column
+        integer, intent(in), optional :: end_line, end_column
+
+        span%start%line = max(line, 0)
+        span%start%column = max(column, 0)
+        span%start%byte_offset = 0
+        span%end = span%start
+        if (present(end_line)) then
+            span%end%line = max(end_line, span%start%line)
+        end if
+        if (present(end_column)) then
+            span%end%column = max(end_column, span%start%column)
+        else if (span%start%column > 0) then
+            span%end%column = span%start%column + 1
+        end if
+    end subroutine set_span
+
+    pure integer function parser_severity(severity) result(public_severity)
+        integer, intent(in) :: severity
+
+        select case (severity)
+        case (PARSER_ERROR_FATAL, PARSER_ERROR_ERROR)
+            public_severity = DIAGNOSTIC_ERROR
+        case (PARSER_ERROR_WARNING)
+            public_severity = DIAGNOSTIC_WARNING
+        case default
+            public_severity = DIAGNOSTIC_INFO
+        end select
+    end function parser_severity
+
+    pure integer function semantic_severity(severity) result(public_severity)
+        integer, intent(in) :: severity
+
+        select case (severity)
+        case (SEMANTIC_ERROR_CRITICAL, SEMANTIC_ERROR_ERROR)
+            public_severity = DIAGNOSTIC_ERROR
+        case (SEMANTIC_ERROR_WARNING)
+            public_severity = DIAGNOSTIC_WARNING
+        case default
+            public_severity = DIAGNOSTIC_INFO
+        end select
+    end function semantic_severity
+
+end module frontend_compiler_diagnostics

--- a/src/frontend/frontend_mixed_constructs.f90
+++ b/src/frontend/frontend_mixed_constructs.f90
@@ -13,6 +13,7 @@ module frontend_mixed_constructs
         create_mixed_construct_container
     use mixed_construct_detector, only: &
         mixed_construct_result_t
+    use error_reporting, only: error_collection_t
 
     implicit none
     private
@@ -25,12 +26,13 @@ contains
 
     ! Parse mixed constructs (Issue #511 support)
     subroutine parse_mixed_constructs(tokens, arena, mixed_result, &
-            prog_index, error_msg)
+            prog_index, error_msg, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         type(mixed_construct_result_t), intent(in) :: mixed_result
         integer, intent(out) :: prog_index
         character(len=*), intent(out) :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         integer, allocatable :: implicit_indices(:), explicit_indices(:)
         integer :: i, stmt_index, range_start, range_end
@@ -64,7 +66,7 @@ contains
 
                 ! Parse this declaration range
                 call parse_declaration_range(range_tokens, arena, &
-                    stmt_index, error_msg)
+                    stmt_index, error_msg, diagnostic_sink)
 
                 if (len_trim(error_msg) > 0) then
                     return
@@ -86,7 +88,8 @@ contains
                 range_tokens = tokens(range_start:range_end)
 
                 ! Parse this program range
-                call parse_program_range(range_tokens, arena, stmt_index, error_msg)
+                call parse_program_range(range_tokens, arena, stmt_index, error_msg, &
+                    diagnostic_sink)
 
                 if (len_trim(error_msg) > 0) then
                     return
@@ -134,7 +137,7 @@ contains
             end do
 
             call parse_remaining_statement_sequences(tokens, used_tokens, arena, &
-                implicit_indices, error_msg)
+                implicit_indices, error_msg, diagnostic_sink)
             if (len_trim(error_msg) > 0) return
         end if
 
@@ -144,30 +147,38 @@ contains
     end subroutine parse_mixed_constructs
 
     ! Parse declaration range
-    subroutine parse_declaration_range(tokens, arena, stmt_index, error_msg)
+    subroutine parse_declaration_range(tokens, arena, stmt_index, error_msg, &
+            diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(out) :: stmt_index
         character(len=*), intent(out) :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
-        call parse_tokens_with_dispatcher(tokens, arena, stmt_index, error_msg)
+        call parse_tokens_with_dispatcher(tokens, arena, stmt_index, error_msg, &
+            diagnostic_sink)
     end subroutine parse_declaration_range
 
     ! Parse program range
-    subroutine parse_program_range(tokens, arena, stmt_index, error_msg)
+    subroutine parse_program_range(tokens, arena, stmt_index, error_msg, &
+            diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(out) :: stmt_index
         character(len=*), intent(out) :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
-        call parse_tokens_with_dispatcher(tokens, arena, stmt_index, error_msg)
+        call parse_tokens_with_dispatcher(tokens, arena, stmt_index, error_msg, &
+            diagnostic_sink)
     end subroutine parse_program_range
 
-    subroutine parse_tokens_with_dispatcher(tokens, arena, stmt_index, error_msg)
+    subroutine parse_tokens_with_dispatcher(tokens, arena, stmt_index, error_msg, &
+            diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(out) :: stmt_index
         character(len=*), intent(out) :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         type(token_t), allocatable, target :: stmt_tokens(:)
         type(parser_prefix_buffer_t) :: prefix_buffer
@@ -191,7 +202,12 @@ contains
             stmt_tokens = tokens
         end if
 
-        stmt_index = parse_statement_dispatcher(stmt_tokens, arena, prefix_buffer)
+        block
+            character(len=:), allocatable :: dispatcher_error
+            stmt_index = parse_statement_dispatcher(stmt_tokens, arena, &
+                prefix_buffer, diagnostic_sink, dispatcher_error)
+            if (allocated(dispatcher_error)) error_msg = dispatcher_error
+        end block
 
         deallocate (stmt_tokens)
     end subroutine parse_tokens_with_dispatcher
@@ -255,12 +271,13 @@ contains
     end subroutine mark_token_range
 
     subroutine parse_remaining_statement_sequences(tokens, used_tokens, arena, &
-            implicit_indices, error_msg)
+            implicit_indices, error_msg, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         logical, intent(inout) :: used_tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, allocatable, intent(inout) :: implicit_indices(:)
         character(len=*), intent(inout) :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: i, seq_start, seq_end, stmt_index
         logical :: in_sequence
         type(token_t), allocatable, target :: segment_tokens(:)
@@ -280,7 +297,7 @@ contains
                 if (in_sequence) then
                     seq_end = i - 1
                     call parse_sequence(tokens, seq_start, seq_end, arena, &
-                        stmt_index, error_msg)
+                        stmt_index, error_msg, diagnostic_sink)
                     if (len_trim(error_msg) > 0) return
                     if (stmt_index > 0) call append_implicit(implicit_indices, &
                         stmt_index)
@@ -293,7 +310,7 @@ contains
         if (in_sequence) then
             seq_end = size(tokens)
             call parse_sequence(tokens, seq_start, seq_end, arena, stmt_index, &
-                error_msg)
+                error_msg, diagnostic_sink)
             if (len_trim(error_msg) > 0) return
             if (stmt_index > 0) call append_implicit(implicit_indices, stmt_index)
             call mark_token_range(used_tokens, seq_start, seq_end)
@@ -311,12 +328,14 @@ contains
         end function token_has_content
 
         subroutine parse_sequence(all_tokens, start_idx, end_idx, arena, &
-                stmt_index, error_msg)
+                stmt_index, error_msg, diagnostic_sink)
             type(token_t), intent(in) :: all_tokens(:)
             integer, intent(in) :: start_idx, end_idx
             type(ast_arena_t), intent(inout) :: arena
             integer, intent(out) :: stmt_index
             character(len=*), intent(inout) :: error_msg
+            type(error_collection_t), target, intent(inout), optional :: &
+                diagnostic_sink
             type(token_t), allocatable, target :: local_tokens(:)
 
             stmt_index = 0
@@ -324,7 +343,7 @@ contains
 
             local_tokens = all_tokens(start_idx:end_idx)
             call parse_tokens_with_dispatcher(local_tokens, arena, stmt_index, &
-                error_msg)
+                error_msg, diagnostic_sink)
         end subroutine parse_sequence
 
         subroutine append_implicit(implicit_indices, stmt_index)

--- a/src/frontend/frontend_program_unit_scanner.f90
+++ b/src/frontend/frontend_program_unit_scanner.f90
@@ -7,6 +7,7 @@ module frontend_program_unit_scanner
     use ast_nodes_transfer, only: entry_node
     use frontend_program_units, only: parse_program_unit
     use mixed_construct_detector, only: function_follows_type_spec
+    use error_reporting, only: error_collection_t
 
     implicit none
     private

--- a/src/frontend/frontend_program_unit_scanner_part1.inc
+++ b/src/frontend/frontend_program_unit_scanner_part1.inc
@@ -257,13 +257,14 @@
     end function should_process_unit
 
     subroutine process_program_unit(tokens, unit_start, unit_end, arena, &
-                                    unit_index, has_explicit_program, error_msg)
+            unit_index, has_explicit_program, error_msg, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: unit_start, unit_end
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(out) :: unit_index
         logical, intent(in) :: has_explicit_program
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         type(token_t), allocatable, target :: unit_tokens(:)
         character(len=:), allocatable :: parse_error
@@ -282,8 +283,13 @@
         unit_tokens(unit_end - unit_start + 2)%line = tokens(unit_end)%line
         unit_tokens(unit_end - unit_start + 2)%column = tokens(unit_end)%column + 1
 
-        unit_index = parse_program_unit(unit_tokens, arena, has_explicit_program, &
-                                        parse_error)
+        if (present(diagnostic_sink)) then
+            unit_index = parse_program_unit(unit_tokens, arena, &
+                has_explicit_program, parse_error, diagnostic_sink)
+        else
+            unit_index = parse_program_unit(unit_tokens, arena, &
+                has_explicit_program, parse_error)
+        end if
 
         if (present(error_msg) .and. allocated(parse_error)) then
             if (len_trim(parse_error) > 0) error_msg = parse_error

--- a/src/frontend/frontend_program_units.f90
+++ b/src/frontend/frontend_program_units.f90
@@ -18,6 +18,7 @@ module frontend_program_units
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_program
     use frontend_utilities, only: is_type_start
+    use error_reporting, only: error_collection_t
 
     implicit none
     private
@@ -37,12 +38,14 @@ module frontend_program_units
 contains
 
     ! Main program unit parsing dispatch
-    function parse_program_unit(tokens, arena, has_explicit_program, error_msg) &
+    function parse_program_unit(tokens, arena, has_explicit_program, error_msg, &
+            diagnostic_sink) &
             result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         logical, intent(in) :: has_explicit_program
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: unit_index
         type(parser_prefix_buffer_t) :: prefix_buffer
         integer :: first_token_pos
@@ -73,31 +76,37 @@ contains
         ! Determine unit type and parse accordingly
         block
             if (is_function_start(trimmed_tokens, 1)) then
-                unit_index = parse_function_unit(trimmed_tokens, arena, parse_error)
+                unit_index = parse_function_unit(trimmed_tokens, arena, parse_error, &
+                    diagnostic_sink)
             else if (is_subroutine_start(trimmed_tokens, 1)) then
-                unit_index = parse_subroutine_unit(trimmed_tokens, arena, parse_error)
+                unit_index = parse_subroutine_unit(trimmed_tokens, arena, parse_error, &
+                    diagnostic_sink)
             else if (is_submodule_start(trimmed_tokens, 1)) then
                 ! Parse the entire submodule with its content
-                unit_index = parse_submodule_unit(trimmed_tokens, arena, parse_error)
+                unit_index = parse_submodule_unit(trimmed_tokens, arena, parse_error, &
+                    diagnostic_sink)
             else if (is_module_start(trimmed_tokens, 1)) then
                 ! Parse the entire module with its content
-                unit_index = parse_module_unit(trimmed_tokens, arena, parse_error)
+                unit_index = parse_module_unit(trimmed_tokens, arena, parse_error, &
+                    diagnostic_sink)
             else if (is_template_start(trimmed_tokens, 1)) then
-                unit_index = parse_template_unit(trimmed_tokens, arena, parse_error)
+                unit_index = parse_template_unit(trimmed_tokens, arena, parse_error, &
+                    diagnostic_sink)
             else if (is_program_start(trimmed_tokens, 1)) then
                 unit_index = parse_explicit_program_unit(trimmed_tokens, arena, &
-                    parse_error)
+                    parse_error, diagnostic_sink)
             else if (is_block_data_start(trimmed_tokens, 1)) then
                 ! Parse BLOCK DATA unit
-                unit_index = parse_block_data_unit(trimmed_tokens, arena, parse_error)
+                unit_index = parse_block_data_unit(trimmed_tokens, arena, parse_error, &
+                    diagnostic_sink)
             else if (is_interface_start(trimmed_tokens, 1)) then
                 unit_index = parse_interface_unit(trimmed_tokens, arena, &
-                    parse_error)
+                    parse_error, diagnostic_sink)
             else
                 ! Mixed module/main files still require implicit main detection
                 unit_index = parse_implicit_main_program(trimmed_tokens, arena, &
                     has_explicit_program, &
-                    parse_error)
+                    parse_error, diagnostic_sink)
             end if
         end block
 
@@ -117,43 +126,47 @@ contains
     end function parse_program_unit
 
     ! Parse module unit with all its content
-    function parse_module_unit(tokens, arena, error_msg) result(unit_index)
+    function parse_module_unit(tokens, arena, error_msg, diagnostic_sink) &
+            result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: unit_index
         type(parser_prefix_buffer_t) :: prefix_buffer
 
         ! Parse the complete module including its content
         ! Module should be parsed with all its statements
-        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer)
-        ! Extract parser errors from dispatcher
-        if (present(error_msg)) error_msg = get_last_parser_errors()
+        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer, &
+            diagnostic_sink, error_msg)
     end function parse_module_unit
 
-    function parse_template_unit(tokens, arena, error_msg) result(unit_index)
+    function parse_template_unit(tokens, arena, error_msg, diagnostic_sink) &
+            result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: unit_index
         type(parser_prefix_buffer_t) :: prefix_buffer
 
-        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer)
-        if (present(error_msg)) error_msg = get_last_parser_errors()
+        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer, &
+            diagnostic_sink, error_msg)
     end function parse_template_unit
 
     ! Parse submodule unit with all its content (Fortran 2008)
-    function parse_submodule_unit(tokens, arena, error_msg) result(unit_index)
+    function parse_submodule_unit(tokens, arena, error_msg, diagnostic_sink) &
+            result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: unit_index
         type(parser_prefix_buffer_t) :: prefix_buffer
 
         ! Parse the complete submodule including its content
-        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer)
-        ! Extract parser errors from dispatcher
-        if (present(error_msg)) error_msg = get_last_parser_errors()
+        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer, &
+            diagnostic_sink, error_msg)
     end function parse_submodule_unit
 
     ! Check if program unit has meaningful content
@@ -179,10 +192,12 @@ contains
     end function not_meaningful_program_unit
 
     ! Parse function unit
-    function parse_function_unit(tokens, arena, error_msg) result(unit_index)
+    function parse_function_unit(tokens, arena, error_msg, diagnostic_sink) &
+            result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: unit_index
 
         ! Initialize error message
@@ -193,7 +208,7 @@ contains
             type(parser_state_t) :: parser
             type(parser_prefix_buffer_t) :: prefix_buffer
             call init_interface_procedure_parser()
-            parser = create_parser_state(tokens)
+            parser = create_parser_state(tokens, diagnostic_sink)
             unit_index = parse_function_definition(parser, arena, prefix_buffer)
             ! Extract parser errors before parser goes out of scope
             if (present(error_msg) .and. parser%has_errors()) then
@@ -203,71 +218,73 @@ contains
     end function parse_function_unit
 
     ! Parse subroutine unit
-    function parse_subroutine_unit(tokens, arena, error_msg) result(unit_index)
+    function parse_subroutine_unit(tokens, arena, error_msg, diagnostic_sink) &
+            result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: unit_index
         type(parser_prefix_buffer_t) :: prefix_buffer
 
         ! Parse the subroutine using the dispatcher
-        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer)
-        ! Extract parser errors from dispatcher
-        if (present(error_msg)) error_msg = get_last_parser_errors()
+        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer, &
+            diagnostic_sink, error_msg)
     end function parse_subroutine_unit
 
     ! Parse type unit
-    function parse_type_unit(tokens, arena, error_msg) result(unit_index)
+    function parse_type_unit(tokens, arena, error_msg, diagnostic_sink) &
+            result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: unit_index
         type(parser_prefix_buffer_t) :: prefix_buffer
 
         ! Statement dispatcher handles parser creation for type definitions
-        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer)
-        ! Extract parser errors from dispatcher
-        if (present(error_msg)) error_msg = get_last_parser_errors()
+        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer, &
+            diagnostic_sink, error_msg)
     end function parse_type_unit
 
     ! Parse BLOCK DATA unit
-    function parse_block_data_unit(tokens, arena, error_msg) result(unit_index)
+    function parse_block_data_unit(tokens, arena, error_msg, diagnostic_sink) &
+            result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: unit_index
         type(parser_prefix_buffer_t) :: prefix_buffer
 
         ! Parse BLOCK DATA using statement dispatcher
-        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer)
-        ! Extract parser errors from dispatcher
-        if (present(error_msg)) error_msg = get_last_parser_errors()
+        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer, &
+            diagnostic_sink, error_msg)
     end function parse_block_data_unit
 
-    function parse_interface_unit(tokens, arena, error_msg) result(unit_index)
+    function parse_interface_unit(tokens, arena, error_msg, diagnostic_sink) &
+            result(unit_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: unit_index
         type(parser_prefix_buffer_t) :: prefix_buffer
 
-        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer)
+        unit_index = parse_statement_dispatcher(tokens, arena, prefix_buffer, &
+            diagnostic_sink)
 
-        if (present(error_msg)) then
-            if (.not. allocated(error_msg)) then
-                allocate (character(len=0) :: error_msg)
-            end if
-            error_msg = ""
-        end if
+        if (present(error_msg)) error_msg = ""
     end function parse_interface_unit
 
     ! Parse implicit main program
     function parse_implicit_main_program(tokens, arena, has_explicit_program, &
-            error_msg) result(prog_index)
+            error_msg, diagnostic_sink) result(prog_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         logical, intent(in) :: has_explicit_program
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: prog_index
         character(len=:), allocatable :: errors
 
@@ -275,10 +292,10 @@ contains
         if (has_any_non_comment_content(tokens)) then
             if (has_executable_statements(tokens)) then
                 ! Parse all statements into a program block (multi-statement aware)
-                prog_index = parse_all_statements(tokens, arena)
+                prog_index = parse_all_statements(tokens, arena, diagnostic_sink)
             else
                 ! Just declarations - still creates implicit main program
-                prog_index = parse_all_statements(tokens, arena)
+                prog_index = parse_all_statements(tokens, arena, diagnostic_sink)
             end if
         else
             ! No meaningful content - create empty program
@@ -287,6 +304,7 @@ contains
 
         ! Extract parser errors if requested (implicit main can have parse errors too)
         if (present(error_msg)) then
+            if (present(diagnostic_sink)) return
             errors = get_last_parser_errors()
             if (len_trim(errors) > 0) then
                 error_msg = errors

--- a/src/frontend/frontend_statement_contains_section.f90
+++ b/src/frontend/frontend_statement_contains_section.f90
@@ -5,6 +5,7 @@ module frontend_statement_contains_section
     use ast_arena_modern, only: ast_arena_t
     use frontend_statement_contains_section_helpers, only: &
         push_implicit_contains_statement, scan_contains_section
+    use error_reporting, only: error_collection_t
 
     implicit none
     private
@@ -60,17 +61,18 @@ contains
     end function is_structural_contains
 
     subroutine parse_implicit_contains_section(tokens, start_pos, arena, &
-            body_indices, end_pos)
+            body_indices, end_pos, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: start_pos
         type(ast_arena_t), intent(inout) :: arena
         integer, allocatable, intent(inout) :: body_indices(:)
         integer, intent(out) :: end_pos
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         type(parser_prefix_buffer_t) :: prefix_buffer
         call push_implicit_contains_statement(arena, body_indices)
         call scan_contains_section(tokens, start_pos, arena, prefix_buffer, &
-            body_indices, end_pos)
+            body_indices, end_pos, diagnostic_sink)
     end subroutine parse_implicit_contains_section
 
 end module frontend_statement_contains_section

--- a/src/frontend/frontend_statement_contains_section_helpers.f90
+++ b/src/frontend/frontend_statement_contains_section_helpers.f90
@@ -222,6 +222,7 @@ module frontend_statement_contains_section_helpers
     use parser_state_module, only: create_parser_state, parser_state_t
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_misc, only: contains_node
+    use error_reporting, only: error_collection_t
 
     implicit none
     private
@@ -243,13 +244,14 @@ contains
     end subroutine push_implicit_contains_statement
 
     subroutine scan_contains_section(tokens, start_pos, arena, prefix_buffer, &
-            body_indices, end_pos)
+            body_indices, end_pos, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: start_pos
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         integer, allocatable, intent(inout) :: body_indices(:)
         integer, intent(out) :: end_pos
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: i
         character(len=:), allocatable :: lowered
         character(len=16), allocatable :: prefix_list(:)
@@ -279,13 +281,13 @@ contains
 
             if (is_contains_type_prefix_keyword(lowered)) then
                 call handle_type_prefixed_contains(tokens, i, arena, prefix_buffer, &
-                    prefix_list, body_indices)
+                    prefix_list, body_indices, diagnostic_sink)
                 cycle
             end if
 
             if (handle_contains_procedure_keyword(tokens, lowered, i, arena, &
                 prefix_buffer, prefix_list, &
-                body_indices)) cycle
+                body_indices, diagnostic_sink)) cycle
 
             i = i + 1
         end do
@@ -326,7 +328,7 @@ contains
 
     logical function handle_contains_procedure_keyword(tokens, lowered, pos, arena, &
             prefix_buffer, prefix_list, &
-            body_indices) result(handled)
+            body_indices, diagnostic_sink) result(handled)
         type(token_t), intent(in) :: tokens(:)
         character(len=*), intent(in) :: lowered
         integer, intent(inout) :: pos
@@ -334,6 +336,7 @@ contains
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         character(len=16), allocatable, intent(inout) :: prefix_list(:)
         integer, allocatable, intent(inout) :: body_indices(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         integer :: proc_end, proc_start
 
@@ -343,7 +346,7 @@ contains
             proc_start = pos
             call find_procedure_end(tokens, proc_start, "function", proc_end)
             call parse_contains_function_span(tokens, proc_start, proc_end, arena, &
-                prefix_buffer, prefix_list, body_indices)
+                prefix_buffer, prefix_list, body_indices, diagnostic_sink)
             pos = proc_end + 1
             handled = .true.
             return
@@ -354,7 +357,7 @@ contains
             call find_procedure_end(tokens, proc_start, "subroutine", proc_end)
             call parse_contains_subroutine_span(tokens, proc_start, proc_end, arena, &
                 prefix_buffer, prefix_list, &
-                body_indices)
+                body_indices, diagnostic_sink)
             pos = proc_end + 1
             handled = .true.
             return
@@ -362,13 +365,14 @@ contains
     end function handle_contains_procedure_keyword
 
     subroutine handle_type_prefixed_contains(tokens, pos, arena, prefix_buffer, &
-            prefix_list, body_indices)
+            prefix_list, body_indices, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(inout) :: pos
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         character(len=16), allocatable, intent(inout) :: prefix_list(:)
         integer, allocatable, intent(inout) :: body_indices(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         integer :: proc_end
         logical :: parsed_procedure
@@ -376,7 +380,7 @@ contains
         call try_parse_typed_function_in_contains(tokens, pos, arena, &
             prefix_buffer, prefix_list, &
             body_indices, parsed_procedure, &
-            proc_end)
+            proc_end, diagnostic_sink)
         if (parsed_procedure) then
             pos = proc_end + 1
             return
@@ -408,7 +412,7 @@ contains
 
     subroutine try_parse_typed_function_in_contains(tokens, type_start, arena, &
             prefix_buffer, prefix_list, &
-            body_indices, parsed, proc_end)
+            body_indices, parsed, proc_end, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: type_start
         type(ast_arena_t), intent(inout) :: arena
@@ -417,6 +421,7 @@ contains
         integer, allocatable, intent(inout) :: body_indices(:)
         logical, intent(out) :: parsed
         integer, intent(out) :: proc_end
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: proc_start
         character(len=:), allocatable :: lowered
 
@@ -430,12 +435,12 @@ contains
 
         call find_procedure_end(tokens, proc_start, "function", proc_end)
         call parse_contains_function_span(tokens, type_start, proc_end, arena, &
-            prefix_buffer, prefix_list, body_indices)
+            prefix_buffer, prefix_list, body_indices, diagnostic_sink)
         parsed = .true.
     end subroutine try_parse_typed_function_in_contains
 
     subroutine parse_contains_function_span(tokens, span_start, proc_end, arena, &
-            prefix_buffer, prefix_list, body_indices)
+            prefix_buffer, prefix_list, body_indices, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: span_start
         integer, intent(in) :: proc_end
@@ -443,6 +448,7 @@ contains
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         character(len=16), allocatable, intent(inout) :: prefix_list(:)
         integer, allocatable, intent(inout) :: body_indices(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         type(parser_state_t) :: parser
         type(token_t), allocatable :: proc_tokens(:)
         integer :: proc_index
@@ -452,7 +458,7 @@ contains
         proc_tokens(proc_end - span_start + 2)%kind = TK_EOF
         proc_tokens(proc_end - span_start + 2)%text = ""
         call prefix_buffer%clear()
-        parser = create_parser_state(proc_tokens)
+        parser = create_parser_state(proc_tokens, diagnostic_sink)
 
         if (size(prefix_list) > 0) then
             proc_index = parse_function_definition(parser, arena, prefix_buffer, &
@@ -468,7 +474,7 @@ contains
 
     subroutine parse_contains_subroutine_span(tokens, proc_start, proc_end, arena, &
             prefix_buffer, prefix_list, &
-            body_indices)
+            body_indices, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: proc_start
         integer, intent(in) :: proc_end
@@ -476,6 +482,7 @@ contains
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         character(len=16), allocatable, intent(inout) :: prefix_list(:)
         integer, allocatable, intent(inout) :: body_indices(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         type(parser_state_t) :: parser
         type(token_t), allocatable :: proc_tokens(:)
         integer :: proc_index
@@ -485,7 +492,7 @@ contains
         proc_tokens(proc_end - proc_start + 2)%kind = TK_EOF
         proc_tokens(proc_end - proc_start + 2)%text = ""
         call prefix_buffer%clear()
-        parser = create_parser_state(proc_tokens)
+        parser = create_parser_state(proc_tokens, diagnostic_sink)
 
         if (size(prefix_list) > 0) then
             proc_index = parse_subroutine_definition(parser, arena, prefix_buffer, &

--- a/src/frontend/frontend_statement_processing.f90
+++ b/src/frontend/frontend_statement_processing.f90
@@ -19,6 +19,7 @@ module frontend_statement_processing
         handle_multiple_program_units, &
         should_include_program_unit, &
         is_empty_main_program
+    use error_reporting, only: error_collection_t
 
     implicit none
     private
@@ -35,9 +36,10 @@ module frontend_statement_processing
 contains
 
     ! Parse all statements into a program block
-    function parse_all_statements(tokens, arena) result(prog_index)
+    function parse_all_statements(tokens, arena, diagnostic_sink) result(prog_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: prog_index
 
         integer, allocatable :: body_indices(:)
@@ -62,7 +64,7 @@ contains
             ! Check for structural contains keyword (implicit main program)
             if (is_structural_contains(tokens, stmt_start, stmt_end)) then
                 call parse_implicit_contains_section(tokens, stmt_end + 1, arena, &
-                    body_indices, i)
+                    body_indices, i, diagnostic_sink)
                 exit
             end if
 
@@ -98,10 +100,10 @@ contains
 
             if (tokens(stmt_start)%kind == TK_COMMENT) then
                 call process_comment_statement(tokens, stmt_start, arena, &
-                    prefix_buffer, stmt_index, body_indices)
+                    prefix_buffer, stmt_index, body_indices, diagnostic_sink)
             else
                 call process_regular_statement(tokens, stmt_start, stmt_end, arena, &
-                    prefix_buffer, stmt_index, body_indices)
+                    prefix_buffer, stmt_index, body_indices, diagnostic_sink)
             end if
 
             if (stmt_index > 0) then

--- a/src/frontend/frontend_statement_token_parsing.f90
+++ b/src/frontend/frontend_statement_token_parsing.f90
@@ -7,6 +7,7 @@ module frontend_statement_token_parsing
         get_last_parser_errors
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t
     use ast_arena_modern, only: ast_arena_t
+    use error_reporting, only: error_collection_t
 
     implicit none
     private
@@ -21,13 +22,14 @@ module frontend_statement_token_parsing
 contains
 
     subroutine process_comment_statement(tokens, i, arena, prefix_buffer, stmt_index, &
-            body_indices)
+            body_indices, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: i
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         integer, intent(out) :: stmt_index
         integer, allocatable, intent(inout) :: body_indices(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         type(token_t), allocatable, target :: stmt_tokens(:)
 
         allocate (stmt_tokens(2))
@@ -37,20 +39,22 @@ contains
         stmt_tokens(2)%line = tokens(i)%line
         stmt_tokens(2)%column = tokens(i)%column + len(tokens(i)%text)
 
-        stmt_index = parse_statement_dispatcher(stmt_tokens, arena, prefix_buffer)
+        stmt_index = parse_statement_dispatcher(stmt_tokens, arena, prefix_buffer, &
+            diagnostic_sink)
         if (stmt_index > 0) then
             body_indices = [body_indices, stmt_index]
         end if
     end subroutine process_comment_statement
 
     subroutine process_regular_statement(tokens, stmt_start, stmt_end, arena, &
-            prefix_buffer, stmt_index, body_indices)
+            prefix_buffer, stmt_index, body_indices, diagnostic_sink)
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: stmt_start, stmt_end
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         integer, intent(out) :: stmt_index
         integer, allocatable, intent(inout) :: body_indices(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         type(token_t), allocatable, target :: stmt_tokens(:)
         integer :: effective_start
 
@@ -65,7 +69,7 @@ contains
         call capture_trailing_comment(stmt_tokens, arena, 0)
         call strip_trailing_comment_from_tokens(stmt_tokens)
         call parse_statement_tokens_with_optional_label(stmt_tokens, arena, &
-            prefix_buffer, stmt_index)
+            prefix_buffer, stmt_index, diagnostic_sink)
         if (stmt_index <= 0) return
 
         call attach_captured_trailing_comment(arena, stmt_index)
@@ -134,11 +138,12 @@ contains
     end subroutine build_statement_tokens
 
     subroutine parse_statement_tokens_with_optional_label(stmt_tokens, arena, &
-            prefix_buffer, stmt_index)
+            prefix_buffer, stmt_index, diagnostic_sink)
         type(token_t), allocatable, intent(inout), target :: stmt_tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         integer, intent(out) :: stmt_index
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         character(len=:), allocatable :: stmt_label
         integer :: label_end_idx, i
         type(token_t), allocatable :: tokens_without_label(:)
@@ -159,7 +164,8 @@ contains
             call move_alloc(tokens_without_label, stmt_tokens)
         end if
 
-        stmt_index = parse_statement_dispatcher(stmt_tokens, arena, prefix_buffer)
+        stmt_index = parse_statement_dispatcher(stmt_tokens, arena, prefix_buffer, &
+            diagnostic_sink)
         if (stmt_index <= 0 .or. .not. allocated(stmt_label)) return
 
         if (stmt_index <= arena%size) then
@@ -180,20 +186,16 @@ contains
         call clear_additional_indices()
     end subroutine append_additional_indices_from_dispatcher
 
-    function parse_explicit_program_unit(tokens, arena, error_msg) result(prog_index)
+    function parse_explicit_program_unit(tokens, arena, error_msg, diagnostic_sink) &
+            result(prog_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         character(len=:), allocatable, intent(out), optional :: error_msg
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: prog_index
         type(parser_prefix_buffer_t) :: prefix_buffer
-        character(len=:), allocatable :: errors
-
-        prog_index = parse_statement_dispatcher(tokens, arena, prefix_buffer)
-
-        if (present(error_msg)) then
-            errors = get_last_parser_errors()
-            error_msg = errors
-        end if
+        prog_index = parse_statement_dispatcher(tokens, arena, prefix_buffer, &
+            diagnostic_sink, error_msg)
     end function parse_explicit_program_unit
 
     logical function is_prefix_only_statement(tokens, start_idx, end_idx) &

--- a/src/frontend_parsing.f90
+++ b/src/frontend_parsing.f90
@@ -18,6 +18,7 @@ module frontend_parsing
         mixed_construct_result_t, &
         is_top_level_declaration
     use error_handling, only: result_t
+    use error_reporting, only: error_collection_t, error_record_t
     use parser_dispatcher_module, only: clear_parser_errors
 
     ! Import from split modules
@@ -85,11 +86,12 @@ contains
     end function create_multi_unit_container
 
     ! Main parsing entry point
-    subroutine parse_tokens(tokens, arena, prog_index, error_msg)
+    subroutine parse_tokens(tokens, arena, prog_index, error_msg, parser_errors)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(out) :: prog_index
         character(len=*), intent(out) :: error_msg
+        type(error_record_t), allocatable, intent(out), optional :: parser_errors(:)
 
         type(mixed_construct_result_t) :: mixed_result
         logical :: has_explicit_program
@@ -98,6 +100,7 @@ contains
         type(token_t), allocatable :: tokens_local(:)
         character(len=:), allocatable :: nested_error
         character(len=:), allocatable :: unit_error
+        type(error_collection_t), target :: diagnostics
 
         error_msg = ""
         prog_index = 0
@@ -112,18 +115,20 @@ contains
         call detect_mixed_constructs(tokens_local, mixed_result)
         if (should_use_mixed_constructs(tokens_local, mixed_result)) then
             call parse_mixed_construct_file(tokens_local, arena, mixed_result, &
-                prog_index, error_msg)
+                prog_index, error_msg, diagnostics)
+            call export_parser_errors(diagnostics, parser_errors)
             return
         end if
 
         has_explicit_program = detect_explicit_program_unit(tokens_local)
         call collect_program_units(tokens_local, arena, has_explicit_program, &
-            debug_units, unit_indices, unit_error)
+            debug_units, unit_indices, unit_error, diagnostics)
 
         if (allocated(unit_error)) then
             if (len_trim(unit_error) > 0) then
                 error_msg = trim(unit_error)
                 prog_index = 0
+                call export_parser_errors(diagnostics, parser_errors)
                 return
             end if
         end if
@@ -136,11 +141,13 @@ contains
                 error_msg = 'Nested internal procedures are not supported.'
             end if
             prog_index = 0
+            call export_parser_errors(diagnostics, parser_errors)
             return
         end if
 
         if (.not. allocated(unit_indices)) allocate (unit_indices(0))
         call finalize_program_result(arena, unit_indices, prog_index, error_msg)
+        call export_parser_errors(diagnostics, parser_errors)
     end subroutine parse_tokens
 
     ! Safe parsing wrapper
@@ -192,31 +199,33 @@ contains
     end function should_use_mixed_constructs
 
     subroutine parse_mixed_construct_file(tokens, arena, mixed_result, prog_index, &
-            error_msg)
+            error_msg, diagnostics)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         type(mixed_construct_result_t), intent(in) :: mixed_result
         integer, intent(out) :: prog_index
         character(len=*), intent(inout) :: error_msg
+        type(error_collection_t), target, intent(inout) :: diagnostics
 
         character(len=500) :: mixed_error
 
         mixed_error = ""
         call parse_mixed_constructs(tokens, arena, mixed_result, prog_index, &
-            mixed_error)
+            mixed_error, diagnostics)
         if (len_trim(mixed_error) > 0) then
             error_msg = trim(mixed_error)
         end if
     end subroutine parse_mixed_construct_file
 
     subroutine collect_program_units(tokens, arena, has_explicit_program, &
-            debug_units, unit_indices, unit_error)
+            debug_units, unit_indices, unit_error, diagnostics)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         logical, intent(in) :: has_explicit_program
         logical, intent(in) :: debug_units
         integer, allocatable, intent(out) :: unit_indices(:)
         character(len=:), allocatable, intent(out) :: unit_error
+        type(error_collection_t), target, intent(inout) :: diagnostics
 
         integer :: i
         integer :: unit_start
@@ -238,7 +247,7 @@ contains
 
             local_error = ""
             call process_program_unit(tokens, unit_start, unit_end, arena, &
-                unit_index, has_explicit_program, local_error)
+                unit_index, has_explicit_program, local_error, diagnostics)
 
             if (debug_units) then
                 call log_unit_bounds(tokens, unit_start, unit_end, unit_index)
@@ -257,6 +266,17 @@ contains
             i = unit_end + 1
         end do
     end subroutine collect_program_units
+
+    subroutine export_parser_errors(diagnostics, parser_errors)
+        type(error_collection_t), intent(in) :: diagnostics
+        type(error_record_t), allocatable, intent(out), optional :: parser_errors(:)
+
+        if (.not. present(parser_errors)) return
+        allocate (parser_errors(diagnostics%count))
+        if (diagnostics%count > 0) then
+            parser_errors = diagnostics%errors(1:diagnostics%count)
+        end if
+    end subroutine export_parser_errors
 
     subroutine log_unit_bounds(tokens, unit_start, unit_end, unit_index)
         use, intrinsic :: iso_fortran_env, only: error_unit

--- a/src/parser/control_flow/parser_do_constructs_part1.inc
+++ b/src/parser/control_flow/parser_do_constructs_part1.inc
@@ -875,7 +875,8 @@
 
                         stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
                                                                   loop_index, &
-                                                                  callbacks)
+                                                                  callbacks, &
+                                                                  parent_parser=parser)
 
                         do k = 1, size(stmt_indices)
                             if (stmt_indices(k) > 0) then

--- a/src/parser/control_flow/parser_do_constructs_part2.inc
+++ b/src/parser/control_flow/parser_do_constructs_part2.inc
@@ -132,7 +132,8 @@
 
                         stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
                                                                   loop_index, &
-                                                                  callbacks)
+                                                                  callbacks, &
+                                                                  parent_parser=parser)
 
                         do n = 1, size(stmt_indices)
                             if (stmt_indices(n) > 0) then

--- a/src/parser/control_flow/parser_forall.f90
+++ b/src/parser/control_flow/parser_forall.f90
@@ -431,7 +431,7 @@ contains
         stmt_tokens(token_count + 1)%column = parser%tokens(end_idx)%column + 1
 
         stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
-            callbacks=callbacks)
+            callbacks=callbacks, parent_parser=parser)
         if (allocated(stmt_indices)) then
             do k = 1, size(stmt_indices)
                 if (stmt_indices(k) > 0) body_indices = [body_indices, stmt_indices(k)]

--- a/src/parser/control_flow/parser_if_body.f90
+++ b/src/parser/control_flow/parser_if_body.f90
@@ -140,11 +140,11 @@ contains
             stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
                 parent_index=parent_index, &
                 callbacks=callbacks, &
-                consumed_count=consumed_tokens)
+                consumed_count=consumed_tokens, parent_parser=parser)
         else
             stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
                 callbacks=callbacks, &
-                consumed_count=consumed_tokens)
+                consumed_count=consumed_tokens, parent_parser=parser)
         end if
 
         if (allocated(stmt_indices) .and. size(stmt_indices) > 0) then

--- a/src/parser/control_flow/parser_if_constructs.f90
+++ b/src/parser/control_flow/parser_if_constructs.f90
@@ -378,7 +378,7 @@ contains
         allocate (remaining_tokens(n))
         remaining_tokens = parser%tokens(parser%current_token:)
 
-        condition_index = parse_expression(remaining_tokens, arena)
+        condition_index = parse_expression(remaining_tokens, arena, parser)
 
         do while (.not. parser%is_at_end())
             paren_token = parser%peek()
@@ -431,7 +431,7 @@ contains
         allocate (remaining_tokens(n))
         remaining_tokens = parser%tokens(parser%current_token:)
 
-        condition_index = parse_expression(remaining_tokens, arena)
+        condition_index = parse_expression(remaining_tokens, arena, parser)
 
         do while (.not. parser%is_at_end())
             paren_token = parser%peek()

--- a/src/parser/control_flow/parser_if_inline.f90
+++ b/src/parser/control_flow/parser_if_inline.f90
@@ -212,7 +212,7 @@ contains
                 stmt_start, stmt_end)
 
             stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
-                callbacks=callbacks)
+                callbacks=callbacks, parent_parser=parser)
             if (allocated(stmt_indices)) then
                 if (size(stmt_indices) > 0 .and. stmt_indices(1) > 0) then
                     then_body_indices(1) = stmt_indices(1)

--- a/src/parser/control_flow/parser_if_statements.f90
+++ b/src/parser/control_flow/parser_if_statements.f90
@@ -6,6 +6,7 @@ module parser_if_statements_module
     use parser_statement_utilities_module, only: parse_statement_in_if_block
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_if
+    use error_reporting, only: error_collection_t
     implicit none
     private
 
@@ -13,9 +14,11 @@ module parser_if_statements_module
 
 contains
 
-    function parse_if_statement_tokens(stmt_tokens, arena) result(if_index)
+    function parse_if_statement_tokens(stmt_tokens, arena, diagnostic_sink) &
+            result(if_index)
         type(token_t), intent(in) :: stmt_tokens(:)
         type(ast_arena_t), intent(inout) :: arena
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: if_index
         integer :: token_count
         integer :: then_pos, else_pos, end_pos
@@ -36,12 +39,13 @@ contains
             return
         end if
 
-        condition_index = build_if_condition(stmt_tokens, then_pos, arena)
+        condition_index = build_if_condition(stmt_tokens, then_pos, arena, &
+            diagnostic_sink)
 
         call parse_then_branch(stmt_tokens, then_pos, else_pos, end_pos, arena, &
-            then_body_indices)
+            then_body_indices, diagnostic_sink)
         call parse_else_branch(stmt_tokens, else_pos, end_pos, arena, &
-            else_body_indices)
+            else_body_indices, diagnostic_sink)
 
         if_index = push_if(arena, condition_index, then_body_indices, &
             else_body_indices=else_body_indices, &
@@ -83,11 +87,13 @@ contains
         end do
     end subroutine locate_if_statement_sections
 
-    integer function build_if_condition(stmt_tokens, then_pos, arena) &
+    integer function build_if_condition(stmt_tokens, then_pos, arena, &
+            diagnostic_sink) &
             result(condition_index)
         type(token_t), intent(in) :: stmt_tokens(:)
         integer, intent(in) :: then_pos
         type(ast_arena_t), intent(inout) :: arena
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         integer :: condition_length
         type(token_t), allocatable, target :: condition_tokens(:)
@@ -104,16 +110,17 @@ contains
         condition_tokens(condition_length + 1)%line = stmt_tokens(2)%line
         condition_tokens(condition_length + 1)%column = stmt_tokens(2)%column
 
-        condition_parser = create_parser_state(condition_tokens)
+        condition_parser = create_parser_state(condition_tokens, diagnostic_sink)
         condition_index = parse_range(condition_parser, arena)
     end function build_if_condition
 
     subroutine parse_then_branch(stmt_tokens, then_pos, else_pos, end_pos, arena, &
-            then_body_indices)
+            then_body_indices, diagnostic_sink)
         type(token_t), intent(in) :: stmt_tokens(:)
         integer, intent(in) :: then_pos, else_pos, end_pos
         type(ast_arena_t), intent(inout) :: arena
         integer, allocatable, intent(out) :: then_body_indices(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         integer :: then_start, then_end
 
@@ -125,15 +132,16 @@ contains
         end if
 
         then_body_indices = parse_if_body_tokens(stmt_tokens, then_start, &
-            then_end, arena)
+            then_end, arena, diagnostic_sink)
     end subroutine parse_then_branch
 
     subroutine parse_else_branch(stmt_tokens, else_pos, end_pos, arena, &
-            else_body_indices)
+            else_body_indices, diagnostic_sink)
         type(token_t), intent(in) :: stmt_tokens(:)
         integer, intent(in) :: else_pos, end_pos
         type(ast_arena_t), intent(inout) :: arena
         integer, allocatable, intent(out) :: else_body_indices(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         integer :: else_start, else_end
 
@@ -145,14 +153,16 @@ contains
         else_start = else_pos + 1
         else_end = end_pos - 1
         else_body_indices = parse_if_body_tokens(stmt_tokens, else_start, &
-            else_end, arena)
+            else_end, arena, diagnostic_sink)
     end subroutine parse_else_branch
 
-    function parse_if_body_tokens(stmt_tokens, start_idx, end_idx, arena) &
+    function parse_if_body_tokens(stmt_tokens, start_idx, end_idx, arena, &
+            diagnostic_sink) &
             result(body_indices)
         type(token_t), intent(in) :: stmt_tokens(:)
         integer, intent(in) :: start_idx, end_idx
         type(ast_arena_t), intent(inout) :: arena
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer, allocatable :: body_indices(:)
 
         type(token_t), allocatable, target :: body_tokens(:)
@@ -163,7 +173,8 @@ contains
         end if
 
         call allocate_if_body_tokens(stmt_tokens, start_idx, end_idx, body_tokens)
-        call parse_if_body_statements(body_tokens, arena, body_indices)
+        call parse_if_body_statements(body_tokens, arena, body_indices, &
+            diagnostic_sink)
     end function parse_if_body_tokens
 
     subroutine allocate_if_body_tokens(stmt_tokens, start_idx, end_idx, body_tokens)
@@ -187,10 +198,12 @@ contains
         body_tokens(body_len + 1)%column = stmt_tokens(start_idx)%column
     end subroutine allocate_if_body_tokens
 
-    subroutine parse_if_body_statements(body_tokens, arena, body_indices)
+    subroutine parse_if_body_statements(body_tokens, arena, body_indices, &
+            diagnostic_sink)
         type(token_t), intent(in) :: body_tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, allocatable, intent(out) :: body_indices(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         type(parser_state_t) :: body_parser
         integer :: stmt_start, stmt_end
@@ -202,7 +215,7 @@ contains
             return
         end if
 
-        body_parser = create_parser_state(body_tokens)
+        body_parser = create_parser_state(body_tokens, diagnostic_sink)
 
         ! Pre-allocate with initial capacity to avoid O(n²) growth
         capacity = 64
@@ -215,7 +228,7 @@ contains
             stmt_start = body_parser%current_token
             stmt_end = find_if_body_line_end(body_tokens, stmt_start)
             call parse_if_body_line_efficient(body_tokens, stmt_start, stmt_end, &
-                arena, body_indices, count, capacity)
+                arena, body_indices, count, capacity, diagnostic_sink)
             body_parser%current_token = stmt_end + 1
         end do
 
@@ -265,12 +278,13 @@ contains
     end function find_if_body_line_end
 
     subroutine parse_if_body_line_efficient(body_tokens, stmt_start, stmt_end, &
-            arena, body_indices, count, capacity)
+            arena, body_indices, count, capacity, diagnostic_sink)
         type(token_t), intent(in) :: body_tokens(:)
         integer, intent(in) :: stmt_start, stmt_end
         type(ast_arena_t), intent(inout) :: arena
         integer, allocatable, intent(inout) :: body_indices(:)
         integer, intent(inout) :: count, capacity
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
 
         type(token_t), allocatable, target :: line_tokens(:)
         type(parser_state_t) :: line_parser
@@ -288,7 +302,7 @@ contains
         line_tokens(stmt_size + 1)%line = body_tokens(stmt_start)%line
         line_tokens(stmt_size + 1)%column = body_tokens(stmt_start)%column
 
-        line_parser = create_parser_state(line_tokens)
+        line_parser = create_parser_state(line_tokens, diagnostic_sink)
         call skip_if_body_line_padding(line_parser)
 
         if (.not. line_parser%is_at_end()) then

--- a/src/parser/control_flow/parser_select_constructs_helpers.inc
+++ b/src/parser/control_flow/parser_select_constructs_helpers.inc
@@ -169,6 +169,9 @@
         tokens_buffer(buffer_len)%column = parser%tokens(end_pos)%column
 
         sub_parser = create_parser_state(tokens_buffer)
+        if (associated(parser%diagnostic_sink)) then
+            sub_parser%diagnostic_sink => parser%diagnostic_sink
+        end if
 
         success = .true.
 

--- a/src/parser/core/parser_dispatcher.f90
+++ b/src/parser/core/parser_dispatcher.f90
@@ -62,6 +62,7 @@ module parser_dispatcher_module
     use parser_assignment_module, only: parse_assignment_statement
     use parser_expressions_module, only: parse_expression
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t, append_prefix_token
+    use error_reporting, only: error_collection_t
     implicit none
     private
 

--- a/src/parser/core/parser_dispatcher_part1.inc
+++ b/src/parser/core/parser_dispatcher_part1.inc
@@ -1,16 +1,25 @@
 
     ! Parse a statement by dispatching to appropriate parsing module
-    function parse_statement_dispatcher(tokens, arena, prefix_buffer) &
+    function parse_statement_dispatcher(tokens, arena, prefix_buffer, &
+            diagnostic_sink, error_msg) &
         result(stmt_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
+        character(len=:), allocatable, intent(out), optional :: error_msg
         integer :: stmt_index
         type(parser_state_t) :: parser
         type(token_t) :: first_token
 
+        if (present(error_msg)) error_msg = ""
+
         call init_interface_procedure_parser()
-        parser = create_parser_state(tokens)
+        if (present(diagnostic_sink)) then
+            parser = create_parser_state(tokens, diagnostic_sink)
+        else
+            parser = create_parser_state(tokens)
+        end if
         first_token = parser%peek()
 
         select case (first_token%kind)
@@ -28,10 +37,11 @@
         case (TK_NEWLINE)
             stmt_index = parse_blank_line(parser, arena)
         case default
-            stmt_index = parse_as_expression(tokens, arena)
+            stmt_index = parse_as_expression(tokens, arena, parser)
         end select
 
         if (parser%has_errors()) then
+            if (present(error_msg)) error_msg = parser%get_error_messages()
             last_parser_errors = parser%get_error_messages()
         end if
     end function parse_statement_dispatcher
@@ -61,7 +71,7 @@
                                       lowered_keyword, stmt_index)) return
         if (.not. try_handle_prefix_sequence(parser, arena, prefix_buffer, &
                                              stmt_index)) then
-            stmt_index = parse_as_expression(tokens, arena)
+            stmt_index = parse_as_expression(tokens, arena, parser)
         end if
     end subroutine dispatch_keyword
 
@@ -620,7 +630,7 @@
         else
             if (.not. try_handle_prefix_sequence(parser, arena, prefix_buffer, &
                                                  stmt_index)) then
-                stmt_index = parse_as_expression(tokens, arena)
+                stmt_index = parse_as_expression(tokens, arena, parser)
             end if
         end if
     end subroutine dispatch_number_token
@@ -762,16 +772,17 @@
             stmt_index = parse_function_definition(parser, arena, prefix_buffer)
             return
         end if
-        stmt_index = parse_as_expression(parser%tokens, arena)
+        stmt_index = parse_as_expression(parser%tokens, arena, parser)
     end function parse_function_or_expression
 
     ! Parse as expression
-    function parse_as_expression(tokens, arena) result(stmt_index)
+    function parse_as_expression(tokens, arena, parent_parser) result(stmt_index)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
+        type(parser_state_t), intent(in) :: parent_parser
         integer :: stmt_index
 
-        stmt_index = parse_expression(tokens, arena)
+        stmt_index = parse_expression(tokens, arena, parent_parser)
     end function parse_as_expression
 
     ! Helper function to check for double colon

--- a/src/parser/core/parser_inline_instantiation.f90
+++ b/src/parser/core/parser_inline_instantiation.f90
@@ -63,7 +63,7 @@ contains
 
         token = peek(parser, view)
         if (token%kind /= TK_OPERATOR .or. token%text /= "(") then
-            call parser%errors%add_error_with_token( &
+            call parser%error_at_token( &
                 "Caret inline instantiation must be followed by ( ...)", &
                 caret_token, suggestion="Use name^(type-list)(...)")
             return
@@ -110,7 +110,7 @@ contains
 
         if (nesting /= 0) then
             count = 0
-            call parser%errors%add_error_with_token( &
+            call parser%error_at_token( &
                 "Unbalanced inline instantiation "//group_name//": expected "// &
                 close_ch//" before end of file", start_token, &
                 suggestion="Add a matching "//close_ch// &

--- a/src/parser/core/parser_state.f90
+++ b/src/parser/core/parser_state.f90
@@ -17,6 +17,7 @@ module parser_state_module
         integer :: current_token = 1
         integer :: generation = 1 ! Generation for lifecycle tracking
         type(error_collection_t) :: errors
+        type(error_collection_t), pointer :: diagnostic_sink => null()
     contains
         procedure :: peek => parser_peek
         procedure :: consume => parser_consume
@@ -24,6 +25,7 @@ module parser_state_module
         procedure :: match => parser_match
         procedure :: expect => parser_expect
         procedure :: error => parser_add_error
+        procedure :: error_at_token => parser_add_error_at_token
         procedure :: has_errors => parser_has_errors
         procedure :: get_error_messages => parser_get_error_messages
 
@@ -42,8 +44,9 @@ module parser_state_module
 contains
 
     ! Create parser state from tokens (view into caller-owned buffer)
-    function create_parser_state(tokens) result(state)
+    function create_parser_state(tokens, diagnostic_sink) result(state)
         type(token_t), target, intent(in) :: tokens(:)
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         type(parser_state_t) :: state
 
         if (size(tokens) > 0) then
@@ -54,6 +57,7 @@ contains
         state%current_token = 1
         state%owns_tokens = .false.
         state%generation = 1
+        if (present(diagnostic_sink)) state%diagnostic_sink => diagnostic_sink
     end function create_parser_state
 
     ! Peek at current token without consuming it
@@ -127,7 +131,7 @@ contains
             else
                 msg = "Unexpected token"
             end if
-            call this%errors%add_error_with_token(msg, current)
+            call this%error_at_token(msg, current)
         end if
     end function parser_expect
 
@@ -139,8 +143,21 @@ contains
         type(token_t) :: current
 
         current = this%peek()
-        call this%errors%add_error_with_token(message, current, suggestion=suggestion)
+        call this%error_at_token(message, current, suggestion)
     end subroutine parser_add_error
+
+    subroutine parser_add_error_at_token(this, message, token, suggestion)
+        class(parser_state_t), intent(inout) :: this
+        character(len=*), intent(in) :: message
+        type(token_t), intent(in) :: token
+        character(len=*), intent(in), optional :: suggestion
+
+        call this%errors%add_error_with_token(message, token, suggestion=suggestion)
+        if (associated(this%diagnostic_sink)) then
+            call this%diagnostic_sink%add_error_with_token(message, token, &
+                suggestion=suggestion)
+        end if
+    end subroutine parser_add_error_at_token
 
     ! Check if parser has any errors
     logical function parser_has_errors(this)
@@ -171,6 +188,7 @@ contains
             end if
         end if
         this%owns_tokens = .false.
+        nullify (this%diagnostic_sink)
 
         ! Reset position
         this%current_token = 1
@@ -216,6 +234,11 @@ contains
         lhs%current_token = rhs%current_token
         lhs%generation = rhs%generation
         lhs%errors = rhs%errors
+        if (associated(rhs%diagnostic_sink)) then
+            lhs%diagnostic_sink => rhs%diagnostic_sink
+        else
+            nullify (lhs%diagnostic_sink)
+        end if
 
         if (associated(rhs%tokens)) then
             if (rhs%owns_tokens) then

--- a/src/parser/declarations/parser_declarations_type_spec_module.f90
+++ b/src/parser/declarations/parser_declarations_type_spec_module.f90
@@ -120,7 +120,8 @@ contains
 
         call gather_derived_type_tokens(parser, collected_tokens)
         if (allocated(collected_tokens)) then
-            call analyze_derived_type_tokens(type_spec, collected_tokens, arena)
+            call analyze_derived_type_tokens(type_spec, collected_tokens, arena, &
+                parser)
             derived_text = tokens_to_text(collected_tokens)
             call move_alloc(collected_tokens, type_spec%derived_type_tokens)
         else

--- a/src/parser/declarations/parser_parameter_statements_module.f90
+++ b/src/parser/declarations/parser_parameter_statements_module.f90
@@ -125,7 +125,7 @@ contains
         expr_tokens(tok_count + 1)%kind = 0
         expr_tokens(tok_count + 1)%text = ""
 
-        value_index = parse_expression(expr_tokens, arena)
+        value_index = parse_expression(expr_tokens, arena, parser)
         if (value_index <= 0) return
 
         applied = apply_parameter_to_variable(arena, var_name, value_index)

--- a/src/parser/declarations/parser_type_spec_result_mod.f90
+++ b/src/parser/declarations/parser_type_spec_result_mod.f90
@@ -227,10 +227,11 @@ contains
         end if
     end subroutine set_derived_type_name_info
 
-    subroutine parse_single_parameter(current, type_spec, arena)
+    subroutine parse_single_parameter(current, type_spec, arena, parent_parser)
         type(token_t), allocatable, intent(in) :: current(:)
         type(type_specifier_t), intent(inout) :: type_spec
         type(ast_arena_t), intent(inout) :: arena
+        type(parser_state_t), intent(in) :: parent_parser
         type(token_t), allocatable :: cleaned(:)
         type(token_t), allocatable :: parser_tokens(:)
         type(token_t) :: eof_token
@@ -248,6 +249,9 @@ contains
         parser_tokens(size(cleaned) + 1) = eof_token
 
         param_parser = create_parser_state(parser_tokens)
+        if (associated(parent_parser%diagnostic_sink)) then
+            param_parser%diagnostic_sink => parent_parser%diagnostic_sink
+        end if
         expr_index = parse_comparison(param_parser, arena)
         if (expr_index > 0) then
             call append_int(type_spec%derived_parameter_nodes, expr_index)
@@ -260,10 +264,11 @@ contains
         end block
     end subroutine parse_single_parameter
 
-    subroutine split_parameters(working, type_spec, arena)
+    subroutine split_parameters(working, type_spec, arena, parent_parser)
         type(token_t), allocatable, intent(in) :: working(:)
         type(type_specifier_t), intent(inout) :: type_spec
         type(ast_arena_t), intent(inout) :: arena
+        type(parser_state_t), intent(in) :: parent_parser
         type(token_t), allocatable :: current(:)
         integer :: depth
         integer :: i
@@ -278,7 +283,8 @@ contains
                     if (depth > 0) depth = depth - 1
                 case (",")
                     if (depth == 0) then
-                        call parse_single_parameter(current, type_spec, arena)
+                        call parse_single_parameter(current, type_spec, arena, &
+                            parent_parser)
                         if (allocated(current)) then
                             block
                                 type(token_t), allocatable :: temp(:)
@@ -291,7 +297,7 @@ contains
             end if
             call append_token(current, working(i))
         end do
-        call parse_single_parameter(current, type_spec, arena)
+        call parse_single_parameter(current, type_spec, arena, parent_parser)
         if (allocated(current)) then
             block
                 type(token_t), allocatable :: temp(:)
@@ -300,10 +306,12 @@ contains
         end if
     end subroutine split_parameters
 
-    subroutine process_derived_type_parameters(type_spec, param_tokens, arena)
+    subroutine process_derived_type_parameters(type_spec, param_tokens, arena, &
+            parent_parser)
         type(type_specifier_t), intent(inout) :: type_spec
         type(token_t), allocatable, intent(in) :: param_tokens(:)
         type(ast_arena_t), intent(inout) :: arena
+        type(parser_state_t), intent(in) :: parent_parser
         type(token_t), allocatable :: working(:)
         type(token_t), allocatable :: trimmed_working(:)
 
@@ -324,7 +332,7 @@ contains
             end block
         end if
 
-        call split_parameters(working, type_spec, arena)
+        call split_parameters(working, type_spec, arena, parent_parser)
 
         if (allocated(type_spec%derived_parameter_nodes)) then
             type_spec%has_derived_type_parameters = &
@@ -334,10 +342,11 @@ contains
         end if
     end subroutine process_derived_type_parameters
 
-    subroutine analyze_derived_type_tokens(type_spec, tokens, arena)
+    subroutine analyze_derived_type_tokens(type_spec, tokens, arena, parent_parser)
         type(type_specifier_t), intent(inout) :: type_spec
         type(token_t), allocatable, intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
+        type(parser_state_t), intent(in) :: parent_parser
         type(token_t), allocatable :: name_tokens(:)
         type(token_t), allocatable :: param_tokens(:)
 
@@ -358,7 +367,8 @@ contains
             end if
             return
         end if
-        call process_derived_type_parameters(type_spec, param_tokens, arena)
+        call process_derived_type_parameters(type_spec, param_tokens, arena, &
+            parent_parser)
 
         if (allocated(type_spec%derived_parameter_tokens)) then
             block

--- a/src/parser/expressions/parser_array_constructs.f90
+++ b/src/parser/expressions/parser_array_constructs.f90
@@ -283,7 +283,7 @@ contains
             stmt_start, stmt_end)
 
         stmt_indices = parse_basic_statement_core(stmt_tokens, arena, &
-            callbacks=callbacks)
+            callbacks=callbacks, parent_parser=parser)
 
         if (allocated(stmt_indices)) then
             call move_alloc(stmt_indices, body_indices)
@@ -374,7 +374,7 @@ contains
 
                 ! Parse expression
                 expr_index = parse_expression( &
-                    parser%tokens(parser%current_token:), arena)
+                    parser%tokens(parser%current_token:), arena, parser)
                 if (expr_index <= 0) then
                     if (allocated(body_indices)) then
                         block
@@ -506,7 +506,7 @@ contains
                 callbacks = build_associate_callbacks()
                 stmt_indices = parse_basic_statement_core( &
                     stmt_tokens, arena, callbacks=callbacks, &
-                    consumed_count=consumed_tokens)
+                    consumed_count=consumed_tokens, parent_parser=parser)
 
                 if (allocated(stmt_indices) .and. size(stmt_indices) > 0) then
                     do k = 1, size(stmt_indices)

--- a/src/parser/expressions/parser_assignment.f90
+++ b/src/parser/expressions/parser_assignment.f90
@@ -124,6 +124,9 @@ contains
                         lhs_tokens(lhs_len)%column = id_token%column
 
                         lhs_parser = create_parser_state(lhs_tokens)
+                        if (associated(parser%diagnostic_sink)) then
+                            lhs_parser%diagnostic_sink => parser%diagnostic_sink
+                        end if
                         target_index = parse_range(lhs_parser, arena)
                     end block
 

--- a/src/parser/expressions/parser_expressions.f90
+++ b/src/parser/expressions/parser_expressions.f90
@@ -643,13 +643,19 @@ end function parse_expression_with_precedence
 !=================================================================================
 
 ! Main expression parsing entry point with stack
-function parse_expression(tokens, arena) result(expr_index)
+function parse_expression(tokens, arena, parent_parser) result(expr_index)
     type(token_t), intent(in) :: tokens(:)
     type(ast_arena_t), intent(inout) :: arena
+    type(parser_state_t), intent(in), optional :: parent_parser
     integer :: expr_index
     type(parser_state_t) :: parser
 
     parser = create_parser_state(tokens)
+    if (present(parent_parser)) then
+        if (associated(parent_parser%diagnostic_sink)) then
+            parser%diagnostic_sink => parent_parser%diagnostic_sink
+        end if
+    end if
     expr_index = parse_range(parser, arena)
 end function parse_expression
 

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -472,7 +472,7 @@ contains
         call maybe_mark_recursive_from_body(stmt_tokens, stmt_size, procedure_name, &
             infer_recursive_flag)
 
-        stmt_index = parse_body_statement_tokens(stmt_tokens, stmt_size, arena)
+        stmt_index = parse_body_statement_tokens(stmt_tokens, stmt_size, arena, parser)
 
         parser%current_token = stmt_end + 1
     end subroutine parse_body_statement
@@ -552,11 +552,13 @@ contains
         end do
     end subroutine maybe_mark_recursive_from_body
 
-    integer function parse_body_statement_tokens(stmt_tokens, stmt_size, arena) &
+    integer function parse_body_statement_tokens(stmt_tokens, stmt_size, arena, &
+            parent_parser) &
             result(stmt_index)
         type(token_t), intent(in) :: stmt_tokens(:)
         integer, intent(in) :: stmt_size
         type(ast_arena_t), intent(inout) :: arena
+        type(parser_state_t), intent(in) :: parent_parser
         integer :: first_token
         character(len=:), allocatable :: token_lower
         type(parser_state_t) :: block_parser
@@ -577,16 +579,31 @@ contains
             if (stmt_tokens(first_token)%kind == TK_KEYWORD) then
                 token_lower = to_lower(stmt_tokens(first_token)%text)
                 if (trim(token_lower) == "if") then
-                    stmt_index = parse_if_statement_tokens(stmt_tokens, arena)
+                    if (associated(parent_parser%diagnostic_sink)) then
+                        stmt_index = parse_if_statement_tokens(stmt_tokens, arena, &
+                            parent_parser%diagnostic_sink)
+                    else
+                        stmt_index = parse_if_statement_tokens(stmt_tokens, arena)
+                    end if
                 else if (trim(token_lower) == "do") then
-                    stmt_index = parse_do_statement_tokens(stmt_tokens, arena)
+                    stmt_index = parse_do_statement_tokens(stmt_tokens, arena, &
+                        parent_parser)
                 else if (trim(token_lower) == "select") then
-                    stmt_index = parse_select_statement_tokens(stmt_tokens, arena)
+                    stmt_index = parse_select_statement_tokens(stmt_tokens, arena, &
+                        parent_parser)
                 else if (trim(token_lower) == "associate") then
                     block_parser = create_parser_state(stmt_tokens)
+                    if (associated(parent_parser%diagnostic_sink)) then
+                        block_parser%diagnostic_sink => &
+                            parent_parser%diagnostic_sink
+                    end if
                     stmt_index = parse_associate(block_parser, arena)
                 else if (trim(token_lower) == "block") then
                     block_parser = create_parser_state(stmt_tokens)
+                    if (associated(parent_parser%diagnostic_sink)) then
+                        block_parser%diagnostic_sink => &
+                            parent_parser%diagnostic_sink
+                    end if
                     stmt_index = parse_block_construct(block_parser, arena)
                 end if
             end if
@@ -594,6 +611,9 @@ contains
 
         if (stmt_index <= 0) then
             block_parser = create_parser_state(stmt_tokens)
+            if (associated(parent_parser%diagnostic_sink)) then
+                block_parser%diagnostic_sink => parent_parser%diagnostic_sink
+            end if
             do while (block_parser%current_token < first_token .and. &
                     .not. block_parser%is_at_end())
                 token = block_parser%consume()
@@ -608,28 +628,37 @@ contains
         end if
     end function parse_body_statement_tokens
 
-    integer function parse_do_statement_tokens(stmt_tokens, arena) result(do_index)
+    integer function parse_do_statement_tokens(stmt_tokens, arena, parent_parser) &
+            result(do_index)
         type(token_t), intent(in) :: stmt_tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         type(parser_state_t) :: do_parser
+        type(parser_state_t), intent(in) :: parent_parser
 
         ! Create a parser state from the tokens
         do_parser = create_parser_state(stmt_tokens)
+        if (associated(parent_parser%diagnostic_sink)) then
+            do_parser%diagnostic_sink => parent_parser%diagnostic_sink
+        end if
 
         ! Parse the DO loop using the existing DO loop parser
         do_index = parse_do_loop(do_parser, arena)
     end function parse_do_statement_tokens
 
-    integer function parse_select_statement_tokens(stmt_tokens, arena) &
+    integer function parse_select_statement_tokens(stmt_tokens, arena, parent_parser) &
             result(select_index)
         type(token_t), intent(in) :: stmt_tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         type(parser_state_t) :: select_parser
+        type(parser_state_t), intent(in) :: parent_parser
         type(token_t) :: next_token
         character(len=:), allocatable :: next_lower
 
         ! Create a parser state from the tokens
         select_parser = create_parser_state(stmt_tokens)
+        if (associated(parent_parser%diagnostic_sink)) then
+            select_parser%diagnostic_sink => parent_parser%diagnostic_sink
+        end if
 
         ! Consume SELECT keyword
         next_token = select_parser%consume()
@@ -653,14 +682,26 @@ contains
                 if (trim(next_lower) == "case") then
                     ! Reset parser to beginning and call parse_select_case
                     select_parser = create_parser_state(stmt_tokens)
+                    if (associated(parent_parser%diagnostic_sink)) then
+                        select_parser%diagnostic_sink => &
+                            parent_parser%diagnostic_sink
+                    end if
                     select_index = parse_select_case(select_parser, arena)
                 else if (trim(next_lower) == "type") then
                     ! Reset parser to beginning and call parse_select_type
                     select_parser = create_parser_state(stmt_tokens)
+                    if (associated(parent_parser%diagnostic_sink)) then
+                        select_parser%diagnostic_sink => &
+                            parent_parser%diagnostic_sink
+                    end if
                     select_index = parse_select_type(select_parser, arena)
                 else if (trim(next_lower) == "rank") then
                     ! Reset parser to beginning and call parse_select_rank
                     select_parser = create_parser_state(stmt_tokens)
+                    if (associated(parent_parser%diagnostic_sink)) then
+                        select_parser%diagnostic_sink => &
+                            parent_parser%diagnostic_sink
+                    end if
                     select_index = parse_select_rank(select_parser, arena)
                 else
                     select_index = 0

--- a/src/parser/procedures/parser_procedure_signatures.f90
+++ b/src/parser/procedures/parser_procedure_signatures.f90
@@ -380,7 +380,7 @@ contains
             end do
 
             if (nesting /= 0) then
-                call parser%errors%add_error_with_token( &
+                call parser%error_at_token( &
                     "Unbalanced inline instantiation braces", start_token, &
                     suggestion="Add matching }")
                 exit

--- a/src/parser/statements/parser_basic_statement_module.f90
+++ b/src/parser/statements/parser_basic_statement_module.f90
@@ -19,12 +19,13 @@ contains
 
     ! Parse basic statement with support for multi-variable declarations
     function parse_basic_statement_multi(tokens, arena, parent_index, callbacks, &
-            consumed_count) result(stmt_indices)
+            consumed_count, parent_parser) result(stmt_indices)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in), optional :: parent_index
         type(statement_callbacks_t), intent(in), optional :: callbacks
         integer, intent(out), optional :: consumed_count
+        type(parser_state_t), intent(in), optional :: parent_parser
         integer, allocatable :: stmt_indices(:)
         type(statement_callbacks_t) :: local_callbacks
 
@@ -39,20 +40,20 @@ contains
                 stmt_indices = parse_basic_statement_core( &
                     tokens, arena, parent_index=parent_index, &
                     callbacks=local_callbacks, &
-                    consumed_count=consumed_count)
+                    consumed_count=consumed_count, parent_parser=parent_parser)
             else
                 stmt_indices = parse_basic_statement_core( &
                     tokens, arena, parent_index=parent_index, &
-                    callbacks=local_callbacks)
+                    callbacks=local_callbacks, parent_parser=parent_parser)
             end if
         else
             if (present(consumed_count)) then
                 stmt_indices = parse_basic_statement_core( &
                     tokens, arena, callbacks=local_callbacks, &
-                    consumed_count=consumed_count)
+                    consumed_count=consumed_count, parent_parser=parent_parser)
             else
                 stmt_indices = parse_basic_statement_core(tokens, arena, &
-                    callbacks=local_callbacks)
+                    callbacks=local_callbacks, parent_parser=parent_parser)
             end if
         end if
     end function parse_basic_statement_multi
@@ -110,7 +111,7 @@ contains
                     stmt_tokens)
                 call parse_and_add_statement(stmt_tokens, arena, parent_index, &
                     local_callbacks, body_indices, &
-                    stmt_count)
+                    stmt_count, parser)
                 call release_statement_tokens(stmt_tokens)
 
                 parser%current_token = next_statement_start(parser%tokens, stmt_end)
@@ -241,23 +242,24 @@ contains
     end subroutine extract_statement_tokens
 
     subroutine parse_and_add_statement(stmt_tokens, arena, parent_index, &
-            callbacks, body_indices, stmt_count)
+            callbacks, body_indices, stmt_count, parent_parser)
         type(token_t), intent(in) :: stmt_tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in), optional :: parent_index
         type(statement_callbacks_t), intent(in) :: callbacks
         integer, allocatable, intent(inout) :: body_indices(:)
         integer, intent(inout) :: stmt_count
+        type(parser_state_t), intent(in) :: parent_parser
 
         integer, allocatable :: stmt_indices(:)
         integer :: k
 
         if (present(parent_index)) then
             stmt_indices = parse_basic_statement_multi(stmt_tokens, arena, &
-                parent_index, callbacks)
+                parent_index, callbacks, parent_parser=parent_parser)
         else
             stmt_indices = parse_basic_statement_multi(stmt_tokens, arena, &
-                callbacks=callbacks)
+                callbacks=callbacks, parent_parser=parent_parser)
         end if
 
         do k = 1, size(stmt_indices)

--- a/src/parser/statements/parser_statement_core.f90
+++ b/src/parser/statements/parser_statement_core.f90
@@ -48,13 +48,14 @@ module parser_statement_core_module
 
 contains
     recursive function parse_basic_statement_core(tokens, arena, parent_index, &
-            callbacks, consumed_count) &
+            callbacks, consumed_count, parent_parser) &
             result(stmt_indices)
         type(token_t), intent(in) :: tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in), optional :: parent_index
         type(statement_callbacks_t), intent(in), optional :: callbacks
         integer, intent(out), optional :: consumed_count
+        type(parser_state_t), intent(in), optional :: parent_parser
         integer, allocatable :: stmt_indices(:)
         type(parser_state_t) :: parser
         type(token_t) :: first_token
@@ -69,6 +70,11 @@ contains
         end if
 
         parser = create_parser_state(tokens)
+        if (present(parent_parser)) then
+            if (associated(parent_parser%diagnostic_sink)) then
+                parser%diagnostic_sink => parent_parser%diagnostic_sink
+            end if
+        end if
         first_token = parser%peek()
         handled = try_handle_declaration(parser, arena, first_token, stmt_indices)
         if (handled) then
@@ -527,7 +533,7 @@ contains
 
         allocate (expr_tokens(remaining_count))
         expr_tokens = tokens(parser%current_token:)
-        value_index = parse_expression(expr_tokens, arena)
+        value_index = parse_expression(expr_tokens, arena, parser)
         if (value_index <= 0) return
 
         if (present(parent_index)) then
@@ -643,7 +649,7 @@ contains
         if (left_end < parser%current_token - 1) return
 
         call build_lhs_tokens(lhs_tokens, id_token, parser, left_end)
-        target_index = parse_expression(lhs_tokens, arena)
+        target_index = parse_expression(lhs_tokens, arena, parser)
         if (target_index <= 0) return
 
         parser%current_token = left_end + 1
@@ -664,7 +670,7 @@ contains
 
         allocate (rhs_tokens(remaining_count))
         rhs_tokens = tokens(parser%current_token:)
-        value_index = parse_expression(rhs_tokens, arena)
+        value_index = parse_expression(rhs_tokens, arena, parser)
         if (value_index <= 0) return
 
         stmt_index = create_assignment_node(arena, parent_index, target_index, &

--- a/src/semantic/analyzers/semantic_abstract_validation.f90
+++ b/src/semantic/analyzers/semantic_abstract_validation.f90
@@ -212,7 +212,9 @@ contains
             context='line '//int_to_string(child%line)//', column '// &
             int_to_string(child%column), &
             suggestion='provide a type-bound procedure for "'// &
-            trim(binding_name)//'", or declare the type ABSTRACT')
+            trim(binding_name)//'", or declare the type ABSTRACT', &
+            line=child%line, column=child%column, end_line=child%line, &
+            end_column=child%column + 1)
     end subroutine report_unimplemented
 
     ! Lower-case and trim a substring for case-insensitive keyword matching.

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl_part3.inc
@@ -76,7 +76,11 @@
                                    component='semantic_analyzer', &
                                    context='strict_allocatable_lhs_realloc', &
                                    suggestion='Resize explicitly with deallocate/'// &
-                                   'allocate, or use infer mode'))
+                                   'allocate, or use infer mode', &
+                                   line=assignment%line, &
+                                   column=assignment%column, &
+                                   end_line=assignment%line, &
+                                   end_column=assignment%column + 1))
     end subroutine validate_strict_allocatable_lhs_reallocation
 
     subroutine get_lhs_identifier_name(arena, target_index, name)

--- a/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
@@ -33,7 +33,9 @@
                                               bind_c_clause=expr%bind_c_clause, &
                                               result_name=elemental_result_name, &
                                               require_declared_dummy_intent= &
-                                              this%input_mode == INPUT_MODE_STANDARD)
+                                              this%input_mode == INPUT_MODE_STANDARD, &
+                                              procedure_line=expr%line, &
+                                              procedure_column=expr%column)
 
             ! Enforce BIND(C) dummy-argument interoperability (F2003 15.3.2)
             call validate_bind_c_procedure(arena, expr%param_indices, &
@@ -78,7 +80,9 @@
                                               proc_name=expr%name, &
                                               bind_c_clause=expr%bind_c_clause, &
                                               require_declared_dummy_intent= &
-                                              this%input_mode == INPUT_MODE_STANDARD)
+                                              this%input_mode == INPUT_MODE_STANDARD, &
+                                              procedure_line=expr%line, &
+                                              procedure_column=expr%column)
 
             ! Enforce BIND(C) dummy-argument interoperability (F2003 15.3.2)
             call validate_bind_c_procedure(arena, expr%param_indices, &
@@ -361,7 +365,15 @@
                                            trim(message), ERROR_SEMANTIC, &
                                            component="semantic_analyzer", &
                                            context="data_statement", &
-                                           suggestion="Declare as array")
+                                           suggestion="Declare as array", &
+                                           line=arena%entries(object_index)%node% &
+                                           line, &
+                                           column=arena%entries(object_index)%node% &
+                                           column, &
+                                           end_line=arena%entries(object_index)% &
+                                           node%line, &
+                                           end_column=arena%entries(object_index)% &
+                                           node%column + 1)
                             call this%errors%add_result(error_result)
                         end block
                         return
@@ -433,7 +445,14 @@
                                    " scalar objects", &
                                    ERROR_SEMANTIC, "semantic_analyzer", &
                                    "data_statement", &
-                                   "Match values to objects")
+                                   "Match values to objects", &
+                                   line=arena%entries(object_indices(1))%node%line, &
+                                   column=arena%entries(object_indices(1))%node% &
+                                   column, &
+                                   end_line=arena%entries(object_indices(1))%node% &
+                                   line, &
+                                   end_column=arena%entries(object_indices(1))% &
+                                   node%column + 1)
                     call this%errors%add_result(error_result)
                 end block
                 return
@@ -549,7 +568,9 @@
                 if (left_is_unsigned .neqv. right_is_unsigned) then
                     if (.not. left_is_int_literal .and. &
                         .not. right_is_int_literal) then
-                        call emit_unsigned_integer_mix_error(this%errors)
+                        call emit_unsigned_integer_mix_error(this%errors, &
+                                                             expr%line, &
+                                                             expr%column)
                     end if
                 end if
             end if
@@ -683,8 +704,8 @@
                         if (actual_is_int) then
                             if (actual_is_unsigned .neqv. expected_is_unsigned) then
                                 if (.not. actual_is_int_literal) then
-                                    call emit_unsigned_integer_mix_error(this% &
-                                                                         errors)
+                                    call emit_unsigned_integer_mix_error( &
+                                        this%errors, expr%line, expr%column)
                                 end if
                             end if
                         end if

--- a/src/semantic/analyzers/semantic_assignment_inference.f90
+++ b/src/semantic/analyzers/semantic_assignment_inference.f90
@@ -151,7 +151,8 @@ contains
                         if (lhs_is_int .and. rhs_is_int) then
                             if (lhs_is_unsigned .neqv. rhs_is_unsigned) then
                                 if (.not. rhs_is_int_literal) then
-                                    call emit_unsigned_integer_mix_error(errors)
+                                    call emit_unsigned_integer_mix_error(errors, &
+                                        assignment%line, assignment%column)
                                 end if
                             end if
                         end if

--- a/src/semantic/analyzers/semantic_bind_c_validation.f90
+++ b/src/semantic/analyzers/semantic_bind_c_validation.f90
@@ -230,7 +230,8 @@ contains
             context='line '//int_to_string(line)//', column '// &
             int_to_string(column), &
             suggestion='remove the '//kind//' attribute or drop BIND(C) '// &
-            'from the type')
+            'from the type', line=line, column=column, end_line=line, &
+            end_column=column + 1)
     end subroutine report_component
 
     subroutine report_dummy(errors, proc_name, dummy_name, kind, line, column)
@@ -246,7 +247,8 @@ contains
             context='line '//int_to_string(line)//', column '// &
             int_to_string(column), &
             suggestion='use an explicit-shape or assumed-rank dummy, or '// &
-            'drop BIND(C) from the procedure')
+            'drop BIND(C) from the procedure', line=line, column=column, &
+            end_line=line, end_column=column + 1)
     end subroutine report_dummy
 
 end module semantic_bind_c_validation

--- a/src/semantic/analyzers/semantic_elemental_validation.f90
+++ b/src/semantic/analyzers/semantic_elemental_validation.f90
@@ -37,7 +37,7 @@ contains
     ! procedures are accepted unchanged.
     subroutine validate_elemental_procedure(arena, param_indices, body_indices, &
             prefix_keywords, errors, proc_name, bind_c_clause, result_name, &
-            require_declared_dummy_intent)
+            require_declared_dummy_intent, procedure_line, procedure_column)
         type(ast_arena_t), intent(in) :: arena
         integer, allocatable, intent(in) :: param_indices(:)
         integer, allocatable, intent(in) :: body_indices(:)
@@ -47,6 +47,7 @@ contains
         character(len=:), allocatable, intent(in), optional :: bind_c_clause
         character(len=*), intent(in), optional :: result_name
         logical, intent(in), optional :: require_declared_dummy_intent
+        integer, intent(in), optional :: procedure_line, procedure_column
         integer :: i, decl_index
         character(len=:), allocatable :: dummy_name
         logical :: check_dummy_intent
@@ -57,7 +58,8 @@ contains
             check_dummy_intent = require_declared_dummy_intent
         end if
 
-        call validate_elemental_bind_c(bind_c_clause, errors)
+        call validate_elemental_bind_c(bind_c_clause, errors, procedure_line, &
+            procedure_column)
         if (present(result_name)) then
             call validate_elemental_result(arena, body_indices, result_name, &
                 errors)
@@ -101,7 +103,7 @@ contains
                 if (.not. dummy_has_intent_or_value(arena, param_indices(i), &
                     body_indices, dummy_name)) then
                     call report_dummy_intent(errors, arena, param_indices(i), &
-                        dummy_name)
+                        body_indices, dummy_name)
                 end if
             end if
         end do
@@ -359,18 +361,26 @@ contains
         matches = to_lower(trim(left)) == to_lower(trim(right))
     end function names_match
 
-    subroutine validate_elemental_bind_c(bind_c_clause, errors)
+    subroutine validate_elemental_bind_c(bind_c_clause, errors, line, column)
         character(len=:), allocatable, intent(in), optional :: bind_c_clause
         type(error_collection_t), intent(inout) :: errors
+        integer, intent(in), optional :: line, column
+        integer :: location_line, location_column
 
         if (.not. present(bind_c_clause)) return
         if (.not. allocated(bind_c_clause)) return
         if (len_trim(bind_c_clause) == 0) return
+        location_line = 0
+        location_column = 0
+        if (present(line)) location_line = line
+        if (present(column)) location_column = column
         call errors%add_error( &
             message='BIND(C) attribute conflicts with ELEMENTAL attribute', &
             code=ERROR_SEMANTIC, &
             component='semantic_elemental_validation', &
-            suggestion='drop BIND(C) or drop the ELEMENTAL prefix')
+            suggestion='drop BIND(C) or drop the ELEMENTAL prefix', &
+            line=location_line, column=location_column, &
+            end_line=location_line, end_column=location_column + 1)
     end subroutine validate_elemental_bind_c
 
     subroutine validate_elemental_result(arena, body_indices, result_name, errors)
@@ -415,7 +425,8 @@ contains
             context='line '//int_to_string(line)//', column '// &
             int_to_string(column), &
             suggestion='make the dummy argument scalar, or drop the '// &
-            'ELEMENTAL prefix')
+            'ELEMENTAL prefix', line=line, column=column, end_line=line, &
+            end_column=column + 1)
     end subroutine report_array_dummy
 
     subroutine report_dummy_procedure(errors, arena, param_index, dummy_name)
@@ -433,25 +444,32 @@ contains
             component='semantic_elemental_validation', &
             context='line '//int_to_string(line)//', column '// &
             int_to_string(column), &
-            suggestion='drop the ELEMENTAL prefix or remove the dummy procedure')
+            suggestion='drop the ELEMENTAL prefix or remove the dummy procedure', &
+            line=line, column=column, end_line=line, end_column=column + 1)
     end subroutine report_dummy_procedure
 
-    subroutine report_dummy_intent(errors, arena, param_index, dummy_name)
+    subroutine report_dummy_intent(errors, arena, param_index, body_indices, &
+            dummy_name)
         type(error_collection_t), intent(inout) :: errors
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: param_index
+        integer, intent(in) :: body_indices(:)
         character(len=*), intent(in) :: dummy_name
-        integer :: line, column
+        integer :: line, column, context_line, context_column, diagnostic_index
 
-        call source_position(arena, param_index, line, column)
+        call source_position(arena, param_index, context_line, context_column)
+        diagnostic_index = find_body_declaration(arena, body_indices, dummy_name)
+        if (diagnostic_index <= 0) diagnostic_index = param_index
+        call source_position(arena, diagnostic_index, line, column)
         call errors%add_error( &
             message='dummy argument "'//trim(dummy_name)// &
             '" of ELEMENTAL procedure must have INTENT or VALUE', &
             code=ERROR_SEMANTIC, &
             component='semantic_elemental_validation', &
-            context='line '//int_to_string(line)//', column '// &
-            int_to_string(column), &
-            suggestion='add INTENT or VALUE, or drop the ELEMENTAL prefix')
+            context='line '//int_to_string(context_line)//', column '// &
+            int_to_string(context_column), &
+            suggestion='add INTENT or VALUE, or drop the ELEMENTAL prefix', &
+            line=line, column=column, end_line=line, end_column=column + 1)
     end subroutine report_dummy_intent
 
     subroutine report_alternate_return(errors, arena, param_index)
@@ -467,7 +485,8 @@ contains
             component='semantic_elemental_validation', &
             context='line '//int_to_string(line)//', column '// &
             int_to_string(column), &
-            suggestion='remove the alternate return, or drop the ELEMENTAL prefix')
+            suggestion='remove the alternate return, or drop the ELEMENTAL prefix', &
+            line=line, column=column, end_line=line, end_column=column + 1)
     end subroutine report_alternate_return
 
     subroutine report_forbidden_attribute(errors, node, attribute, entity)
@@ -483,7 +502,8 @@ contains
             context='line '//int_to_string(node%line)//', column '// &
             int_to_string(node%column), &
             suggestion='remove '//trim(attribute)// &
-            ', or drop the ELEMENTAL prefix')
+            ', or drop the ELEMENTAL prefix', line=node%line, column=node%column, &
+            end_line=node%line, end_column=node%column + 1)
     end subroutine report_forbidden_attribute
 
     subroutine report_array_result(errors, node)
@@ -496,7 +516,9 @@ contains
             component='semantic_elemental_validation', &
             context='line '//int_to_string(node%line)//', column '// &
             int_to_string(node%column), &
-            suggestion='make the result scalar, or drop the ELEMENTAL prefix')
+            suggestion='make the result scalar, or drop the ELEMENTAL prefix', &
+            line=node%line, column=node%column, end_line=node%line, &
+            end_column=node%column + 1)
     end subroutine report_array_result
 
     subroutine report_pointer_result(errors, node)
@@ -509,7 +531,9 @@ contains
             component='semantic_elemental_validation', &
             context='line '//int_to_string(node%line)//', column '// &
             int_to_string(node%column), &
-            suggestion='remove POINTER, or drop the ELEMENTAL prefix')
+            suggestion='remove POINTER, or drop the ELEMENTAL prefix', &
+            line=node%line, column=node%column, end_line=node%line, &
+            end_column=node%column + 1)
     end subroutine report_pointer_result
 
     subroutine source_position(arena, node_index, line, column)

--- a/src/semantic/analyzers/semantic_explicit_interface_checker.f90
+++ b/src/semantic/analyzers/semantic_explicit_interface_checker.f90
@@ -46,7 +46,8 @@ contains
         if (is_known_array_reference(scopes, proc_name)) return
         if (has_explicit_interface_in_cache(cache, proc_name)) return
 
-        call emit_missing_explicit_interface(errors, expr%name)
+        call emit_missing_explicit_interface(errors, expr%name, expr%line, &
+            expr%column)
     end subroutine validate_explicit_interface_for_function_reference
 
     subroutine validate_explicit_interface_for_subroutine_call(arena, scopes, &
@@ -68,7 +69,8 @@ contains
         if (is_intrinsic_subroutine(proc_name)) return
         if (has_explicit_interface_in_cache(cache, proc_name)) return
 
-        call emit_missing_explicit_interface(errors, expr%name)
+        call emit_missing_explicit_interface(errors, expr%name, expr%line, &
+            expr%column)
     end subroutine validate_explicit_interface_for_subroutine_call
 
     logical function is_known_array_reference(scopes, name) result(is_array)
@@ -223,9 +225,10 @@ contains
         interned_id = identifier_table_intern(cache, lowered)
     end subroutine cache_allocated_name
 
-    subroutine emit_missing_explicit_interface(errors, original_name)
+    subroutine emit_missing_explicit_interface(errors, original_name, line, column)
         type(error_collection_t), intent(inout) :: errors
         character(len=*), intent(in) :: original_name
+        integer, intent(in) :: line, column
         character(len=:), allocatable :: message
         character(len=:), allocatable :: suggestion
 
@@ -238,7 +241,8 @@ contains
             message, ERROR_SEMANTIC, &
             component="semantic_analyzer", &
             context="explicit_interface_requirement", &
-            suggestion=suggestion))
+            suggestion=suggestion, line=line, column=column, end_line=line, &
+            end_column=column + 1))
     end subroutine emit_missing_explicit_interface
 
 end module semantic_explicit_interface_checker

--- a/src/semantic/analyzers/semantic_implied_do_validation.f90
+++ b/src/semantic/analyzers/semantic_implied_do_validation.f90
@@ -198,7 +198,8 @@ contains
             component='semantic_implied_do_validation', &
             context='line '//int_to_string(line)//', column '// &
             int_to_string(column), &
-            suggestion='rename the nested implied-DO index')
+            suggestion='rename the nested implied-DO index', &
+            line=line, column=column, end_line=line, end_column=column + 1)
     end subroutine report_duplicate_index
 
     subroutine report_out_of_scope(errors, name, line, column)
@@ -213,7 +214,8 @@ contains
             component='semantic_implied_do_validation', &
             context='line '//int_to_string(line)//', column '// &
             int_to_string(column), &
-            suggestion='use a variable in scope for the implied-DO bounds')
+            suggestion='use a variable in scope for the implied-DO bounds', &
+            line=line, column=column, end_line=line, end_column=column + 1)
     end subroutine report_out_of_scope
 
 end module semantic_implied_do_validation

--- a/src/semantic/analyzers/semantic_pure_validation.f90
+++ b/src/semantic/analyzers/semantic_pure_validation.f90
@@ -138,7 +138,8 @@ contains
             context='line '//int_to_string(line)//', column '// &
             int_to_string(column), &
             suggestion='remove the I/O or control statement, or drop the '// &
-            'PURE/ELEMENTAL prefix')
+            'PURE/ELEMENTAL prefix', line=line, column=column, end_line=line, &
+            end_column=column + 1)
     end subroutine report_impure_stmt
 
 end module semantic_pure_validation

--- a/src/semantic/analyzers/semantic_strict_argument_type_checker_validation.f90
+++ b/src/semantic/analyzers/semantic_strict_argument_type_checker_validation.f90
@@ -69,8 +69,8 @@ contains
                 call extract_keyword_name_if_present(arena, arg_indices(i), keyword, &
                     is_keyword)
                 if (is_keyword) cycle
-                call map_positional_argument(errors, arg_indices(i), next_positional, &
-                    arg_for_param)
+                call map_positional_argument(arena, errors, arg_indices(i), &
+                    next_positional, arg_for_param)
             end do
         end if
 
@@ -162,7 +162,7 @@ contains
                 if (arg_for_param(i) /= 0) then
                     call emit_argument_error(errors, &
                         "Duplicate argument for dummy '"// &
-                        trim(param_names(i))//"'")
+                        trim(param_names(i))//"'", arena, arg_index)
                     return
                 end if
                 arg_for_param(i) = value_index_if_keyword_arg(arena, arg_index)
@@ -171,11 +171,12 @@ contains
         end do
 
         call emit_argument_error(errors, &
-            "Unknown keyword argument '"//trim(keyword)//"'")
+            "Unknown keyword argument '"//trim(keyword)//"'", arena, arg_index)
     end subroutine map_keyword_argument
 
-    subroutine map_positional_argument(errors, arg_index, next_positional, &
+    subroutine map_positional_argument(arena, errors, arg_index, next_positional, &
             arg_for_param)
+        type(ast_arena_t), intent(in) :: arena
         type(error_collection_t), intent(inout) :: errors
         integer, intent(in) :: arg_index
         integer, intent(inout) :: next_positional
@@ -187,7 +188,8 @@ contains
         end do
 
         if (next_positional > size(arg_for_param)) then
-            call emit_argument_error(errors, "Too many actual arguments")
+            call emit_argument_error(errors, "Too many actual arguments", arena, &
+                arg_index)
             return
         end if
 
@@ -234,7 +236,9 @@ contains
         if (actual_is_int .and. dummy_is_int) then
             if (actual_is_unsigned .neqv. dummy_is_unsigned) then
                 if (.not. actual_is_int_literal) then
-                    call emit_unsigned_integer_mix_error(errors)
+                    call emit_unsigned_integer_mix_error(errors, &
+                        arena%entries(arg_expr_index)%node%line, &
+                        arena%entries(arg_expr_index)%node%column)
                     return
                 end if
             end if
@@ -248,7 +252,7 @@ contains
             "Type mismatch in call to '"//trim(proc_name)// &
             "': actual argument '"//trim(dummy_name)// &
             "' is "//trim(actual_string)// &
-            ", but dummy expects "//trim(dummy_string))
+            ", but dummy expects "//trim(dummy_string), arena, arg_expr_index)
     end subroutine validate_mapped_argument
 
     subroutine extract_keyword_name_if_present(arena, arg_index, keyword, is_keyword)
@@ -352,9 +356,15 @@ contains
         write (name, '(A,I0)') "arg", position
     end function resolve_param_name
 
-    subroutine emit_argument_error(errors, message)
+    subroutine emit_argument_error(errors, message, arena, node_index)
         type(error_collection_t), intent(inout) :: errors
         character(len=*), intent(in) :: message
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer :: line, column
+
+        line = arena%entries(node_index)%node%line
+        column = arena%entries(node_index)%node%column
 
         call errors%add_result(create_error_result( &
             trim(message), ERROR_SEMANTIC, &
@@ -362,7 +372,8 @@ contains
             context="strict_argument_type_check", &
             suggestion="Use explicit conversion functions "// &
             "(real/int/dble) to match dummy "// &
-            "argument types"))
+            "argument types", line=line, column=column, end_line=line, &
+            end_column=column + 1))
     end subroutine emit_argument_error
 
 end module semantic_strict_argument_type_checker_validation

--- a/src/semantic/analyzers/semantic_type_hierarchy_validation.f90
+++ b/src/semantic/analyzers/semantic_type_hierarchy_validation.f90
@@ -162,7 +162,8 @@ contains
             context='line '//int_to_string(line)//', column '// &
             int_to_string(column), &
             suggestion='define the parent type before extending it, or '// &
-            'break the circular EXTENDS chain')
+            'break the circular EXTENDS chain', line=line, column=column, &
+            end_line=line, end_column=column + 1)
     end subroutine report_hierarchy_error
 
 end module semantic_type_hierarchy_validation

--- a/src/semantic/analyzers/semantic_undefined_variable_checker.f90
+++ b/src/semantic/analyzers/semantic_undefined_variable_checker.f90
@@ -82,7 +82,9 @@ contains
                     component="semantic_analyzer", &
                     context="check_undefined_variables", &
                     suggestion="Declare the variable before using it"// &
-                    " or remove 'implicit none'" &
+                    " or remove 'implicit none'", &
+                    line=node%line, column=node%column, end_line=node%line, &
+                    end_column=node%column + 1 &
                     )
                 call errors%add_result(error_result)
             end if

--- a/src/semantic/analyzers/semantic_walrus_checker.f90
+++ b/src/semantic/analyzers/semantic_walrus_checker.f90
@@ -133,7 +133,9 @@ contains
                 ERROR_SEMANTIC, &
                 component="semantic_walrus_checker", &
                 context="check_walrus_redeclaration", &
-                suggestion="Use '=' to assign to an existing variable" &
+                suggestion="Use '=' to assign to an existing variable", &
+                line=stmt%line, column=stmt%column, end_line=stmt%line, &
+                end_column=stmt%column + 1 &
                 )
             call errors%add_result(error_result)
             return

--- a/src/semantic/analyzers/semantic_where_validation.f90
+++ b/src/semantic/analyzers/semantic_where_validation.f90
@@ -126,7 +126,9 @@ contains
             trim(int_to_string(where_line)), &
             suggestion="WHERE/ELSEWHERE may only contain array "// &
             "assignments, nested WHERE statements, or "// &
-            "nested WHERE constructs (F2018 10.2.3.2)" &
+            "nested WHERE constructs (F2018 10.2.3.2)", &
+            line=stmt_line, column=stmt_col, end_line=stmt_line, &
+            end_column=stmt_col + 1 &
             )
 
         call errors%add_result(error_result)

--- a/src/semantic/semantic_unsigned_integer_mix_diagnostics.f90
+++ b/src/semantic/semantic_unsigned_integer_mix_diagnostics.f90
@@ -13,8 +13,9 @@ module semantic_unsigned_integer_mix_diagnostics
 
 contains
 
-    subroutine emit_unsigned_integer_mix_error(errors)
+    subroutine emit_unsigned_integer_mix_error(errors, line, column)
         type(error_collection_t), intent(inout) :: errors
+        integer, intent(in) :: line, column
 
         call errors%add_result(create_error_result( &
             "Implicit mixing of signed and unsigned " // &
@@ -23,7 +24,8 @@ contains
             component="semantic_analyzer", &
             context="unsigned_integer_mix", &
             suggestion="Convert explicitly with uint(...) or " // &
-            "int(...)"))
+            "int(...)", line=line, column=column, end_line=line, &
+            end_column=column + 1))
     end subroutine emit_unsigned_integer_mix_error
 
     subroutine extract_integer_signedness(typ, is_int, is_unsigned)

--- a/test/api/test_error_api.f90
+++ b/test/api/test_error_api.f90
@@ -9,6 +9,12 @@ program test_error_api
         ERROR_WARNING, &
         ERROR_ERROR, &
         ERROR_FATAL
+    use fortfront_compiler, only: compiler_frontend_result_t, &
+        compiler_frontend_options_t, compiler_diagnostic_t, &
+        compile_frontend_from_string, get_compiler_diagnostics, &
+        INPUT_MODE_STANDARD, OPERATING_MODE_STRICT, DIAGNOSTIC_ERROR, &
+        DIAGNOSTIC_PHASE_PARSER, DIAGNOSTIC_PHASE_SEMANTIC, &
+        DIAGNOSTIC_CODE_PARSER, DIAGNOSTIC_CODE_SEMANTIC
     implicit none
 
     logical :: all_passed
@@ -24,6 +30,11 @@ program test_error_api
     if (.not. test_error_collection_add_with_context()) all_passed = .false.
     if (.not. test_error_collection_format_and_clear()) all_passed = .false.
     if (.not. test_error_collection_format_long_message()) all_passed = .false.
+    if (.not. test_compiler_diagnostics_valid()) all_passed = .false.
+    if (.not. test_compiler_parser_diagnostic()) all_passed = .false.
+    if (.not. test_compiler_function_parser_diagnostic()) all_passed = .false.
+    if (.not. test_compiler_diagnostic_result_ownership()) all_passed = .false.
+    if (.not. test_compiler_semantic_diagnostic()) all_passed = .false.
 
     print *
     if (all_passed) then
@@ -321,5 +332,157 @@ contains
 
         print *, '  PASS: Error collection long-message formatting'
     end function test_error_collection_format_long_message
+
+    logical function test_compiler_diagnostics_valid()
+        type(compiler_frontend_result_t) :: result
+        type(compiler_diagnostic_t), allocatable :: diagnostics(:)
+        character(len=*), parameter :: source = &
+            'program valid'//new_line('a')// &
+            '  integer :: value'//new_line('a')// &
+            '  value = 1'//new_line('a')// &
+            'end program valid'
+
+        test_compiler_diagnostics_valid = .true.
+        call compile_frontend_from_string(source, result)
+        diagnostics = get_compiler_diagnostics(result)
+        if (size(diagnostics) /= 0) then
+            print *, '  FAIL: valid source returned compiler diagnostics'
+            test_compiler_diagnostics_valid = .false.
+        end if
+    end function test_compiler_diagnostics_valid
+
+    logical function test_compiler_parser_diagnostic()
+        type(compiler_frontend_result_t) :: result
+        type(compiler_diagnostic_t), allocatable :: diagnostics(:)
+        character(len=*), parameter :: source = &
+            'program broken'//new_line('a')// &
+            '    implicit none'//new_line('a')// &
+            '    integer :: value'//new_line('a')// &
+            '    value = identity{integer'//new_line('a')// &
+            'end program broken'
+
+        test_compiler_parser_diagnostic = .true.
+        call compile_frontend_from_string(source, result)
+        diagnostics = get_compiler_diagnostics(result)
+        if (size(diagnostics) == 0) then
+            print *, '  FAIL: malformed source returned no diagnostic'
+            test_compiler_parser_diagnostic = .false.
+            return
+        end if
+        if (diagnostics(1)%phase /= DIAGNOSTIC_PHASE_PARSER .or. &
+            diagnostics(1)%code /= DIAGNOSTIC_CODE_PARSER .or. &
+            diagnostics(1)%severity /= DIAGNOSTIC_ERROR) then
+            print *, '  FAIL: parser diagnostic classification is unstable'
+            test_compiler_parser_diagnostic = .false.
+            return
+        end if
+        if (diagnostics(1)%span%start%line /= 4 .or. &
+            diagnostics(1)%span%start%column /= 21 .or. &
+            diagnostics(1)%span%end%line /= 4 .or. &
+            diagnostics(1)%span%end%column /= 22) then
+            print *, '  FAIL: parser diagnostic span is incorrect'
+            test_compiler_parser_diagnostic = .false.
+        end if
+    end function test_compiler_parser_diagnostic
+
+    logical function test_compiler_function_parser_diagnostic()
+        type(compiler_frontend_result_t) :: result
+        type(compiler_diagnostic_t), allocatable :: diagnostics(:)
+        character(len=*), parameter :: source = &
+            'integer function broken(value)'//new_line('a')// &
+            '  integer :: value'//new_line('a')// &
+            '  broken = identity{integer'//new_line('a')// &
+            'end function broken'
+
+        test_compiler_function_parser_diagnostic = .true.
+        call compile_frontend_from_string(source, result)
+        diagnostics = get_compiler_diagnostics(result)
+        if (size(diagnostics) == 0) then
+            print *, '  FAIL: malformed top-level function returned no diagnostic'
+            test_compiler_function_parser_diagnostic = .false.
+            return
+        end if
+        if (diagnostics(1)%phase /= DIAGNOSTIC_PHASE_PARSER) then
+            print *, '  FAIL: malformed function diagnostic phase is not parser'
+            test_compiler_function_parser_diagnostic = .false.
+        end if
+    end function test_compiler_function_parser_diagnostic
+
+    logical function test_compiler_diagnostic_result_ownership()
+        type(compiler_frontend_result_t) :: invalid_result, valid_result
+        type(compiler_diagnostic_t), allocatable :: before(:), after(:), valid(:)
+        character(len=:), allocatable :: first_message
+        character(len=*), parameter :: invalid_source = &
+            'program broken'//new_line('a')// &
+            '  value = identity{integer'//new_line('a')// &
+            'end program broken'
+        character(len=*), parameter :: valid_source = &
+            'program valid'//new_line('a')// &
+            '  integer :: value'//new_line('a')// &
+            '  value = 1'//new_line('a')// &
+            'end program valid'
+
+        test_compiler_diagnostic_result_ownership = .true.
+        call compile_frontend_from_string(invalid_source, invalid_result)
+        before = get_compiler_diagnostics(invalid_result)
+        if (size(before) == 0) then
+            print *, '  FAIL: ownership fixture returned no parser diagnostic'
+            test_compiler_diagnostic_result_ownership = .false.
+            return
+        end if
+        first_message = before(1)%message
+
+        call compile_frontend_from_string(valid_source, valid_result)
+        valid = get_compiler_diagnostics(valid_result)
+        after = get_compiler_diagnostics(invalid_result)
+        if (size(valid) /= 0) then
+            print *, '  FAIL: later valid result inherited parser diagnostics'
+            test_compiler_diagnostic_result_ownership = .false.
+        end if
+        if (size(after) /= size(before)) then
+            print *, '  FAIL: later parse changed prior diagnostic count'
+            test_compiler_diagnostic_result_ownership = .false.
+            return
+        end if
+        if (after(1)%message /= first_message) then
+            print *, '  FAIL: later parse changed prior diagnostic message'
+            test_compiler_diagnostic_result_ownership = .false.
+        end if
+    end function test_compiler_diagnostic_result_ownership
+
+    logical function test_compiler_semantic_diagnostic()
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+        type(compiler_diagnostic_t), allocatable :: diagnostics(:)
+        character(len=*), parameter :: source = &
+            'elemental subroutine invalid_intent(value)'//new_line('a')// &
+            '  integer :: value'//new_line('a')// &
+            'end subroutine invalid_intent'
+
+        test_compiler_semantic_diagnostic = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%operating_mode = OPERATING_MODE_STRICT
+        call compile_frontend_from_string(source, result, options)
+        diagnostics = get_compiler_diagnostics(result)
+        if (size(diagnostics) == 0) then
+            print *, '  FAIL: invalid declaration returned no diagnostic'
+            test_compiler_semantic_diagnostic = .false.
+            return
+        end if
+        if (diagnostics(1)%phase /= DIAGNOSTIC_PHASE_SEMANTIC .or. &
+            diagnostics(1)%code /= DIAGNOSTIC_CODE_SEMANTIC .or. &
+            diagnostics(1)%severity /= DIAGNOSTIC_ERROR) then
+            print *, '  FAIL: semantic diagnostic classification is unstable'
+            test_compiler_semantic_diagnostic = .false.
+            return
+        end if
+        if (diagnostics(1)%span%start%line /= 2 .or. &
+            diagnostics(1)%span%start%column /= 3 .or. &
+            diagnostics(1)%span%end%line /= 2 .or. &
+            diagnostics(1)%span%end%column /= 4) then
+            print *, '  FAIL: semantic diagnostic span is incorrect'
+            test_compiler_semantic_diagnostic = .false.
+        end if
+    end function test_compiler_semantic_diagnostic
 
 end program test_error_api


### PR DESCRIPTION
Expose parser and semantic diagnostics through the public compiler facade with stable phase and code values, severity, owned messages, and exact nonempty source anchors. Parser records are collected per compilation across nested parser paths, so later compilations cannot overwrite prior results. Semantic diagnostic producers now attach typed locations without parsing or changing diagnostic prose.

Parser dispatch, recovery decisions, AST indices, generated code, and existing formatted diagnostics are preserved. The public compiler result and internal semantic result layouts gain appended diagnostic fields, so consumers must recompile against the updated modules.

Closes #2877

## Verification
### Test fails on main
```text
fo test test_error_api
test_error_api FAIL
FAIL: malformed source returned no diagnostic
FAIL: invalid declaration returned no diagnostic
Summary: 0 passed, 1 failed, 0 skipped
```

### Test passes after fix
```text
fo test test_error_api test_all_examples
test_error_api PASS
test_all_examples PASS
Summary: 2 passed, 0 failed, 0 skipped

fo
Static: OK (1372 modules)
Build: OK (361/361)
Tests: OK (483/483)
Lint: OK
All stages passed
```