### PR TITLE
Reject malformed iterators and invalid DO CONCURRENT locality specifiers

### DIFF
--- a/src/parser/control_flow/parser_do_concurrent_locality.f90
+++ b/src/parser/control_flow/parser_do_concurrent_locality.f90
@@ -1,0 +1,333 @@
+module parser_do_concurrent_locality_module
+    ! Parses and validates the locality-spec-list of a DO CONCURRENT statement
+    ! (Fortran 2023 R1130/R1131) and enforces the locality constraints that are
+    ! decidable from the statement text alone:
+    !   C1129  DEFAULT (NONE) shall not appear more than once.
+    !   C1130  A variable-name shall not appear in more than one locality-spec.
+    ! The reduce-operation is restricted to the operators and intrinsic function
+    ! names listed in R1131, and REDUCE requires a ":" between the operation and
+    ! its variable-name-list.
+    use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_OPERATOR, &
+        TK_KEYWORD, TK_NEWLINE, TK_COMMENT, TK_WHITESPACE, to_lower
+    use parser_state_module, only: parser_state_t
+    implicit none
+    private
+
+    integer, parameter :: MAX_LOCALITY_NAME = 63
+
+    public :: parse_do_concurrent_locality_specs
+
+contains
+
+    ! Consume every locality-spec that follows the concurrent-header. Returns
+    ! .false. after recording a parser diagnostic when the list is malformed or
+    ! violates a locality constraint.
+    logical function parse_do_concurrent_locality_specs(parser) result(valid)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=MAX_LOCALITY_NAME), allocatable :: seen(:)
+        type(token_t) :: tok
+        character(len=:), allocatable :: spec
+        integer :: default_none_count
+
+        valid = .true.
+        default_none_count = 0
+        allocate (seen(0))
+
+        do
+            call skip_blanks(parser)
+            tok = parser%peek()
+            if (ends_locality_list(tok)) return
+
+            ! Only "name (" can start a locality-spec. Anything else is left
+            ! alone so that token streams which omit the statement-ending
+            ! newline still fall through to the loop body unchanged.
+            if (.not. starts_locality_spec(parser)) return
+
+            spec = to_lower(trim(tok%text))
+            select case (spec)
+            case ("local", "local_init", "shared")
+                tok = parser%consume()
+                if (.not. parse_name_list_spec(parser, spec, seen)) then
+                    valid = .false.
+                    return
+                end if
+            case ("default")
+                tok = parser%consume()
+                if (.not. parse_default_spec(parser, default_none_count)) then
+                    valid = .false.
+                    return
+                end if
+            case ("reduce")
+                tok = parser%consume()
+                if (.not. parse_reduce_spec(parser, seen)) then
+                    valid = .false.
+                    return
+                end if
+            case default
+                call parser%error_at_token("Syntax error in DO CONCURRENT "// &
+                    "statement: unknown locality specifier '"// &
+                    trim(tok%text)//"'", tok, &
+                    suggestion="use LOCAL, LOCAL_INIT, SHARED, REDUCE or "// &
+                    "DEFAULT (NONE)")
+                valid = .false.
+                return
+            end select
+        end do
+    end function parse_do_concurrent_locality_specs
+
+    ! LOCAL / LOCAL_INIT / SHARED ( variable-name-list )
+    logical function parse_name_list_spec(parser, spec, seen) result(valid)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=*), intent(in) :: spec
+        character(len=MAX_LOCALITY_NAME), allocatable, intent(inout) :: seen(:)
+
+        valid = expect_open_paren(parser, spec)
+        if (.not. valid) return
+        valid = parse_variable_name_list(parser, spec, seen)
+        if (.not. valid) return
+        valid = expect_close_paren(parser, spec)
+    end function parse_name_list_spec
+
+    ! DEFAULT ( NONE ), at most once per statement (C1129).
+    logical function parse_default_spec(parser, default_none_count) result(valid)
+        type(parser_state_t), intent(inout) :: parser
+        integer, intent(inout) :: default_none_count
+        type(token_t) :: tok
+
+        valid = expect_open_paren(parser, "default")
+        if (.not. valid) return
+
+        call skip_blanks(parser)
+        tok = parser%peek()
+        if (tok%kind /= TK_IDENTIFIER .and. tok%kind /= TK_KEYWORD) then
+            call report_expected(parser, tok, "NONE", "DEFAULT")
+            valid = .false.
+            return
+        end if
+        if (to_lower(trim(tok%text)) /= "none") then
+            call report_expected(parser, tok, "NONE", "DEFAULT")
+            valid = .false.
+            return
+        end if
+        tok = parser%consume()
+
+        valid = expect_close_paren(parser, "default")
+        if (.not. valid) return
+
+        default_none_count = default_none_count + 1
+        if (default_none_count > 1) then
+            call parser%error_at_token("DEFAULT (NONE) specified more than "// &
+                "once in DO CONCURRENT", tok, &
+                suggestion="give DEFAULT (NONE) exactly once")
+            valid = .false.
+        end if
+    end function parse_default_spec
+
+    ! REDUCE ( reduce-operation : variable-name-list )
+    logical function parse_reduce_spec(parser, seen) result(valid)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=MAX_LOCALITY_NAME), allocatable, intent(inout) :: seen(:)
+        type(token_t) :: tok
+
+        valid = expect_open_paren(parser, "reduce")
+        if (.not. valid) return
+
+        call skip_blanks(parser)
+        tok = parser%peek()
+        if (.not. is_reduce_operation(tok)) then
+            call parser%error_at_token("Expected reduction operator or "// &
+                "function name in DO CONCURRENT REDUCE specifier", tok, &
+                suggestion="use +, *, .and., .or., .eqv., .neqv., max, min, "// &
+                "iand, ior or ieor")
+            valid = .false.
+            return
+        end if
+        tok = parser%consume()
+
+        call skip_blanks(parser)
+        tok = parser%peek()
+        if (tok%kind /= TK_OPERATOR .or. tok%text /= ":") then
+            call report_expected(parser, tok, "':'", "REDUCE")
+            valid = .false.
+            return
+        end if
+        tok = parser%consume()
+
+        valid = parse_variable_name_list(parser, "reduce", seen)
+        if (.not. valid) return
+        valid = expect_close_paren(parser, "reduce")
+    end function parse_reduce_spec
+
+    ! variable-name-list with the C1130 single-appearance check.
+    logical function parse_variable_name_list(parser, spec, seen) result(valid)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=*), intent(in) :: spec
+        character(len=MAX_LOCALITY_NAME), allocatable, intent(inout) :: seen(:)
+        type(token_t) :: tok
+        character(len=:), allocatable :: name
+
+        valid = .true.
+        do
+            call skip_blanks(parser)
+            tok = parser%peek()
+            if (tok%kind /= TK_IDENTIFIER .and. tok%kind /= TK_KEYWORD) then
+                call report_expected(parser, tok, "a variable name", spec)
+                valid = .false.
+                return
+            end if
+            name = to_lower(trim(tok%text))
+            if (name_already_seen(name, seen)) then
+                call parser%error_at_token("Variable '"//trim(tok%text)// &
+                    "' has already been specified in a locality-spec of this "// &
+                    "DO CONCURRENT statement", tok, &
+                    suggestion="name each variable in at most one locality-spec")
+                valid = .false.
+                return
+            end if
+            call remember_name(name, seen)
+            tok = parser%consume()
+
+            call skip_blanks(parser)
+            tok = parser%peek()
+            if (tok%kind == TK_OPERATOR .and. tok%text == ",") then
+                tok = parser%consume()
+                cycle
+            end if
+            return
+        end do
+    end function parse_variable_name_list
+
+    logical function expect_open_paren(parser, spec) result(valid)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=*), intent(in) :: spec
+        type(token_t) :: tok
+
+        call skip_blanks(parser)
+        tok = parser%peek()
+        valid = tok%kind == TK_OPERATOR
+        if (valid) valid = tok%text == "("
+        if (.not. valid) then
+            call report_expected(parser, tok, "'('", spec)
+            return
+        end if
+        tok = parser%consume()
+    end function expect_open_paren
+
+    logical function expect_close_paren(parser, spec) result(valid)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=*), intent(in) :: spec
+        type(token_t) :: tok
+
+        call skip_blanks(parser)
+        tok = parser%peek()
+        valid = tok%kind == TK_OPERATOR
+        if (valid) valid = tok%text == ")"
+        if (.not. valid) then
+            call report_expected(parser, tok, "')'", spec)
+            return
+        end if
+        tok = parser%consume()
+    end function expect_close_paren
+
+    subroutine report_expected(parser, tok, expected, spec)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t), intent(in) :: tok
+        character(len=*), intent(in) :: expected
+        character(len=*), intent(in) :: spec
+
+        call parser%error_at_token("Expected "//expected//" in DO CONCURRENT "// &
+            trim(spec)//" locality specifier", tok)
+    end subroutine report_expected
+
+    ! R1131 reduce-operation: an intrinsic operator or intrinsic function name.
+    logical function is_reduce_operation(tok) result(is_operation)
+        type(token_t), intent(in) :: tok
+        character(len=:), allocatable :: text
+
+        is_operation = .false.
+        if (tok%kind /= TK_OPERATOR .and. tok%kind /= TK_IDENTIFIER .and. &
+            tok%kind /= TK_KEYWORD) return
+
+        text = to_lower(trim(tok%text))
+        select case (text)
+        case ("+", "*", ".and.", ".or.", ".eqv.", ".neqv.", &
+                "max", "min", "iand", "ior", "ieor")
+            is_operation = .true.
+        end select
+    end function is_reduce_operation
+
+    ! A locality-spec is always "name ( ... )". Peeking one token past the name
+    ! keeps the check off ordinary loop-body statements.
+    logical function starts_locality_spec(parser) result(is_spec)
+        type(parser_state_t), intent(in) :: parser
+        type(token_t) :: name_tok
+        type(token_t) :: next_tok
+        integer :: idx
+
+        is_spec = .false.
+        name_tok = parser%peek()
+        if (name_tok%kind /= TK_IDENTIFIER .and. name_tok%kind /= TK_KEYWORD) return
+
+        idx = parser%current_token + 1
+        do
+            next_tok = parser%get_token_at_index(idx)
+            if (next_tok%kind /= TK_WHITESPACE) exit
+            idx = idx + 1
+        end do
+
+        if (next_tok%kind /= TK_OPERATOR) return
+        is_spec = next_tok%text == "("
+    end function starts_locality_spec
+
+    logical function ends_locality_list(tok) result(is_end)
+        type(token_t), intent(in) :: tok
+
+        is_end = .false.
+        select case (tok%kind)
+        case (TK_NEWLINE, TK_EOF, TK_COMMENT)
+            is_end = .true.
+            return
+        end select
+        if (tok%kind /= TK_OPERATOR) return
+        is_end = tok%text == ";"
+    end function ends_locality_list
+
+    subroutine skip_blanks(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: tok
+
+        do
+            tok = parser%peek()
+            if (tok%kind /= TK_WHITESPACE) return
+            tok = parser%consume()
+        end do
+    end subroutine skip_blanks
+
+    logical function name_already_seen(name, seen) result(is_present)
+        character(len=*), intent(in) :: name
+        character(len=MAX_LOCALITY_NAME), intent(in) :: seen(:)
+        integer :: i
+
+        is_present = .false.
+        do i = 1, size(seen)
+            if (trim(seen(i)) == name) then
+                is_present = .true.
+                return
+            end if
+        end do
+    end function name_already_seen
+
+    subroutine remember_name(name, seen)
+        character(len=*), intent(in) :: name
+        character(len=MAX_LOCALITY_NAME), allocatable, intent(inout) :: seen(:)
+        character(len=MAX_LOCALITY_NAME), allocatable :: grown(:)
+        integer :: n
+
+        n = size(seen)
+        allocate (grown(n + 1))
+        if (n > 0) grown(1:n) = seen
+        grown(n + 1) = name
+        call move_alloc(grown, seen)
+    end subroutine remember_name
+
+end module parser_do_concurrent_locality_module

--- a/src/parser/control_flow/parser_do_constructs.f90
+++ b/src/parser/control_flow/parser_do_constructs.f90
@@ -11,6 +11,8 @@ module parser_do_constructs_module
     use parser_select_constructs_module, only: parse_select_case
     use parser_array_constructs_module, only: parse_where_construct, parse_associate
     use parser_forall_module, only: parse_forall
+    use parser_do_concurrent_locality_module, only: &
+        parse_do_concurrent_locality_specs
     use parser_statement_core_module, only: parse_basic_statement_core, &
         statement_callbacks_t, &
         null_statement_callbacks, &

--- a/src/parser/control_flow/parser_do_constructs_part1.inc
+++ b/src/parser/control_flow/parser_do_constructs_part1.inc
@@ -128,6 +128,16 @@
         end if
     end function next_tokens_form_control
 
+    ! A DO iterator separates its bounds with "," (F2023 R1125) or, for the
+    ! range form fortfront also accepts, with ":".
+    logical function is_iterator_separator(tok) result(is_separator)
+        type(token_t), intent(in) :: tok
+
+        is_separator = .false.
+        if (tok%kind /= TK_OPERATOR) return
+        is_separator = tok%text == "," .or. tok%text == ":"
+    end function is_iterator_separator
+
     logical function parse_standard_control(parser, arena, control) result(success)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
@@ -145,16 +155,32 @@
         tok = parser%consume()
         if (tok%kind /= TK_OPERATOR .or. tok%text /= "=") return
 
+        ! Past the "name =" prefix this statement can only be a DO iterator
+        ! (F2023 R1125 loop-control), so a malformed remainder is a hard
+        ! syntax error rather than a silent parse failure.
         control%start_index = parse_logical_or(parser, arena)
-        if (control%start_index <= 0) return
+        if (control%start_index <= 0) then
+            call parser%error("Syntax error in DO iterator: expected an "// &
+                "initial loop bound expression")
+            return
+        end if
 
+        tok = parser%peek()
+        if (.not. is_iterator_separator(tok)) then
+            call parser%error_at_token("Syntax error in DO iterator: expected "// &
+                "',' after the initial loop bound", tok, &
+                suggestion="write the iterator as do var = start, end [, step]")
+            return
+        end if
         tok = parser%consume()
-        if (tok%kind /= TK_OPERATOR) return
         allow_colon_step = tok%text == ":"
-        if (.not. (tok%text == "," .or. tok%text == ":")) return
 
         control%end_index = parse_logical_or(parser, arena)
-        if (control%end_index <= 0) return
+        if (control%end_index <= 0) then
+            call parser%error("Syntax error in DO iterator: expected a "// &
+                "terminal loop bound expression")
+            return
+        end if
 
         if (.not. parser%is_at_end()) then
             tok = parser%peek()

--- a/src/parser/control_flow/parser_do_constructs_part1.inc
+++ b/src/parser/control_flow/parser_do_constructs_part1.inc
@@ -627,6 +627,12 @@
                     return
                 end if
             end if
+
+            ! Everything left on the DO CONCURRENT statement is a locality-spec.
+            if (.not. parse_do_concurrent_locality_specs(parser)) then
+                loop_index = 0
+                return
+            end if
         else
             if (.not. parse_standard_control(parser, arena, control)) then
                 loop_index = 0

--- a/src/parser/expressions/parser_expression_arrays.f90
+++ b/src/parser/expressions/parser_expression_arrays.f90
@@ -552,19 +552,42 @@ contains
         if (current%text /= "=") return
         current = parser%consume()
 
+        ! Past "name =" the construct can only be an implied-DO control
+        ! (F2023 R777 ac-implied-do-control), so a malformed remainder is a
+        ! syntax error in the iterator rather than a speculative parse failure.
         start_index = helpers%parse_comparison(parser, arena)
+        if (start_index <= 0) then
+            call parser%error("Syntax error in iterator: expected an initial "// &
+                "bound expression")
+            return
+        end if
 
         current = parser%peek()
-        if (current%text /= ",") return
+        if (current%text /= ",") then
+            call parser%error_at_token("Syntax error in iterator: expected "// &
+                "',' after the initial bound", current, &
+                suggestion="write the iterator as (expr, var = start, end)")
+            return
+        end if
         current = parser%consume()
 
         end_index = helpers%parse_comparison(parser, arena)
+        if (end_index <= 0) then
+            call parser%error("Syntax error in iterator: expected a terminal "// &
+                "bound expression")
+            return
+        end if
 
         step_index = 0
         current = parser%peek()
         if (current%text == ",") then
             current = parser%consume()
             step_index = helpers%parse_comparison(parser, arena)
+            if (step_index <= 0) then
+                call parser%error("Syntax error in iterator: expected a "// &
+                    "stride expression")
+                return
+            end if
         end if
 
         success = .true.

--- a/src/parser/statements/parser_io_statements_common.inc
+++ b/src/parser/statements/parser_io_statements_common.inc
@@ -330,14 +330,21 @@
         end if
         token = parser%consume()
 
+        ! Past "( expr , name =" the item can only be an io-implied-do
+        ! (F2023 R1224), so the rest of the iterator and its closing right
+        ! parenthesis are required rather than speculative.
         start_index = parse_comparison(parser, arena)
         if (start_index <= 0) then
+            call parser%error("Syntax error in iterator: expected an initial "// &
+                "bound expression")
             expr_index = fail_and_restore()
             return
         end if
 
         token = parser%peek()
         if (token%kind /= TK_OPERATOR .or. token%text /= ",") then
+            call parser%error_at_token("Syntax error in iterator: expected "// &
+                "',' after the initial bound", token)
             expr_index = fail_and_restore()
             return
         end if
@@ -345,6 +352,8 @@
 
         end_index = parse_comparison(parser, arena)
         if (end_index <= 0) then
+            call parser%error("Syntax error in iterator: expected a terminal "// &
+                "bound expression")
             expr_index = fail_and_restore()
             return
         end if
@@ -355,6 +364,8 @@
             token = parser%consume()
             step_index = parse_comparison(parser, arena)
             if (step_index <= 0) then
+                call parser%error("Syntax error in iterator: expected a "// &
+                    "stride expression")
                 expr_index = fail_and_restore()
                 return
             end if
@@ -362,6 +373,9 @@
 
         token = parser%peek()
         if (token%kind /= TK_OPERATOR .or. token%text /= ")") then
+            call parser%error_at_token("Expected a right parenthesis closing "// &
+                "the implied-DO in the I/O list", token, &
+                suggestion="close the implied-DO with ')'")
             expr_index = fail_and_restore()
             return
         end if

--- a/test/api/test_reject_do_concurrent_01_diagnostics.f90
+++ b/test/api/test_reject_do_concurrent_01_diagnostics.f90
@@ -1,0 +1,195 @@
+program test_reject_do_concurrent_01_diagnostics
+    ! Issue #2901: DO CONCURRENT locality-spec constraints (F2023 C1129/C1130
+    ! and the R1131 reduce-operation list) must be rejected with a
+    ! rule-specific source diagnostic, while corrected neighbours stay accepted.
+    use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use lexer_core, only: token_t
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    ! C1130: a variable named in two locality-specs.
+    call expect_rejected( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, total"//new_line('a')// &
+        "  total = 0"//new_line('a')// &
+        "  do concurrent (i = 1:10) shared(total) reduce(+:total)"// &
+        new_line('a')// &
+        "    total = total + i"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "has already been specified in a locality-spec", &
+        "duplicate variable in locality-spec-list")
+
+    ! C1129: DEFAULT (NONE) given twice.
+    call expect_rejected( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, b"//new_line('a')// &
+        "  do concurrent (i = 1:4) default(none) shared(b) default(none)"// &
+        new_line('a')// &
+        "    b = i"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "DEFAULT (NONE) specified more than once", &
+        "repeated DEFAULT (NONE)")
+
+    ! R1131: "-" is not a reduce-operation.
+    call expect_rejected( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, x"//new_line('a')// &
+        "  x = 0"//new_line('a')// &
+        "  do concurrent (i = 2:4) reduce(-:x)"//new_line('a')// &
+        "    x = x - i"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "Expected reduction operator or function name", &
+        "invalid reduce-operation")
+
+    ! R1131: the reduce-operation must be followed by ":".
+    call expect_rejected( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, x"//new_line('a')// &
+        "  x = 0"//new_line('a')// &
+        "  do concurrent (i = 2:4) reduce(+ x)"//new_line('a')// &
+        "    x = x + i"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "Expected ':' in DO CONCURRENT", "missing reduce colon")
+
+    ! R1130: REDUCTION is not a locality-spec keyword.
+    call expect_rejected( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, x"//new_line('a')// &
+        "  x = 0"//new_line('a')// &
+        "  do concurrent (i = 2:4) reduction(+: x)"//new_line('a')// &
+        "    x = x + i"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "unknown locality specifier", "misspelled locality-spec")
+
+    ! Corrected neighbours: every locality-spec form, each name used once.
+    call expect_accepted( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, arr(10), total, temp"//new_line('a')// &
+        "  total = 0"//new_line('a')// &
+        "  do concurrent (i = 1:10) default(none) local(temp) shared(arr) "// &
+        "reduce(+:total)"//new_line('a')// &
+        "    temp = i * 2"//new_line('a')// &
+        "    arr(i) = temp"//new_line('a')// &
+        "    total = total + arr(i)"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "full locality-spec-list")
+
+    call expect_accepted( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, m"//new_line('a')// &
+        "  m = 0"//new_line('a')// &
+        "  do concurrent (i = 1:10) reduce(max:m)"//new_line('a')// &
+        "    m = max(m, i)"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "intrinsic-function reduce-operation")
+
+    call expect_accepted( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, a(10), b(10), t"//new_line('a')// &
+        "  a = 0"//new_line('a')// &
+        "  do concurrent (i = 1:10) local_init(t) shared(a, b)"// &
+        new_line('a')// &
+        "    a(i) = b(i)"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "LOCAL_INIT and multi-name SHARED")
+
+    ! A DO CONCURRENT with no locality-spec at all must stay accepted.
+    call expect_accepted( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, a(10)"//new_line('a')// &
+        "  do concurrent (i = 1:10)"//new_line('a')// &
+        "    a(i) = i"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "bare DO CONCURRENT")
+
+    if (failures /= 0) then
+        write (error_unit, '(A,I0,A)') "FAIL: ", failures, " locality checks"
+        error stop 1
+    end if
+    write (output_unit, '(A)') "PASS: reject-do-concurrent-01 diagnostics"
+
+contains
+
+    subroutine expect_rejected(source, expected_fragment, label)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected_fragment
+        character(len=*), intent(in) :: label
+        character(len=5000) :: parse_error
+
+        call parse_source(source, parse_error)
+
+        if (len_trim(parse_error) == 0) then
+            write (output_unit, '(A)') "FAIL: accepted invalid "//label
+            failures = failures + 1
+            return
+        end if
+        if (index(parse_error, expected_fragment) == 0) then
+            write (output_unit, '(A)') "FAIL: wrong diagnostic for "//label
+            write (output_unit, '(A)') trim(parse_error)
+            failures = failures + 1
+            return
+        end if
+        write (output_unit, '(A)') "PASS: rejected invalid "//label
+    end subroutine expect_rejected
+
+    subroutine expect_accepted(source, label)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: label
+        character(len=5000) :: parse_error
+
+        call parse_source(source, parse_error)
+
+        if (len_trim(parse_error) /= 0) then
+            write (output_unit, '(A)') "FAIL: rejected valid "//label
+            write (output_unit, '(A)') trim(parse_error)
+            failures = failures + 1
+            return
+        end if
+        write (output_unit, '(A)') "PASS: accepted valid "//label
+    end subroutine expect_accepted
+
+    subroutine parse_source(source, parse_error)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(out) :: parse_error
+        character(len=:), allocatable :: lex_error
+        type(ast_arena_t) :: arena
+        type(token_t), allocatable :: tokens(:)
+        integer :: root_index
+
+        parse_error = ""
+        arena = create_ast_arena()
+        call lex_source(source, tokens, lex_error)
+        if (allocated(lex_error)) then
+            if (len_trim(lex_error) > 0) then
+                parse_error = "lexer: "//trim(lex_error)
+                return
+            end if
+        end if
+        call parse_tokens(tokens, arena, root_index, parse_error)
+    end subroutine parse_source
+
+end program test_reject_do_concurrent_01_diagnostics

--- a/test/api/test_reject_iterator_01_diagnostics.f90
+++ b/test/api/test_reject_iterator_01_diagnostics.f90
@@ -1,0 +1,162 @@
+program test_reject_iterator_01_diagnostics
+    ! Issue #2898: malformed iterators and implied-DO delimiters must be
+    ! rejected with a rule-specific source diagnostic, while the corrected
+    ! neighbouring form stays accepted.
+    use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use lexer_core, only: token_t
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    ! gfortran.dg/pr19936_2.f90: iterator bound followed by junk in an
+    ! array-constructor implied-DO.
+    call expect_rejected( &
+        "program p"//new_line('a')// &
+        "  integer i"//new_line('a')// &
+        "  print *,(/(i,i=1a,4)/)"//new_line('a')// &
+        "end program p", &
+        "Syntax error in iterator", "array-constructor iterator")
+    call expect_accepted( &
+        "program p"//new_line('a')// &
+        "  integer i"//new_line('a')// &
+        "  print *,(/(i,i=1,4)/)"//new_line('a')// &
+        "end program p", &
+        "array-constructor iterator")
+
+    ! The same iterator rule outside an I/O list, where the array-constructor
+    ! parser owns the implied-DO control.
+    call expect_rejected( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, a(4)"//new_line('a')// &
+        "  a = (/ (i, i = 1a, 4) /)"//new_line('a')// &
+        "end program p", &
+        "Syntax error in iterator", "assigned array-constructor iterator")
+    call expect_accepted( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, a(4)"//new_line('a')// &
+        "  a = (/ (i, i = 1, 4) /)"//new_line('a')// &
+        "end program p", &
+        "assigned array-constructor iterator")
+
+    ! gfortran.dg/implied_do_2.f90: I/O implied-DO with no closing parenthesis.
+    call expect_rejected( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: ir"//new_line('a')// &
+        "  write(*,*) ( ir, ir = 1,10"//new_line('a')// &
+        "end program p", &
+        "Expected a right parenthesis", "I/O implied-DO delimiter")
+    call expect_accepted( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: ir"//new_line('a')// &
+        "  write(*,*) ( ir, ir = 1,10 )"//new_line('a')// &
+        "end program p", &
+        "I/O implied-DO delimiter")
+
+    ! The same iterator rule on a DO construct: a bound followed by junk.
+    call expect_rejected( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, s"//new_line('a')// &
+        "  s = 0"//new_line('a')// &
+        "  do i = 1a, 4"//new_line('a')// &
+        "    s = s + i"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "Syntax error in DO iterator", "DO construct iterator")
+    call expect_accepted( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, s"//new_line('a')// &
+        "  s = 0"//new_line('a')// &
+        "  do i = 1, 4"//new_line('a')// &
+        "    s = s + i"//new_line('a')// &
+        "  end do"//new_line('a')// &
+        "end program p", &
+        "DO construct iterator")
+
+    ! A stride and a nested I/O implied-DO must keep parsing cleanly.
+    call expect_accepted( &
+        "program p"//new_line('a')// &
+        "  implicit none"//new_line('a')// &
+        "  integer :: i, a(9)"//new_line('a')// &
+        "  a = 0"//new_line('a')// &
+        "  write(*,*) (a(i), i = 1, 9, 2)"//new_line('a')// &
+        "end program p", &
+        "implied-DO with stride")
+
+    if (failures /= 0) then
+        write (error_unit, '(A,I0,A)') "FAIL: ", failures, " iterator checks"
+        error stop 1
+    end if
+    write (output_unit, '(A)') "PASS: reject-iterator-01 diagnostics"
+
+contains
+
+    subroutine expect_rejected(source, expected_fragment, label)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected_fragment
+        character(len=*), intent(in) :: label
+        character(len=5000) :: parse_error
+
+        call parse_source(source, parse_error)
+
+        if (len_trim(parse_error) == 0) then
+            write (output_unit, '(A)') "FAIL: accepted invalid "//label
+            failures = failures + 1
+            return
+        end if
+        if (index(parse_error, expected_fragment) == 0) then
+            write (output_unit, '(A)') "FAIL: wrong diagnostic for "//label
+            write (output_unit, '(A)') trim(parse_error)
+            failures = failures + 1
+            return
+        end if
+        write (output_unit, '(A)') "PASS: rejected invalid "//label
+    end subroutine expect_rejected
+
+    subroutine expect_accepted(source, label)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: label
+        character(len=5000) :: parse_error
+
+        call parse_source(source, parse_error)
+
+        if (len_trim(parse_error) /= 0) then
+            write (output_unit, '(A)') "FAIL: rejected valid "//label
+            write (output_unit, '(A)') trim(parse_error)
+            failures = failures + 1
+            return
+        end if
+        write (output_unit, '(A)') "PASS: accepted valid "//label
+    end subroutine expect_accepted
+
+    subroutine parse_source(source, parse_error)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(out) :: parse_error
+        character(len=:), allocatable :: lex_error
+        type(ast_arena_t) :: arena
+        type(token_t), allocatable :: tokens(:)
+        integer :: root_index
+
+        parse_error = ""
+        arena = create_ast_arena()
+        call lex_source(source, tokens, lex_error)
+        if (allocated(lex_error)) then
+            if (len_trim(lex_error) > 0) then
+                parse_error = "lexer: "//trim(lex_error)
+                return
+            end if
+        end if
+        call parse_tokens(tokens, arena, root_index, parse_error)
+    end subroutine parse_source
+
+end program test_reject_iterator_01_diagnostics


### PR DESCRIPTION
Closes #2898. Closes #2901.

Two rejection families that share the DO/implied-DO parsers, one commit each.

## #2898 — malformed iterators and delimiters

Once a DO iterator or an implied-DO control has consumed its `name =`, nothing
else can follow, so the rest of the iterator is required rather than
speculative. All three parsers that read those controls previously returned
silently on a malformed remainder, their callers backtracked, and the statement
reparsed into something that happened to succeed. Past the commit point they now
record a source diagnostic:

- `src/parser/expressions/parser_expression_arrays.f90` — array-constructor
  implied-DO control (`(/(i,i=1a,4)/)`).
- `src/parser/control_flow/parser_do_constructs_part1.inc` — DO loop-control
  (`do i = 1a, 4`).
- `src/parser/statements/parser_io_statements_common.inc` — I/O implied-DO,
  including the missing right parenthesis of `write(*,*) (ir, ir = 1,10`. This
  file is not named in the issue, but it owns the `implied_do_2.f90` case; the
  named files do not see it.

## #2901 — DO CONCURRENT locality constraints

The locality-spec-list was not parsed at all: everything after the
concurrent-header's `)` was handed to the loop-body parser, so
`local(temp) shared(arr) reduce(+:sum)` became body statements and every
locality violation was accepted. New module
`src/parser/control_flow/parser_do_concurrent_locality.f90` parses the list and
enforces what is decidable from the statement text:

- F2023 C1129 — `DEFAULT (NONE)` more than once.
- F2023 C1130 — a variable named in more than one locality-spec.
- R1131 — reduce-operation restricted to `+ * .and. .or. .eqv. .neqv. max min
  iand ior ieor`, and the required `:` before the variable-name-list.
- an unknown clause name (catches the common `reduction(...)` misspelling).

A clause is recognised only when a name is directly followed by `(`, so token
streams that omit the statement-ending newline still fall through to the body
unchanged.

## Deliberately left out

- **`do_concurrent_15.f90` is still accepted.** gfortran's diagnostic there is
  `Sorry, LOCAL specifier ... is not yet supported`, an implementation
  limitation, not a standard violation — and the arrays in that fixture are
  assumed-shape, which C1128 permits in `LOCAL`. Rejecting them would make
  conforming programs uncompilable. The real C1128 rule (assumed-size arrays)
  needs declaration attributes, so it belongs in semantic analysis; it is not
  implemented here.
- **`error_recovery_2.f90` and `pr95586_{1,2}.f90` are still accepted.** Those
  are entity-declaration, DATA and IMPLICIT statement syntax errors. They belong
  to the declaration parsers, not to either file the issue names, and widening
  the iterator rule to reach them would over-reject.
- `semantic_array_slice.f90` is untouched: it infers array-slice types and has
  nothing to do with locality specs.
- The locality specs are validated and consumed but not stored on the AST, so a
  round trip still drops them (as it did before, differently).

## Verification

- Before-state: all eight negative fixtures were accepted
  (`parse_ok=true, semantic_ok=true` via `frontend_probe`); after, all eight are
  rejected with the rule-specific diagnostic and every corrected neighbour is
  still accepted.
- Negative controls: eight separate breakages of the new checks were applied one
  at a time; each made exactly one assertion fail and no other, then the tree was
  restored and both tests passed again.
- `fo` — all stages passed. Valid-program tests still pass: the full suite is
  green, including the DO CONCURRENT preservation, multi-index and type-spec
  tests and `test_all_examples`.
- `make check-duplication` is unchanged from its baseline: the single
  pre-existing violation in `test/api/test_compiler_statement_queries.f90`
  (#2910).
