### PR TITLE
Expose structured compiler statement queries

### DIFF
--- a/src/ast/arena/ast_arena_clone.f90
+++ b/src/ast/arena/ast_arena_clone.f90
@@ -165,6 +165,7 @@ contains
             if (new_idx <= 0 .or. new_idx > arena%size) cycle
             if (.not. arena%has_node_at(new_idx)) cycle
             call remap_node_indices(arena, new_idx, index_map)
+            call remap_public_query_indices(arena, new_idx, index_map)
         end do
     end subroutine remap_indices_in_cloned
 
@@ -549,6 +550,57 @@ contains
             ! Node has no integer index fields to remap
         end select
     end subroutine remap_node_indices
+
+    subroutine remap_public_query_indices(arena, idx, index_map)
+        use ast_nodes_array, only: where_node
+        use ast_nodes_io, only: write_statement_node, read_statement_node, &
+            open_statement_node, close_statement_node, inquire_statement_node, &
+            backspace_statement_node, rewind_statement_node, &
+            endfile_statement_node
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: idx, index_map(:)
+        integer :: i
+
+        select type (node => arena%entries(idx)%node)
+            type is (where_node)
+            if (allocated(node%elsewhere_clauses)) then
+                do i = 1, size(node%elsewhere_clauses)
+                    node%elsewhere_clauses(i)%mask_index = &
+                        remap_one(index_map, &
+                        node%elsewhere_clauses(i)%mask_index)
+                end do
+            end if
+            type is (write_statement_node)
+            call remap_io_specifiers(index_map, node%specifiers)
+            type is (read_statement_node)
+            call remap_io_specifiers(index_map, node%specifiers)
+            type is (open_statement_node)
+            call remap_io_specifiers(index_map, node%specifiers)
+            type is (close_statement_node)
+            call remap_io_specifiers(index_map, node%specifiers)
+            type is (inquire_statement_node)
+            call remap_io_specifiers(index_map, node%specifiers)
+            type is (backspace_statement_node)
+            call remap_io_specifiers(index_map, node%specifiers)
+            type is (rewind_statement_node)
+            call remap_io_specifiers(index_map, node%specifiers)
+            type is (endfile_statement_node)
+            call remap_io_specifiers(index_map, node%specifiers)
+        end select
+    end subroutine remap_public_query_indices
+
+    subroutine remap_io_specifiers(index_map, specifiers)
+        use ast_nodes_io, only: io_specifier_t
+        integer, intent(in) :: index_map(:)
+        type(io_specifier_t), allocatable, intent(inout) :: specifiers(:)
+        integer :: i
+
+        if (.not. allocated(specifiers)) return
+        do i = 1, size(specifiers)
+            specifiers(i)%value_node_index = &
+                remap_one(index_map, specifiers(i)%value_node_index)
+        end do
+    end subroutine remap_io_specifiers
 
     ! Remap a single index: if old_idx is in the map, return new idx; else unchanged
     pure integer function remap_one(index_map, old_idx) result(new_idx)

--- a/src/ast/arena/ast_arena_clone.f90
+++ b/src/ast/arena/ast_arena_clone.f90
@@ -605,11 +605,10 @@ contains
     ! Remap a single index: if old_idx is in the map, return new idx; else unchanged
     pure integer function remap_one(index_map, old_idx) result(new_idx)
         integer, intent(in) :: index_map(:), old_idx
-        if (old_idx > 0 .and. old_idx <= size(index_map) .and. index_map(old_idx) > 0) then
-            new_idx = index_map(old_idx)
-        else
-            new_idx = old_idx
-        end if
+        new_idx = old_idx
+        if (old_idx <= 0) return
+        if (old_idx > size(index_map)) return
+        if (index_map(old_idx) > 0) new_idx = index_map(old_idx)
     end function remap_one
 
     ! Remap an array of indices

--- a/src/ast/factory/ast_factory_control_part1.inc
+++ b/src/ast/factory/ast_factory_control_part1.inc
@@ -226,6 +226,7 @@ function push_do_loop(arena, var_name, start_index, end_index, step_index, &
 
         call arena%push(assoc, "associate", parent_index)
         assoc_index = arena%size
+        call link_association_expressions(arena, assoc_index, associations)
 
         ! Link children to this parent for AST traversal
         if (present(body_indices)) then
@@ -234,6 +235,26 @@ function push_do_loop(arena, var_name, start_index, end_index, step_index, &
             end if
         end if
     end function push_associate
+
+    subroutine link_association_expressions(arena, parent_index, associations)
+        use ast_nodes_control, only: association_t
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: parent_index
+        type(association_t), intent(in) :: associations(:)
+        integer, allocatable :: expression_indices(:)
+        integer :: i, expression_count
+
+        expression_count = count(associations%expr_index > 0)
+        if (expression_count == 0) return
+        allocate (expression_indices(expression_count))
+        expression_count = 0
+        do i = 1, size(associations)
+            if (associations(i)%expr_index <= 0) cycle
+            expression_count = expression_count + 1
+            expression_indices(expression_count) = associations(i)%expr_index
+        end do
+        call link_children_to_parent(arena, parent_index, expression_indices)
+    end subroutine link_association_expressions
 
     function push_block_construct(arena, body_indices, line, column, &
                                   parent_index) result(block_index)

--- a/src/ast/factory/ast_factory_control_part2.inc
+++ b/src/ast/factory/ast_factory_control_part2.inc
@@ -2,100 +2,29 @@
     ! Create WHERE construct node and add to stack
     function push_where(arena, mask_expr_index, where_body_indices, &
                         elsewhere_body_indices, elsewhere_clauses, &
-                        line, column, parent_index) result(where_index)
+                        line, column, parent_index, is_single_line) &
+                        result(where_index)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in) :: mask_expr_index
         integer, intent(in), optional :: where_body_indices(:)
         integer, intent(in), optional :: elsewhere_body_indices(:)
         type(elsewhere_clause_t), intent(in), optional :: elsewhere_clauses(:)
         integer, intent(in), optional :: line, column, parent_index
+        logical, intent(in), optional :: is_single_line
         integer :: where_index
         type(where_node) :: where_stmt
-        integer :: i, j
-        type(result_t) :: validation
+        integer :: i
 
         where_stmt%uid = generate_uid()
         where_stmt%mask_is_simple = .false.
         where_stmt%can_vectorize = .false.
+        if (present(is_single_line)) where_stmt%is_single_line = is_single_line
 
-        ! Validate arena is initialized
-        validation = validate_arena(arena, "push_where")
-        if (validation%is_failure()) then
-            write (error_unit, '(A)') &
-                "ERROR [ast_factory_control]: " // &
-                validation%get_full_message()
+        if (.not. where_inputs_are_valid(arena, mask_expr_index, &
+                where_body_indices, elsewhere_body_indices, &
+                elsewhere_clauses)) then
             where_index = 0
             return
-        end if
-
-        ! Validate mask expression index
-        validation = validate_node_index(arena, mask_expr_index, "push_where mask")
-        if (validation%is_failure()) then
-            write (error_unit, '(A)') &
-                "ERROR [ast_factory_control]: " // &
-                validation%get_full_message()
-            where_index = 0
-            return
-        end if
-
-        ! Validate where body indices
-        if (present(where_body_indices)) then
-            do i = 1, size(where_body_indices)
-                validation = validate_node_index( &
-                    arena, where_body_indices(i), "push_where body")
-                if (validation%is_failure()) then
-                    write (error_unit, '(A)') &
-                        "ERROR [ast_factory_control]: " // &
-                        validation%get_full_message()
-                    where_index = 0
-                    return
-                end if
-            end do
-        end if
-
-        ! Validate elsewhere body indices
-        if (present(elsewhere_body_indices)) then
-            do i = 1, size(elsewhere_body_indices)
-                validation = validate_node_index( &
-                    arena, elsewhere_body_indices(i), "push_where elsewhere")
-                if (validation%is_failure()) then
-                    write (error_unit, '(A)') &
-                        "ERROR [ast_factory_control]: " // &
-                        validation%get_full_message()
-                    where_index = 0
-                    return
-                end if
-            end do
-        end if
-        if (present(elsewhere_clauses)) then
-            do i = 1, size(elsewhere_clauses)
-                if (elsewhere_clauses(i)%mask_index > 0) then
-                    validation = validate_node_index( &
-                        arena, elsewhere_clauses(i)%mask_index, &
-                        "push_where elsewhere mask")
-                    if (validation%is_failure()) then
-                        write (error_unit, '(A)') &
-                            "ERROR [ast_factory_control]: " // &
-                            validation%get_full_message()
-                        where_index = 0
-                        return
-                    end if
-                end if
-                if (allocated(elsewhere_clauses(i)%body_indices)) then
-                    do j = 1, size(elsewhere_clauses(i)%body_indices)
-                        validation = validate_node_index( &
-                            arena, elsewhere_clauses(i)%body_indices(j), &
-                            "push_where elsewhere body")
-                        if (validation%is_failure()) then
-                            write (error_unit, '(A)') &
-                                "ERROR [ast_factory_control]: " // &
-                                validation%get_full_message()
-                            where_index = 0
-                            return
-                        end if
-                    end do
-                end if
-            end do
         end if
 
         where_stmt%mask_expr_index = mask_expr_index
@@ -133,22 +62,113 @@
 
         call arena%push(where_stmt, "where_node", parent_index)
         where_index = arena%size
+        call link_where_children(arena, where_index, mask_expr_index, &
+            where_body_indices, elsewhere_body_indices, elsewhere_clauses)
+    end function push_where
 
-        ! Link children to this parent for AST traversal
-        if (mask_expr_index > 0) then
-            call link_children_to_parent(arena, where_index, [mask_expr_index])
-        end if
+    logical function where_inputs_are_valid(arena, mask_expr_index, &
+            where_body_indices, elsewhere_body_indices, elsewhere_clauses)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: mask_expr_index
+        integer, intent(in), optional :: where_body_indices(:)
+        integer, intent(in), optional :: elsewhere_body_indices(:)
+        type(elsewhere_clause_t), intent(in), optional :: elsewhere_clauses(:)
+        type(result_t) :: validation
+        integer :: i
+
+        where_inputs_are_valid = .false.
+        validation = validate_arena(arena, 'push_where')
+        if (.not. report_valid(validation)) return
+        validation = validate_node_index(arena, mask_expr_index, 'push_where mask')
+        if (.not. report_valid(validation)) return
         if (present(where_body_indices)) then
-            if (size(where_body_indices) > 0) then
-                call link_children_to_parent(arena, where_index, where_body_indices)
-            end if
+            if (.not. index_list_is_valid(arena, where_body_indices, &
+                    'push_where body')) return
         end if
         if (present(elsewhere_body_indices)) then
-            if (size(elsewhere_body_indices) > 0) then
-                call link_children_to_parent(arena, where_index, elsewhere_body_indices)
-            end if
+            if (.not. index_list_is_valid(arena, elsewhere_body_indices, &
+                    'push_where elsewhere')) return
         end if
-    end function push_where
+        if (present(elsewhere_clauses)) then
+            do i = 1, size(elsewhere_clauses)
+                if (.not. elsewhere_clause_is_valid(arena, &
+                        elsewhere_clauses(i))) return
+            end do
+        end if
+        where_inputs_are_valid = .true.
+    end function where_inputs_are_valid
+
+    logical function elsewhere_clause_is_valid(arena, clause)
+        type(ast_arena_t), intent(in) :: arena
+        type(elsewhere_clause_t), intent(in) :: clause
+        type(result_t) :: validation
+
+        elsewhere_clause_is_valid = .false.
+        if (clause%mask_index > 0) then
+            validation = validate_node_index(arena, clause%mask_index, &
+                'push_where elsewhere mask')
+            if (.not. report_valid(validation)) return
+        end if
+        if (allocated(clause%body_indices)) then
+            if (.not. index_list_is_valid(arena, clause%body_indices, &
+                    'push_where elsewhere body')) return
+        end if
+        elsewhere_clause_is_valid = .true.
+    end function elsewhere_clause_is_valid
+
+    logical function index_list_is_valid(arena, indices, context)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        character(len=*), intent(in) :: context
+        type(result_t) :: validation
+        integer :: i
+
+        index_list_is_valid = .false.
+        do i = 1, size(indices)
+            validation = validate_node_index(arena, indices(i), context)
+            if (.not. report_valid(validation)) return
+        end do
+        index_list_is_valid = .true.
+    end function index_list_is_valid
+
+    logical function report_valid(validation)
+        type(result_t), intent(in) :: validation
+
+        report_valid = .not. validation%is_failure()
+        if (report_valid) return
+        write (error_unit, '(A)') 'ERROR [ast_factory_control]: '// &
+            validation%get_full_message()
+    end function report_valid
+
+    subroutine link_where_children(arena, where_index, mask_expr_index, &
+            where_body_indices, elsewhere_body_indices, elsewhere_clauses)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: where_index, mask_expr_index
+        integer, intent(in), optional :: where_body_indices(:)
+        integer, intent(in), optional :: elsewhere_body_indices(:)
+        type(elsewhere_clause_t), intent(in), optional :: elsewhere_clauses(:)
+        integer :: i
+
+        call link_children_to_parent(arena, where_index, [mask_expr_index])
+        if (present(where_body_indices)) then
+            if (size(where_body_indices) > 0) call link_children_to_parent( &
+                arena, where_index, where_body_indices)
+        end if
+        if (present(elsewhere_body_indices)) then
+            if (size(elsewhere_body_indices) > 0) call link_children_to_parent( &
+                arena, where_index, elsewhere_body_indices)
+        end if
+        if (.not. present(elsewhere_clauses)) return
+        do i = 1, size(elsewhere_clauses)
+            if (elsewhere_clauses(i)%mask_index > 0) call link_children_to_parent( &
+                arena, where_index, [elsewhere_clauses(i)%mask_index])
+            if (allocated(elsewhere_clauses(i)%body_indices)) then
+                if (size(elsewhere_clauses(i)%body_indices) > 0) &
+                    call link_children_to_parent(arena, where_index, &
+                    elsewhere_clauses(i)%body_indices)
+            end if
+        end do
+    end subroutine link_where_children
 
     ! Create WHERE construct node and add to stack (simplified interface)
     function push_where_construct(arena, mask_expr_index, where_body_indices, &

--- a/src/ast/factory/ast_factory_io.f90
+++ b/src/ast/factory/ast_factory_io.f90
@@ -1,6 +1,7 @@
 module ast_factory_io
     use ast_arena_modern, only: ast_arena_t, link_children_to_parent
-    use ast_nodes_io, only: print_statement_node, write_statement_node, &
+    use ast_nodes_io, only: io_specifier_t, print_statement_node, &
+        write_statement_node, &
         read_statement_node, format_statement_node, &
         open_statement_node, close_statement_node, &
         inquire_statement_node, backspace_statement_node, &
@@ -54,7 +55,7 @@ contains
     function push_write_statement(arena, unit_spec, arg_indices, format_spec, &
             namelist_group, io_control_list, &
             format_expr_index, line, column, &
-            parent_index) result(write_index)
+            parent_index, specifiers) result(write_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec
         integer, intent(in), optional :: arg_indices(:)
@@ -63,6 +64,7 @@ contains
         character(len=*), intent(in), optional :: io_control_list
         integer, intent(in), optional :: format_expr_index
         integer, intent(in), optional :: line, column, parent_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
         integer :: write_index
         type(write_statement_node) :: write_stmt
 
@@ -86,26 +88,22 @@ contains
         end if
         if (present(line)) write_stmt%line = line
         if (present(column)) write_stmt%column = column
+        call apply_io_specifiers(write_stmt%specifiers, &
+            write_stmt%iostat_var_index, write_stmt%err_label_index, &
+            write_stmt%end_label_index, specifiers)
 
         call arena%push(write_stmt, "write_statement", parent_index)
         write_index = arena%size
+        call link_io_specifier_children(arena, write_index, specifiers)
 
-        ! Link children to this parent for AST traversal
-        if (write_stmt%format_expr_index > 0) then
-            call link_children_to_parent(arena, write_index, &
-                [write_stmt%format_expr_index])
-        end if
-        if (present(arg_indices)) then
-            if (size(arg_indices) > 0) then
-                call link_children_to_parent(arena, write_index, arg_indices)
-            end if
-        end if
+        call link_transfer_io_children(arena, write_index, &
+            write_stmt%format_expr_index, arg_indices)
     end function push_write_statement
 
     function push_read_statement(arena, unit_spec, var_indices, format_spec, &
             namelist_group, io_control_list, &
             format_expr_index, line, column, &
-            parent_index) result(read_index)
+            parent_index, specifiers) result(read_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec
         integer, intent(in), optional :: var_indices(:)
@@ -114,6 +112,7 @@ contains
         character(len=*), intent(in), optional :: io_control_list
         integer, intent(in), optional :: format_expr_index
         integer, intent(in), optional :: line, column, parent_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
         integer :: read_index
         type(read_statement_node) :: read_stmt
 
@@ -137,20 +136,16 @@ contains
         end if
         if (present(line)) read_stmt%line = line
         if (present(column)) read_stmt%column = column
+        call apply_io_specifiers(read_stmt%specifiers, &
+            read_stmt%iostat_var_index, read_stmt%err_label_index, &
+            read_stmt%end_label_index, specifiers)
 
         call arena%push(read_stmt, "read_statement", parent_index)
         read_index = arena%size
+        call link_io_specifier_children(arena, read_index, specifiers)
 
-        ! Link children to this parent for AST traversal
-        if (read_stmt%format_expr_index > 0) then
-            call link_children_to_parent(arena, read_index, &
-                [read_stmt%format_expr_index])
-        end if
-        if (present(var_indices)) then
-            if (size(var_indices) > 0) then
-                call link_children_to_parent(arena, read_index, var_indices)
-            end if
-        end if
+        call link_transfer_io_children(arena, read_index, &
+            read_stmt%format_expr_index, var_indices)
     end function push_read_statement
 
     ! Extended I/O statement functions with iostat/err/end specifiers
@@ -310,100 +305,202 @@ contains
         format_index = arena%size
     end function push_format_statement
 
-    function push_open_statement(arena, spec_text, line, column, parent_index) &
+    function push_open_statement(arena, spec_text, line, column, parent_index, &
+            specifiers) &
             result(open_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: spec_text
         integer, intent(in), optional :: line, column, parent_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
         integer :: open_index
         type(open_statement_node) :: open_stmt
 
         open_stmt%unit_spec = spec_text
         if (present(line)) open_stmt%line = line
         if (present(column)) open_stmt%column = column
+        call apply_position_specifiers(open_stmt%specifiers, &
+            open_stmt%iostat_var_index, open_stmt%err_label_index, specifiers)
 
         call arena%push(open_stmt, "open_statement", parent_index)
         open_index = arena%size
+        call link_io_specifier_children(arena, open_index, specifiers)
     end function push_open_statement
 
-    function push_close_statement(arena, spec_text, line, column, parent_index) &
+    function push_close_statement(arena, spec_text, line, column, parent_index, &
+            specifiers) &
             result(close_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: spec_text
         integer, intent(in), optional :: line, column, parent_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
         integer :: close_index
         type(close_statement_node) :: close_stmt
 
         close_stmt%unit_spec = spec_text
         if (present(line)) close_stmt%line = line
         if (present(column)) close_stmt%column = column
+        call apply_position_specifiers(close_stmt%specifiers, &
+            close_stmt%iostat_var_index, close_stmt%err_label_index, specifiers)
 
         call arena%push(close_stmt, "close_statement", parent_index)
         close_index = arena%size
+        call link_io_specifier_children(arena, close_index, specifiers)
     end function push_close_statement
 
     function push_inquire_statement(arena, spec_text, line, column, &
-            parent_index) result(inquire_index)
+            parent_index, specifiers) result(inquire_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: spec_text
         integer, intent(in), optional :: line, column, parent_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
         integer :: inquire_index
         type(inquire_statement_node) :: inquire_stmt
 
         inquire_stmt%spec_list = spec_text
         if (present(line)) inquire_stmt%line = line
         if (present(column)) inquire_stmt%column = column
+        call apply_position_specifiers(inquire_stmt%specifiers, &
+            inquire_stmt%iostat_var_index, inquire_stmt%err_label_index, &
+            specifiers)
 
         call arena%push(inquire_stmt, "inquire_statement", parent_index)
         inquire_index = arena%size
+        call link_io_specifier_children(arena, inquire_index, specifiers)
     end function push_inquire_statement
 
     function push_backspace_statement(arena, unit_spec, line, column, &
-            parent_index) result(backspace_index)
+            parent_index, specifiers) result(backspace_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec
         integer, intent(in), optional :: line, column, parent_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
         integer :: backspace_index
         type(backspace_statement_node) :: backspace_stmt
 
         backspace_stmt%unit_spec = unit_spec
         if (present(line)) backspace_stmt%line = line
         if (present(column)) backspace_stmt%column = column
+        call apply_position_specifiers(backspace_stmt%specifiers, &
+            backspace_stmt%iostat_var_index, backspace_stmt%err_label_index, &
+            specifiers)
 
         call arena%push(backspace_stmt, "backspace_statement", parent_index)
         backspace_index = arena%size
+        call link_io_specifier_children(arena, backspace_index, specifiers)
     end function push_backspace_statement
 
     function push_rewind_statement(arena, unit_spec, line, column, &
-            parent_index) result(rewind_index)
+            parent_index, specifiers) result(rewind_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec
         integer, intent(in), optional :: line, column, parent_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
         integer :: rewind_index
         type(rewind_statement_node) :: rewind_stmt
 
         rewind_stmt%unit_spec = unit_spec
         if (present(line)) rewind_stmt%line = line
         if (present(column)) rewind_stmt%column = column
+        call apply_position_specifiers(rewind_stmt%specifiers, &
+            rewind_stmt%iostat_var_index, rewind_stmt%err_label_index, specifiers)
 
         call arena%push(rewind_stmt, "rewind_statement", parent_index)
         rewind_index = arena%size
+        call link_io_specifier_children(arena, rewind_index, specifiers)
     end function push_rewind_statement
 
     function push_endfile_statement(arena, unit_spec, line, column, &
-            parent_index) result(endfile_index)
+            parent_index, specifiers) result(endfile_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: unit_spec
         integer, intent(in), optional :: line, column, parent_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
         integer :: endfile_index
         type(endfile_statement_node) :: endfile_stmt
 
         endfile_stmt%unit_spec = unit_spec
         if (present(line)) endfile_stmt%line = line
         if (present(column)) endfile_stmt%column = column
+        call apply_position_specifiers(endfile_stmt%specifiers, &
+            endfile_stmt%iostat_var_index, endfile_stmt%err_label_index, specifiers)
 
         call arena%push(endfile_stmt, "endfile_statement", parent_index)
         endfile_index = arena%size
+        call link_io_specifier_children(arena, endfile_index, specifiers)
     end function push_endfile_statement
+
+    subroutine apply_io_specifiers(target, iostat_index, err_index, end_index, &
+            specifiers)
+        type(io_specifier_t), allocatable, intent(inout) :: target(:)
+        integer, intent(inout) :: iostat_index, err_index, end_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
+
+        if (.not. present(specifiers)) return
+        target = specifiers
+        iostat_index = specifier_node_index(specifiers, 'iostat')
+        err_index = specifier_node_index(specifiers, 'err')
+        end_index = specifier_node_index(specifiers, 'end')
+    end subroutine apply_io_specifiers
+
+    subroutine link_transfer_io_children(arena, parent_index, format_index, &
+            item_indices)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: parent_index, format_index
+        integer, intent(in), optional :: item_indices(:)
+
+        if (format_index > 0) then
+            call link_children_to_parent(arena, parent_index, [format_index])
+        end if
+        if (.not. present(item_indices)) return
+        if (size(item_indices) > 0) then
+            call link_children_to_parent(arena, parent_index, item_indices)
+        end if
+    end subroutine link_transfer_io_children
+
+    subroutine apply_position_specifiers(target, iostat_index, err_index, &
+            specifiers)
+        type(io_specifier_t), allocatable, intent(inout) :: target(:)
+        integer, intent(inout) :: iostat_index, err_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
+
+        if (.not. present(specifiers)) return
+        target = specifiers
+        iostat_index = specifier_node_index(specifiers, 'iostat')
+        err_index = specifier_node_index(specifiers, 'err')
+    end subroutine apply_position_specifiers
+
+    integer function specifier_node_index(specifiers, name) result(node_index)
+        type(io_specifier_t), intent(in) :: specifiers(:)
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        node_index = 0
+        do i = 1, size(specifiers)
+            if (.not. allocated(specifiers(i)%name)) cycle
+            if (specifiers(i)%name /= name) cycle
+            node_index = specifiers(i)%value_node_index
+            return
+        end do
+    end function specifier_node_index
+
+    subroutine link_io_specifier_children(arena, parent_index, specifiers)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: parent_index
+        type(io_specifier_t), intent(in), optional :: specifiers(:)
+        integer, allocatable :: child_indices(:)
+        integer :: i, child_count
+
+        if (.not. present(specifiers)) return
+        child_count = count(specifiers%value_node_index > 0)
+        if (child_count == 0) return
+        allocate (child_indices(child_count))
+        child_count = 0
+        do i = 1, size(specifiers)
+            if (specifiers(i)%value_node_index <= 0) cycle
+            child_count = child_count + 1
+            child_indices(child_count) = specifiers(i)%value_node_index
+        end do
+        call link_children_to_parent(arena, parent_index, child_indices)
+    end subroutine link_io_specifier_children
 
 end module ast_factory_io

--- a/src/ast/nodes/ast_nodes_array.f90
+++ b/src/ast/nodes/ast_nodes_array.f90
@@ -28,6 +28,7 @@ module ast_nodes_array
         ! Optimization hints
         logical :: mask_is_simple = .false. ! True if mask is simple comparison
         logical :: can_vectorize = .false. ! True if all assignments vectorizable
+        logical :: is_single_line = .false.
     contains
         procedure :: accept => where_accept
         procedure :: assign => where_assign
@@ -88,6 +89,7 @@ contains
         end if
         lhs%mask_is_simple = rhs%mask_is_simple
         lhs%can_vectorize = rhs%can_vectorize
+        lhs%is_single_line = rhs%is_single_line
     end subroutine where_assign
 
     ! WHERE statement implementations

--- a/src/ast/nodes/ast_nodes_io.f90
+++ b/src/ast/nodes/ast_nodes_io.f90
@@ -5,6 +5,14 @@ module ast_nodes_io
     implicit none
     private
 
+    public :: io_specifier_t
+
+    type :: io_specifier_t
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: value
+        integer :: value_node_index = 0
+    end type io_specifier_t
+
     ! Public factory functions
     public :: create_print_statement
     public :: create_io_implied_do
@@ -55,6 +63,7 @@ module ast_nodes_io
         integer :: format_expr_index = 0 ! Optional runtime
         ! format expression
         logical :: is_formatted = .false. ! True if formatted I/O
+        type(io_specifier_t), allocatable :: specifiers(:)
     contains
         procedure :: accept => write_statement_accept
         procedure :: assign => write_statement_assign
@@ -75,6 +84,7 @@ module ast_nodes_io
         integer :: format_expr_index = 0 ! Optional runtime
         ! format expression
         logical :: is_formatted = .false. ! True if formatted I/O
+        type(io_specifier_t), allocatable :: specifiers(:)
     contains
         procedure :: accept => read_statement_accept
         procedure :: assign => read_statement_assign
@@ -120,6 +130,7 @@ module ast_nodes_io
         character(len=:), allocatable :: pad_spec
         integer :: iostat_var_index = 0
         integer :: err_label_index = 0
+        type(io_specifier_t), allocatable :: specifiers(:)
     contains
         procedure :: accept => open_statement_accept
         procedure :: assign => open_statement_assign
@@ -132,6 +143,7 @@ module ast_nodes_io
         character(len=:), allocatable :: status_spec
         integer :: iostat_var_index = 0
         integer :: err_label_index = 0
+        type(io_specifier_t), allocatable :: specifiers(:)
     contains
         procedure :: accept => close_statement_accept
         procedure :: assign => close_statement_assign
@@ -143,6 +155,7 @@ module ast_nodes_io
         character(len=:), allocatable :: spec_list
         integer :: iostat_var_index = 0
         integer :: err_label_index = 0
+        type(io_specifier_t), allocatable :: specifiers(:)
     contains
         procedure :: accept => inquire_statement_accept
         procedure :: assign => inquire_statement_assign
@@ -154,6 +167,7 @@ module ast_nodes_io
         character(len=:), allocatable :: unit_spec
         integer :: iostat_var_index = 0
         integer :: err_label_index = 0
+        type(io_specifier_t), allocatable :: specifiers(:)
     contains
         procedure :: accept => backspace_statement_accept
         procedure :: assign => backspace_statement_assign
@@ -165,6 +179,7 @@ module ast_nodes_io
         character(len=:), allocatable :: unit_spec
         integer :: iostat_var_index = 0
         integer :: err_label_index = 0
+        type(io_specifier_t), allocatable :: specifiers(:)
     contains
         procedure :: accept => rewind_statement_accept
         procedure :: assign => rewind_statement_assign
@@ -176,6 +191,7 @@ module ast_nodes_io
         character(len=:), allocatable :: unit_spec
         integer :: iostat_var_index = 0
         integer :: err_label_index = 0
+        type(io_specifier_t), allocatable :: specifiers(:)
     contains
         procedure :: accept => endfile_statement_accept
         procedure :: assign => endfile_statement_assign
@@ -286,6 +302,7 @@ contains
         lhs%end_label_index = rhs%end_label_index
         lhs%format_expr_index = rhs%format_expr_index
         lhs%is_formatted = rhs%is_formatted
+        call copy_io_specifiers(rhs%specifiers, lhs%specifiers)
     end subroutine write_statement_assign
 
     ! Read statement implementations
@@ -322,6 +339,7 @@ contains
         lhs%end_label_index = rhs%end_label_index
         lhs%format_expr_index = rhs%format_expr_index
         lhs%is_formatted = rhs%is_formatted
+        call copy_io_specifiers(rhs%specifiers, lhs%specifiers)
     end subroutine read_statement_assign
 
     ! Format descriptor implementations
@@ -406,6 +424,7 @@ contains
         if (allocated(rhs%pad_spec)) lhs%pad_spec = rhs%pad_spec
         lhs%iostat_var_index = rhs%iostat_var_index
         lhs%err_label_index = rhs%err_label_index
+        call copy_io_specifiers(rhs%specifiers, lhs%specifiers)
     end subroutine open_statement_assign
 
     ! CLOSE statement implementations
@@ -431,6 +450,7 @@ contains
         if (allocated(rhs%status_spec)) lhs%status_spec = rhs%status_spec
         lhs%iostat_var_index = rhs%iostat_var_index
         lhs%err_label_index = rhs%err_label_index
+        call copy_io_specifiers(rhs%specifiers, lhs%specifiers)
     end subroutine close_statement_assign
 
     ! Factory functions
@@ -515,6 +535,7 @@ contains
         if (allocated(rhs%spec_list)) lhs%spec_list = rhs%spec_list
         lhs%iostat_var_index = rhs%iostat_var_index
         lhs%err_label_index = rhs%err_label_index
+        call copy_io_specifiers(rhs%specifiers, lhs%specifiers)
     end subroutine inquire_statement_assign
 
     function create_inquire_statement() result(node)
@@ -544,6 +565,7 @@ contains
         if (allocated(rhs%unit_spec)) lhs%unit_spec = rhs%unit_spec
         lhs%iostat_var_index = rhs%iostat_var_index
         lhs%err_label_index = rhs%err_label_index
+        call copy_io_specifiers(rhs%specifiers, lhs%specifiers)
     end subroutine backspace_statement_assign
 
     function create_backspace_statement() result(node)
@@ -573,6 +595,7 @@ contains
         if (allocated(rhs%unit_spec)) lhs%unit_spec = rhs%unit_spec
         lhs%iostat_var_index = rhs%iostat_var_index
         lhs%err_label_index = rhs%err_label_index
+        call copy_io_specifiers(rhs%specifiers, lhs%specifiers)
     end subroutine rewind_statement_assign
 
     function create_rewind_statement() result(node)
@@ -602,11 +625,20 @@ contains
         if (allocated(rhs%unit_spec)) lhs%unit_spec = rhs%unit_spec
         lhs%iostat_var_index = rhs%iostat_var_index
         lhs%err_label_index = rhs%err_label_index
+        call copy_io_specifiers(rhs%specifiers, lhs%specifiers)
     end subroutine endfile_statement_assign
 
     function create_endfile_statement() result(node)
         type(endfile_statement_node) :: node
         node%uid = generate_uid()
     end function create_endfile_statement
+
+    subroutine copy_io_specifiers(source, target)
+        type(io_specifier_t), allocatable, intent(in) :: source(:)
+        type(io_specifier_t), allocatable, intent(inout) :: target(:)
+
+        if (allocated(target)) deallocate (target)
+        if (allocated(source)) target = source
+    end subroutine copy_io_specifiers
 
 end module ast_nodes_io

--- a/src/fortfront_compiler.f90
+++ b/src/fortfront_compiler.f90
@@ -34,6 +34,9 @@ module fortfront_compiler
         get_compiler_diagnostics, &
         DIAGNOSTIC_PHASE_PARSER, DIAGNOSTIC_PHASE_SEMANTIC, &
         DIAGNOSTIC_CODE_PARSER, DIAGNOSTIC_CODE_SEMANTIC
+    use frontend_compiler_io_queries
+    use frontend_compiler_control_queries
+    use frontend_compiler_branch_queries
     use frontend_compiler_node_queries, only: is_declaration_node, &
         is_derived_type_node, &
         get_declaration_var_name, get_declaration_type_name, &

--- a/src/frontend/frontend_compiler_branch_queries.f90
+++ b/src/frontend/frontend_compiler_branch_queries.f90
@@ -1,0 +1,230 @@
+module frontend_compiler_branch_queries
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: program_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+    use ast_nodes_transfer, only: goto_node, pause_node, continue_node
+    implicit none
+    private
+
+    integer, parameter, public :: BRANCH_GOTO = 1
+    integer, parameter, public :: BRANCH_PAUSE = 2
+    integer, parameter, public :: BRANCH_CONTINUE = 3
+
+    type, public :: branch_target_query_t
+        character(len=:), allocatable :: label
+        logical :: has_node = .false.
+        integer :: node_index = 0
+    end type branch_target_query_t
+
+    type, public :: branch_statement_query_t
+        logical :: found = .false.
+        integer :: statement_kind = 0
+        integer :: line = 0
+        integer :: column = 0
+        logical :: has_statement_label = .false.
+        character(len=:), allocatable :: statement_label
+        logical :: has_target_label = .false.
+        character(len=:), allocatable :: target_label
+        logical :: has_target_labels = .false.
+        character(len=:), allocatable :: target_labels
+        type(branch_target_query_t), allocatable :: targets(:)
+        logical :: is_computed = .false.
+        logical :: has_selector = .false.
+        integer :: selector_node_index = 0
+        logical :: has_code = .false.
+        integer :: code_node_index = 0
+        logical :: has_message = .false.
+        character(len=:), allocatable :: message
+    end type branch_statement_query_t
+
+    public :: query_branch_statement
+
+contains
+
+    function query_branch_statement(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(branch_statement_query_t) :: query
+
+        call initialize_branch_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (goto_node)
+            call fill_goto_query(arena, node_index, node, query)
+            type is (pause_node)
+            call fill_pause_query(node, query)
+            type is (continue_node)
+            query%found = .true.
+            query%statement_kind = BRANCH_CONTINUE
+        end select
+        if (.not. query%found) return
+        query%line = arena%entries(node_index)%node%line
+        query%column = arena%entries(node_index)%node%column
+        call copy_statement_label(arena, node_index, query)
+    end function query_branch_statement
+
+    subroutine initialize_branch_query(query)
+        type(branch_statement_query_t), intent(out) :: query
+
+        query%statement_label = ''
+        query%target_label = ''
+        query%target_labels = ''
+        query%message = ''
+        allocate (query%targets(0))
+    end subroutine initialize_branch_query
+
+    subroutine copy_statement_label(arena, node_index, query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(branch_statement_query_t), intent(inout) :: query
+
+        if (.not. allocated(arena%entries(node_index)%node%stmt_label)) return
+        query%statement_label = arena%entries(node_index)%node%stmt_label
+        query%has_statement_label = len(query%statement_label) > 0
+    end subroutine copy_statement_label
+
+    subroutine fill_goto_query(arena, node_index, node, query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(goto_node), intent(in) :: node
+        type(branch_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = BRANCH_GOTO
+        call copy_text(node%label, query%target_label, query%has_target_label)
+        call copy_text(node%label_list, query%target_labels, &
+            query%has_target_labels)
+        call copy_index(node%selector_index, query%selector_node_index, &
+            query%has_selector)
+        query%is_computed = query%has_target_labels .or. query%has_selector
+        call collect_goto_targets(arena, node_index, query)
+    end subroutine fill_goto_query
+
+    subroutine collect_goto_targets(arena, source_index, query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: source_index
+        type(branch_statement_query_t), intent(inout) :: query
+        character(len=:), allocatable :: remaining, label
+        integer :: comma
+
+        if (query%has_target_label) then
+            call append_target(arena, source_index, query%target_label, query)
+            return
+        end if
+        if (.not. query%has_target_labels) return
+        remaining = query%target_labels
+        do
+            comma = index(remaining, ',')
+            if (comma == 0) then
+                label = trim(adjustl(remaining))
+            else
+                label = trim(adjustl(remaining(:comma - 1)))
+            end if
+            call append_target(arena, source_index, label, query)
+            if (comma == 0) exit
+            remaining = remaining(comma + 1:)
+        end do
+    end subroutine collect_goto_targets
+
+    subroutine append_target(arena, source_index, label, query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: source_index
+        character(len=*), intent(in) :: label
+        type(branch_statement_query_t), intent(inout) :: query
+        type(branch_target_query_t) :: target
+
+        target%label = label
+        target%node_index = resolve_target_node(arena, source_index, label)
+        target%has_node = target%node_index > 0
+        query%targets = [query%targets, target]
+    end subroutine append_target
+
+    integer function resolve_target_node(arena, source_index, label) &
+            result(target_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: source_index
+        character(len=*), intent(in) :: label
+        integer :: i, source_scope, matches
+
+        target_index = 0
+        matches = 0
+        source_scope = nearest_scoping_unit(arena, source_index)
+        if (source_scope <= 0) return
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            if (.not. allocated(arena%entries(i)%node%stmt_label)) cycle
+            if (trim(arena%entries(i)%node%stmt_label) /= trim(label)) cycle
+            if (nearest_scoping_unit(arena, i) /= source_scope) cycle
+            matches = matches + 1
+            target_index = i
+        end do
+        if (matches == 1) return
+        target_index = 0
+    end function resolve_target_node
+
+    integer function nearest_scoping_unit(arena, node_index) result(scope_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer :: current_index, parent_index, steps
+
+        scope_index = 0
+        current_index = node_index
+        do steps = 1, arena%size
+            if (is_scoping_unit(arena, current_index)) then
+                scope_index = current_index
+                return
+            end if
+            parent_index = arena%entries(current_index)%parent_index
+            if (parent_index <= 0) return
+            if (.not. arena%has_node_at(parent_index)) return
+            current_index = parent_index
+        end do
+    end function nearest_scoping_unit
+
+    logical function is_scoping_unit(arena, node_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+
+        is_scoping_unit = .false.
+        select type (node => arena%entries(node_index)%node)
+            type is (program_node)
+            is_scoping_unit = .true.
+            type is (function_def_node)
+            is_scoping_unit = .true.
+            type is (subroutine_def_node)
+            is_scoping_unit = .true.
+        end select
+    end function is_scoping_unit
+
+    subroutine fill_pause_query(node, query)
+        type(pause_node), intent(in) :: node
+        type(branch_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = BRANCH_PAUSE
+        call copy_index(node%pause_code_index, query%code_node_index, &
+            query%has_code)
+        call copy_text(node%pause_message, query%message, query%has_message)
+    end subroutine fill_pause_query
+
+    subroutine copy_text(source, target, present_flag)
+        character(len=:), allocatable, intent(in) :: source
+        character(len=:), allocatable, intent(inout) :: target
+        logical, intent(inout) :: present_flag
+
+        if (.not. allocated(source)) return
+        target = source
+        present_flag = .true.
+    end subroutine copy_text
+
+    subroutine copy_index(source, target, present_flag)
+        integer, intent(in) :: source
+        integer, intent(inout) :: target
+        logical, intent(inout) :: present_flag
+
+        if (source <= 0) return
+        target = source
+        present_flag = .true.
+    end subroutine copy_index
+
+end module frontend_compiler_branch_queries

--- a/src/frontend/frontend_compiler_control_queries.f90
+++ b/src/frontend/frontend_compiler_control_queries.f90
@@ -1,0 +1,265 @@
+module frontend_compiler_control_queries
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_associate, only: associate_node, block_construct_node
+    use ast_nodes_conditional, only: select_type_node, type_guard_block_node, &
+        select_rank_node, rank_block_node
+    use ast_nodes_array, only: where_node, where_stmt_node
+    implicit none
+    private
+
+    integer, parameter, public :: CONTROL_ASSOCIATE = 1
+    integer, parameter, public :: CONTROL_BLOCK = 2
+    integer, parameter, public :: CONTROL_SELECT_TYPE = 3
+    integer, parameter, public :: CONTROL_TYPE_GUARD = 4
+    integer, parameter, public :: CONTROL_SELECT_RANK = 5
+    integer, parameter, public :: CONTROL_RANK_BLOCK = 6
+    integer, parameter, public :: CONTROL_WHERE = 7
+    integer, parameter, public :: CONTROL_WHERE_STATEMENT = 8
+
+    type, public :: association_query_t
+        character(len=:), allocatable :: name
+        integer :: expression_node_index = 0
+    end type association_query_t
+
+    type, public :: elsewhere_clause_query_t
+        logical :: has_mask = .false.
+        integer :: mask_node_index = 0
+        integer, allocatable :: body_node_indices(:)
+    end type elsewhere_clause_query_t
+
+    type, public :: control_statement_query_t
+        logical :: found = .false.
+        integer :: statement_kind = 0
+        integer :: line = 0
+        integer :: column = 0
+        type(association_query_t), allocatable :: associations(:)
+        integer, allocatable :: body_node_indices(:)
+        logical :: has_selector = .false.
+        integer :: selector_node_index = 0
+        integer, allocatable :: child_node_indices(:)
+        logical :: has_default = .false.
+        integer :: default_node_index = 0
+        character(len=:), allocatable :: guard_type
+        logical :: has_type_name = .false.
+        integer :: type_name_node_index = 0
+        logical :: has_rank = .false.
+        integer :: rank_value = 0
+        logical :: is_default = .false.
+        logical :: is_assumed_size = .false.
+        logical :: has_mask = .false.
+        integer :: mask_node_index = 0
+        type(elsewhere_clause_query_t), allocatable :: elsewhere_clauses(:)
+        logical :: has_assignment = .false.
+        integer :: assignment_node_index = 0
+        logical :: is_single_line = .false.
+    end type control_statement_query_t
+
+    public :: query_control_statement
+
+contains
+
+    function query_control_statement(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(control_statement_query_t) :: query
+
+        call initialize_control_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (associate_node)
+            call fill_associate_query(node, query)
+            type is (block_construct_node)
+            call fill_block_query(node, query)
+            type is (select_type_node)
+            call fill_select_type_query(node, query)
+            type is (type_guard_block_node)
+            call fill_type_guard_query(node, query)
+            type is (select_rank_node)
+            call fill_select_rank_query(node, query)
+            type is (rank_block_node)
+            call fill_rank_block_query(node, query)
+            type is (where_node)
+            call fill_where_query(node, query)
+            type is (where_stmt_node)
+            call fill_where_statement_query(node, query)
+        end select
+        if (.not. query%found) return
+        query%line = arena%entries(node_index)%node%line
+        query%column = arena%entries(node_index)%node%column
+    end function query_control_statement
+
+    subroutine initialize_control_query(query)
+        type(control_statement_query_t), intent(out) :: query
+
+        query%guard_type = ''
+        allocate (query%associations(0))
+        allocate (query%body_node_indices(0))
+        allocate (query%child_node_indices(0))
+        allocate (query%elsewhere_clauses(0))
+    end subroutine initialize_control_query
+
+    subroutine fill_associate_query(node, query)
+        type(associate_node), intent(in) :: node
+        type(control_statement_query_t), intent(inout) :: query
+        integer :: i
+
+        query%found = .true.
+        query%statement_kind = CONTROL_ASSOCIATE
+        if (allocated(node%body_indices)) query%body_node_indices = node%body_indices
+        if (.not. allocated(node%associations)) return
+        deallocate (query%associations)
+        allocate (query%associations(size(node%associations)))
+        do i = 1, size(node%associations)
+            query%associations(i)%name = ''
+            if (allocated(node%associations(i)%name)) then
+                query%associations(i)%name = node%associations(i)%name
+            end if
+            query%associations(i)%expression_node_index = &
+                node%associations(i)%expr_index
+        end do
+    end subroutine fill_associate_query
+
+    subroutine fill_block_query(node, query)
+        type(block_construct_node), intent(in) :: node
+        type(control_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = CONTROL_BLOCK
+        if (allocated(node%body_indices)) query%body_node_indices = node%body_indices
+    end subroutine fill_block_query
+
+    subroutine fill_select_type_query(node, query)
+        type(select_type_node), intent(in) :: node
+        type(control_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = CONTROL_SELECT_TYPE
+        call set_present_index(node%selector_index, query%selector_node_index, &
+            query%has_selector)
+        if (allocated(node%guard_indices)) then
+            query%child_node_indices = node%guard_indices
+        end if
+        call set_present_index(node%default_index, query%default_node_index, &
+            query%has_default)
+    end subroutine fill_select_type_query
+
+    subroutine fill_type_guard_query(node, query)
+        type(type_guard_block_node), intent(in) :: node
+        type(control_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = CONTROL_TYPE_GUARD
+        query%guard_type = trim(node%guard_type)
+        query%is_default = query%guard_type == 'class_default'
+        call set_present_index(node%type_name_index, &
+            query%type_name_node_index, query%has_type_name)
+        if (allocated(node%body_indices)) query%body_node_indices = node%body_indices
+    end subroutine fill_type_guard_query
+
+    subroutine fill_select_rank_query(node, query)
+        type(select_rank_node), intent(in) :: node
+        type(control_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = CONTROL_SELECT_RANK
+        call set_present_index(node%selector_index, query%selector_node_index, &
+            query%has_selector)
+        if (allocated(node%rank_indices)) then
+            query%child_node_indices = node%rank_indices
+        end if
+        call set_present_index(node%default_index, query%default_node_index, &
+            query%has_default)
+    end subroutine fill_select_rank_query
+
+    subroutine fill_rank_block_query(node, query)
+        type(rank_block_node), intent(in) :: node
+        type(control_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = CONTROL_RANK_BLOCK
+        query%is_default = node%rank_value == -1
+        query%is_assumed_size = node%rank_value == -2
+        query%has_rank = .not. query%is_default .and. &
+            .not. query%is_assumed_size
+        if (query%has_rank) query%rank_value = node%rank_value
+        if (allocated(node%body_indices)) query%body_node_indices = node%body_indices
+    end subroutine fill_rank_block_query
+
+    subroutine fill_where_query(node, query)
+        type(where_node), intent(in) :: node
+        type(control_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%is_single_line = node%is_single_line
+        if (node%is_single_line) then
+            query%statement_kind = CONTROL_WHERE_STATEMENT
+        else
+            query%statement_kind = CONTROL_WHERE
+        end if
+        call set_present_index(node%mask_expr_index, query%mask_node_index, &
+            query%has_mask)
+        if (allocated(node%where_body_indices)) then
+            query%body_node_indices = node%where_body_indices
+        end if
+        if (node%is_single_line) call set_single_assignment(query)
+        call copy_elsewhere_clauses(node, query)
+    end subroutine fill_where_query
+
+    subroutine fill_where_statement_query(node, query)
+        type(where_stmt_node), intent(in) :: node
+        type(control_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = CONTROL_WHERE_STATEMENT
+        query%is_single_line = .true.
+        call set_present_index(node%mask_expr_index, query%mask_node_index, &
+            query%has_mask)
+        call set_present_index(node%assignment_index, &
+            query%assignment_node_index, query%has_assignment)
+    end subroutine fill_where_statement_query
+
+    subroutine set_single_assignment(query)
+        type(control_statement_query_t), intent(inout) :: query
+
+        if (size(query%body_node_indices) /= 1) return
+        query%assignment_node_index = query%body_node_indices(1)
+        query%has_assignment = query%assignment_node_index > 0
+    end subroutine set_single_assignment
+
+    subroutine copy_elsewhere_clauses(node, query)
+        type(where_node), intent(in) :: node
+        type(control_statement_query_t), intent(inout) :: query
+        integer :: i
+
+        if (.not. allocated(node%elsewhere_clauses)) return
+        deallocate (query%elsewhere_clauses)
+        allocate (query%elsewhere_clauses(size(node%elsewhere_clauses)))
+        do i = 1, size(node%elsewhere_clauses)
+            call initialize_elsewhere(query%elsewhere_clauses(i))
+            call set_present_index(node%elsewhere_clauses(i)%mask_index, &
+                query%elsewhere_clauses(i)%mask_node_index, &
+                query%elsewhere_clauses(i)%has_mask)
+            if (allocated(node%elsewhere_clauses(i)%body_indices)) then
+                query%elsewhere_clauses(i)%body_node_indices = &
+                    node%elsewhere_clauses(i)%body_indices
+            end if
+        end do
+    end subroutine copy_elsewhere_clauses
+
+    subroutine initialize_elsewhere(clause)
+        type(elsewhere_clause_query_t), intent(out) :: clause
+
+        allocate (clause%body_node_indices(0))
+    end subroutine initialize_elsewhere
+
+    subroutine set_present_index(source, target, present_flag)
+        integer, intent(in) :: source
+        integer, intent(inout) :: target
+        logical, intent(inout) :: present_flag
+
+        if (source <= 0) return
+        target = source
+        present_flag = .true.
+    end subroutine set_present_index
+
+end module frontend_compiler_control_queries

--- a/src/frontend/frontend_compiler_io_queries.f90
+++ b/src/frontend/frontend_compiler_io_queries.f90
@@ -1,0 +1,406 @@
+module frontend_compiler_io_queries
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_io, only: io_specifier_t, print_statement_node, &
+        write_statement_node, read_statement_node, format_statement_node, &
+        open_statement_node, close_statement_node, inquire_statement_node, &
+        backspace_statement_node, rewind_statement_node, endfile_statement_node
+    implicit none
+    private
+
+    integer, parameter, public :: IO_STATEMENT_PRINT = 1
+    integer, parameter, public :: IO_STATEMENT_WRITE = 2
+    integer, parameter, public :: IO_STATEMENT_READ = 3
+    integer, parameter, public :: IO_STATEMENT_FORMAT = 4
+    integer, parameter, public :: IO_STATEMENT_OPEN = 5
+    integer, parameter, public :: IO_STATEMENT_CLOSE = 6
+    integer, parameter, public :: IO_STATEMENT_INQUIRE = 7
+    integer, parameter, public :: IO_STATEMENT_BACKSPACE = 8
+    integer, parameter, public :: IO_STATEMENT_REWIND = 9
+    integer, parameter, public :: IO_STATEMENT_ENDFILE = 10
+
+    type, public :: io_specifier_query_t
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: value
+        logical :: has_value_node = .false.
+        integer :: value_node_index = 0
+    end type io_specifier_query_t
+
+    type, public :: io_statement_query_t
+        logical :: found = .false.
+        integer :: statement_kind = 0
+        integer :: line = 0
+        integer :: column = 0
+        logical :: has_statement_label = .false.
+        character(len=:), allocatable :: statement_label
+        type(io_specifier_query_t), allocatable :: specifiers(:)
+        integer, allocatable :: item_node_indices(:)
+        logical :: has_unit_spec = .false.
+        character(len=:), allocatable :: unit_spec
+        logical :: has_unit_node = .false.
+        integer :: unit_node_index = 0
+        logical :: has_format_spec = .false.
+        character(len=:), allocatable :: format_spec
+        logical :: has_file_spec = .false.
+        character(len=:), allocatable :: file_spec
+        logical :: has_status_spec = .false.
+        character(len=:), allocatable :: status_spec
+        logical :: has_access_spec = .false.
+        character(len=:), allocatable :: access_spec
+        logical :: has_form_spec = .false.
+        character(len=:), allocatable :: form_spec
+        logical :: has_recl_spec = .false.
+        character(len=:), allocatable :: recl_spec
+        logical :: has_blank_spec = .false.
+        character(len=:), allocatable :: blank_spec
+        logical :: has_position_spec = .false.
+        character(len=:), allocatable :: position_spec
+        logical :: has_action_spec = .false.
+        character(len=:), allocatable :: action_spec
+        logical :: has_delim_spec = .false.
+        character(len=:), allocatable :: delim_spec
+        logical :: has_pad_spec = .false.
+        character(len=:), allocatable :: pad_spec
+        logical :: has_namelist_group = .false.
+        character(len=:), allocatable :: namelist_group
+        character(len=:), allocatable :: specifier_list
+        logical :: has_iostat_node = .false.
+        integer :: iostat_node_index = 0
+        logical :: has_err_label = .false.
+        integer :: err_label_node_index = 0
+        logical :: has_end_label = .false.
+        integer :: end_label_node_index = 0
+        logical :: has_format_node = .false.
+        integer :: format_node_index = 0
+        logical :: is_formatted = .false.
+    end type io_statement_query_t
+
+    public :: query_io_statement
+
+contains
+
+    function query_io_statement(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(io_statement_query_t) :: query
+
+        call initialize_io_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (print_statement_node)
+            call fill_print_query(node, query)
+            type is (write_statement_node)
+            call fill_write_query(node, query)
+            type is (read_statement_node)
+            call fill_read_query(node, query)
+            type is (format_statement_node)
+            call fill_format_query(node, query)
+            type is (open_statement_node)
+            call fill_open_query(node, query)
+            type is (close_statement_node)
+            call fill_close_query(node, query)
+            type is (inquire_statement_node)
+            call fill_inquire_query(node, query)
+            type is (backspace_statement_node)
+            call fill_position_query(node%unit_spec, node%specifiers, &
+                IO_STATEMENT_BACKSPACE, query)
+            type is (rewind_statement_node)
+            call fill_position_query(node%unit_spec, node%specifiers, &
+                IO_STATEMENT_REWIND, query)
+            type is (endfile_statement_node)
+            call fill_position_query(node%unit_spec, node%specifiers, &
+                IO_STATEMENT_ENDFILE, query)
+        end select
+        if (.not. query%found) return
+        query%line = arena%entries(node_index)%node%line
+        query%column = arena%entries(node_index)%node%column
+        call copy_statement_label(arena, node_index, query)
+    end function query_io_statement
+
+    subroutine initialize_io_query(query)
+        type(io_statement_query_t), intent(out) :: query
+
+        query%statement_label = ''
+        query%unit_spec = ''
+        query%format_spec = ''
+        query%file_spec = ''
+        query%status_spec = ''
+        query%access_spec = ''
+        query%form_spec = ''
+        query%recl_spec = ''
+        query%blank_spec = ''
+        query%position_spec = ''
+        query%action_spec = ''
+        query%delim_spec = ''
+        query%pad_spec = ''
+        query%namelist_group = ''
+        query%specifier_list = ''
+        allocate (query%specifiers(0))
+        allocate (query%item_node_indices(0))
+    end subroutine initialize_io_query
+
+    subroutine copy_statement_label(arena, node_index, query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(io_statement_query_t), intent(inout) :: query
+
+        if (.not. allocated(arena%entries(node_index)%node%stmt_label)) return
+        query%statement_label = arena%entries(node_index)%node%stmt_label
+        query%has_statement_label = len(query%statement_label) > 0
+    end subroutine copy_statement_label
+
+    subroutine fill_print_query(node, query)
+        type(print_statement_node), intent(in) :: node
+        type(io_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = IO_STATEMENT_PRINT
+        if (allocated(node%expression_indices)) then
+            query%item_node_indices = node%expression_indices
+        end if
+        call copy_text(node%format_spec, query%format_spec, &
+            query%has_format_spec)
+    end subroutine fill_print_query
+
+    subroutine fill_write_query(node, query)
+        type(write_statement_node), intent(in) :: node
+        type(io_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = IO_STATEMENT_WRITE
+        if (allocated(node%arg_indices)) query%item_node_indices = node%arg_indices
+        call copy_common_transfer_io(node%unit_spec, node%format_spec, &
+            node%namelist_group, node%specifiers, node%format_expr_index, query)
+        query%is_formatted = node%is_formatted
+    end subroutine fill_write_query
+
+    subroutine fill_read_query(node, query)
+        type(read_statement_node), intent(in) :: node
+        type(io_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = IO_STATEMENT_READ
+        if (allocated(node%var_indices)) query%item_node_indices = node%var_indices
+        call copy_common_transfer_io(node%unit_spec, node%format_spec, &
+            node%namelist_group, node%specifiers, node%format_expr_index, query)
+        query%is_formatted = node%is_formatted
+    end subroutine fill_read_query
+
+    subroutine fill_format_query(node, query)
+        type(format_statement_node), intent(in) :: node
+        type(io_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = IO_STATEMENT_FORMAT
+        call copy_text(node%format_spec, query%format_spec, &
+            query%has_format_spec)
+    end subroutine fill_format_query
+
+    subroutine fill_open_query(node, query)
+        type(open_statement_node), intent(in) :: node
+        type(io_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = IO_STATEMENT_OPEN
+        call copy_io_specifiers(node%specifiers, query)
+        call copy_index(node%iostat_var_index, query%iostat_node_index, &
+            query%has_iostat_node)
+        call copy_index(node%err_label_index, query%err_label_node_index, &
+            query%has_err_label)
+    end subroutine fill_open_query
+
+    subroutine fill_close_query(node, query)
+        type(close_statement_node), intent(in) :: node
+        type(io_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = IO_STATEMENT_CLOSE
+        call copy_io_specifiers(node%specifiers, query)
+        call copy_index(node%iostat_var_index, query%iostat_node_index, &
+            query%has_iostat_node)
+        call copy_index(node%err_label_index, query%err_label_node_index, &
+            query%has_err_label)
+    end subroutine fill_close_query
+
+    subroutine fill_inquire_query(node, query)
+        type(inquire_statement_node), intent(in) :: node
+        type(io_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = IO_STATEMENT_INQUIRE
+        call copy_text_value(node%spec_list, query%specifier_list)
+        call copy_io_specifiers(node%specifiers, query)
+        call copy_index(node%iostat_var_index, query%iostat_node_index, &
+            query%has_iostat_node)
+        call copy_index(node%err_label_index, query%err_label_node_index, &
+            query%has_err_label)
+    end subroutine fill_inquire_query
+
+    subroutine fill_position_query(raw_spec, specifiers, statement_kind, query)
+        character(len=:), allocatable, intent(in) :: raw_spec
+        type(io_specifier_t), allocatable, intent(in) :: specifiers(:)
+        integer, intent(in) :: statement_kind
+        type(io_statement_query_t), intent(inout) :: query
+
+        query%found = .true.
+        query%statement_kind = statement_kind
+        call copy_text_value(raw_spec, query%specifier_list)
+        call copy_io_specifiers(specifiers, query)
+    end subroutine fill_position_query
+
+    subroutine copy_common_transfer_io(unit_spec, format_spec, namelist_group, &
+            specifiers, format_node_index, query)
+        character(len=:), allocatable, intent(in) :: unit_spec, format_spec
+        character(len=:), allocatable, intent(in) :: namelist_group
+        type(io_specifier_t), allocatable, intent(in) :: specifiers(:)
+        integer, intent(in) :: format_node_index
+        type(io_statement_query_t), intent(inout) :: query
+
+        call copy_text(unit_spec, query%unit_spec, query%has_unit_spec)
+        call copy_text(format_spec, query%format_spec, query%has_format_spec)
+        call copy_text(namelist_group, query%namelist_group, &
+            query%has_namelist_group)
+        call copy_io_specifiers(specifiers, query)
+        call copy_index(format_node_index, query%format_node_index, &
+            query%has_format_node)
+    end subroutine copy_common_transfer_io
+
+    subroutine copy_io_specifiers(source, query)
+        type(io_specifier_t), allocatable, intent(in) :: source(:)
+        type(io_statement_query_t), intent(inout) :: query
+        integer :: i
+
+        if (.not. allocated(source)) return
+        deallocate (query%specifiers)
+        allocate (query%specifiers(size(source)))
+        do i = 1, size(source)
+            call copy_one_specifier(source(i), query%specifiers(i))
+            call apply_named_specifier(source(i), query)
+        end do
+        call set_control_indices(source, query)
+    end subroutine copy_io_specifiers
+
+    subroutine copy_one_specifier(source, target)
+        type(io_specifier_t), intent(in) :: source
+        type(io_specifier_query_t), intent(out) :: target
+
+        target%name = ''
+        target%value = ''
+        if (allocated(source%name)) target%name = source%name
+        if (allocated(source%value)) target%value = source%value
+        call copy_index(source%value_node_index, target%value_node_index, &
+            target%has_value_node)
+    end subroutine copy_one_specifier
+
+    subroutine apply_named_specifier(specifier, query)
+        type(io_specifier_t), intent(in) :: specifier
+        type(io_statement_query_t), intent(inout) :: query
+
+        if (.not. allocated(specifier%name)) return
+        select case (specifier%name)
+        case ('unit')
+            call apply_unit_specifier(specifier, query)
+        case ('fmt', 'format')
+            call apply_text_specifier(specifier, query%format_spec, &
+                query%has_format_spec)
+        case ('file')
+            call apply_text_specifier(specifier, query%file_spec, &
+                query%has_file_spec)
+        case ('status')
+            call apply_text_specifier(specifier, query%status_spec, &
+                query%has_status_spec)
+        case ('access')
+            call apply_text_specifier(specifier, query%access_spec, &
+                query%has_access_spec)
+        case ('form')
+            call apply_text_specifier(specifier, query%form_spec, &
+                query%has_form_spec)
+        case ('recl')
+            call apply_text_specifier(specifier, query%recl_spec, &
+                query%has_recl_spec)
+        case ('blank')
+            call apply_text_specifier(specifier, query%blank_spec, &
+                query%has_blank_spec)
+        case ('position')
+            call apply_text_specifier(specifier, query%position_spec, &
+                query%has_position_spec)
+        case ('action')
+            call apply_text_specifier(specifier, query%action_spec, &
+                query%has_action_spec)
+        case ('delim')
+            call apply_text_specifier(specifier, query%delim_spec, &
+                query%has_delim_spec)
+        case ('pad')
+            call apply_text_specifier(specifier, query%pad_spec, &
+                query%has_pad_spec)
+        end select
+    end subroutine apply_named_specifier
+
+    subroutine apply_unit_specifier(specifier, query)
+        type(io_specifier_t), intent(in) :: specifier
+        type(io_statement_query_t), intent(inout) :: query
+
+        call apply_text_specifier(specifier, query%unit_spec, &
+            query%has_unit_spec)
+        call copy_index(specifier%value_node_index, query%unit_node_index, &
+            query%has_unit_node)
+    end subroutine apply_unit_specifier
+
+    subroutine apply_text_specifier(specifier, value, present_flag)
+        type(io_specifier_t), intent(in) :: specifier
+        character(len=:), allocatable, intent(inout) :: value
+        logical, intent(inout) :: present_flag
+
+        if (.not. allocated(specifier%value)) return
+        value = specifier%value
+        present_flag = .true.
+    end subroutine apply_text_specifier
+
+    subroutine set_control_indices(specifiers, query)
+        type(io_specifier_t), intent(in) :: specifiers(:)
+        type(io_statement_query_t), intent(inout) :: query
+        integer :: i
+
+        do i = 1, size(specifiers)
+            if (.not. allocated(specifiers(i)%name)) cycle
+            select case (specifiers(i)%name)
+            case ('iostat')
+                call copy_index(specifiers(i)%value_node_index, &
+                    query%iostat_node_index, query%has_iostat_node)
+            case ('err')
+                call copy_index(specifiers(i)%value_node_index, &
+                    query%err_label_node_index, query%has_err_label)
+            case ('end')
+                call copy_index(specifiers(i)%value_node_index, &
+                    query%end_label_node_index, query%has_end_label)
+            end select
+        end do
+    end subroutine set_control_indices
+
+    subroutine copy_text(source, target, present_flag)
+        character(len=:), allocatable, intent(in) :: source
+        character(len=:), allocatable, intent(inout) :: target
+        logical, intent(inout) :: present_flag
+
+        if (.not. allocated(source)) return
+        target = source
+        present_flag = .true.
+    end subroutine copy_text
+
+    subroutine copy_text_value(source, target)
+        character(len=:), allocatable, intent(in) :: source
+        character(len=:), allocatable, intent(inout) :: target
+
+        if (allocated(source)) target = source
+    end subroutine copy_text_value
+
+    subroutine copy_index(source, target, present_flag)
+        integer, intent(in) :: source
+        integer, intent(inout) :: target
+        logical, intent(inout) :: present_flag
+
+        if (source <= 0) return
+        target = source
+        present_flag = .true.
+    end subroutine copy_index
+
+end module frontend_compiler_io_queries

--- a/src/parser/expressions/parser_array_constructs.f90
+++ b/src/parser/expressions/parser_array_constructs.f90
@@ -76,36 +76,7 @@ contains
                 return
             end if
 
-            ! Check if this is single-line WHERE
-            token = parser%peek()
-            single_line = .true.
-            block
-                integer :: lookahead
-
-                do lookahead = parser%current_token, size(parser%tokens)
-                    if (parser%tokens(lookahead)%kind /= TK_WHITESPACE) then
-                        token = parser%tokens(lookahead)
-                        exit
-                    end if
-                end do
-
-                if (lookahead > size(parser%tokens)) then
-                    token%kind = TK_EOF
-                    token%text = ""
-                end if
-            end block
-
-            if (token%kind == TK_NEWLINE .or. token%kind == TK_EOF) then
-                single_line = .false.
-            else if (token%kind == TK_OPERATOR .and. token%text == ";") then
-                single_line = .false.
-            else if (token%kind == TK_COMMENT) then
-                single_line = .false.
-            else if (token%kind == TK_KEYWORD) then
-                if (token%text == "elsewhere" .or. token%text == "end") then
-                    single_line = .false.
-                end if
-            end if
+            single_line = remaining_where_is_single_line(parser)
 
             if (single_line) then
                 callbacks = build_where_callbacks()
@@ -114,7 +85,7 @@ contains
 
                 ! Create WHERE node with single statement
                 where_index = push_where(arena, mask_expr_index, where_body_indices, &
-                    line=line, column=column)
+                    line=line, column=column, is_single_line=.true.)
 
                 return
             end if
@@ -139,7 +110,7 @@ contains
                 where_body_indices)
 
             where_index = push_where(arena, mask_expr_index, where_body_indices, &
-                line=line, column=column)
+                line=line, column=column, is_single_line=.true.)
             return
         end if
 
@@ -156,6 +127,31 @@ contains
             where_end_keywords, &
             line, column)
     end function parse_where_construct
+
+    logical function remaining_where_is_single_line(parser)
+        type(parser_state_t), intent(in) :: parser
+        type(token_t) :: token
+        integer :: lookahead
+
+        token%kind = TK_EOF
+        token%text = ''
+        do lookahead = parser%current_token, size(parser%tokens)
+            if (parser%tokens(lookahead)%kind == TK_WHITESPACE) cycle
+            token = parser%tokens(lookahead)
+            exit
+        end do
+        remaining_where_is_single_line = .true.
+        select case (token%kind)
+        case (TK_NEWLINE, TK_EOF, TK_COMMENT)
+            remaining_where_is_single_line = .false.
+        case (TK_OPERATOR)
+            if (token%text == ';') remaining_where_is_single_line = .false.
+        case (TK_KEYWORD)
+            if (token%text == 'elsewhere' .or. token%text == 'end') then
+                remaining_where_is_single_line = .false.
+            end if
+        end select
+    end function remaining_where_is_single_line
 
     function create_where_with_elsewhere_clauses(arena, parser, &
             mask_expr_index, &

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -2,7 +2,7 @@ module parser_procedure_definition_bodies_module
     use, intrinsic :: iso_fortran_env, only: error_unit
     use string_utils_mod, only: to_lower
     use lexer_core, only: token_t, TK_KEYWORD, TK_IDENTIFIER, TK_NEWLINE, &
-        TK_WHITESPACE, TK_OPERATOR, TK_COMMENT, TK_EOF
+        TK_WHITESPACE, TK_OPERATOR, TK_COMMENT, TK_EOF, TK_NUMBER
     use parser_state_module, only: parser_state_t, create_parser_state
     use parser_if_statements_module, only: parse_if_statement_tokens
     use parser_do_constructs_module, only: parse_do_loop
@@ -560,7 +560,7 @@ contains
         type(ast_arena_t), intent(inout) :: arena
         type(parser_state_t), intent(in) :: parent_parser
         integer :: first_token
-        character(len=:), allocatable :: token_lower
+        character(len=:), allocatable :: token_lower, stmt_label
         type(parser_state_t) :: block_parser
         type(token_t) :: token
 
@@ -574,6 +574,17 @@ contains
                 exit
             end select
         end do
+
+        if (first_token <= stmt_size) then
+            if (stmt_tokens(first_token)%kind == TK_NUMBER) then
+                stmt_label = trim(stmt_tokens(first_token)%text)
+                first_token = first_token + 1
+                do while (first_token <= stmt_size)
+                    if (stmt_tokens(first_token)%kind /= TK_WHITESPACE) exit
+                    first_token = first_token + 1
+                end do
+            end if
+        end if
 
         if (first_token <= stmt_size) then
             if (stmt_tokens(first_token)%kind == TK_KEYWORD) then
@@ -624,6 +635,11 @@ contains
                     first_token)))
             else
                 stmt_index = 0
+            end if
+        end if
+        if (stmt_index > 0 .and. allocated(stmt_label)) then
+            if (arena%has_node_at(stmt_index)) then
+                arena%entries(stmt_index)%node%stmt_label = stmt_label
             end if
         end if
     end function parse_body_statement_tokens

--- a/src/parser/statements/parser_io_specifiers.f90
+++ b/src/parser/statements/parser_io_specifiers.f90
@@ -1,0 +1,152 @@
+module parser_io_specifiers
+    use lexer_core, only: token_t, TK_IDENTIFIER, TK_KEYWORD, TK_OPERATOR, &
+        TK_WHITESPACE, TK_NEWLINE, TK_COMMENT, to_lower
+    use parser_state_module, only: parser_state_t
+    use parser_expressions_module, only: parse_comparison
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_io, only: io_specifier_t
+    implicit none
+    private
+
+    public :: parse_io_specifier_nodes
+
+contains
+
+    subroutine parse_io_specifier_nodes(parser, arena, positional_names, &
+            specifiers)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: positional_names(:)
+        type(io_specifier_t), allocatable, intent(out) :: specifiers(:)
+        type(token_t) :: token
+        type(io_specifier_t) :: specifier
+        integer :: position
+
+        allocate (specifiers(0))
+        position = 0
+        do while (.not. parser%is_at_end())
+            call skip_separators(parser)
+            token = parser%peek()
+            if (is_specifier_end(token)) exit
+            call parse_one_specifier(parser, arena, positional_names, &
+                position, specifier)
+            specifiers = [specifiers, specifier]
+        end do
+    end subroutine parse_io_specifier_nodes
+
+    subroutine parse_one_specifier(parser, arena, positional_names, position, &
+            specifier)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: positional_names(:)
+        integer, intent(inout) :: position
+        type(io_specifier_t), intent(out) :: specifier
+        integer :: first_token, last_token
+
+        call parse_specifier_name(parser, positional_names, position, &
+            specifier%name)
+        first_token = parser%current_token
+        specifier%value_node_index = parse_specifier_value(parser, arena)
+        last_token = parser%current_token - 1
+        specifier%value = compact_token_text(parser, first_token, last_token)
+    end subroutine parse_one_specifier
+
+    subroutine parse_specifier_name(parser, positional_names, position, name)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=*), intent(in) :: positional_names(:)
+        integer, intent(inout) :: position
+        character(len=:), allocatable, intent(out) :: name
+        type(parser_state_t) :: checkpoint
+        type(token_t) :: token
+
+        checkpoint = parser
+        token = checkpoint%peek()
+        if (is_name_token(token)) then
+            token = checkpoint%consume()
+            if (is_equals_token(checkpoint%peek())) then
+                name = trim(to_lower(token%text))
+                token = checkpoint%consume()
+                parser = checkpoint
+                return
+            end if
+        end if
+        position = position + 1
+        if (position <= size(positional_names)) then
+            name = trim(positional_names(position))
+        else
+            name = ''
+        end if
+    end subroutine parse_specifier_name
+
+    integer function parse_specifier_value(parser, arena) result(node_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(token_t) :: token
+        integer :: start_token
+
+        start_token = parser%current_token
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. token%text == '*') then
+            token = parser%consume()
+            node_index = 0
+            return
+        end if
+        node_index = parse_comparison(parser, arena)
+        if (parser%current_token == start_token) token = parser%consume()
+    end function parse_specifier_value
+
+    subroutine skip_separators(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        do
+            token = parser%peek()
+            if (token%kind == TK_WHITESPACE) then
+                token = parser%consume()
+            else if (token%kind == TK_OPERATOR .and. token%text == ',') then
+                token = parser%consume()
+            else
+                exit
+            end if
+        end do
+    end subroutine skip_separators
+
+    logical function is_name_token(token)
+        type(token_t), intent(in) :: token
+
+        is_name_token = token%kind == TK_IDENTIFIER .or. &
+            token%kind == TK_KEYWORD
+    end function is_name_token
+
+    logical function is_equals_token(token)
+        type(token_t), intent(in) :: token
+
+        is_equals_token = token%kind == TK_OPERATOR .and. token%text == '='
+    end function is_equals_token
+
+    logical function is_specifier_end(token)
+        type(token_t), intent(in) :: token
+
+        is_specifier_end = token%kind == TK_NEWLINE .or. &
+            token%kind == TK_COMMENT
+        if (token%kind == TK_OPERATOR) then
+            is_specifier_end = is_specifier_end .or. token%text == ')' .or. &
+                token%text == ';'
+        end if
+    end function is_specifier_end
+
+    function compact_token_text(parser, first_token, last_token) result(text)
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(in) :: first_token, last_token
+        character(len=:), allocatable :: text
+        integer :: i
+
+        text = ''
+        if (.not. associated(parser%tokens)) return
+        do i = first_token, min(last_token, size(parser%tokens))
+            if (parser%tokens(i)%kind == TK_WHITESPACE) cycle
+            text = text//parser%tokens(i)%text
+        end do
+    end function compact_token_text
+
+end module parser_io_specifiers

--- a/src/parser/statements/parser_io_statements.f90
+++ b/src/parser/statements/parser_io_statements.f90
@@ -8,8 +8,9 @@ module parser_io_statements_module
     use parser_expressions_module, only: parse_comparison
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_io, only: &
-        inquire_statement_node, backspace_statement_node, &
+        io_specifier_t, inquire_statement_node, backspace_statement_node, &
         rewind_statement_node, endfile_statement_node
+    use parser_io_specifiers, only: parse_io_specifier_nodes
     use ast_factory, only: push_print_statement, push_write_statement, &
         push_read_statement, push_format_statement, &
         push_open_statement, push_close_statement, &

--- a/src/parser/statements/parser_io_statements_common.inc
+++ b/src/parser/statements/parser_io_statements_common.inc
@@ -227,6 +227,18 @@
         spec_text = trim(spec_text)
     end function collect_position_spec
 
+    subroutine prepare_position_specifier_parser(parser, specifier_parser)
+        type(parser_state_t), intent(in) :: parser
+        type(parser_state_t), intent(out) :: specifier_parser
+        type(token_t) :: token
+
+        specifier_parser = parser
+        token = specifier_parser%peek()
+        if (token%kind == TK_OPERATOR) then
+            if (token%text == '(') token = specifier_parser%consume()
+        end if
+    end subroutine prepare_position_specifier_parser
+
     ! Parse argument list (common logic for print/write/read)
     subroutine parse_argument_list(parser, arena, arg_indices)
         type(parser_state_t), intent(inout) :: parser
@@ -387,4 +399,3 @@
             fail_and_restore = 0
         end function fail_and_restore
     end function parse_io_implied_do
-

--- a/src/parser/statements/parser_io_statements_parsers.inc
+++ b/src/parser/statements/parser_io_statements_parsers.inc
@@ -42,8 +42,9 @@
         integer :: line, column
         character(len=:), allocatable :: unit_spec, format_spec, namelist_group
         character(len=:), allocatable :: io_control_list
-        logical :: has_keyworded_format
         integer :: format_expr_index
+        type(parser_state_t) :: specifier_parser
+        type(io_specifier_t), allocatable :: specifiers(:)
 
         format_expr_index = 0
 
@@ -67,6 +68,7 @@
             write_index = 0
             return
         end if
+        specifier_parser = parser
 
         ! Parse unit specifier
         unit_spec = parse_unit_specifier(parser)
@@ -78,45 +80,8 @@
             return
         end if
 
-        ! Check for format specifier or namelist (optional)
-        has_keyworded_format = .false.
-        token = parser%peek()
-        if (token%kind == TK_OPERATOR .and. token%text == ",") then
-            token = parser%consume()  ! consume comma
-
-            ! Check if next token is nml keyword
-            token = parser%peek()
-            if (token%kind == TK_IDENTIFIER .and. token%text == "nml") then
-                token = parser%consume()  ! consume nml
-
-                ! Expect = after nml
-                token = parser%peek()
-                if (token%kind == TK_OPERATOR .and. token%text == "=") then
-                    token = parser%consume()  ! consume =
-
-                    ! Parse namelist group name
-                    token = parser%peek()
-                    if (token%kind == TK_IDENTIFIER) then
-                        namelist_group = token%text
-                        token = parser%consume()
-                    else
-                        write (error_unit, *) &
-                            "Error: Expected namelist group name after 'nml='", &
-                            " at line ", token%line
-                    end if
-                end if
-            else
-                has_keyworded_format = parse_keyworded_format_clause(parser, &
-                                                                     format_spec)
-                if (.not. has_keyworded_format) then
-                    ! Parse positional format specifier (literal or expression)
-                    call parse_positional_format(parser, arena, format_spec, &
-                                                 format_expr_index, &
-                                                 is_control_specifier= &
-                                                 is_write_io_control_specifier)
-                end if
-            end if
-        end if
+        call parse_write_format_clause(parser, arena, format_spec, &
+            namelist_group, format_expr_index)
 
         ! Collect any additional I/O control specifiers (iostat, iomsg, etc.)
         io_control_list = collect_io_control_specifiers(parser, &
@@ -131,31 +96,15 @@
             write_index = 0
             return
         end if
+        call parse_io_specifier_nodes(specifier_parser, arena, &
+            [character(len=4) :: 'unit', 'fmt'], specifiers)
 
         ! Parse all write arguments
         call parse_argument_list(parser, arena, arg_indices)
 
-        ! Create write statement node with parsed arguments
-        if (allocated(namelist_group)) then
-            write_index = push_write_statement(arena, unit_spec, arg_indices, &
-                                               namelist_group=namelist_group, &
-                                               io_control_list=io_control_list, &
-                                               line=line, column=column)
-        else if (format_expr_index > 0) then
-            write_index = push_write_statement(arena, unit_spec, arg_indices, &
-                                               format_expr_index=format_expr_index, &
-                                               io_control_list=io_control_list, &
-                                               line=line, column=column)
-        else if (allocated(format_spec)) then
-            write_index = push_write_statement(arena, unit_spec, arg_indices, &
-                                               format_spec=format_spec, &
-                                               io_control_list=io_control_list, &
-                                               line=line, column=column)
-        else
-            write_index = push_write_statement(arena, unit_spec, arg_indices, &
-                                               io_control_list=io_control_list, &
-                                               line=line, column=column)
-        end if
+        write_index = push_parsed_write_statement(arena, unit_spec, arg_indices, &
+            format_spec, namelist_group, io_control_list, format_expr_index, &
+            specifiers, line, column)
     end function parse_write_statement
 
     function parse_read_statement(parser, arena) result(read_index)
@@ -168,10 +117,12 @@
         integer :: line, column
         character(len=:), allocatable :: unit_spec, format_spec, namelist_group
         character(len=:), allocatable :: io_control_list
-        type(parser_state_t) :: checkpoint
         integer :: format_expr_index
+        type(parser_state_t) :: specifier_parser
+        type(io_specifier_t), allocatable :: specifiers(:)
 
         format_expr_index = 0
+        allocate (specifiers(0))
 
         ! Consume read keyword
         token = parser%consume()
@@ -183,6 +134,7 @@
         if (token%kind == TK_OPERATOR .and. token%text == "(") then
             ! Format: read (unit, format) variables
             token = parser%consume()  ! consume (
+            specifier_parser = parser
 
             ! Parse unit specifier
             unit_spec = parse_unit_specifier(parser)
@@ -194,57 +146,8 @@
                 return
             end if
 
-            ! Check for format specifier or namelist (optional)
-            format_spec = ""
-            token = parser%peek()
-            if (token%kind == TK_OPERATOR .and. token%text == ",") then
-                token = parser%consume()  ! consume comma
-
-                ! Check if next token is nml keyword for namelist
-                token = parser%peek()
-                if (token%kind == TK_IDENTIFIER .and. token%text == "nml") then
-                    token = parser%consume()  ! consume nml
-
-                    ! Expect = after nml
-                    token = parser%peek()
-                    if (token%kind == TK_OPERATOR .and. token%text == "=") then
-                        token = parser%consume()  ! consume =
-
-                        ! Parse namelist group name
-                        token = parser%peek()
-                        if (token%kind == TK_IDENTIFIER) then
-                            namelist_group = token%text
-                            token = parser%consume()
-                        else
-                            write (error_unit, *) &
-                                "Error: Expected namelist group name after 'nml=' &
-                                &at line ", token%line
-                        end if
-                    end if
-                else if (is_format_specifier_keyword(token)) then
-                    ! Check if next token is a keyword parameter (e.g., fmt=)
-                    ! Only consume keyword if followed by =
-                    ! Save position to check for = before committing
-                    checkpoint = parser
-                    token = checkpoint%consume()  ! tentatively consume keyword
-
-                    ! Check if = follows
-                    token = checkpoint%peek()
-                    if (token%kind == TK_OPERATOR .and. token%text == "=") then
-                        ! Its a keyworded format (fmt= or format=)
-                        parser = checkpoint  ! commit keyword consumption
-                        token = parser%consume()  ! consume =
-                    end if
-                    ! Otherwise, treat as positional format variable
-                end if
-
-                if (.not. allocated(namelist_group)) then
-                    call parse_positional_format(parser, arena, format_spec, &
-                                                 format_expr_index, &
-                                                 is_control_specifier= &
-                                                 is_read_io_control_specifier)
-                end if
-            end if
+            call parse_read_format_clause(parser, arena, format_spec, &
+                namelist_group, format_expr_index)
 
             ! Collect any additional I/O control specifiers (iostat, iomsg, etc.)
             io_control_list = collect_io_control_specifiers( &
@@ -259,6 +162,8 @@
                 read_index = 0
                 return
             end if
+            call parse_io_specifier_nodes(specifier_parser, arena, &
+                [character(len=4) :: 'unit', 'fmt'], specifiers)
         else
             ! Format: read format, variables (list-directed without unit)
             unit_spec = "*"  ! Default to standard input
@@ -277,29 +182,152 @@
         ! Parse all read variables
         call parse_argument_list(parser, arena, var_indices)
 
-        ! Create read statement node with parsed variables
+        read_index = push_parsed_read_statement(arena, unit_spec, var_indices, &
+            format_spec, namelist_group, io_control_list, format_expr_index, &
+            specifiers, line, column)
+    end function parse_read_statement
+
+    subroutine parse_write_format_clause(parser, arena, format_spec, &
+            namelist_group, format_expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=:), allocatable, intent(out) :: format_spec
+        character(len=:), allocatable, intent(out) :: namelist_group
+        integer, intent(inout) :: format_expr_index
+        type(token_t) :: token
+        logical :: has_keyworded_format
+
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= ',') return
+        token = parser%consume()
+        if (parse_namelist_clause(parser, namelist_group)) return
+        has_keyworded_format = parse_keyworded_format_clause(parser, format_spec)
+        if (has_keyworded_format) return
+        call parse_positional_format(parser, arena, format_spec, &
+            format_expr_index, is_control_specifier= &
+            is_write_io_control_specifier)
+    end subroutine parse_write_format_clause
+
+    subroutine parse_read_format_clause(parser, arena, format_spec, &
+            namelist_group, format_expr_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=:), allocatable, intent(out) :: format_spec
+        character(len=:), allocatable, intent(out) :: namelist_group
+        integer, intent(inout) :: format_expr_index
+        type(token_t) :: token
+
+        format_spec = ''
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= ',') return
+        token = parser%consume()
+        if (parse_namelist_clause(parser, namelist_group)) return
+        call consume_read_format_keyword(parser)
+        call parse_positional_format(parser, arena, format_spec, &
+            format_expr_index, is_control_specifier= &
+            is_read_io_control_specifier)
+    end subroutine parse_read_format_clause
+
+    logical function parse_namelist_clause(parser, namelist_group) result(found)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=:), allocatable, intent(out) :: namelist_group
+        type(token_t) :: token
+
+        found = .false.
+        token = parser%peek()
+        if (token%kind /= TK_IDENTIFIER .or. token%text /= 'nml') return
+        found = .true.
+        token = parser%consume()
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= '=') return
+        token = parser%consume()
+        token = parser%peek()
+        if (token%kind == TK_IDENTIFIER) then
+            namelist_group = token%text
+            token = parser%consume()
+            return
+        end if
+        write (error_unit, *) "Error: Expected namelist group name after 'nml='", &
+            ' at line ', token%line
+    end function parse_namelist_clause
+
+    subroutine consume_read_format_keyword(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(parser_state_t) :: checkpoint
+        type(token_t) :: token
+
+        token = parser%peek()
+        if (.not. is_format_specifier_keyword(token)) return
+        checkpoint = parser
+        token = checkpoint%consume()
+        token = checkpoint%peek()
+        if (token%kind /= TK_OPERATOR .or. token%text /= '=') return
+        token = checkpoint%consume()
+        parser = checkpoint
+    end subroutine consume_read_format_keyword
+
+    integer function push_parsed_write_statement(arena, unit_spec, arg_indices, &
+            format_spec, namelist_group, io_control_list, format_expr_index, &
+            specifiers, line, column) result(write_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: unit_spec
+        integer, intent(in) :: arg_indices(:), format_expr_index, line, column
+        character(len=:), allocatable, intent(in) :: format_spec
+        character(len=:), allocatable, intent(in) :: namelist_group
+        character(len=:), allocatable, intent(in) :: io_control_list
+        type(io_specifier_t), intent(in) :: specifiers(:)
+
+        if (allocated(namelist_group)) then
+            write_index = push_write_statement(arena, unit_spec, arg_indices, &
+                namelist_group=namelist_group, io_control_list=io_control_list, &
+                specifiers=specifiers, line=line, column=column)
+        else if (format_expr_index > 0) then
+            write_index = push_write_statement(arena, unit_spec, arg_indices, &
+                format_expr_index=format_expr_index, &
+                io_control_list=io_control_list, specifiers=specifiers, &
+                line=line, column=column)
+        else if (allocated(format_spec)) then
+            write_index = push_write_statement(arena, unit_spec, arg_indices, &
+                format_spec=format_spec, io_control_list=io_control_list, &
+                specifiers=specifiers, line=line, column=column)
+        else
+            write_index = push_write_statement(arena, unit_spec, arg_indices, &
+                io_control_list=io_control_list, specifiers=specifiers, &
+                line=line, column=column)
+        end if
+    end function push_parsed_write_statement
+
+    integer function push_parsed_read_statement(arena, unit_spec, var_indices, &
+            format_spec, namelist_group, io_control_list, format_expr_index, &
+            specifiers, line, column) result(read_index)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: unit_spec
+        integer, intent(in) :: var_indices(:), format_expr_index, line, column
+        character(len=:), allocatable, intent(in) :: format_spec
+        character(len=:), allocatable, intent(in) :: namelist_group
+        character(len=:), allocatable, intent(in) :: io_control_list
+        type(io_specifier_t), intent(in) :: specifiers(:)
+
         if (allocated(namelist_group)) then
             read_index = push_read_statement(arena, unit_spec, var_indices, &
-                                             format_spec=format_spec, &
-                                             namelist_group=namelist_group, &
-                                             io_control_list=io_control_list, &
-                                             line=line, column=column)
+                format_spec=format_spec, namelist_group=namelist_group, &
+                io_control_list=io_control_list, specifiers=specifiers, &
+                line=line, column=column)
         else if (format_expr_index > 0) then
             read_index = push_read_statement(arena, unit_spec, var_indices, &
-                                             format_expr_index=format_expr_index, &
-                                             io_control_list=io_control_list, &
-                                             line=line, column=column)
+                format_expr_index=format_expr_index, &
+                io_control_list=io_control_list, specifiers=specifiers, &
+                line=line, column=column)
         else if (allocated(format_spec)) then
             read_index = push_read_statement(arena, unit_spec, var_indices, &
-                                             format_spec=format_spec, &
-                                             io_control_list=io_control_list, &
-                                             line=line, column=column)
+                format_spec=format_spec, io_control_list=io_control_list, &
+                specifiers=specifiers, line=line, column=column)
         else
             read_index = push_read_statement(arena, unit_spec, var_indices, &
-                                             io_control_list=io_control_list, &
-                                             line=line, column=column)
+                io_control_list=io_control_list, specifiers=specifiers, &
+                line=line, column=column)
         end if
-    end function parse_read_statement
+    end function push_parsed_read_statement
 
     pure logical function is_format_specifier_keyword(token)
         type(token_t), intent(in) :: token
@@ -606,6 +634,8 @@
         integer :: line, column
         character(len=:), allocatable :: spec_text
         character(len=:), allocatable :: lowered
+        type(parser_state_t) :: specifier_parser
+        type(io_specifier_t), allocatable :: specifiers(:)
 
         token = parser%peek()
         lowered = trim(to_lower(token%text))
@@ -623,6 +653,7 @@
             return
         end if
         token = parser%consume()
+        specifier_parser = parser
 
         spec_text = ""
         do while (.not. parser%is_at_end())
@@ -651,7 +682,10 @@
             end if
         end do
 
-        open_index = push_open_statement(arena, spec_text, line, column)
+        call parse_io_specifier_nodes(specifier_parser, arena, &
+            [character(len=4) :: 'unit'], specifiers)
+        open_index = push_open_statement(arena, spec_text, line, column, &
+            specifiers=specifiers)
     end function parse_open_statement
 
     function parse_close_statement(parser, arena) result(close_index)
@@ -662,6 +696,8 @@
         integer :: line, column
         character(len=:), allocatable :: spec_text
         character(len=:), allocatable :: lowered
+        type(parser_state_t) :: specifier_parser
+        type(io_specifier_t), allocatable :: specifiers(:)
 
         token = parser%peek()
         lowered = trim(to_lower(token%text))
@@ -679,6 +715,7 @@
             return
         end if
         token = parser%consume()
+        specifier_parser = parser
 
         spec_text = ""
         do while (.not. parser%is_at_end())
@@ -700,7 +737,10 @@
             token = parser%consume()
         end do
 
-        close_index = push_close_statement(arena, spec_text, line, column)
+        call parse_io_specifier_nodes(specifier_parser, arena, &
+            [character(len=4) :: 'unit'], specifiers)
+        close_index = push_close_statement(arena, spec_text, line, column, &
+            specifiers=specifiers)
     end function parse_close_statement
 
     function parse_inquire_statement(parser, arena) result(inquire_index)
@@ -711,6 +751,8 @@
         integer :: line, column
         character(len=:), allocatable :: spec_text
         character(len=:), allocatable :: lowered
+        type(parser_state_t) :: specifier_parser
+        type(io_specifier_t), allocatable :: specifiers(:)
 
         token = parser%peek()
         lowered = trim(to_lower(token%text))
@@ -728,6 +770,7 @@
             return
         end if
         token = parser%consume()
+        specifier_parser = parser
 
         spec_text = ""
         do while (.not. parser%is_at_end())
@@ -749,7 +792,10 @@
             token = parser%consume()
         end do
 
-        inquire_index = push_inquire_statement(arena, spec_text, line, column)
+        call parse_io_specifier_nodes(specifier_parser, arena, &
+            [character(len=4) :: 'unit'], specifiers)
+        inquire_index = push_inquire_statement(arena, spec_text, line, column, &
+            specifiers=specifiers)
     end function parse_inquire_statement
 
     function parse_backspace_statement(parser, arena) result(backspace_index)
@@ -760,6 +806,8 @@
         integer :: line, column
         character(len=:), allocatable :: unit_spec
         character(len=:), allocatable :: lowered
+        type(parser_state_t) :: specifier_parser
+        type(io_specifier_t), allocatable :: specifiers(:)
 
         token = parser%peek()
         lowered = trim(to_lower(token%text))
@@ -770,6 +818,7 @@
         line = token%line
         column = token%column
         token = parser%consume()
+        call prepare_position_specifier_parser(parser, specifier_parser)
 
         unit_spec = collect_position_spec(parser)
         unit_spec = trim(unit_spec)
@@ -777,7 +826,10 @@
             backspace_index = 0
             return
         end if
-        backspace_index = push_backspace_statement(arena, unit_spec, line, column)
+        call parse_io_specifier_nodes(specifier_parser, arena, &
+            [character(len=4) :: 'unit'], specifiers)
+        backspace_index = push_backspace_statement(arena, unit_spec, line, &
+            column, specifiers=specifiers)
     end function parse_backspace_statement
 
     function parse_rewind_statement(parser, arena) result(rewind_index)
@@ -788,6 +840,8 @@
         integer :: line, column
         character(len=:), allocatable :: unit_spec
         character(len=:), allocatable :: lowered
+        type(parser_state_t) :: specifier_parser
+        type(io_specifier_t), allocatable :: specifiers(:)
 
         token = parser%peek()
         lowered = trim(to_lower(token%text))
@@ -798,6 +852,7 @@
         line = token%line
         column = token%column
         token = parser%consume()
+        call prepare_position_specifier_parser(parser, specifier_parser)
 
         unit_spec = collect_position_spec(parser)
         unit_spec = trim(unit_spec)
@@ -805,7 +860,10 @@
             rewind_index = 0
             return
         end if
-        rewind_index = push_rewind_statement(arena, unit_spec, line, column)
+        call parse_io_specifier_nodes(specifier_parser, arena, &
+            [character(len=4) :: 'unit'], specifiers)
+        rewind_index = push_rewind_statement(arena, unit_spec, line, column, &
+            specifiers=specifiers)
     end function parse_rewind_statement
 
     function parse_endfile_statement(parser, arena) result(endfile_index)
@@ -816,6 +874,8 @@
         integer :: line, column
         character(len=:), allocatable :: unit_spec
         character(len=:), allocatable :: lowered
+        type(parser_state_t) :: specifier_parser
+        type(io_specifier_t), allocatable :: specifiers(:)
 
         token = parser%peek()
         lowered = trim(to_lower(token%text))
@@ -826,6 +886,7 @@
         line = token%line
         column = token%column
         token = parser%consume()
+        call prepare_position_specifier_parser(parser, specifier_parser)
 
         unit_spec = collect_position_spec(parser)
         unit_spec = trim(unit_spec)
@@ -833,5 +894,8 @@
             endfile_index = 0
             return
         end if
-        endfile_index = push_endfile_statement(arena, unit_spec, line, column)
+        call parse_io_specifier_nodes(specifier_parser, arena, &
+            [character(len=4) :: 'unit'], specifiers)
+        endfile_index = push_endfile_statement(arena, unit_spec, line, column, &
+            specifiers=specifiers)
     end function parse_endfile_statement

--- a/test/api/test_compiler_statement_queries.f90
+++ b/test/api/test_compiler_statement_queries.f90
@@ -1,0 +1,641 @@
+program test_compiler_statement_queries
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use fortfront_compiler, only: ast_arena_t, compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD, io_statement_query_t, control_statement_query_t, &
+        branch_statement_query_t, query_io_statement, query_control_statement, &
+        query_branch_statement, IO_STATEMENT_PRINT, IO_STATEMENT_WRITE, &
+        IO_STATEMENT_READ, IO_STATEMENT_FORMAT, IO_STATEMENT_OPEN, &
+        IO_STATEMENT_CLOSE, IO_STATEMENT_INQUIRE, IO_STATEMENT_BACKSPACE, &
+        IO_STATEMENT_REWIND, IO_STATEMENT_ENDFILE, CONTROL_ASSOCIATE, &
+        CONTROL_BLOCK, CONTROL_SELECT_TYPE, CONTROL_TYPE_GUARD, &
+        CONTROL_SELECT_RANK, CONTROL_RANK_BLOCK, CONTROL_WHERE, &
+        CONTROL_WHERE_STATEMENT, BRANCH_GOTO, BRANCH_PAUSE, BRANCH_CONTINUE
+    use ast_arena_clone, only: clone_subtree, clone_result_t
+    implicit none
+
+    type(compiler_frontend_result_t) :: result
+    type(compiler_frontend_options_t) :: options
+    type(clone_result_t) :: cloned
+
+    options = compiler_frontend_options_t()
+    options%input_mode = INPUT_MODE_STANDARD
+    options%run_semantics = .false.
+    call compile_frontend_from_string(statement_source(), result, options)
+    if (.not. result%success()) call fail('frontend rejected statement source')
+
+    call test_io_queries(result%arena)
+    call test_control_queries(result%arena)
+    call test_branch_queries(result%arena)
+    call test_absent_queries(result%arena, result%root_index)
+    call test_absent_queries(result%arena, 0)
+    call test_labeled_wrong_kind_queries(result%arena)
+    cloned = clone_subtree(result%arena, result%root_index)
+    call test_cloned_io_indices(result%arena, cloned)
+    call test_cloned_control_indices(result%arena, cloned)
+    print *, 'PASS: compiler statement queries'
+
+contains
+
+    function statement_source() result(source)
+        character(len=:), allocatable :: source
+
+        source = 'program statements'//new_line('a')// &
+            'class(*), allocatable :: object'//new_line('a')// &
+            'integer :: values(3), choice, ios'//new_line('a')// &
+            'logical :: mask(3), opened'//new_line('a')// &
+            "open(unit=10,file='data.txt',status='old',access='sequential',"// &
+            "form='formatted',recl=80,blank='null',position='rewind',"// &
+            "action='read',delim='quote',pad='yes',iostat=ios,err=900)"// &
+            new_line('a')// &
+            "close(unit=10,status='keep',iostat=ios,err=900)"//new_line('a')// &
+            'close(unit=11)'//new_line('a')// &
+            'rewind(unit=10,iostat=ios,err=900)'//new_line('a')// &
+            'backspace(unit=10,iostat=ios,err=900)'//new_line('a')// &
+            'endfile(unit=10,iostat=ios,err=900)'//new_line('a')// &
+            'inquire(unit=10,opened=opened,iostat=ios,err=900)'//new_line('a')// &
+            "print '(I0)', choice"//new_line('a')// &
+            "write(unit=10,fmt='(I0)',iostat=ios,err=900) choice"// &
+            new_line('a')// &
+            "read(unit=10,fmt='(I0)',iostat=ios,end=800,err=900) choice"// &
+            new_line('a')// &
+            '700 format(I0)'//new_line('a')// &
+            'associate(alias => choice)'//new_line('a')// &
+            'values(1) = alias'//new_line('a')//'end associate'//new_line('a')// &
+            'block'//new_line('a')//'integer :: local'//new_line('a')// &
+            'local = choice'//new_line('a')//'end block'//new_line('a')// &
+            'allocate(object, source=choice)'//new_line('a')// &
+            'select type (object)'//new_line('a')//'type is (integer)'// &
+            new_line('a')//'values(1) = object'//new_line('a')// &
+            'class default'//new_line('a')//'values(1) = 0'//new_line('a')// &
+            'end select'//new_line('a')//'select rank(values)'//new_line('a')// &
+            'rank(1)'//new_line('a')//'values = 1'//new_line('a')// &
+            'rank default'//new_line('a')//'values = 0'//new_line('a')// &
+            'end select'//new_line('a')//'where(mask)'//new_line('a')// &
+            'values = 1'//new_line('a')//'elsewhere(.not. mask)'//new_line('a')// &
+            'values = 2'//new_line('a')//'elsewhere'//new_line('a')// &
+            'values = 3'//new_line('a')//'end where'//new_line('a')// &
+            'where(mask) values = 3'//new_line('a')//'goto 100'//new_line('a')// &
+            'goto (100,200), choice'//new_line('a')//'pause 1'//new_line('a')// &
+            "pause 'hold'"//new_line('a')//'pause'//new_line('a')// &
+            '100 continue'//new_line('a')//'200 continue'//new_line('a')// &
+            '800 continue'//new_line('a')//'900 continue'//new_line('a')// &
+            'contains'//new_line('a')//'subroutine inner'//new_line('a')// &
+            'goto 100'//new_line('a')//'100 continue'//new_line('a')// &
+            'end subroutine inner'//new_line('a')// &
+            'end program statements'
+    end function statement_source
+
+    subroutine test_io_queries(arena)
+        type(ast_arena_t), intent(in) :: arena
+        integer :: counts(10)
+        integer :: i
+        type(io_statement_query_t) :: query
+
+        counts = 0
+        do i = 1, arena%size
+            query = query_io_statement(arena, i)
+            if (.not. query%found) cycle
+            counts(query%statement_kind) = counts(query%statement_kind) + 1
+            call check_io_query(query)
+        end do
+        call require_equal(counts(IO_STATEMENT_PRINT), 1, 'PRINT count')
+        call require_equal(counts(IO_STATEMENT_WRITE), 1, 'WRITE count')
+        call require_equal(counts(IO_STATEMENT_READ), 1, 'READ count')
+        call require_equal(counts(IO_STATEMENT_FORMAT), 1, 'FORMAT count')
+        call require_equal(counts(IO_STATEMENT_OPEN), 1, 'OPEN count')
+        call require_equal(counts(IO_STATEMENT_CLOSE), 2, 'CLOSE count')
+        call require_equal(counts(IO_STATEMENT_INQUIRE), 1, 'INQUIRE count')
+        call require_equal(counts(IO_STATEMENT_BACKSPACE), 1, 'BACKSPACE count')
+        call require_equal(counts(IO_STATEMENT_REWIND), 1, 'REWIND count')
+        call require_equal(counts(IO_STATEMENT_ENDFILE), 1, 'ENDFILE count')
+    end subroutine test_io_queries
+
+    subroutine check_io_query(query)
+        type(io_statement_query_t), intent(in) :: query
+
+        if (.not. allocated(query%item_node_indices)) then
+            call fail('I/O item indices are not initialized')
+        end if
+        select case (query%statement_kind)
+        case (IO_STATEMENT_OPEN)
+            call check_open_query(query)
+        case (IO_STATEMENT_CLOSE)
+            if (query%has_status_spec) then
+                call require_string(query%unit_spec, '10', 'CLOSE unit')
+                call require_string(query%status_spec, "'keep'", 'CLOSE status')
+                call require_present_indices(query, .false.)
+            else
+                call require_string(query%unit_spec, '11', 'minimal CLOSE unit')
+                call require_absent_indices(query)
+            end if
+            call require_unit_node(query)
+        case (IO_STATEMENT_INQUIRE)
+            call require_specifier(query, 'opened', 'opened')
+            call require_unit_node(query)
+            call require_present_indices(query, .false.)
+        case (IO_STATEMENT_BACKSPACE, IO_STATEMENT_REWIND, IO_STATEMENT_ENDFILE)
+            call require_string(query%unit_spec, '10', 'positioning unit')
+            call require_unit_node(query)
+            call require_present_indices(query, .false.)
+        case (IO_STATEMENT_WRITE)
+            call require_string(query%unit_spec, '10', 'WRITE unit')
+            call require_unit_node(query)
+            call require_equal(size(query%item_node_indices), 1, 'WRITE items')
+            call require_present_indices(query, .false.)
+        case (IO_STATEMENT_READ)
+            call require_string(query%unit_spec, '10', 'READ unit')
+            call require_unit_node(query)
+            call require_equal(size(query%item_node_indices), 1, 'READ items')
+            call require_present_indices(query, .true.)
+        case (IO_STATEMENT_PRINT)
+            call require_equal(size(query%item_node_indices), 1, 'PRINT items')
+            if (.not. query%has_format_spec) call fail('PRINT format absent')
+        case (IO_STATEMENT_FORMAT)
+            if (.not. query%has_format_spec) call fail('FORMAT spec absent')
+        end select
+    end subroutine check_io_query
+
+    subroutine check_open_query(query)
+        type(io_statement_query_t), intent(in) :: query
+
+        call require_string(query%unit_spec, '10', 'OPEN unit')
+        call require_string(query%file_spec, "'data.txt'", 'OPEN file')
+        call require_string(query%status_spec, "'old'", 'OPEN status')
+        call require_string(query%access_spec, "'sequential'", 'OPEN access')
+        call require_string(query%form_spec, "'formatted'", 'OPEN form')
+        call require_string(query%recl_spec, '80', 'OPEN recl')
+        call require_string(query%blank_spec, "'null'", 'OPEN blank')
+        call require_string(query%position_spec, "'rewind'", 'OPEN position')
+        call require_string(query%action_spec, "'read'", 'OPEN action')
+        call require_string(query%delim_spec, "'quote'", 'OPEN delim')
+        call require_string(query%pad_spec, "'yes'", 'OPEN pad')
+        call require_unit_node(query)
+        call require_present_indices(query, .false.)
+    end subroutine check_open_query
+
+    subroutine require_unit_node(query)
+        type(io_statement_query_t), intent(in) :: query
+
+        if (.not. query%has_unit_node) call fail('unit node absent')
+        if (query%unit_node_index <= 0) call fail('invalid unit node index')
+    end subroutine require_unit_node
+
+    subroutine require_present_indices(query, expect_end)
+        type(io_statement_query_t), intent(in) :: query
+        logical, intent(in) :: expect_end
+
+        if (.not. query%has_iostat_node) call fail('IOSTAT index absent')
+        if (query%iostat_node_index <= 0) call fail('invalid IOSTAT index')
+        if (.not. query%has_err_label) call fail('ERR label absent')
+        if (query%err_label_node_index <= 0) call fail('invalid ERR label index')
+        if (query%has_end_label .neqv. expect_end) call fail('END presence mismatch')
+        if (expect_end) then
+            if (query%end_label_node_index <= 0) call fail('invalid END label index')
+        end if
+    end subroutine require_present_indices
+
+    subroutine require_absent_indices(query)
+        type(io_statement_query_t), intent(in) :: query
+
+        if (query%has_iostat_node .or. query%iostat_node_index /= 0) then
+            call fail('absent IOSTAT is ambiguous')
+        end if
+        if (query%has_err_label .or. query%err_label_node_index /= 0) then
+            call fail('absent ERR is ambiguous')
+        end if
+        if (query%has_end_label .or. query%end_label_node_index /= 0) then
+            call fail('absent END is ambiguous')
+        end if
+    end subroutine require_absent_indices
+
+    subroutine require_specifier(query, name, value)
+        type(io_statement_query_t), intent(in) :: query
+        character(len=*), intent(in) :: name, value
+        integer :: i
+
+        do i = 1, size(query%specifiers)
+            if (query%specifiers(i)%name /= name) cycle
+            call require_string(query%specifiers(i)%value, value, &
+                'INQUIRE '//name)
+            if (.not. query%specifiers(i)%has_value_node) then
+                call fail('INQUIRE '//name//' node absent')
+            end if
+            return
+        end do
+        call fail('INQUIRE specifier absent: '//name)
+    end subroutine require_specifier
+
+    subroutine test_control_queries(arena)
+        type(ast_arena_t), intent(in) :: arena
+        integer :: counts(8)
+        integer :: i
+        type(control_statement_query_t) :: query
+
+        counts = 0
+        do i = 1, arena%size
+            query = query_control_statement(arena, i)
+            if (.not. query%found) cycle
+            counts(query%statement_kind) = counts(query%statement_kind) + 1
+            call check_control_query(query)
+        end do
+        call require_equal(counts(CONTROL_ASSOCIATE), 1, 'ASSOCIATE count')
+        call require_equal(counts(CONTROL_BLOCK), 1, 'BLOCK count')
+        call require_equal(counts(CONTROL_SELECT_TYPE), 1, 'SELECT TYPE count')
+        call require_equal(counts(CONTROL_TYPE_GUARD), 2, 'TYPE guard count')
+        call require_equal(counts(CONTROL_SELECT_RANK), 1, 'SELECT RANK count')
+        call require_equal(counts(CONTROL_RANK_BLOCK), 2, 'RANK block count')
+        call require_equal(counts(CONTROL_WHERE), 1, 'WHERE construct count')
+        call require_equal(counts(CONTROL_WHERE_STATEMENT), 1, &
+            'WHERE statement count')
+    end subroutine test_control_queries
+
+    subroutine check_control_query(query)
+        type(control_statement_query_t), intent(in) :: query
+
+        if (.not. allocated(query%body_node_indices)) then
+            call fail('control body is not initialized')
+        end if
+        select case (query%statement_kind)
+        case (CONTROL_ASSOCIATE)
+            call require_equal(size(query%associations), 1, 'association count')
+            call require_string(query%associations(1)%name, 'alias', &
+                'association name')
+            if (query%associations(1)%expression_node_index <= 0) then
+                call fail('association expression absent')
+            end if
+            call require_nonempty(query%body_node_indices, 'ASSOCIATE body')
+        case (CONTROL_BLOCK)
+            call require_nonempty(query%body_node_indices, 'BLOCK body')
+        case (CONTROL_SELECT_TYPE, CONTROL_SELECT_RANK)
+            if (.not. query%has_selector) call fail('selector absent')
+            if (query%selector_node_index <= 0) call fail('invalid selector')
+            call require_nonempty(query%child_node_indices, 'selector arms')
+            if (.not. query%has_default) call fail('default arm absent')
+        case (CONTROL_TYPE_GUARD)
+            call check_type_guard_query(query)
+        case (CONTROL_RANK_BLOCK)
+            call check_rank_block_query(query)
+        case (CONTROL_WHERE)
+            if (.not. query%has_mask) call fail('WHERE mask absent')
+            call require_nonempty(query%body_node_indices, 'WHERE body')
+            call require_equal(size(query%elsewhere_clauses), 2, &
+                'ELSEWHERE count')
+            if (.not. query%elsewhere_clauses(1)%has_mask) then
+                call fail('masked ELSEWHERE mask absent')
+            end if
+            if (query%elsewhere_clauses(1)%mask_node_index <= 0) then
+                call fail('invalid ELSEWHERE mask index')
+            end if
+            call require_nonempty(query%elsewhere_clauses(1)%body_node_indices, &
+                'masked ELSEWHERE body')
+            if (query%elsewhere_clauses(2)%has_mask) then
+                call fail('final ELSEWHERE unexpectedly has a mask')
+            end if
+            call require_nonempty(query%elsewhere_clauses(2)%body_node_indices, &
+                'final ELSEWHERE body')
+        case (CONTROL_WHERE_STATEMENT)
+            if (.not. query%has_mask) call fail('WHERE statement mask absent')
+            if (.not. query%has_assignment) call fail('WHERE assignment absent')
+        end select
+    end subroutine check_control_query
+
+    subroutine check_type_guard_query(query)
+        type(control_statement_query_t), intent(in) :: query
+
+        if (query%is_default) then
+            call require_string(query%guard_type, 'class_default', &
+                'default guard type')
+            if (query%has_type_name) call fail('default type name present')
+        else
+            call require_string(query%guard_type, 'type_is', 'guard type')
+            if (.not. query%has_type_name) call fail('type name absent')
+        end if
+        call require_nonempty(query%body_node_indices, 'TYPE guard body')
+    end subroutine check_type_guard_query
+
+    subroutine check_rank_block_query(query)
+        type(control_statement_query_t), intent(in) :: query
+
+        if (query%is_default) then
+            if (query%has_rank) call fail('default rank has a value')
+        else
+            if (.not. query%has_rank) call fail('rank value absent')
+            call require_equal(query%rank_value, 1, 'rank value')
+        end if
+        call require_nonempty(query%body_node_indices, 'RANK body')
+    end subroutine check_rank_block_query
+
+    subroutine test_branch_queries(arena)
+        type(ast_arena_t), intent(in) :: arena
+        integer :: counts(3)
+        integer :: direct_targets(2)
+        integer :: i, direct_count
+        type(branch_statement_query_t) :: query
+
+        counts = 0
+        direct_count = 0
+        direct_targets = 0
+        do i = 1, arena%size
+            query = query_branch_statement(arena, i)
+            if (.not. query%found) cycle
+            counts(query%statement_kind) = counts(query%statement_kind) + 1
+            if (query%statement_kind == BRANCH_GOTO) then
+                if (.not. query%is_computed) then
+                    direct_count = direct_count + 1
+                    direct_targets(direct_count) = query%targets(1)%node_index
+                end if
+            end if
+            call check_branch_query(query)
+        end do
+        call require_equal(counts(BRANCH_GOTO), 3, 'GOTO count')
+        call require_equal(counts(BRANCH_PAUSE), 3, 'PAUSE count')
+        call require_equal(counts(BRANCH_CONTINUE), 5, 'CONTINUE count')
+        call require_equal(direct_count, 2, 'direct GOTO count')
+        if (direct_targets(1) == direct_targets(2)) then
+            call fail('GOTO targets crossed scoping-unit boundaries')
+        end if
+    end subroutine test_branch_queries
+
+    subroutine check_branch_query(query)
+        type(branch_statement_query_t), intent(in) :: query
+
+        select case (query%statement_kind)
+        case (BRANCH_GOTO)
+            if (query%is_computed) then
+                if (.not. query%has_selector) call fail('GOTO selector absent')
+                call require_string(query%target_labels, '100, 200', &
+                    'computed GOTO labels')
+                call require_equal(size(query%targets), 2, &
+                    'computed GOTO targets')
+            else
+                call require_string(query%target_label, '100', 'GOTO label')
+                call require_equal(size(query%targets), 1, 'GOTO targets')
+            end if
+            call require_resolved_targets(query)
+        case (BRANCH_PAUSE)
+            call check_pause_query(query)
+        case (BRANCH_CONTINUE)
+            if (.not. query%has_statement_label) then
+                call fail('CONTINUE statement label absent')
+            end if
+        end select
+    end subroutine check_branch_query
+
+    subroutine check_pause_query(query)
+        type(branch_statement_query_t), intent(in) :: query
+
+        if (query%has_code) then
+            if (query%code_node_index <= 0) call fail('invalid PAUSE code')
+        else if (query%has_message) then
+            call require_string(query%message, "'hold'", 'PAUSE message')
+        else
+            if (query%code_node_index /= 0) call fail('absent PAUSE code ambiguous')
+            call require_string(query%message, '', 'absent PAUSE message')
+        end if
+    end subroutine check_pause_query
+
+    subroutine require_resolved_targets(query)
+        type(branch_statement_query_t), intent(in) :: query
+        integer :: i
+
+        do i = 1, size(query%targets)
+            if (.not. query%targets(i)%has_node) then
+                call fail('GOTO target node absent: '//query%targets(i)%label)
+            end if
+            if (query%targets(i)%node_index <= 0) then
+                call fail('invalid GOTO target node')
+            end if
+        end do
+    end subroutine require_resolved_targets
+
+    subroutine test_absent_queries(arena, node_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(io_statement_query_t) :: io
+        type(control_statement_query_t) :: control
+        type(branch_statement_query_t) :: branch
+
+        io = query_io_statement(arena, node_index)
+        control = query_control_statement(arena, node_index)
+        branch = query_branch_statement(arena, node_index)
+        if (io%found) call fail('wrong-kind I/O query found a node')
+        if (control%found) call fail('wrong-kind control query found a node')
+        if (branch%found) call fail('wrong-kind branch query found a node')
+        if (io%has_iostat_node .or. io%iostat_node_index /= 0) then
+            call fail('absent IOSTAT is ambiguous')
+        end if
+        if (.not. allocated(io%item_node_indices)) then
+            call fail('absent I/O item indices are not initialized')
+        end if
+        if (.not. allocated(control%body_node_indices)) then
+            call fail('absent control body is not initialized')
+        end if
+    end subroutine test_absent_queries
+
+    subroutine test_labeled_wrong_kind_queries(arena)
+        type(ast_arena_t), intent(in) :: arena
+        type(io_statement_query_t) :: io
+        type(control_statement_query_t) :: control
+        type(branch_statement_query_t) :: branch
+        integer :: i
+
+        do i = 1, arena%size
+            io = query_io_statement(arena, i)
+            if (io%found) then
+                if (io%statement_kind == IO_STATEMENT_FORMAT) then
+                    control = query_control_statement(arena, i)
+                    branch = query_branch_statement(arena, i)
+                    call require_empty_wrong_kind(control, branch)
+                end if
+            end if
+            branch = query_branch_statement(arena, i)
+            if (.not. branch%found) cycle
+            if (branch%statement_kind /= BRANCH_CONTINUE) cycle
+            io = query_io_statement(arena, i)
+            if (io%found .or. io%has_statement_label) then
+                call fail('wrong-kind I/O query retained statement metadata')
+            end if
+            return
+        end do
+        call fail('labeled CONTINUE fixture absent')
+    end subroutine test_labeled_wrong_kind_queries
+
+    subroutine require_empty_wrong_kind(control, branch)
+        type(control_statement_query_t), intent(in) :: control
+        type(branch_statement_query_t), intent(in) :: branch
+
+        if (control%found .or. control%line /= 0 .or. control%column /= 0) then
+            call fail('wrong-kind control query retained metadata')
+        end if
+        if (branch%found .or. branch%has_statement_label) then
+            call fail('wrong-kind branch query retained statement metadata')
+        end if
+        if (branch%line /= 0 .or. branch%column /= 0) then
+            call fail('wrong-kind branch query retained source location')
+        end if
+    end subroutine require_empty_wrong_kind
+
+    subroutine test_cloned_io_indices(original, clone)
+        type(ast_arena_t), intent(in) :: original
+        type(clone_result_t), intent(in) :: clone
+        type(io_statement_query_t) :: old_query, new_query
+        integer :: i, j, new_index, found_count
+
+        found_count = 0
+        do i = 1, size(clone%index_map)
+            new_index = clone%index_map(i)
+            if (new_index <= 0) cycle
+            old_query = query_io_statement(original, i)
+            if (.not. old_query%found) cycle
+            new_query = query_io_statement(clone%cloned_arena, new_index)
+            if (.not. new_query%found) call fail('cloned I/O statement absent')
+            found_count = found_count + 1
+            call require_equal(size(new_query%specifiers), &
+                size(old_query%specifiers), 'cloned I/O specifier count')
+            do j = 1, size(old_query%specifiers)
+                if (.not. old_query%specifiers(j)%has_value_node) cycle
+                call require_mapped_index(clone, &
+                    old_query%specifiers(j)%value_node_index, &
+                    new_query%specifiers(j)%value_node_index, &
+                    'cloned I/O specifier')
+            end do
+        end do
+        if (found_count == 0) call fail('cloned I/O statements absent')
+    end subroutine test_cloned_io_indices
+
+    subroutine test_cloned_control_indices(original, clone)
+        type(ast_arena_t), intent(in) :: original
+        type(clone_result_t), intent(in) :: clone
+        type(control_statement_query_t) :: old_query, new_query
+        integer :: i, j, new_index, found_count
+
+        found_count = 0
+        do i = 1, size(clone%index_map)
+            new_index = clone%index_map(i)
+            if (new_index <= 0) cycle
+            old_query = query_control_statement(original, i)
+            if (.not. old_query%found) cycle
+            new_query = query_control_statement(clone%cloned_arena, new_index)
+            if (.not. new_query%found) call fail('cloned control absent')
+            found_count = found_count + 1
+            call compare_optional_control_indices(clone, old_query, new_query)
+            call require_mapped_indices(clone, old_query%child_node_indices, &
+                new_query%child_node_indices, 'cloned control child')
+            call require_mapped_indices(clone, old_query%body_node_indices, &
+                new_query%body_node_indices, 'cloned control body')
+            call require_equal(size(new_query%associations), &
+                size(old_query%associations), 'cloned association count')
+            do j = 1, size(old_query%associations)
+                call require_mapped_index(clone, &
+                    old_query%associations(j)%expression_node_index, &
+                    new_query%associations(j)%expression_node_index, &
+                    'cloned association')
+            end do
+            call check_cloned_elsewhere(clone, old_query, new_query)
+        end do
+        if (found_count == 0) call fail('cloned control statements absent')
+    end subroutine test_cloned_control_indices
+
+    subroutine compare_optional_control_indices(clone, old_query, new_query)
+        type(clone_result_t), intent(in) :: clone
+        type(control_statement_query_t), intent(in) :: old_query, new_query
+
+        if (old_query%has_selector) call require_mapped_index(clone, &
+            old_query%selector_node_index, new_query%selector_node_index, &
+            'cloned selector')
+        if (old_query%has_default) call require_mapped_index(clone, &
+            old_query%default_node_index, new_query%default_node_index, &
+            'cloned default')
+        if (old_query%has_type_name) call require_mapped_index(clone, &
+            old_query%type_name_node_index, new_query%type_name_node_index, &
+            'cloned type name')
+        if (old_query%has_mask) call require_mapped_index(clone, &
+            old_query%mask_node_index, new_query%mask_node_index, 'cloned mask')
+        if (old_query%has_assignment) call require_mapped_index(clone, &
+            old_query%assignment_node_index, new_query%assignment_node_index, &
+            'cloned assignment')
+    end subroutine compare_optional_control_indices
+
+    subroutine check_cloned_elsewhere(clone, old_query, new_query)
+        type(clone_result_t), intent(in) :: clone
+        type(control_statement_query_t), intent(in) :: old_query, new_query
+        integer :: i
+
+        call require_equal(size(new_query%elsewhere_clauses), &
+            size(old_query%elsewhere_clauses), 'cloned ELSEWHERE count')
+        do i = 1, size(old_query%elsewhere_clauses)
+            if (old_query%elsewhere_clauses(i)%has_mask) then
+                call require_mapped_index(clone, &
+                    old_query%elsewhere_clauses(i)%mask_node_index, &
+                    new_query%elsewhere_clauses(i)%mask_node_index, &
+                    'cloned ELSEWHERE mask')
+            end if
+            call require_mapped_indices(clone, &
+                old_query%elsewhere_clauses(i)%body_node_indices, &
+                new_query%elsewhere_clauses(i)%body_node_indices, &
+                'cloned ELSEWHERE body')
+        end do
+    end subroutine check_cloned_elsewhere
+
+    subroutine require_mapped_indices(clone, old_indices, new_indices, label)
+        type(clone_result_t), intent(in) :: clone
+        integer, intent(in) :: old_indices(:), new_indices(:)
+        character(len=*), intent(in) :: label
+        integer :: i
+
+        call require_equal(size(new_indices), size(old_indices), label//' count')
+        do i = 1, size(old_indices)
+            call require_mapped_index(clone, old_indices(i), new_indices(i), &
+                label)
+        end do
+    end subroutine require_mapped_indices
+
+    subroutine require_mapped_index(clone, old_index, new_index, label)
+        type(clone_result_t), intent(in) :: clone
+        integer, intent(in) :: old_index, new_index
+        character(len=*), intent(in) :: label
+
+        if (old_index <= 0) call fail(label//' source is absent')
+        if (old_index > size(clone%index_map)) call fail(label//' source is stale')
+        call require_equal(new_index, clone%index_map(old_index), label)
+        if (.not. clone%cloned_arena%has_node_at(new_index)) then
+            call fail(label//' target is stale')
+        end if
+    end subroutine require_mapped_index
+
+    subroutine require_nonempty(values, label)
+        integer, intent(in) :: values(:)
+        character(len=*), intent(in) :: label
+
+        if (size(values) == 0) call fail(label//' is empty')
+    end subroutine require_nonempty
+
+    subroutine require_equal(actual, expected, label)
+        integer, intent(in) :: actual, expected
+        character(len=*), intent(in) :: label
+
+        if (actual /= expected) then
+            write (error_unit, '(A,I0,A,I0)') trim(label)//': got ', actual, &
+                ', expected ', expected
+            error stop 1
+        end if
+    end subroutine require_equal
+
+    subroutine require_string(actual, expected, label)
+        character(len=*), intent(in) :: actual, expected, label
+
+        if (actual /= expected) then
+            call fail(trim(label)//': got "'//actual//'", expected "'// &
+                expected//'"')
+        end if
+    end subroutine require_string
+
+    subroutine fail(message)
+        character(len=*), intent(in) :: message
+
+        write (error_unit, '(A)') 'FAIL: '//message
+        error stop 1
+    end subroutine fail
+
+end program test_compiler_statement_queries


### PR DESCRIPTION
Closes #2878

- expose owned I/O, control-construct, and branch query records
- preserve structured I/O specifier indices across parsing and subtree cloning
- resolve statement-label targets within their Fortran scoping unit
- distinguish wrong-kind and absent optional values explicitly

## Verification

### Test fails on main

```text
$ fo test test_compiler_statement_queries
Error: Symbol 'io_statement_query_t' referenced at (1) not found in module 'fortfront_compiler'
Tests: 0 passed, 1 failed, 0 skipped
```

### Test passes after fix

```text
$ fo test test_compiler_statement_queries
Tests: 1 passed, 0 failed, 0 skipped

$ fo
Static: OK (1377 modules, 1012 changed, 1012 affected)
Build: OK (365/365)
Tests: OK (483/483)
Lint: OK
All stages passed (34.2s)
```
