### PR TITLE
Enforce submodule declaration consistency

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -33,3 +33,4 @@ f90/pr96099_2.f90
 f90/pr19936_3.f90
 f90/submodule_twice.f90
 f90/submodule_unexp.f90
+f90/pr93423.f90

--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -31,3 +31,5 @@ f90/pr91715.f90
 f90/pr96099_1.f90
 f90/pr96099_2.f90
 f90/pr19936_3.f90
+f90/submodule_twice.f90
+f90/submodule_unexp.f90

--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -34,3 +34,6 @@ f90/pr19936_3.f90
 f90/submodule_twice.f90
 f90/submodule_unexp.f90
 f90/pr93423.f90
+f90/submodule_36.f90
+f90/pr89943_3.f90
+f90/pr89943_4.f90

--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -39,6 +39,7 @@ docs_unsigned_integers_out.f90  # EXTENSION: uint/wrap_* intrinsics are fortfron
 # Submodule standalone examples require parent module compilation
 issue_1827_submodule_simple.f90  # LIMITATION: submodule needs parent module (#1827)
 issue_1827_submodule_with_contents.f90  # LIMITATION: submodule needs parent module (#1827)
+submodule_module_procedure_valid.f90  # LIMITATION: emission drops the dummy arguments of a separate module procedure
 
 # ============================================================================
 # ERROR-TESTS - Intentionally invalid input for error detection testing

--- a/examples/f90/pr89943_3.f90
+++ b/examples/f90/pr89943_3.f90
@@ -1,0 +1,19 @@
+! Rejection fixture (gfortran.dg/pr89943_3.f90, PR fortran/89943):
+! a separate module subroutine must repeat the binding label of its module
+! procedure interface body (F2018 C1550).
+module pr89943_3_mod
+    implicit none
+    interface
+        module subroutine run_foo(ndim) bind(c, name="runFoo")
+            integer, intent(in) :: ndim
+        end subroutine run_foo
+    end interface
+end module pr89943_3_mod
+
+submodule (pr89943_3_mod) pr89943_3_sub
+contains
+    module subroutine run_foo(ndim) bind(c, name="runFu")
+        integer, intent(in) :: ndim
+        print *, ndim
+    end subroutine run_foo
+end submodule pr89943_3_sub

--- a/examples/f90/pr89943_4.f90
+++ b/examples/f90/pr89943_4.f90
@@ -1,0 +1,21 @@
+! Rejection fixture (gfortran.dg/pr89943_4.f90, PR fortran/89943):
+! a separate module function must repeat the binding label of its module
+! procedure interface body (F2018 C1550).
+module pr89943_4_mod
+    implicit none
+    interface
+        module function run_foo(ndim) bind(c, name="runFoo")
+            integer, intent(in) :: ndim
+            integer :: run_foo
+        end function run_foo
+    end interface
+end module pr89943_4_mod
+
+submodule (pr89943_4_mod) pr89943_4_sub
+contains
+    module function run_foo(ndim) bind(c, name="runFu")
+        integer, intent(in) :: ndim
+        integer :: run_foo
+        run_foo = ndim
+    end function run_foo
+end submodule pr89943_4_sub

--- a/examples/f90/pr93423.f90
+++ b/examples/f90/pr93423.f90
@@ -1,0 +1,19 @@
+! Rejection fixture (gfortran.dg/pr93423.f90, PR fortran/93423):
+! an mp-subprogram-stmt is "MODULE PROCEDURE procedure-name" (F2018 R1505);
+! it must not repeat the dummy argument list of the interface body.
+module pr93423_mod
+    implicit none
+    interface
+        module function bp(s) result(res)
+            integer, intent(inout) :: s
+            integer :: res
+        end function bp
+    end interface
+end module pr93423_mod
+
+submodule (pr93423_mod) pr93423_sub
+contains
+    module procedure bp(s)
+        res = s
+    end procedure bp
+end submodule pr93423_sub

--- a/examples/f90/submodule_36.f90
+++ b/examples/f90/submodule_36.f90
@@ -1,0 +1,19 @@
+! Rejection fixture (gfortran.dg/submodule_36.f90, PR fortran/121379):
+! a separate module subprogram that implements a module procedure interface
+! must carry the MODULE prefix (F2018 15.6.2.5).
+module submodule_36_mod
+    implicit none
+    interface h
+        real module function realg2(arg1, arg2)
+            real, intent(in) :: arg1, arg2
+        end function realg2
+    end interface h
+end module submodule_36_mod
+
+submodule (submodule_36_mod) submodule_36_sub
+contains
+    real function realg2(arg1, arg2)
+        real, intent(in) :: arg1, arg2
+        realg2 = arg1 + arg2
+    end function realg2
+end submodule submodule_36_sub

--- a/examples/f90/submodule_bind_c_name_valid.f90
+++ b/examples/f90/submodule_bind_c_name_valid.f90
@@ -1,0 +1,35 @@
+! Corrected neighbour of pr89943_3.f90 / pr89943_4.f90: the separate module
+! subprograms repeat the binding label of their interface bodies.
+module submodule_bind_mod
+    implicit none
+    interface
+        module subroutine run_foo(ndim) bind(c, name="runFoo")
+            integer, intent(in) :: ndim
+        end subroutine run_foo
+        module function scale_foo(ndim) bind(c, name="scaleFoo")
+            integer, intent(in) :: ndim
+            integer :: scale_foo
+        end function scale_foo
+    end interface
+end module submodule_bind_mod
+
+submodule (submodule_bind_mod) submodule_bind_sub
+contains
+    module subroutine run_foo(ndim) bind(c, name="runFoo")
+        integer, intent(in) :: ndim
+        print *, 'run_foo', ndim
+    end subroutine run_foo
+
+    module function scale_foo(ndim) bind(c, name="scaleFoo")
+        integer, intent(in) :: ndim
+        integer :: scale_foo
+        scale_foo = 2 * ndim
+    end function scale_foo
+end submodule submodule_bind_sub
+
+program submodule_bind_c_name_valid
+    use submodule_bind_mod, only: run_foo, scale_foo
+    implicit none
+    call run_foo(3)
+    print *, scale_foo(21)
+end program submodule_bind_c_name_valid

--- a/examples/f90/submodule_module_prefix_valid.f90
+++ b/examples/f90/submodule_module_prefix_valid.f90
@@ -1,0 +1,30 @@
+! Corrected neighbour of submodule_36.f90: the separate module subprogram
+! keeps the MODULE prefix, and a submodule-local helper without the prefix
+! stays legal because no interface body declares it.
+module submodule_prefix_mod
+    implicit none
+    interface h
+        real module function realg2(arg1, arg2)
+            real, intent(in) :: arg1, arg2
+        end function realg2
+    end interface h
+end module submodule_prefix_mod
+
+submodule (submodule_prefix_mod) submodule_prefix_sub
+contains
+    real module function realg2(arg1, arg2)
+        real, intent(in) :: arg1, arg2
+        realg2 = scale_local(arg1) + arg2
+    end function realg2
+
+    real function scale_local(arg1)
+        real, intent(in) :: arg1
+        scale_local = 2.0 * arg1
+    end function scale_local
+end submodule submodule_prefix_sub
+
+program submodule_module_prefix_valid
+    use submodule_prefix_mod, only: h
+    implicit none
+    print *, h(1.0, 1.0)
+end program submodule_module_prefix_valid

--- a/examples/f90/submodule_module_procedure_valid.f90
+++ b/examples/f90/submodule_module_procedure_valid.f90
@@ -3,22 +3,24 @@
 module submodule_mp_mod
     implicit none
     interface
-        module function bp(s) result(res)
-            integer, intent(in) :: s
-            integer :: res
-        end function bp
+        module subroutine bp(s)
+            integer, intent(inout) :: s
+        end subroutine bp
     end interface
 end module submodule_mp_mod
 
 submodule (submodule_mp_mod) submodule_mp_sub
 contains
     module procedure bp
-        res = s + 1
+        s = s + 1
     end procedure bp
 end submodule submodule_mp_sub
 
 program submodule_module_procedure_valid
     use submodule_mp_mod, only: bp
     implicit none
-    print *, bp(41)
+    integer :: value
+    value = 41
+    call bp(value)
+    print *, value
 end program submodule_module_procedure_valid

--- a/examples/f90/submodule_module_procedure_valid.f90
+++ b/examples/f90/submodule_module_procedure_valid.f90
@@ -1,0 +1,24 @@
+! Corrected neighbour of pr93423.f90: the separate module procedure repeats
+! only the name, never the dummy argument list.
+module submodule_mp_mod
+    implicit none
+    interface
+        module function bp(s) result(res)
+            integer, intent(in) :: s
+            integer :: res
+        end function bp
+    end interface
+end module submodule_mp_mod
+
+submodule (submodule_mp_mod) submodule_mp_sub
+contains
+    module procedure bp
+        res = s + 1
+    end procedure bp
+end submodule submodule_mp_sub
+
+program submodule_module_procedure_valid
+    use submodule_mp_mod, only: bp
+    implicit none
+    print *, bp(41)
+end program submodule_module_procedure_valid

--- a/examples/f90/submodule_placement_valid.f90
+++ b/examples/f90/submodule_placement_valid.f90
@@ -1,0 +1,30 @@
+! Corrected neighbour of submodule_twice.f90 / submodule_unexp.f90: the
+! submodule is written at file scope, and "submodule" is still usable as an
+! ordinary variable name inside a program body.
+module submodule_placement_mod
+    implicit none
+    interface
+        module subroutine report(value)
+            integer, intent(in) :: value
+        end subroutine report
+    end interface
+end module submodule_placement_mod
+
+submodule (submodule_placement_mod) submodule_placement_sub
+contains
+    module subroutine report(value)
+        integer, intent(in) :: value
+        print *, 'report', value
+    end subroutine report
+end submodule submodule_placement_sub
+
+program submodule_placement_valid
+    use submodule_placement_mod, only: report
+    implicit none
+    integer :: submodule
+    integer :: t(3)
+    submodule = 7
+    t = 0
+    t(2) = submodule
+    call report(t(2))
+end program submodule_placement_valid

--- a/examples/f90/submodule_twice.f90
+++ b/examples/f90/submodule_twice.f90
@@ -1,0 +1,8 @@
+! Rejection fixture (gfortran.dg/submodule_twice.f90, PR fortran/69498):
+! a SUBMODULE statement is a program unit (F2018 R1116) and cannot appear
+! inside the body of another program unit.
+program submodule_twice
+    implicit none
+    submodule (m) sm
+    submodule (m2) sm2
+end program submodule_twice

--- a/examples/f90/submodule_unexp.f90
+++ b/examples/f90/submodule_unexp.f90
@@ -1,0 +1,8 @@
+! Rejection fixture (gfortran.dg/submodule_unexp.f90, PR fortran/69498):
+! a SUBMODULE statement cannot appear inside a derived-type definition.
+program submodule_unexp
+    implicit none
+    type :: t
+    submodule (m) sm
+    end type t
+end program submodule_unexp

--- a/src/frontend/frontend_program_units.f90
+++ b/src/frontend/frontend_program_units.f90
@@ -427,10 +427,33 @@ contains
         if (pos <= size(tokens)) then
             if (tokens(pos)%kind == TK_KEYWORD .and. &
                 to_lower(tokens(pos)%text) == "submodule") then
-                is_start = .true.
+                ! A submodule-stmt (F2018 R1117) always continues with the
+                ! parenthesised parent identifier; "submodule = 7" is an
+                ! assignment to an ordinary variable of that name.
+                is_start = submodule_parent_follows(tokens, pos)
             end if
         end if
     end function is_submodule_start
+
+    function submodule_parent_follows(tokens, pos) result(follows)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: pos
+        logical :: follows
+        integer :: i
+
+        follows = .false.
+        do i = pos + 1, size(tokens)
+            select case (tokens(i)%kind)
+            case (TK_WHITESPACE, TK_COMMENT)
+                cycle
+            case (TK_OPERATOR)
+                follows = (tokens(i)%text == "(")
+                return
+            case default
+                return
+            end select
+        end do
+    end function submodule_parent_follows
 
     function is_program_start(tokens, pos) result(is_start)
         type(token_t), intent(in) :: tokens(:)

--- a/src/frontend/frontend_statement_boundary.f90
+++ b/src/frontend/frontend_statement_boundary.f90
@@ -189,6 +189,27 @@ contains
         end do
     end function find_statement_start
 
+    ! True when "submodule" at stmt_start starts a submodule-stmt, which is
+    ! recognisable by the '(' introducing the parent identifier.
+    pure logical function begins_submodule_unit(tokens, stmt_start) result(is_unit)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: stmt_start
+        integer :: i
+
+        is_unit = .false.
+        do i = stmt_start + 1, size(tokens)
+            select case (tokens(i)%kind)
+            case (TK_WHITESPACE, TK_COMMENT)
+                cycle
+            case (TK_OPERATOR)
+                is_unit = (tokens(i)%text == "(")
+                return
+            case default
+                return
+            end select
+        end do
+    end function begins_submodule_unit
+
     pure subroutine detect_multiline_construct(tokens, stmt_start, &
             is_multiline, nesting_level)
         type(token_t), intent(in) :: tokens(:)
@@ -243,6 +264,9 @@ contains
                 end do
             end if
         case ("submodule")
+            ! Only a submodule-stmt (F2018 R1117) opens a program unit; the
+            ! name may also be an ordinary variable, as in "submodule = 7".
+            if (.not. begins_submodule_unit(tokens, stmt_start)) return
             is_multiline = .true.
             nesting_level = 1
         case ("type")

--- a/src/parser/declarations/parser_declarations_derived_module.f90
+++ b/src/parser/declarations/parser_declarations_derived_module.f90
@@ -8,6 +8,7 @@ module parser_declarations_derived_module
         skip_type_definition_attributes
     use parser_type_spec_attributes_mod, only: extract_extends_from_attributes
     use parser_declarations_core_module, only: parse_declaration
+    use parser_submodule_placement_module, only: reject_misplaced_submodule
     use string_utils_mod, only: to_lower
     implicit none
     private
@@ -157,6 +158,13 @@ contains
             if (end_type_ahead(parser)) then
                 call consume_end_type_sequence(parser)
                 exit
+            end if
+
+            ! A submodule is a program unit and cannot appear in a type.
+            if (reject_misplaced_submodule(parser, &
+                "a derived-type definition")) then
+                call skip_component_trivia(parser)
+                cycle
             end if
 
             if (contains_ahead(parser)) then

--- a/src/parser/declarations/parser_submodule_helpers.f90
+++ b/src/parser/declarations/parser_submodule_helpers.f90
@@ -377,6 +377,29 @@ contains
         procedure_name = trim(token%text)
         token = parser%consume()
 
+        ! Fortran 2018 R1505: an mp-subprogram-stmt is
+        !     MODULE PROCEDURE procedure-name
+        ! with no dummy argument list. The characteristics come from the
+        ! module procedure interface body, so repeating them here is invalid.
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%kind /= TK_WHITESPACE) exit
+            token = parser%consume()
+        end do
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. token%text == "(") then
+            call parser%error_at_token( &
+                "MODULE PROCEDURE statement for '"//procedure_name// &
+                "' must not have a dummy argument list", token, &
+                suggestion="write 'module procedure "//procedure_name// &
+                "' without arguments")
+            proc_index = push_error_node(arena, &
+                "MODULE PROCEDURE statement for '"//procedure_name// &
+                "' must not have a dummy argument list", &
+                line=line, column=column)
+            return
+        end if
+
         ! Parse the procedure body until end procedure
         call parse_procedure_body(parser, arena, procedure_name, "procedure", &
             body_indices, infer_recursive)

--- a/src/parser/declarations/parser_submodule_placement.f90
+++ b/src/parser/declarations/parser_submodule_placement.f90
@@ -1,0 +1,130 @@
+module parser_submodule_placement_module
+    ! Placement validation for the SUBMODULE statement.
+    !
+    ! A submodule is a program unit (Fortran 2018 R502 program-unit, R1116
+    ! submodule, R1117 submodule-stmt). It can only appear at the top level of
+    ! a program file. A SUBMODULE statement written inside another program unit
+    ! or inside a derived-type definition is invalid; gfortran diagnoses it as
+    ! "SUBMODULE declaration at (1) ...".
+    !
+    ! The recogniser below matches only the exact shape of R1117
+    !     SUBMODULE ( parent-identifier [ : parent-submodule-name ] ) name
+    ! so that ordinary uses of "submodule" as a variable name, such as
+    ! "submodule = 3" or "submodule(i) = 3", are never rejected.
+    use lexer_core, only: token_t, TK_IDENTIFIER, TK_KEYWORD, TK_OPERATOR, &
+        TK_NEWLINE, TK_COMMENT, TK_WHITESPACE, TK_EOF, to_lower
+    use parser_state_module, only: parser_state_t
+    implicit none
+    private
+
+    public :: at_submodule_statement
+    public :: reject_misplaced_submodule
+
+contains
+
+    ! Index of the next token that carries syntax, or 0 when the statement ends.
+    integer function next_significant(parser, from_index) result(idx)
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(in) :: from_index
+        type(token_t) :: token
+
+        idx = from_index
+        do while (idx <= parser%get_token_count())
+            token = parser%get_token_at_index(idx)
+            select case (token%kind)
+            case (TK_WHITESPACE, TK_COMMENT)
+                idx = idx + 1
+            case (TK_NEWLINE, TK_EOF)
+                idx = 0
+                return
+            case default
+                return
+            end select
+        end do
+        idx = 0
+    end function next_significant
+
+    logical function is_name_token(token) result(is_name)
+        type(token_t), intent(in) :: token
+
+        is_name = (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD)
+    end function is_name_token
+
+    logical function is_operator_token(token, text) result(matches)
+        type(token_t), intent(in) :: token
+        character(len=*), intent(in) :: text
+
+        matches = .false.
+        if (token%kind /= TK_OPERATOR) return
+        if (.not. allocated(token%text)) return
+        matches = (token%text == text)
+    end function is_operator_token
+
+    ! True when the parser sits on a complete R1117 submodule-stmt.
+    logical function at_submodule_statement(parser) result(is_stmt)
+        type(parser_state_t), intent(in) :: parser
+        type(token_t) :: token
+        integer :: idx
+
+        is_stmt = .false.
+
+        idx = parser%current_token
+        if (idx < 1 .or. idx > parser%get_token_count()) return
+        token = parser%get_token_at_index(idx)
+        if (.not. is_name_token(token)) return
+        if (.not. allocated(token%text)) return
+        if (to_lower(trim(token%text)) /= "submodule") return
+
+        idx = next_significant(parser, idx + 1)
+        if (idx == 0) return
+        if (.not. is_operator_token(parser%get_token_at_index(idx), "(")) return
+
+        idx = next_significant(parser, idx + 1)
+        if (idx == 0) return
+        if (.not. is_name_token(parser%get_token_at_index(idx))) return
+
+        idx = next_significant(parser, idx + 1)
+        if (idx == 0) return
+        if (is_operator_token(parser%get_token_at_index(idx), ":")) then
+            idx = next_significant(parser, idx + 1)
+            if (idx == 0) return
+            if (.not. is_name_token(parser%get_token_at_index(idx))) return
+            idx = next_significant(parser, idx + 1)
+            if (idx == 0) return
+        end if
+
+        if (.not. is_operator_token(parser%get_token_at_index(idx), ")")) return
+
+        idx = next_significant(parser, idx + 1)
+        if (idx == 0) return
+        if (.not. is_name_token(parser%get_token_at_index(idx))) return
+
+        is_stmt = .true.
+    end function at_submodule_statement
+
+    ! Report and skip a SUBMODULE statement that is nested inside another
+    ! construct. Returns .true. when a statement was rejected and consumed.
+    logical function reject_misplaced_submodule(parser, context) result(rejected)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=*), intent(in) :: context
+        type(token_t) :: token
+
+        rejected = .false.
+        if (.not. at_submodule_statement(parser)) return
+
+        token = parser%peek()
+        call parser%error_at_token( &
+            "SUBMODULE declaration is not allowed inside "//trim(context)// &
+            "; a submodule is a program unit", token, &
+            suggestion="move the submodule to file scope")
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%kind == TK_NEWLINE .or. token%kind == TK_EOF) exit
+            token = parser%consume()
+        end do
+
+        rejected = .true.
+    end function reject_misplaced_submodule
+
+end module parser_submodule_placement_module

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -64,6 +64,7 @@ module parser_execution_statements_module
     use parser_common_statement_module, only: parse_common_statement
     use parser_enum_statement_module, only: parse_enum_construct
     use parser_trailing_comment_module, only: capture_trailing_comment
+    use parser_submodule_placement_module, only: reject_misplaced_submodule
     implicit none
     private
 

--- a/src/parser/statements/parser_execution_statements_module.inc
+++ b/src/parser/statements/parser_execution_statements_module.inc
@@ -84,6 +84,9 @@
                 exit
             end if
 
+            ! A submodule is a program unit and cannot appear in a body.
+            if (reject_misplaced_submodule(parser, "a program unit body")) cycle
+
             stmt_index = 0
             ! Clear label for this statement
             if (allocated(stmt_label)) deallocate (stmt_label)

--- a/src/parser/statements/parser_keyword_disambiguation.f90
+++ b/src/parser/statements/parser_keyword_disambiguation.f90
@@ -48,7 +48,7 @@ contains
         case ("call", "stop", "cycle", "exit", "return", &
                 "continue", "goto", "go", "entry", "select", &
                 "contains", "else", "dimension", "common", &
-                "program", "module", "if", "data", &
+                "program", "module", "submodule", "if", "data", &
                 "read", "write", "print", "open", "close", &
                 "inquire", "backspace", "rewind", "endfile", "format")
             is_supported = .true.

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -16,15 +16,12 @@ use constant_transformation, only: fold_constants_in_arena
 use error_handling, only: create_error_collection
 use type_hierarchy, only: create_type_hierarchy
 use semantic_type_hierarchy_validation, only: populate_type_hierarchy
-<<<<<<< HEAD
 use semantic_enum_validation, only: validate_enum_definitions
 use semantic_literal_form_validation, only: validate_literal_forms
 use semantic_use_nature_validation, only: validate_use_module_nature
 use semantic_local_name_collision_validation, only: &
     validate_local_name_collisions
-=======
 use semantic_submodule_validation, only: validate_submodule_interfaces
->>>>>>> 76130004 (Check separate module subprograms against their interface bodies)
 use call_graph_signatures_mod, only: create_signatures_map
 use semantic_validation_utils, only: int_to_str
 use ast_nodes_data, only: declaration_node
@@ -97,7 +94,6 @@ contains
         ! resolution can consult the (now populated) inheritance hierarchy.
         call populate_type_hierarchy(arena, ctx%type_hierarchy, ctx%errors)
 
-<<<<<<< HEAD
         ! Report ENUM constraint violations recorded by the parser. The sweep
         ! is arena-wide so module-level enumerations are covered too.
         call validate_enum_definitions(arena, ctx%errors)
@@ -110,11 +106,10 @@ contains
         ! including a bare module root, which the dispatch below skips.
         call validate_use_module_nature(arena, ctx%errors)
         call validate_local_name_collisions(arena, ctx%errors)
-=======
+
         ! Separate module subprograms are checked against the interface bodies
         ! of their ancestor module, which only the whole arena exposes.
         call validate_submodule_interfaces(arena, ctx%errors)
->>>>>>> 76130004 (Check separate module subprograms against their interface bodies)
 
         if (trace_is_enabled()) then
             select type (ast => arena%entries(root_index)%node)

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -16,11 +16,15 @@ use constant_transformation, only: fold_constants_in_arena
 use error_handling, only: create_error_collection
 use type_hierarchy, only: create_type_hierarchy
 use semantic_type_hierarchy_validation, only: populate_type_hierarchy
+<<<<<<< HEAD
 use semantic_enum_validation, only: validate_enum_definitions
 use semantic_literal_form_validation, only: validate_literal_forms
 use semantic_use_nature_validation, only: validate_use_module_nature
 use semantic_local_name_collision_validation, only: &
     validate_local_name_collisions
+=======
+use semantic_submodule_validation, only: validate_submodule_interfaces
+>>>>>>> 76130004 (Check separate module subprograms against their interface bodies)
 use call_graph_signatures_mod, only: create_signatures_map
 use semantic_validation_utils, only: int_to_str
 use ast_nodes_data, only: declaration_node
@@ -93,6 +97,7 @@ contains
         ! resolution can consult the (now populated) inheritance hierarchy.
         call populate_type_hierarchy(arena, ctx%type_hierarchy, ctx%errors)
 
+<<<<<<< HEAD
         ! Report ENUM constraint violations recorded by the parser. The sweep
         ! is arena-wide so module-level enumerations are covered too.
         call validate_enum_definitions(arena, ctx%errors)
@@ -105,6 +110,11 @@ contains
         ! including a bare module root, which the dispatch below skips.
         call validate_use_module_nature(arena, ctx%errors)
         call validate_local_name_collisions(arena, ctx%errors)
+=======
+        ! Separate module subprograms are checked against the interface bodies
+        ! of their ancestor module, which only the whole arena exposes.
+        call validate_submodule_interfaces(arena, ctx%errors)
+>>>>>>> 76130004 (Check separate module subprograms against their interface bodies)
 
         if (trace_is_enabled()) then
             select type (ast => arena%entries(root_index)%node)

--- a/src/semantic/analyzers/semantic_submodule_validation.f90
+++ b/src/semantic/analyzers/semantic_submodule_validation.f90
@@ -1,0 +1,253 @@
+module semantic_submodule_validation
+    ! Consistency between a module procedure interface body and the separate
+    ! module subprogram that implements it (Fortran 2018 15.6.2.5).
+    !
+    ! Two constraints are checked, and both need the ancestor module, so this
+    ! is the earliest layer with enough information: the parser only ever sees
+    ! one program unit at a time.
+    !
+    !   * A subprogram in a submodule whose name matches a module procedure
+    !     interface in the ancestor module implements that interface and must
+    !     carry the MODULE prefix.
+    !   * C1550: when the interface body specifies a binding label, the
+    !     separate module subprogram must specify the same one.
+    !
+    ! Nothing is reported when the ancestor module is not in the same file,
+    ! because then there is no interface to compare against.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_data, only: module_node, submodule_node
+    use ast_nodes_misc, only: interface_block_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use string_utils_mod, only: int_to_string, to_lower
+    implicit none
+    private
+
+    public :: validate_submodule_interfaces
+
+contains
+
+    ! Name of the ancestor module, i.e. the part of parent_identifier before
+    ! any ":parent-submodule-name".
+    function ancestor_module_name(parent_identifier) result(name)
+        character(len=*), intent(in) :: parent_identifier
+        character(len=:), allocatable :: name
+        integer :: colon_pos
+
+        colon_pos = index(parent_identifier, ':')
+        if (colon_pos > 0) then
+            name = to_lower(trim(parent_identifier(1:colon_pos - 1)))
+        else
+            name = to_lower(trim(parent_identifier))
+        end if
+    end function ancestor_module_name
+
+    logical function has_module_prefix(prefix_keywords) result(has_prefix)
+        character(len=16), allocatable, intent(in) :: prefix_keywords(:)
+        integer :: i
+
+        has_prefix = .false.
+        if (.not. allocated(prefix_keywords)) return
+        do i = 1, size(prefix_keywords)
+            if (to_lower(trim(prefix_keywords(i))) == 'module') then
+                has_prefix = .true.
+                return
+            end if
+        end do
+    end function has_module_prefix
+
+    ! Explicit binding label of a bind(c, name="...") clause. The result is
+    ! unallocated when the clause is absent or carries no NAME= specifier,
+    ! because then there is no label to compare.
+    function binding_label(bind_c_clause) result(label)
+        character(len=:), allocatable, intent(in) :: bind_c_clause
+        character(len=:), allocatable :: label
+        character(len=:), allocatable :: lowered
+        integer :: name_pos, first_quote, last_quote
+        character :: quote_char
+
+        if (.not. allocated(bind_c_clause)) return
+        lowered = to_lower(bind_c_clause)
+        name_pos = index(lowered, 'name')
+        if (name_pos == 0) return
+        if (index(lowered(name_pos:), '=') == 0) return
+
+        first_quote = 0
+        do first_quote = name_pos, len(bind_c_clause)
+            quote_char = bind_c_clause(first_quote:first_quote)
+            if (quote_char == '"' .or. quote_char == "'") exit
+        end do
+        if (first_quote > len(bind_c_clause)) return
+
+        quote_char = bind_c_clause(first_quote:first_quote)
+        last_quote = index(bind_c_clause(first_quote + 1:), quote_char)
+        if (last_quote == 0) return
+        label = bind_c_clause(first_quote + 1:first_quote + last_quote - 1)
+    end function binding_label
+
+    ! Characteristics of one module procedure interface body.
+    subroutine interface_procedure_facts(arena, node_index, name, is_module, &
+            label)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable, intent(out) :: name
+        logical, intent(out) :: is_module
+        character(len=:), allocatable, intent(out) :: label
+
+        is_module = .false.
+        if (.not. arena%has_node_at(node_index)) return
+
+        select type (node => arena%entries(node_index)%node)
+        type is (function_def_node)
+            if (allocated(node%name)) name = to_lower(trim(node%name))
+            is_module = has_module_prefix(node%prefix_keywords)
+            label = binding_label(node%bind_c_clause)
+        type is (subroutine_def_node)
+            if (allocated(node%name)) name = to_lower(trim(node%name))
+            is_module = has_module_prefix(node%prefix_keywords)
+            label = binding_label(node%bind_c_clause)
+        end select
+    end subroutine interface_procedure_facts
+
+    ! Locate the interface body in module_index that declares a module
+    ! procedure called proc_name. Returns 0 when there is none.
+    function find_interface_body(arena, module_index, proc_name) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: module_index
+        character(len=*), intent(in) :: proc_name
+        integer :: found
+        integer :: i, j, decl_index, proc_index
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: label
+        logical :: is_module
+
+        found = 0
+        if (.not. arena%has_node_at(module_index)) return
+
+        select type (host => arena%entries(module_index)%node)
+        type is (module_node)
+            if (.not. allocated(host%declaration_indices)) return
+            do i = 1, size(host%declaration_indices)
+                decl_index = host%declaration_indices(i)
+                if (.not. arena%has_node_at(decl_index)) cycle
+                select type (decl => arena%entries(decl_index)%node)
+                type is (interface_block_node)
+                    if (.not. allocated(decl%procedure_indices)) cycle
+                    do j = 1, size(decl%procedure_indices)
+                        proc_index = decl%procedure_indices(j)
+                        call interface_procedure_facts(arena, proc_index, name, &
+                            is_module, label)
+                        if (.not. is_module) cycle
+                        if (.not. allocated(name)) cycle
+                        if (name /= proc_name) cycle
+                        found = proc_index
+                        return
+                    end do
+                end select
+            end do
+        end select
+    end function find_interface_body
+
+    ! Index of the module_node named module_name, or 0 when the ancestor
+    ! module is not part of this compilation unit.
+    function find_module(arena, module_name) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: module_name
+        integer :: found
+        integer :: i
+
+        found = 0
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+            type is (module_node)
+                if (.not. allocated(node%name)) cycle
+                if (to_lower(trim(node%name)) /= module_name) cycle
+                found = i
+                return
+            end select
+        end do
+    end function find_module
+
+    subroutine report(errors, message, suggestion, line, column)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: message
+        character(len=*), intent(in) :: suggestion
+        integer, intent(in) :: line, column
+
+        call errors%add_error(message=message, code=ERROR_SEMANTIC, &
+            component='semantic_submodule_validation', &
+            context='line '//int_to_string(line)//', column '// &
+            int_to_string(column), suggestion=suggestion, &
+            line=line, column=column, end_line=line, end_column=column + 1)
+    end subroutine report
+
+    ! Compare one separate module subprogram against its interface body.
+    subroutine check_definition(arena, def_index, module_index, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: def_index
+        integer, intent(in) :: module_index
+        type(error_collection_t), intent(inout) :: errors
+        character(len=:), allocatable :: name, label, interface_label
+        character(len=:), allocatable :: interface_name
+        logical :: is_module, interface_is_module
+        integer :: interface_index, line, column
+
+        if (.not. arena%has_node_at(def_index)) return
+
+        call interface_procedure_facts(arena, def_index, name, is_module, label)
+        if (.not. allocated(name)) return
+
+        interface_index = find_interface_body(arena, module_index, name)
+        if (interface_index == 0) return
+
+        line = arena%entries(def_index)%node%line
+        column = arena%entries(def_index)%node%column
+
+        if (.not. is_module) then
+            call report(errors, 'separate module subprogram "'//name// &
+                '" requires the MODULE prefix', &
+                'add the MODULE prefix to the subprogram statement', &
+                line, column)
+            return
+        end if
+
+        call interface_procedure_facts(arena, interface_index, interface_name, &
+            interface_is_module, interface_label)
+        if (.not. allocated(interface_label)) return
+        if (.not. allocated(label)) return
+        if (label == interface_label) return
+
+        call report(errors, 'mismatch in BIND(C) names ("'//label//'"/"'// &
+            interface_label//'") for module procedure "'//name//'"', &
+            'use the binding label of the module procedure interface body', &
+            line, column)
+    end subroutine check_definition
+
+    ! Entry point: check every submodule in the arena whose ancestor module is
+    ! present in the same file.
+    subroutine validate_submodule_interfaces(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i, j, module_index
+        character(len=:), allocatable :: parent_name
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+            type is (submodule_node)
+                if (.not. allocated(node%parent_identifier)) cycle
+                if (.not. allocated(node%procedure_indices)) cycle
+                parent_name = ancestor_module_name(node%parent_identifier)
+                if (len(parent_name) == 0) cycle
+                module_index = find_module(arena, parent_name)
+                if (module_index == 0) cycle
+                do j = 1, size(node%procedure_indices)
+                    call check_definition(arena, node%procedure_indices(j), &
+                        module_index, errors)
+                end do
+            end select
+        end do
+    end subroutine validate_submodule_interfaces
+
+end module semantic_submodule_validation

--- a/test/api/test_reject_submodule_01_diagnostics.f90
+++ b/test/api/test_reject_submodule_01_diagnostics.f90
@@ -22,8 +22,14 @@ program test_reject_submodule_01_diagnostics
     call assert_rejected('examples/f90/submodule_unexp.f90', &
         'SUBMODULE declaration is not allowed', all_passed)
 
+    ! Separate module procedure with a dummy argument list (F2018 R1505)
+    call assert_rejected('examples/f90/pr93423.f90', &
+        'must not have a dummy argument list', all_passed)
+
     ! Corrected neighbours must keep compiling
     call assert_accepted('examples/f90/submodule_placement_valid.f90', all_passed)
+    call assert_accepted('examples/f90/submodule_module_procedure_valid.f90', &
+        all_passed)
     call assert_accepted('examples/f90/issue_1827_submodule_simple.f90', all_passed)
     call assert_accepted('examples/f90/issue_1827_submodule_with_contents.f90', &
         all_passed)

--- a/test/api/test_reject_submodule_01_diagnostics.f90
+++ b/test/api/test_reject_submodule_01_diagnostics.f90
@@ -1,0 +1,101 @@
+program test_reject_submodule_01_diagnostics
+    ! Rejection coverage for submodule declaration consistency.
+    !
+    ! Every negative fixture must be rejected with a diagnostic from this rule
+    ! family, and every corrected neighbour must still be accepted. Over-eager
+    ! rejection is the failure mode this test guards against, so the positive
+    ! cases are as load bearing as the negative ones.
+    use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use lexer_core, only: token_t
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    ! Nested SUBMODULE declarations (F2018 R1116: a submodule is a program unit)
+    call assert_rejected('examples/f90/submodule_twice.f90', &
+        'SUBMODULE declaration is not allowed', all_passed)
+    call assert_rejected('examples/f90/submodule_unexp.f90', &
+        'SUBMODULE declaration is not allowed', all_passed)
+
+    ! Corrected neighbours must keep compiling
+    call assert_accepted('examples/f90/submodule_placement_valid.f90', all_passed)
+    call assert_accepted('examples/f90/issue_1827_submodule_simple.f90', all_passed)
+    call assert_accepted('examples/f90/issue_1827_submodule_with_contents.f90', &
+        all_passed)
+
+    if (.not. all_passed) error stop 1
+    write (output_unit, '(A)') 'PASS: submodule rejection diagnostics'
+
+contains
+
+    include '../common/read_example.inc'
+
+    subroutine parse_example(path, parse_error)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: parse_error
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: lex_error
+        character(len=5000) :: error_buffer
+        type(ast_arena_t) :: arena
+        type(token_t), allocatable :: tokens(:)
+        integer :: root_index
+
+        call read_example(path, source)
+
+        arena = create_ast_arena()
+        call lex_source(source, tokens, lex_error)
+        if (allocated(lex_error)) then
+            if (len_trim(lex_error) > 0) then
+                write (error_unit, '(A)') 'FAIL: lexing error in '//path//': '// &
+                    trim(lex_error)
+                error stop 1
+            end if
+        end if
+
+        error_buffer = ''
+        call parse_tokens(tokens, arena, root_index, error_buffer)
+        parse_error = trim(error_buffer)
+    end subroutine parse_example
+
+    subroutine assert_rejected(path, expected_fragment, passed)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: expected_fragment
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: parse_error
+
+        call parse_example(path, parse_error)
+
+        if (len_trim(parse_error) == 0) then
+            write (error_unit, '(A)') 'FAIL: '//path//' was accepted'
+            passed = .false.
+            return
+        end if
+
+        if (index(parse_error, expected_fragment) == 0) then
+            write (error_unit, '(A)') 'FAIL: '//path// &
+                ' missing expected diagnostic "'//expected_fragment//'"'
+            write (error_unit, '(A)') trim(parse_error)
+            passed = .false.
+        end if
+    end subroutine assert_rejected
+
+    subroutine assert_accepted(path, passed)
+        character(len=*), intent(in) :: path
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: parse_error
+
+        call parse_example(path, parse_error)
+
+        if (len_trim(parse_error) /= 0) then
+            write (error_unit, '(A)') 'FAIL: '//path//' was rejected'
+            write (error_unit, '(A)') trim(parse_error)
+            passed = .false.
+        end if
+    end subroutine assert_accepted
+
+end program test_reject_submodule_01_diagnostics

--- a/test/api/test_reject_submodule_01_diagnostics.f90
+++ b/test/api/test_reject_submodule_01_diagnostics.f90
@@ -6,10 +6,8 @@ program test_reject_submodule_01_diagnostics
     ! rejection is the failure mode this test guards against, so the positive
     ! cases are as load bearing as the negative ones.
     use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
-    use frontend_core, only: lex_source
-    use frontend_parsing, only: parse_tokens
-    use ast_arena_modern, only: ast_arena_t, create_ast_arena
-    use lexer_core, only: token_t
+    use frontend_compiler_api, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string
     implicit none
 
     logical :: all_passed
@@ -26,10 +24,23 @@ program test_reject_submodule_01_diagnostics
     call assert_rejected('examples/f90/pr93423.f90', &
         'must not have a dummy argument list', all_passed)
 
+    ! Separate module subprogram without the MODULE prefix (F2018 15.6.2.5)
+    call assert_rejected('examples/f90/submodule_36.f90', &
+        'requires the MODULE prefix', all_passed)
+
+    ! Binding label that disagrees with the interface body (F2018 C1550)
+    call assert_rejected('examples/f90/pr89943_3.f90', &
+        'mismatch in BIND(C) names', all_passed)
+    call assert_rejected('examples/f90/pr89943_4.f90', &
+        'mismatch in BIND(C) names', all_passed)
+
     ! Corrected neighbours must keep compiling
     call assert_accepted('examples/f90/submodule_placement_valid.f90', all_passed)
     call assert_accepted('examples/f90/submodule_module_procedure_valid.f90', &
         all_passed)
+    call assert_accepted('examples/f90/submodule_module_prefix_valid.f90', &
+        all_passed)
+    call assert_accepted('examples/f90/submodule_bind_c_name_valid.f90', all_passed)
     call assert_accepted('examples/f90/issue_1827_submodule_simple.f90', all_passed)
     call assert_accepted('examples/f90/issue_1827_submodule_with_contents.f90', &
         all_passed)
@@ -41,51 +52,46 @@ contains
 
     include '../common/read_example.inc'
 
-    subroutine parse_example(path, parse_error)
+    subroutine compile_example(path, rejected, diagnostic)
         character(len=*), intent(in) :: path
-        character(len=:), allocatable, intent(out) :: parse_error
+        logical, intent(out) :: rejected
+        character(len=:), allocatable, intent(out) :: diagnostic
         character(len=:), allocatable :: source
-        character(len=:), allocatable :: lex_error
-        character(len=5000) :: error_buffer
-        type(ast_arena_t) :: arena
-        type(token_t), allocatable :: tokens(:)
-        integer :: root_index
+        type(compiler_frontend_result_t) :: result
+        type(compiler_frontend_options_t) :: options
 
         call read_example(path, source)
 
-        arena = create_ast_arena()
-        call lex_source(source, tokens, lex_error)
-        if (allocated(lex_error)) then
-            if (len_trim(lex_error) > 0) then
-                write (error_unit, '(A)') 'FAIL: lexing error in '//path//': '// &
-                    trim(lex_error)
-                error stop 1
-            end if
-        end if
+        options%run_semantics = .true.
+        call compile_frontend_from_string(source, result, options)
 
-        error_buffer = ''
-        call parse_tokens(tokens, arena, root_index, error_buffer)
-        parse_error = trim(error_buffer)
-    end subroutine parse_example
+        rejected = .not. (result%parse_ok .and. result%semantic_ok)
+        if (allocated(result%error_msg)) then
+            diagnostic = result%error_msg
+        else
+            diagnostic = ''
+        end if
+    end subroutine compile_example
 
     subroutine assert_rejected(path, expected_fragment, passed)
         character(len=*), intent(in) :: path
         character(len=*), intent(in) :: expected_fragment
         logical, intent(inout) :: passed
-        character(len=:), allocatable :: parse_error
+        character(len=:), allocatable :: diagnostic
+        logical :: rejected
 
-        call parse_example(path, parse_error)
+        call compile_example(path, rejected, diagnostic)
 
-        if (len_trim(parse_error) == 0) then
+        if (.not. rejected) then
             write (error_unit, '(A)') 'FAIL: '//path//' was accepted'
             passed = .false.
             return
         end if
 
-        if (index(parse_error, expected_fragment) == 0) then
+        if (index(diagnostic, expected_fragment) == 0) then
             write (error_unit, '(A)') 'FAIL: '//path// &
                 ' missing expected diagnostic "'//expected_fragment//'"'
-            write (error_unit, '(A)') trim(parse_error)
+            write (error_unit, '(A)') trim(diagnostic)
             passed = .false.
         end if
     end subroutine assert_rejected
@@ -93,13 +99,14 @@ contains
     subroutine assert_accepted(path, passed)
         character(len=*), intent(in) :: path
         logical, intent(inout) :: passed
-        character(len=:), allocatable :: parse_error
+        character(len=:), allocatable :: diagnostic
+        logical :: rejected
 
-        call parse_example(path, parse_error)
+        call compile_example(path, rejected, diagnostic)
 
-        if (len_trim(parse_error) /= 0) then
+        if (rejected) then
             write (error_unit, '(A)') 'FAIL: '//path//' was rejected'
-            write (error_unit, '(A)') trim(parse_error)
+            write (error_unit, '(A)') trim(diagnostic)
             passed = .false.
         end if
     end subroutine assert_accepted


### PR DESCRIPTION
Closes #2900.

Fortfront accepted all six gfortran.dg files named by the issue. Each is now
rejected with a diagnostic from this rule family, and a corrected neighbour is
added for every distinct rule.

## Rules

**Placement of the SUBMODULE statement** (F2018 R1116; `submodule_twice.f90`,
`submodule_unexp.f90`). A submodule is a program unit, so the statement can
only start one. Fortfront used to swallow it silently inside a program body or
a derived-type definition, and the construct vanished from the AST. The new
recogniser in `parser_submodule_placement.f90` matches the full submodule-stmt
shape rather than the leading keyword, so `submodule = 3` and `submodule(i) = 3`
keep parsing as ordinary code; the corrected neighbour exercises both.

**MODULE PROCEDURE with a dummy argument list** (F2018 R1505; `pr93423.f90`).
An mp-subprogram-stmt names the procedure and nothing else. The check lives in
`parser_submodule_helpers.f90` and fires only on the separate module procedure
form, where an opening parenthesis after the name can never be valid;
`module procedure(iface)` and `module procedure :: a, b` are untouched.

**Interface consistency of separate module subprograms** (F2018 15.6.2.5 and
C1550; `submodule_36.f90`, `pr89943_3.f90`, `pr89943_4.f90`). A subprogram in a
submodule whose name matches a module procedure interface in the ancestor
module implements that interface, so it needs the MODULE prefix and the same
binding label. The comparison needs the whole arena, which the parser never
has, so it runs in a new `semantic_submodule_validation` pass.

## Precision

The two things that could over-reject are handled by staying narrow:

- Nothing is reported when the ancestor module is not in the same file. There
  is then no interface body to compare against, so a submodule compiled against
  a separate `.mod` behaves exactly as before.
- Binding labels are only compared when both the interface body and the
  definition state one explicitly. A default binding label is never inferred.

## Verification

- `fo` — all stages pass, 483 tests.
- `make check-duplication` — 1 violation, the pre-existing
  `test/api/test_compiler_statement_queries.f90` one tracked by #2910.
- Negative controls: disabling the placement recogniser and the parenthesis
  check makes the three parser assertions fail with "was accepted"; disabling
  the semantic pass makes the three interface assertions fail the same way.
  Both were reverted and the test passes again.
- All four corrected neighbours compile under gfortran, and the frontend
  accepts them along with the two pre-existing submodule examples.

## Known limitation recorded, not fixed

`submodule_module_procedure_valid.f90` is listed in `expected_failures.txt`.
Emission rewrites a separate module procedure as a subroutine with no dummy
arguments and drops the ones the interface body declares, so its round trip
does not compile. That is a pre-existing codegen gap unrelated to this
rejection family; the frontend accepts the file, which is what the rejection
test asserts.
