### PR TITLE
Reject duplicate and incompatible declaration attributes

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -16,3 +16,9 @@ f90/enum_8.f90
 f90/pr56520.f90
 f90/pr67526.f90
 f90/print_fmt_2.f90
+f90/parameter_save.f90
+f90/public_private_module.f90
+f90/pr77583.f90
+f90/protected_9.f90
+f90/contiguous_12.f90
+f90/external_initializer.f90

--- a/examples/f90/attribute_conflicts_corrected.f90
+++ b/examples/f90/attribute_conflicts_corrected.f90
@@ -1,0 +1,18 @@
+module attribute_conflicts_corrected_mod
+    implicit none
+
+    integer, public :: shared_counter = 0
+    integer, parameter :: limit = 4
+    integer, save :: counter = 0
+    integer, protected :: buffer = 0
+    real, allocatable :: pool(:)
+    real, contiguous, pointer :: view(:) => null()
+end module attribute_conflicts_corrected_mod
+
+program attribute_conflicts_corrected
+    use attribute_conflicts_corrected_mod, only: limit, counter, buffer, &
+        shared_counter
+    implicit none
+
+    print *, limit, counter, buffer, shared_counter
+end program attribute_conflicts_corrected

--- a/examples/f90/contiguous_12.f90
+++ b/examples/f90/contiguous_12.f90
@@ -1,0 +1,8 @@
+program contiguous_12
+    implicit none
+
+    real, contiguous :: scalar_value
+
+    scalar_value = 1.0
+    print *, scalar_value
+end program contiguous_12

--- a/examples/f90/external_initializer.f90
+++ b/examples/f90/external_initializer.f90
@@ -1,0 +1,7 @@
+program external_initializer
+    implicit none
+
+    integer, external :: helper = 1
+
+    print *, helper
+end program external_initializer

--- a/examples/f90/external_procedure_declaration.f90
+++ b/examples/f90/external_procedure_declaration.f90
@@ -1,0 +1,7 @@
+program external_procedure_declaration
+    implicit none
+
+    integer, external :: helper
+
+    print *, 0
+end program external_procedure_declaration

--- a/examples/f90/parameter_save.f90
+++ b/examples/f90/parameter_save.f90
@@ -1,0 +1,7 @@
+program parameter_save
+    implicit none
+
+    integer, parameter, save :: limit = 4
+
+    print *, limit
+end program parameter_save

--- a/examples/f90/pr77583.f90
+++ b/examples/f90/pr77583.f90
@@ -1,0 +1,8 @@
+program pr77583
+    implicit none
+
+    integer, save, save :: counter
+
+    counter = 0
+    print *, counter
+end program pr77583

--- a/examples/f90/protected_9.f90
+++ b/examples/f90/protected_9.f90
@@ -1,0 +1,5 @@
+module protected_9
+    implicit none
+
+    integer, protected, parameter :: limit = 4
+end module protected_9

--- a/examples/f90/public_private_module.f90
+++ b/examples/f90/public_private_module.f90
@@ -1,0 +1,5 @@
+module public_private_module
+    implicit none
+
+    integer, public, private :: shared_counter
+end module public_private_module

--- a/src/common/declaration_attribute_utils.f90
+++ b/src/common/declaration_attribute_utils.f90
@@ -6,9 +6,33 @@ module declaration_attribute_utils
     private
 
     public :: declaration_attribute_info_t
+    public :: attribute_validation_t
     public :: reset_declaration_attributes
     public :: set_declaration_intent
     public :: append_declaration_attributes
+    public :: validate_attribute_addition
+
+    ! Result of checking one attr-spec against the attributes already seen in
+    ! the same attribute list. Invalid means the source must be rejected.
+    type :: attribute_validation_t
+        logical :: valid = .true.
+        character(len=:), allocatable :: message
+    end type attribute_validation_t
+
+    ! Attributes that may not appear together on the same entity. Each entry
+    ! is "|<attr>|" separated so a whole-word lookup is a plain index() test.
+    ! Sources: Fortran 2023 C862 (PARAMETER), C860 (POINTER/ALLOCATABLE),
+    ! C861 (TARGET), C868 (VALUE), C858 (PROTECTED).
+    character(len=*), parameter :: CONFLICTS_PARAMETER = &
+        "|save|pointer|allocatable|external|target|optional|value|volatile|" // &
+        "protected|asynchronous|contiguous|intent|"
+    character(len=*), parameter :: CONFLICTS_POINTER = &
+        "|allocatable|target|value|"
+    character(len=*), parameter :: CONFLICTS_ALLOCATABLE = "|value|external|"
+    character(len=*), parameter :: CONFLICTS_VALUE = "|volatile|external|"
+    character(len=*), parameter :: CONFLICTS_PROTECTED = "|external|"
+    character(len=*), parameter :: CONFLICTS_SAVE = "|intent|"
+    character(len=*), parameter :: CONFLICTS_PUBLIC = "|private|"
 
     type :: declaration_attribute_info_t
         logical :: is_allocatable = .false.
@@ -229,5 +253,187 @@ contains
         end do
         clause = clause // ")"
     end subroutine build_dimension_attribute
+
+    ! Check one attr-spec against the attributes already recorded for the same
+    ! entity. `name` is lowercase and carries the intent direction when it has
+    ! one, for example "intent(out)".
+    function validate_attribute_addition(attr, name) result(validation)
+        type(declaration_attribute_info_t), intent(in) :: attr
+        character(len=*), intent(in) :: name
+        type(attribute_validation_t) :: validation
+
+        character(len=16) :: seen(20)
+        character(len=:), allocatable :: added
+        integer :: seen_count, i
+
+        validation%valid = .true.
+        added = attribute_base_name(name)
+        call collect_present_attributes(attr, seen, seen_count)
+
+        do i = 1, seen_count
+            if (attribute_base_name(seen(i)) == added) then
+                validation%valid = .false.
+                validation%message = "Duplicate " // to_upper(added) // &
+                    " attribute specified"
+                return
+            end if
+        end do
+
+        do i = 1, seen_count
+            if (attributes_conflict(seen(i), name)) then
+                validation%valid = .false.
+                validation%message = to_upper(added) // &
+                    " attribute conflicts with " // &
+                    to_upper(attribute_base_name(seen(i))) // " attribute"
+                return
+            end if
+        end do
+    end function validate_attribute_addition
+
+    subroutine collect_present_attributes(attr, names, name_count)
+        type(declaration_attribute_info_t), intent(in) :: attr
+        character(len=*), intent(out) :: names(:)
+        integer, intent(out) :: name_count
+
+        name_count = 0
+        call add_present_attribute(attr%is_allocatable, "allocatable", &
+            names, name_count)
+        call add_present_attribute(attr%is_pointer, "pointer", names, name_count)
+        call add_present_attribute(attr%is_target, "target", names, name_count)
+        call add_present_attribute(attr%is_parameter, "parameter", &
+            names, name_count)
+        call add_present_attribute(attr%is_external, "external", names, name_count)
+        call add_present_attribute(attr%is_unsigned, "unsigned", names, name_count)
+        call add_present_attribute(attr%is_optional, "optional", names, name_count)
+        call add_present_attribute(attr%is_save, "save", names, name_count)
+        call add_present_attribute(attr%is_volatile, "volatile", names, name_count)
+        call add_present_attribute(attr%is_protected, "protected", &
+            names, name_count)
+        call add_present_attribute(attr%is_asynchronous, "asynchronous", &
+            names, name_count)
+        call add_present_attribute(attr%is_contiguous, "contiguous", &
+            names, name_count)
+        call add_present_attribute(attr%is_value, "value", names, name_count)
+        call add_present_attribute(attr%is_bind_c, "bind", names, name_count)
+        call add_present_attribute(attr%has_global_dimensions, "dimension", &
+            names, name_count)
+        if (attr%has_intent) then
+            if (allocated(attr%intent)) then
+                call add_present_attribute(.true., "intent(" // &
+                    to_lower(trim(attr%intent)) // ")", names, name_count)
+            else
+                call add_present_attribute(.true., "intent", names, name_count)
+            end if
+        end if
+        if (allocated(attr%accessibility)) then
+            call add_present_attribute(.true., to_lower(trim(attr%accessibility)), &
+                names, name_count)
+        end if
+    end subroutine collect_present_attributes
+
+    subroutine add_present_attribute(is_present, name, names, name_count)
+        logical, intent(in) :: is_present
+        character(len=*), intent(in) :: name
+        character(len=*), intent(inout) :: names(:)
+        integer, intent(inout) :: name_count
+
+        if (.not. is_present) return
+        if (name_count >= size(names)) return
+        name_count = name_count + 1
+        names(name_count) = name
+    end subroutine add_present_attribute
+
+    function attribute_base_name(name) result(base)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: base
+        integer :: paren
+
+        base = to_lower(trim(adjustl(name)))
+        paren = index(base, "(")
+        if (paren > 1) base = base(1:paren - 1)
+    end function attribute_base_name
+
+    logical function attributes_conflict(existing, added) result(conflict)
+        character(len=*), intent(in) :: existing
+        character(len=*), intent(in) :: added
+
+        conflict = pair_conflicts(attribute_base_name(existing), &
+            attribute_base_name(added))
+        if (.not. conflict) then
+            conflict = pair_conflicts(attribute_base_name(added), &
+                attribute_base_name(existing))
+        end if
+        if (.not. conflict) conflict = value_intent_conflict(existing, added)
+        if (.not. conflict) conflict = value_intent_conflict(added, existing)
+    end function attributes_conflict
+
+    logical function pair_conflicts(first, second) result(conflict)
+        character(len=*), intent(in) :: first
+        character(len=*), intent(in) :: second
+        character(len=:), allocatable :: probe
+
+        probe = "|" // second // "|"
+        select case (first)
+        case ("parameter")
+            conflict = index(CONFLICTS_PARAMETER, probe) > 0
+        case ("pointer")
+            conflict = index(CONFLICTS_POINTER, probe) > 0
+        case ("allocatable")
+            conflict = index(CONFLICTS_ALLOCATABLE, probe) > 0
+        case ("value")
+            conflict = index(CONFLICTS_VALUE, probe) > 0
+        case ("protected")
+            conflict = index(CONFLICTS_PROTECTED, probe) > 0
+        case ("save")
+            conflict = index(CONFLICTS_SAVE, probe) > 0
+        case ("public")
+            conflict = index(CONFLICTS_PUBLIC, probe) > 0
+        case default
+            conflict = .false.
+        end select
+    end function pair_conflicts
+
+    ! VALUE is compatible with INTENT(IN) only; the other two directions are
+    ! forbidden, so the direction has to be inspected rather than the bare name.
+    logical function value_intent_conflict(value_name, intent_name) result(conflict)
+        character(len=*), intent(in) :: value_name
+        character(len=*), intent(in) :: intent_name
+        character(len=:), allocatable :: direction
+
+        conflict = .false.
+        if (attribute_base_name(value_name) /= "value") return
+        if (attribute_base_name(intent_name) /= "intent") return
+        direction = intent_direction(intent_name)
+        conflict = direction == "out" .or. direction == "inout"
+    end function value_intent_conflict
+
+    function intent_direction(name) result(direction)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: direction
+        character(len=:), allocatable :: text
+        integer :: lparen, rparen
+
+        text = trim(adjustl(name))
+        direction = ""
+        lparen = index(text, "(")
+        rparen = index(text, ")", back=.true.)
+        if (lparen < 1) return
+        if (rparen < lparen + 2) return
+        direction = to_lower(text(lparen + 1:rparen - 1))
+    end function intent_direction
+
+    function to_upper(text) result(upper)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: upper
+        integer :: i, code
+
+        upper = text
+        do i = 1, len(upper)
+            code = iachar(upper(i:i))
+            if (code >= iachar('a') .and. code <= iachar('z')) then
+                upper(i:i) = achar(code - 32)
+            end if
+        end do
+    end function to_upper
 
 end module declaration_attribute_utils

--- a/src/parser/declarations/parser_declaration_attributes_module.f90
+++ b/src/parser/declarations/parser_declaration_attributes_module.f90
@@ -5,7 +5,9 @@ module parser_declaration_attributes_module
     use parser_expressions_module, only: parse_range
     use declaration_attribute_utils, only: declaration_attribute_info_t, &
         reset_declaration_attributes, &
-        set_declaration_intent
+        set_declaration_intent, &
+        attribute_validation_t, &
+        validate_attribute_addition
     implicit none
     private
 
@@ -44,7 +46,7 @@ contains
         type(ast_arena_t), intent(inout) :: arena
         type(declaration_attribute_info_t), intent(inout) :: attr_info
 
-        type(token_t) :: token
+        type(token_t) :: token, attribute_token
         character(len=:), allocatable :: lowered
 
         handled = .false.
@@ -54,7 +56,17 @@ contains
         end if
 
         token = parser%peek()
+        attribute_token = token
         lowered = to_lower(trim(token%text))
+
+        ! INTENT is checked inside its own handler because the conflict rules
+        ! depend on the direction, which is not known until it is parsed.
+        if (is_declaration_attribute_keyword(lowered)) then
+            if (lowered /= "intent") then
+                call check_attribute_addition(parser, attr_info, lowered, &
+                    attribute_token)
+            end if
+        end if
 
         select case (lowered)
         case ("allocatable")
@@ -82,7 +94,8 @@ contains
             call handle_dimension_attribute(parser, arena, attr_info, handled)
         case ("intent")
             token = parser%consume()
-            call handle_intent_attribute(parser, attr_info, handled)
+            call handle_intent_attribute(parser, attr_info, handled, &
+                attribute_token)
         case ("bind")
             token = parser%consume()
             call handle_bind_attribute(parser, attr_info, handled)
@@ -127,6 +140,34 @@ contains
         end select
     end function parse_single_declaration_attribute
 
+    logical function is_declaration_attribute_keyword(name) result(is_attribute)
+        character(len=*), intent(in) :: name
+
+        select case (name)
+        case ("allocatable", "pointer", "parameter", "external", "unsigned", &
+                "dimension", "intent", "bind", "optional", "save", "target", &
+                "volatile", "protected", "asynchronous", "contiguous", "value", &
+                "public", "private")
+            is_attribute = .true.
+        case default
+            is_attribute = .false.
+        end select
+    end function is_declaration_attribute_keyword
+
+    subroutine check_attribute_addition(parser, attr_info, name, token)
+        type(parser_state_t), intent(inout) :: parser
+        type(declaration_attribute_info_t), intent(in) :: attr_info
+        character(len=*), intent(in) :: name
+        type(token_t), intent(in) :: token
+
+        type(attribute_validation_t) :: validation
+
+        validation = validate_attribute_addition(attr_info, name)
+        if (validation%valid) return
+        if (.not. allocated(validation%message)) return
+        call parser%error_at_token(validation%message, token)
+    end subroutine check_attribute_addition
+
     subroutine handle_dimension_attribute(parser, arena, attr_info, handled)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
@@ -151,10 +192,11 @@ contains
         attr_info%has_global_dimensions = .true.
     end subroutine handle_dimension_attribute
 
-    subroutine handle_intent_attribute(parser, attr_info, handled)
+    subroutine handle_intent_attribute(parser, attr_info, handled, attribute_token)
         type(parser_state_t), intent(inout) :: parser
         type(declaration_attribute_info_t), intent(inout) :: attr_info
         logical, intent(out) :: handled
+        type(token_t), intent(in) :: attribute_token
 
         type(token_t) :: token
         character(len=:), allocatable :: lowered
@@ -178,14 +220,10 @@ contains
         token = parser%peek()
         lowered = to_lower(trim(token%text))
         select case (lowered)
-        case ("in")
-            call set_declaration_intent(attr_info, "in")
-            token = parser%consume()
-        case ("out")
-            call set_declaration_intent(attr_info, "out")
-            token = parser%consume()
-        case ("inout")
-            call set_declaration_intent(attr_info, "inout")
+        case ("in", "out", "inout")
+            call check_attribute_addition(parser, attr_info, &
+                "intent(" // lowered // ")", attribute_token)
+            call set_declaration_intent(attr_info, lowered)
             token = parser%consume()
         case default
             return

--- a/src/parser/declarations/parser_declarations_core_module.f90
+++ b/src/parser/declarations/parser_declarations_core_module.f90
@@ -75,6 +75,8 @@ contains
         call parse_variable_dimensions(parser, arena, local_dimension_indices, &
             has_local_dimensions)
         initializer_index = parse_variable_initializer(parser, arena, type_spec)
+        call validate_entity_attributes(parser, attr_info, has_local_dimensions, &
+            initializer_index, identifier_token)
 
         if (has_local_dimensions .and. allocated(local_dimension_indices)) then
             decl_index = add_single_declaration( &
@@ -95,6 +97,40 @@ contains
             end if
         end if
     end function parse_declaration
+
+    ! Attribute rules that the attr-spec list alone cannot decide because they
+    ! also depend on the entity's array spec or its initializer.
+    subroutine validate_entity_attributes(parser, attr_info, has_local_dims, &
+            initializer_index, entity_token)
+        type(parser_state_t), intent(inout) :: parser
+        type(declaration_attribute_info_t), intent(in) :: attr_info
+        logical, intent(in) :: has_local_dims
+        integer, intent(in) :: initializer_index
+        type(token_t), intent(in) :: entity_token
+
+        logical :: is_array
+
+        ! F2023 C8xx: an entity declared EXTERNAL is a procedure, so it has no
+        ! object to initialize.
+        if (attr_info%is_external) then
+            if (initializer_index > 0) then
+                call parser%error_at_token( &
+                    "EXTERNAL attribute conflicts with initialization", &
+                    entity_token)
+                return
+            end if
+        end if
+
+        ! F2023 C830: CONTIGUOUS requires an array pointer or an assumed-shape
+        ! array. Only the unambiguous scalar case is rejected here.
+        is_array = has_local_dims .or. attr_info%has_global_dimensions
+        if (attr_info%is_contiguous) then
+            if (.not. is_array) then
+                call parser%error_at_token( &
+                    "CONTIGUOUS attribute requires an array", entity_token)
+            end if
+        end if
+    end subroutine validate_entity_attributes
 
     subroutine skip_declaration_separator(parser)
         type(parser_state_t), intent(inout) :: parser

--- a/test/api/test_reject_attr_01_diagnostics.f90
+++ b/test/api/test_reject_attr_01_diagnostics.f90
@@ -1,0 +1,187 @@
+program test_reject_attr_01_diagnostics
+    ! Issue #2895: duplicate or incompatible declaration attributes must be
+    ! rejected with a source diagnostic, while the corrected neighbouring
+    ! forms stay accepted.
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use semantic_operating_mode, only: OPERATING_MODE_STRICT
+    use transformation_api, only: transform_with_context, transform_context_t
+    use declaration_attribute_utils, only: declaration_attribute_info_t, &
+        attribute_validation_t, reset_declaration_attributes, &
+        set_declaration_intent, validate_attribute_addition
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    call expect_rejected('examples/f90/parameter_save.f90', &
+        'SAVE attribute conflicts with PARAMETER attribute')
+    call expect_rejected('examples/f90/public_private_module.f90', &
+        'PRIVATE attribute conflicts with PUBLIC attribute')
+    call expect_rejected('examples/f90/pr77583.f90', &
+        'Duplicate SAVE attribute specified')
+    call expect_rejected('examples/f90/protected_9.f90', &
+        'PARAMETER attribute conflicts with PROTECTED attribute')
+    call expect_rejected('examples/f90/contiguous_12.f90', &
+        'CONTIGUOUS attribute requires an array')
+    call expect_rejected('examples/f90/external_initializer.f90', &
+        'EXTERNAL attribute conflicts with initialization')
+
+    call expect_accepted('examples/f90/attribute_conflicts_corrected.f90')
+    call expect_accepted('examples/f90/external_procedure_declaration.f90')
+
+    call check_value_intent_rule()
+    call check_compatible_combinations()
+
+    if (failures /= 0) then
+        write (error_unit, '(A,I0,A)') 'FAIL: ', failures, ' check(s) failed'
+        error stop 1
+    end if
+    write (*, '(A)') 'PASS: reject-attr-01 diagnostics'
+
+contains
+
+    subroutine expect_rejected(path, expected_fragment)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: expected_fragment
+        character(len=:), allocatable :: error_msg
+
+        call compile_example(path, error_msg)
+
+        if (len_trim(error_msg) == 0) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: expected rejection for ' // path
+            return
+        end if
+
+        if (index(error_msg, expected_fragment) == 0) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: wrong diagnostic for ' // path
+            write (error_unit, '(A)') '  expected: ' // expected_fragment
+            write (error_unit, '(A)') '  actual:   ' // trim(error_msg)
+        end if
+    end subroutine expect_rejected
+
+    subroutine expect_accepted(path)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable :: error_msg
+
+        call compile_example(path, error_msg)
+
+        if (len_trim(error_msg) /= 0) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: valid source rejected: ' // path
+            write (error_unit, '(A)') '  actual: ' // trim(error_msg)
+        end if
+    end subroutine expect_accepted
+
+    subroutine compile_example(path, error_msg)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: input_code, output_code
+        type(transform_context_t) :: context
+
+        call read_example(path, input_code)
+
+        context%input_mode = INPUT_MODE_STANDARD
+        context%operating_mode = OPERATING_MODE_STRICT
+        context%has_filename = .true.
+        context%source_name = path
+
+        call transform_with_context(input_code, output_code, error_msg, context)
+        if (.not. allocated(error_msg)) error_msg = ''
+    end subroutine compile_example
+
+    ! VALUE is compatible with INTENT(IN) and with nothing else. The rule can
+    ! only be exercised on a dummy argument, and parser diagnostics raised
+    ! inside a procedure body are not surfaced by the driver yet, so this is
+    ! checked directly against the validator.
+    subroutine check_value_intent_rule()
+        type(declaration_attribute_info_t) :: attr
+        type(attribute_validation_t) :: validation
+
+        call reset_declaration_attributes(attr)
+        attr%is_value = .true.
+        validation = validate_attribute_addition(attr, 'intent(out)')
+        call require_invalid(validation, 'VALUE with INTENT(OUT)')
+
+        call reset_declaration_attributes(attr)
+        attr%is_value = .true.
+        validation = validate_attribute_addition(attr, 'intent(inout)')
+        call require_invalid(validation, 'VALUE with INTENT(INOUT)')
+
+        call reset_declaration_attributes(attr)
+        call set_declaration_intent(attr, 'out')
+        validation = validate_attribute_addition(attr, 'value')
+        call require_invalid(validation, 'INTENT(OUT) then VALUE')
+
+        call reset_declaration_attributes(attr)
+        attr%is_value = .true.
+        validation = validate_attribute_addition(attr, 'intent(in)')
+        call require_valid(validation, 'VALUE with INTENT(IN)')
+    end subroutine check_value_intent_rule
+
+    ! Guard against over-rejection: these pairs are legal Fortran and must not
+    ! be flagged by the validator.
+    subroutine check_compatible_combinations()
+        type(declaration_attribute_info_t) :: attr
+        type(attribute_validation_t) :: validation
+
+        call reset_declaration_attributes(attr)
+        attr%is_parameter = .true.
+        attr%has_global_dimensions = .true.
+        validation = validate_attribute_addition(attr, 'public')
+        call require_valid(validation, 'PARAMETER with DIMENSION and PUBLIC')
+
+        call reset_declaration_attributes(attr)
+        attr%is_allocatable = .true.
+        validation = validate_attribute_addition(attr, 'target')
+        call require_valid(validation, 'ALLOCATABLE with TARGET')
+
+        call reset_declaration_attributes(attr)
+        attr%is_pointer = .true.
+        validation = validate_attribute_addition(attr, 'contiguous')
+        call require_valid(validation, 'POINTER with CONTIGUOUS')
+
+        call reset_declaration_attributes(attr)
+        attr%is_optional = .true.
+        validation = validate_attribute_addition(attr, 'intent(inout)')
+        call require_valid(validation, 'OPTIONAL with INTENT(INOUT)')
+
+        call reset_declaration_attributes(attr)
+        attr%is_save = .true.
+        validation = validate_attribute_addition(attr, 'volatile')
+        call require_valid(validation, 'SAVE with VOLATILE')
+    end subroutine check_compatible_combinations
+
+    subroutine require_invalid(validation, label)
+        type(attribute_validation_t), intent(in) :: validation
+        character(len=*), intent(in) :: label
+
+        if (validation%valid) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: expected rejection of ' // label
+            return
+        end if
+        if (.not. allocated(validation%message)) then
+            failures = failures + 1
+            write (error_unit, '(A)') 'FAIL: no message for ' // label
+        end if
+    end subroutine require_invalid
+
+    subroutine require_valid(validation, label)
+        type(attribute_validation_t), intent(in) :: validation
+        character(len=*), intent(in) :: label
+
+        if (validation%valid) return
+        failures = failures + 1
+        write (error_unit, '(A)') 'FAIL: valid combination rejected: ' // label
+        if (allocated(validation%message)) then
+            write (error_unit, '(A)') '  actual: ' // validation%message
+        end if
+    end subroutine require_valid
+
+    include '../common/read_example.inc'
+
+end program test_reject_attr_01_diagnostics


### PR DESCRIPTION
Closes #2895.

## What changed

Declaration attribute lists were accepted whatever they contained. Each attr-spec is now validated against the attributes already recorded for the same entity, so a repeated attribute and a forbidden pair both produce a source diagnostic and a nonzero exit.

- `src/common/declaration_attribute_utils.f90` owns the rule: `validate_attribute_addition` returns an `attribute_validation_t` carrying the message.
- `src/parser/declarations/parser_declaration_attributes_module.f90` calls it for every attr-spec and reports through `parser%error_at_token`. INTENT is checked inside its own handler because the rule depends on the direction.
- `src/parser/declarations/parser_declarations_core_module.f90` holds the two rules that need entity-level information: EXTERNAL with an initializer, and CONTIGUOUS on a scalar.

## Rules implemented

| Diagnostic | Negative fixture |
|---|---|
| Duplicate `<ATTR>` attribute specified | `examples/f90/pr77583.f90` |
| SAVE conflicts with PARAMETER | `examples/f90/parameter_save.f90` |
| PRIVATE conflicts with PUBLIC | `examples/f90/public_private_module.f90` |
| PARAMETER conflicts with PROTECTED | `examples/f90/protected_9.f90` |
| CONTIGUOUS requires an array | `examples/f90/contiguous_12.f90` |
| EXTERNAL conflicts with initialization | `examples/f90/external_initializer.f90` |

Plus POINTER/ALLOCATABLE, POINTER/TARGET, ALLOCATABLE/VALUE, VALUE/VOLATILE and VALUE with INTENT(OUT)/INTENT(INOUT) from the same table.

## Guarding against over-rejection

The conflict table only lists pairs that are unconditionally invalid. VALUE with INTENT(IN) stays legal, DIMENSION stays compatible with PARAMETER, ALLOCATABLE with TARGET and POINTER with CONTIGUOUS stay legal. `examples/f90/attribute_conflicts_corrected.f90` and `examples/f90/external_procedure_declaration.f90` are the corrected neighbours and are asserted to remain accepted; `test/api/test_reject_attr_01_diagnostics.f90` additionally asserts a list of legal combinations directly against the validator.

CONTIGUOUS is deliberately narrowed to the scalar case. Distinguishing an assumed-shape array from an explicit-shape one needs dummy-argument context the declaration parser does not have, and guessing there would reject correct programs.

## Left out of this PR

Four of the fixture names listed in the issue are not attribute-list rules and are not addressed here:

- `duplicate_type_3.f90` and `implicit_4.f90` are symbol-table and IMPLICIT-statement rules, a different diagnostic family.
- `non_module_public.f90` needs to know whether the enclosing scope is a module; the declaration parser has no scope information.
- `value_3.f90` needs a dummy argument, and parser diagnostics raised inside a procedure body are not surfaced by the driver today (an unrelated malformed expression inside a bare `subroutine` file is also silently accepted). The VALUE/INTENT rule itself is implemented and covered by unit assertions against the validator.

## Verification

- `fo` — all stages pass (static, build, tests, lint).
- `fo test test_reject_attr_01_diagnostics` — passes.
- `make check-duplication` — 1 violation, the pre-existing one in `test/api/test_compiler_statement_queries.f90` tracked by #2910; unchanged from baseline.

Each fixture was confirmed accepted with exit 0 before the change. Negative controls: disabling `validate_attribute_addition` fails 7 checks, disabling `validate_entity_attributes` fails the CONTIGUOUS and EXTERNAL checks, and widening the conflict table to reject ALLOCATABLE with TARGET fails the corresponding legal-combination assertion.