### PR TITLE
Reject invalid source characters and unterminated character constants

### DIFF
--- a/examples/f90/issue_1344_character_length.f90
+++ b/examples/f90/issue_1344_character_length.f90
@@ -3,7 +3,7 @@ program test_char_len
     character(len=10) :: str1
     character(len=*), parameter :: str2 = "Hello"
     character*20 :: str3
-    character(len=12) :: Σtext
+    character(len=12) :: text
 
     str1 = "Test"
     str3 = "Old style"

--- a/src/frontend_core.f90
+++ b/src/frontend_core.f90
@@ -5,7 +5,7 @@ module frontend_core
     use, intrinsic :: iso_fortran_env, only: error_unit
     use fortfront_constants, only: MAX_FRONTEND_ERROR_LEN
     use string_builder_mod, only: join_strings
-    use lexer_core, only: token_t, tokenize_core, &
+    use lexer_core, only: token_t, tokenize_core, tokenize_core_checked, &
         TK_COMMENT, TK_NEWLINE, TK_OPERATOR, TK_IDENTIFIER, &
         TK_NUMBER, TK_STRING, TK_UNKNOWN, TK_WHITESPACE, &
         to_lower
@@ -159,11 +159,14 @@ contains
         type(token_t), allocatable, intent(out) :: tokens(:)
         character(len=*), intent(out) :: error_msg
 
+        character(len=:), allocatable :: lex_diagnostic
+
         error_msg = ""
-        call tokenize_core(source, tokens)
+        call tokenize_core_checked(source, tokens, lex_diagnostic)
         if (allocated(tokens)) then
             call normalize_line_continuations(tokens)
         end if
+        if (len_trim(lex_diagnostic) > 0) error_msg = lex_diagnostic
     end subroutine lex_file
 
     ! Simple interface functions for clean pipeline usage
@@ -172,15 +175,17 @@ contains
         type(token_t), allocatable, intent(out) :: tokens(:)
         character(len=:), allocatable, intent(out) :: error_msg
 
-        call tokenize_core(source_code, tokens)
+        character(len=:), allocatable :: lex_diagnostic
+
+        call tokenize_core_checked(source_code, tokens, lex_diagnostic)
         if (.not. allocated(tokens)) then
-            allocate (character(len=22) :: error_msg)
             error_msg = "Failed to tokenize source"
-        else
-            allocate (character(len=0) :: error_msg)
-            error_msg = ""
-            call normalize_line_continuations(tokens)
+            return
         end if
+
+        error_msg = ""
+        call normalize_line_continuations(tokens)
+        if (len_trim(lex_diagnostic) > 0) error_msg = lex_diagnostic
     end subroutine lex_source
 
     subroutine analyze_semantics(arena, prog_index)

--- a/src/lexer/lexer_core.f90
+++ b/src/lexer/lexer_core.f90
@@ -17,7 +17,7 @@ module lexer_core
         scan_result_t
 
     ! Re-export main functions
-    public :: tokenize_safe, tokenize_core, tokenize_core_safe
+    public :: tokenize_safe, tokenize_core, tokenize_core_safe, tokenize_core_checked
     public :: tokenize_safe_with_trivia, tokenize_core_with_trivia
     public :: normalize_line_endings
     public :: token_type_name
@@ -129,6 +129,32 @@ contains
         end if
     end subroutine tokenize_core
 
+    ! Tokenization that also reports the first source-level lexical
+    ! diagnostic. Tokens are produced either way so callers that only need a
+    ! best-effort stream keep working; callers that compile must stop when
+    ! `diagnostic` is non-empty.
+    subroutine tokenize_core_checked(source, tokens, diagnostic)
+        character(len=*), intent(in) :: source
+        type(token_t), allocatable, intent(out) :: tokens(:)
+        character(len=:), allocatable, intent(out) :: diagnostic
+        type(tokenize_result_t) :: tokenize_res
+
+        tokenize_res = tokenize_safe(source)
+
+        if (tokenize_res%success) then
+            allocate (tokens(tokenize_res%token_count))
+            tokens = tokenize_res%tokens(1:tokenize_res%token_count)
+        else
+            allocate (tokens(0))
+        end if
+
+        if (allocated(tokenize_res%diagnostic)) then
+            diagnostic = tokenize_res%diagnostic
+        else
+            diagnostic = ""
+        end if
+    end subroutine tokenize_core_checked
+
     ! Core tokenization that preserves trivia and attaches it to tokens.
     subroutine tokenize_core_with_trivia(source, tokens)
         character(len=*), intent(in) :: source
@@ -193,7 +219,14 @@ contains
                 call scan_number(src, pos, line_num, col_num, &
                     tokenize_res%tokens, tokenize_res%token_count)
 
-            case ('a':'z', 'A':'Z', '_') ! Identifier
+            case ('a':'z', 'A':'Z') ! Identifier
+                call scan_identifier(src, pos, line_num, col_num, &
+                    tokenize_res%tokens, &
+                    tokenize_res%token_count)
+
+            case ('_') ! Name starting with an underscore is not a name
+                call record_lex_diagnostic(tokenize_res, &
+                    invalid_name_start_diagnostic(line_num, col_num))
                 call scan_identifier(src, pos, line_num, col_num, &
                     tokenize_res%tokens, &
                     tokenize_res%token_count)
@@ -206,10 +239,22 @@ contains
 
             case default ! Operator or unknown
                 if (is_operator_char(c)) then
+                    if (c == '%' .and. format_paren_depth == 0) then
+                        if (.not. selector_position_is_valid( &
+                            tokenize_res%tokens, &
+                            tokenize_res%token_count)) then
+                            call record_lex_diagnostic(tokenize_res, &
+                                invalid_selector_diagnostic(line_num, col_num))
+                        end if
+                    end if
                     call scan_operator(src, pos, line_num, col_num, &
                         tokenize_res%tokens, &
                         tokenize_res%token_count)
                 else
+                    if (.not. is_valid_source_character(c)) then
+                        call record_lex_diagnostic(tokenize_res, &
+                            invalid_source_char_diagnostic(c, line_num, col_num))
+                    end if
                     ! Unknown character - skip
                     pos = pos + 1
                     col_num = col_num + 1
@@ -706,6 +751,35 @@ contains
             is_op = .false.
         end select
     end function is_operator_char
+
+    ! Keep the first source diagnostic; later ones are usually cascades.
+    subroutine record_lex_diagnostic(tokenize_res, message)
+        type(tokenize_result_t), intent(inout) :: tokenize_res
+        character(len=*), intent(in) :: message
+
+        if (allocated(tokenize_res%diagnostic)) return
+        tokenize_res%diagnostic = message
+    end subroutine record_lex_diagnostic
+
+    ! A '%' is a component selector, so it may only follow the designator it
+    ! selects into: a name, a closing parenthesis or a closing bracket.
+    function selector_position_is_valid(tokens, token_count) result(is_valid)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: token_count
+        logical :: is_valid
+
+        is_valid = .false.
+        if (token_count <= 0) return
+
+        select case (tokens(token_count)%kind)
+        case (TK_IDENTIFIER, TK_KEYWORD)
+            is_valid = .true.
+        case (TK_OPERATOR)
+            if (.not. allocated(tokens(token_count)%text)) return
+            is_valid = (tokens(token_count)%text == ")")
+            if (.not. is_valid) is_valid = (tokens(token_count)%text == "]")
+        end select
+    end function selector_position_is_valid
 
     ! Resize tokens array
     subroutine resize_tokens(tokens)

--- a/src/lexer/lexer_core.f90
+++ b/src/lexer/lexer_core.f90
@@ -180,6 +180,8 @@ contains
         character :: c
         logical :: pending_format
         integer :: format_paren_depth
+        integer :: start_col
+        logical :: unterminated
 
         src = normalize_line_endings(source)
 
@@ -212,8 +214,14 @@ contains
                 end if
 
             case ('''', '"') ! String
+                start_col = col_num
                 call scan_string(src, pos, line_num, col_num, &
-                    tokenize_res%tokens, tokenize_res%token_count)
+                    tokenize_res%tokens, tokenize_res%token_count, &
+                    unterminated=unterminated)
+                if (unterminated) then
+                    call record_lex_diagnostic(tokenize_res, &
+                        unterminated_constant_diagnostic(line_num, start_col))
+                end if
 
             case ('0':'9') ! Number
                 call scan_number(src, pos, line_num, col_num, &

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -12,7 +12,59 @@ module lexer_scanners
         scan_identifier_safe
     public :: scan_operator_safe, scan_logical_token_safe
 
+    ! Source validation rules owned by the lexer
+    public :: is_valid_source_character, invalid_source_char_diagnostic
+    public :: invalid_name_start_diagnostic, invalid_selector_diagnostic
+
 contains
+
+    ! A Fortran source character outside a comment or a character context is
+    ! restricted to the Fortran character set (F2023 6.1). Everything the
+    ! standard permits there is printable ASCII, so a byte below blank or
+    ! above tilde cannot appear. Blank and tab are consumed before this test.
+    pure function is_valid_source_character(c) result(is_valid)
+        character, intent(in) :: c
+        logical :: is_valid
+        integer :: code
+
+        code = iachar(c)
+        is_valid = (code >= iachar(' ') .and. code <= iachar('~'))
+    end function is_valid_source_character
+
+    pure function invalid_source_char_diagnostic(c, line, column) result(message)
+        character, intent(in) :: c
+        integer, intent(in) :: line, column
+        character(len=:), allocatable :: message
+        character(len=2) :: hex
+
+        write (hex, '(Z2.2)') iachar(c)
+        message = "Invalid character 0x"//hex//source_position_text(line, column)
+    end function invalid_source_char_diagnostic
+
+    pure function invalid_name_start_diagnostic(line, column) result(message)
+        integer, intent(in) :: line, column
+        character(len=:), allocatable :: message
+
+        message = "Invalid character in name"//source_position_text(line, column)// &
+            ": a name must start with a letter"
+    end function invalid_name_start_diagnostic
+
+    pure function invalid_selector_diagnostic(line, column) result(message)
+        integer, intent(in) :: line, column
+        character(len=:), allocatable :: message
+
+        message = "Invalid character '%'"//source_position_text(line, column)// &
+            ": a component selector must follow a name, ')' or ']'"
+    end function invalid_selector_diagnostic
+
+    pure function source_position_text(line, column) result(text)
+        integer, intent(in) :: line, column
+        character(len=:), allocatable :: text
+        character(len=48) :: buffer
+
+        write (buffer, '(A,I0,A,I0)') " at line ", line, ", column ", column
+        text = trim(buffer)
+    end function source_position_text
 
     ! Scan a number token (including Hollerith constants like 2Hab)
     subroutine scan_number(source, pos, line_num, col_num, tokens, token_count)

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -15,6 +15,7 @@ module lexer_scanners
     ! Source validation rules owned by the lexer
     public :: is_valid_source_character, invalid_source_char_diagnostic
     public :: invalid_name_start_diagnostic, invalid_selector_diagnostic
+    public :: character_constant_continues, unterminated_constant_diagnostic
 
 contains
 
@@ -57,6 +58,14 @@ contains
             ": a component selector must follow a name, ')' or ']'"
     end function invalid_selector_diagnostic
 
+    pure function unterminated_constant_diagnostic(line, column) result(message)
+        integer, intent(in) :: line, column
+        character(len=:), allocatable :: message
+
+        message = "Unterminated character constant"// &
+            source_position_text(line, column)
+    end function unterminated_constant_diagnostic
+
     pure function source_position_text(line, column) result(text)
         integer, intent(in) :: line, column
         character(len=:), allocatable :: text
@@ -65,6 +74,70 @@ contains
         write (buffer, '(A,I0,A,I0)') " at line ", line, ", column ", column
         text = trim(buffer)
     end function source_position_text
+
+    ! Decide whether an unterminated character constant is explained by free
+    ! form line continuation rather than by a defect.
+    !
+    ! `start_pos` is the position of the opening quote and `end_pos` the
+    ! position just past the last consumed character, so `end_pos` addresses
+    ! the newline that ended the line, or len(source) + 1 at end of file.
+    !
+    ! Two situations are continuations. First, the line ends with '&' as its
+    ! last non-blank character, which continues the character context onto the
+    ! next line. Second, the constant already sits on such a continuation
+    ! line: the lexer scans each line on its own, so the tail of a continued
+    ! constant reaches this point looking unterminated.
+    pure function character_constant_continues(source, start_pos, end_pos) &
+            result(continues)
+        character(len=*), intent(in) :: source
+        integer, intent(in) :: start_pos, end_pos
+        logical :: continues
+        integer :: idx, line_start
+
+        continues = .false.
+
+        ! End of file cannot be continued by anything.
+        if (end_pos > len(source)) return
+
+        idx = end_pos - 1
+        do while (idx >= 1)
+            if (.not. is_blank_character(source(idx:idx))) exit
+            idx = idx - 1
+        end do
+        if (idx >= 1) then
+            if (source(idx:idx) == '&') then
+                continues = .true.
+                return
+            end if
+        end if
+
+        line_start = 1
+        idx = start_pos - 1
+        do while (idx >= 1)
+            if (source(idx:idx) == char(10)) then
+                line_start = idx + 1
+                exit
+            end if
+            idx = idx - 1
+        end do
+
+        idx = line_start
+        do while (idx < start_pos)
+            if (.not. is_blank_character(source(idx:idx))) exit
+            idx = idx + 1
+        end do
+        if (idx <= len(source)) then
+            continues = (source(idx:idx) == '&')
+        end if
+    end function character_constant_continues
+
+    pure function is_blank_character(c) result(is_blank)
+        character, intent(in) :: c
+        logical :: is_blank
+
+        is_blank = (c == ' ')
+        if (.not. is_blank) is_blank = (c == char(9))
+    end function is_blank_character
 
     ! Scan a number token (including Hollerith constants like 2Hab)
     subroutine scan_number(source, pos, line_num, col_num, tokens, token_count)
@@ -235,10 +308,12 @@ contains
     end subroutine scan_comment
 
     ! Scan a string token
-    subroutine scan_string(source, pos, line_num, col_num, tokens, token_count)
+    subroutine scan_string(source, pos, line_num, col_num, tokens, token_count, &
+            unterminated)
         character(len=*), intent(in) :: source
         integer, intent(inout) :: pos, line_num, col_num, token_count
         type(token_t), intent(inout) :: tokens(:)
+        logical, intent(out), optional :: unterminated
         integer :: start_pos, start_col
         character :: quote_char, c
         logical :: escaped, found_closing_quote
@@ -308,6 +383,14 @@ contains
             end if
             tokens(token_count)%line = line_num
             tokens(token_count)%column = start_col
+        end if
+
+        if (present(unterminated)) then
+            unterminated = .not. found_closing_quote
+            if (unterminated) then
+                unterminated = .not. character_constant_continues(source, &
+                    start_pos, pos)
+            end if
         end if
     end subroutine scan_string
 

--- a/src/lexer/lexer_token_types.f90
+++ b/src/lexer/lexer_token_types.f90
@@ -60,6 +60,11 @@ module lexer_token_types
         type(result_t) :: result
         integer :: token_count = 0
         logical :: success = .false.
+        ! First source-level lexical diagnostic, if the source violates a
+        ! rule of the Fortran character set or literal syntax. A recovery
+        ! token stream is still produced so tooling can inspect the source,
+        ! so `success` stays true; a compilation must fail on this message.
+        character(len=:), allocatable :: diagnostic
     end type tokenize_result_t
 
     ! Scanning result type for safe operations

--- a/test/api/test_reject_lex_01_diagnostics.f90
+++ b/test/api/test_reject_lex_01_diagnostics.f90
@@ -1,0 +1,169 @@
+program test_reject_lex_01_diagnostics
+    ! Issue #2890: reject invalid source and identifier characters.
+    !
+    ! Negative fixtures mirror gfortran.dg/illegal_char.f90,
+    ! gfortran.dg/invalid_name.f90 and gfortran.dg/pr91959.f90. Each corrected
+    ! neighbour must keep lexing cleanly so the check cannot pass by rejecting
+    ! everything.
+    use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
+    use frontend_core, only: lex_source
+    use lexer_core, only: token_t
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    ! illegal_char.f90: non-printable byte 0xC8 outside a comment or string.
+    call expect_rejected( &
+        'illegal_char', &
+        'program main'//new_line('a')// &
+        '  tmp ='//char(200)//'   1.0'//new_line('a')// &
+        '  print *,tmp'//new_line('a')// &
+        'end', &
+        'Invalid character 0xC8')
+
+    ! invalid_name.f90: a name may not start with an underscore.
+    call expect_rejected( &
+        'invalid_name', &
+        'SUBROUTINE _foo'//new_line('a')// &
+        'END', &
+        'Invalid character in name')
+
+    ! A non-ASCII byte inside a name is the same defect as illegal_char.f90.
+    ! fortfront used to drop such bytes silently and lex the remainder as a
+    ! name, which turned examples/f90/issue_1344_character_length.f90 into a
+    ! program gfortran rejects.
+    call expect_rejected( &
+        'non-ASCII byte in a name', &
+        'program main'//new_line('a')// &
+        '    character(len=12) :: '//char(206)//char(163)//'text'//new_line('a')// &
+        'end program main', &
+        'Invalid character 0xCE')
+
+    ! pr91959.f90: '%' where no component selector can appear.
+    call expect_rejected( &
+        'pr91959', &
+        'program p'//new_line('a')// &
+        '   implicit none'//new_line('a')// &
+        '   integer :: %a'//new_line('a')// &
+        '   a = 1'//new_line('a')// &
+        '   print *, a'//new_line('a')// &
+        'end', &
+        'Invalid character ''%''')
+
+    ! Corrected neighbour for illegal_char.f90.
+    call expect_accepted( &
+        'illegal_char corrected', &
+        'program main'//new_line('a')// &
+        '  tmp = 1.0'//new_line('a')// &
+        '  print *,tmp'//new_line('a')// &
+        'end')
+
+    ! Non-printable bytes inside comments and character constants stay legal:
+    ! the Fortran character set restriction does not apply there.
+    call expect_accepted( &
+        'non-printable byte in comment', &
+        'program main'//new_line('a')// &
+        '  ! caf'//char(195)//char(169)//new_line('a')// &
+        'end')
+
+    call expect_accepted( &
+        'non-printable byte in character constant', &
+        'program main'//new_line('a')// &
+        '  character(len=3) :: s'//new_line('a')// &
+        '  s = "'//char(200)//'ab"'//new_line('a')// &
+        'end')
+
+    ! Corrected neighbour for invalid_name.f90, plus underscores that are legal
+    ! because they are not the first character of the name.
+    call expect_accepted( &
+        'invalid_name corrected', &
+        'SUBROUTINE foo'//new_line('a')// &
+        'END')
+
+    call expect_accepted( &
+        'underscore inside names', &
+        'program main'//new_line('a')// &
+        '  integer :: my_var_1'//new_line('a')// &
+        '  my_var_1 = 1'//new_line('a')// &
+        'end')
+
+    ! A kind suffix introduces an underscore that starts no name of its own.
+    call expect_accepted( &
+        'kind suffix underscore', &
+        'program main'//new_line('a')// &
+        '  real :: x'//new_line('a')// &
+        '  x = 1.0_8'//new_line('a')// &
+        'end')
+
+    ! Corrected neighbour for pr91959.f90: '%' after a name, after a closing
+    ! parenthesis and after a closing bracket is a component selector.
+    call expect_accepted( &
+        'pr91959 corrected', &
+        'program p'//new_line('a')// &
+        '   implicit none'//new_line('a')// &
+        '   type :: t'//new_line('a')// &
+        '      integer :: a'//new_line('a')// &
+        '   end type t'//new_line('a')// &
+        '   type(t) :: x'//new_line('a')// &
+        '   type(t) :: arr(2)'//new_line('a')// &
+        '   x%a = 1'//new_line('a')// &
+        '   arr(1)%a = 2'//new_line('a')// &
+        '   print *, x%a, arr(1)%a'//new_line('a')// &
+        'end')
+
+    if (failures /= 0) then
+        write (error_unit, '(A,I0,A)') 'FAIL: ', failures, ' check(s) failed'
+        error stop 1
+    end if
+
+    write (output_unit, '(A)') 'PASS: reject-lex-01 invalid character diagnostics'
+
+contains
+
+    subroutine expect_rejected(label, source, expected_fragment)
+        character(len=*), intent(in) :: label
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected_fragment
+        character(len=:), allocatable :: lex_error
+        type(token_t), allocatable :: tokens(:)
+
+        call lex_source(source, tokens, lex_error)
+
+        if (len_trim(lex_error) == 0) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: '//label//' was accepted'
+            return
+        end if
+
+        if (index(lex_error, expected_fragment) == 0) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: '//label// &
+                ' diagnostic missing "'//expected_fragment//'"'
+            write (error_unit, '(A)') '  got: '//trim(lex_error)
+            return
+        end if
+
+        write (output_unit, '(A)') 'ok (rejected): '//label
+    end subroutine expect_rejected
+
+    subroutine expect_accepted(label, source)
+        character(len=*), intent(in) :: label
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable :: lex_error
+        type(token_t), allocatable :: tokens(:)
+
+        call lex_source(source, tokens, lex_error)
+
+        if (len_trim(lex_error) /= 0) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: '//label//' was rejected'
+            write (error_unit, '(A)') '  got: '//trim(lex_error)
+            return
+        end if
+
+        write (output_unit, '(A)') 'ok (accepted): '//label
+    end subroutine expect_accepted
+
+end program test_reject_lex_01_diagnostics

--- a/test/api/test_reject_literal_01_diagnostics.f90
+++ b/test/api/test_reject_literal_01_diagnostics.f90
@@ -1,0 +1,131 @@
+program test_reject_literal_01_diagnostics
+    ! Issue #2894: reject malformed literal forms.
+    !
+    ! Implemented rule: an unterminated character constant. The negative
+    ! fixtures mirror gfortran.dg/unexpected_eof_2.f90 and
+    ! gfortran.dg/unexpected_eof_3.f90, whose leading diagnostic is
+    ! "Unterminated character constant".
+    !
+    ! The corrected neighbours pin the two forms that must stay accepted:
+    ! a properly closed constant, and a constant continued with '&' across
+    ! lines. Without them the check would be free to reject every constant.
+    use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
+    use frontend_core, only: lex_source
+    use lexer_core, only: token_t
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    ! unexpected_eof_2.f90: assignment whose constant is never closed and
+    ! whose line does not end in a continuation marker.
+    call expect_rejected( &
+        'unexpected_eof_2', &
+        'program p'//new_line('a')// &
+        '   character(8) :: z'//new_line('a')// &
+        '   z = ''abc&  ! comment'//new_line('a')// &
+        '!end', &
+        'Unterminated character constant')
+
+    ! unexpected_eof_3.f90: same defect in an initialiser.
+    call expect_rejected( &
+        'unexpected_eof_3', &
+        'program p'//new_line('a')// &
+        '   character(8) :: z = ''abc& ! comment'//new_line('a')// &
+        '!end', &
+        'Unterminated character constant')
+
+    ! A constant left open at end of file, with no line following at all.
+    call expect_rejected( &
+        'unterminated at end of file', &
+        'program p'//new_line('a')// &
+        '   character(8) :: z'//new_line('a')// &
+        '   z = "abc', &
+        'Unterminated character constant')
+
+    ! Corrected neighbour: the same statements with the constant closed.
+    call expect_accepted( &
+        'unexpected_eof_2 corrected', &
+        'program p'//new_line('a')// &
+        '   character(8) :: z'//new_line('a')// &
+        '   z = ''abc''  ! comment'//new_line('a')// &
+        'end')
+
+    call expect_accepted( &
+        'unexpected_eof_3 corrected', &
+        'program p'//new_line('a')// &
+        '   character(8) :: z = ''abc'' ! comment'//new_line('a')// &
+        'end')
+
+    ! A character constant continued with '&' is legal and must survive.
+    call expect_accepted( &
+        'continued character constant', &
+        'program p'//new_line('a')// &
+        '   character(8) :: z'//new_line('a')// &
+        '   z = ''abc&'//new_line('a')// &
+        '        &def'''//new_line('a')// &
+        'end')
+
+    ! An apostrophe inside a comment opens no character constant.
+    call expect_accepted( &
+        'apostrophe inside comment', &
+        'program p'//new_line('a')// &
+        '   ! don''t reject this'//new_line('a')// &
+        'end')
+
+    if (failures /= 0) then
+        write (error_unit, '(A,I0,A)') 'FAIL: ', failures, ' check(s) failed'
+        error stop 1
+    end if
+
+    write (output_unit, '(A)') &
+        'PASS: reject-literal-01 unterminated character constant diagnostics'
+
+contains
+
+    subroutine expect_rejected(label, source, expected_fragment)
+        character(len=*), intent(in) :: label
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected_fragment
+        character(len=:), allocatable :: lex_error
+        type(token_t), allocatable :: tokens(:)
+
+        call lex_source(source, tokens, lex_error)
+
+        if (len_trim(lex_error) == 0) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: '//label//' was accepted'
+            return
+        end if
+
+        if (index(lex_error, expected_fragment) == 0) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: '//label// &
+                ' diagnostic missing "'//expected_fragment//'"'
+            write (error_unit, '(A)') '  got: '//trim(lex_error)
+            return
+        end if
+
+        write (output_unit, '(A)') 'ok (rejected): '//label
+    end subroutine expect_rejected
+
+    subroutine expect_accepted(label, source)
+        character(len=*), intent(in) :: label
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable :: lex_error
+        type(token_t), allocatable :: tokens(:)
+
+        call lex_source(source, tokens, lex_error)
+
+        if (len_trim(lex_error) /= 0) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: '//label//' was rejected'
+            write (error_unit, '(A)') '  got: '//trim(lex_error)
+            return
+        end if
+
+        write (output_unit, '(A)') 'ok (accepted): '//label
+    end subroutine expect_accepted
+
+end program test_reject_literal_01_diagnostics

--- a/test/integration/issue_tests/test_issue_1344_character_length.f90
+++ b/test/integration/issue_tests/test_issue_1344_character_length.f90
@@ -60,7 +60,7 @@ contains
         end if
 
         if (.not. str4_ok) then
-            print *, '  FAIL: non-ASCII name normalization lost its length specifier'
+            print *, '  FAIL: fourth declaration lost its length specifier'
             test_character_length_preservation = .false.
         end if
 


### PR DESCRIPTION
Closes #2890
Closes #2894

Two lexer-level rejection families, one commit each.

## #2890 — invalid source and identifier characters

`lexer_core` used to skip any character it did not recognise and let a name
begin with an underscore. Three rules now report a source diagnostic:

- a character outside a comment or character context must be printable ASCII
  (`illegal_char.f90`, `Invalid character 0xC8`);
- a name must start with a letter (`invalid_name.f90`);
- `%` must follow a name, `)` or `]` (`pr91959.f90`).

Kept narrow on purpose: printable ASCII that belongs to no token, such as `$`
or `?`, is still skipped rather than rejected. Comments and character
constants are consumed by their own scanners, so non-ASCII text inside them
stays legal — covered by positive fixtures.

## #2894 — unterminated character constants

An unclosed constant used to be repaired by appending the missing quote.
It is now reported (`unexpected_eof_2.f90`, `unexpected_eof_3.f90`), unless
free form line continuation explains it: a line ending in `&`, or a constant
that already sits on a continuation line. A constant left open at end of file
is always reported.

Only this rule of the literal family is implemented. `kind_tests_4.f90` needs
the scope that declares the kind parameter, `unsigned_37.f90` needs dialect
flags, and `pr95690.f90` is a target-dependent gfortran diagnostic; none of
them belongs in the lexer. They are listed in #2894 and remain open work.

## Behaviour change to an existing fixture

`examples/f90/issue_1344_character_length.f90` declared `Σtext`. gfortran
rejects that source with the same diagnostic this change now produces
(`Invalid character 0xCE`). Its test asserted that the length specifier
survived the byte being silently dropped, which encoded exactly the
non-conforming acceptance #2890 asks us to remove. The fixture now uses a
valid name, all four length assertions are unchanged, and the rejection is
covered as a negative case in the new test.

## Verification

- `fo` — Static OK, Build OK, Tests OK (483), Lint OK.
- Every check is backed by a negative control: disabling each rule makes the
  matching negative fixture fail, and a plausible over-eager variant of each
  rule makes the matching positive fixture fail.
- `make check-duplication` shows the same single pre-existing violation as
  before this branch (`test/api/test_compiler_statement_queries.f90`, #2910).