### PR TITLE
Reject invalid FINAL and overriding type-bound procedure signatures

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -45,3 +45,9 @@ f90/elemental_result_1.f90
 f90/impure_assignment_2.f90
 f90/pure_formal_proc_3.f90
 f90/recursive_check_3.f90
+f90/finalize_22.f90
+f90/pr104572.f90
+f90/typebound_override_1.f90
+f90/typebound_override_2.f90
+f90/typebound_override_4.f90
+f90/typebound_override_5.f90

--- a/examples/f90/finalize_22.f90
+++ b/examples/f90/finalize_22.f90
@@ -1,0 +1,20 @@
+! The dummy argument of a FINAL subroutine must be a nonpolymorphic variable of
+! the type being finalized (F2018 C790).
+module finalize_22
+    implicit none
+
+    type :: cfml
+    contains
+        final :: mld
+    end type cfml
+
+    type, extends(cfml) :: cfmde
+    end type cfmde
+
+contains
+
+    subroutine mld(s)
+        class(cfml), intent(inout) :: s
+    end subroutine mld
+
+end module finalize_22

--- a/examples/f90/finalize_22_valid.f90
+++ b/examples/f90/finalize_22_valid.f90
@@ -1,0 +1,20 @@
+! Corrected neighbour of finalize_22.f90: the FINAL subroutine takes a
+! nonpolymorphic dummy argument of the finalized type.
+module finalize_22_valid
+    implicit none
+
+    type :: cfml
+    contains
+        final :: mld
+    end type cfml
+
+    type, extends(cfml) :: cfmde
+    end type cfmde
+
+contains
+
+    subroutine mld(s)
+        type(cfml), intent(inout) :: s
+    end subroutine mld
+
+end module finalize_22_valid

--- a/examples/f90/pr104572.f90
+++ b/examples/f90/pr104572.f90
@@ -1,0 +1,16 @@
+! The single dummy argument of a FINAL subroutine must be a data object, so an
+! alternate return indicator is not allowed (F2018 C789).
+module pr104572
+    implicit none
+
+    type :: t
+    contains
+        final :: s
+    end type t
+
+contains
+
+    subroutine s(*)
+    end subroutine s
+
+end module pr104572

--- a/examples/f90/pr104572_valid.f90
+++ b/examples/f90/pr104572_valid.f90
@@ -1,0 +1,17 @@
+! Corrected neighbour of pr104572.f90: the FINAL subroutine takes a single data
+! object of the finalized type instead of an alternate return indicator.
+module pr104572_valid
+    implicit none
+
+    type :: t
+    contains
+        final :: s
+    end type t
+
+contains
+
+    subroutine s(x)
+        type(t), intent(inout) :: x
+    end subroutine s
+
+end module pr104572_valid

--- a/examples/f90/typebound_override_1.f90
+++ b/examples/f90/typebound_override_1.f90
@@ -1,0 +1,54 @@
+! An overriding type-bound function result must keep the rank and the constant
+! character length of the result it overrides (F2018 7.5.7.3).
+module typebound_override_1
+    implicit none
+
+    type :: base_t
+    contains
+        procedure, nopass :: a => a_base
+        procedure, nopass :: b => b_base
+        procedure, nopass :: e => e_base
+    end type base_t
+
+    type, extends(base_t) :: derived_t
+    contains
+        procedure, nopass :: a => a_derived
+        procedure, nopass :: b => b_derived
+        procedure, nopass :: e => e_derived
+    end type derived_t
+
+contains
+
+    function a_base()
+        character(len=6) :: a_base
+        a_base = 'aaaaaa'
+    end function a_base
+
+    function a_derived()
+        character(len=7) :: a_derived
+        a_derived = 'bbbbbbb'
+    end function a_derived
+
+    function b_base()
+        integer :: b_base
+        b_base = 0
+    end function b_base
+
+    function b_derived()
+        integer :: b_derived(2)
+        b_derived = 0
+    end function b_derived
+
+    function e_base(z)
+        integer, intent(in) :: z
+        character(len=3) :: e_base
+        e_base = 'ccc'
+    end function e_base
+
+    function e_derived(z)
+        integer, intent(in) :: z
+        character(len=z) :: e_derived
+        e_derived = ''
+    end function e_derived
+
+end module typebound_override_1

--- a/examples/f90/typebound_override_1_valid.f90
+++ b/examples/f90/typebound_override_1_valid.f90
@@ -1,0 +1,55 @@
+! Corrected neighbour of typebound_override_1.f90: the overriding results keep
+! the rank and the constant character length, and a nonconstant character
+! length on the overridden result stays accepted.
+module typebound_override_1_valid
+    implicit none
+
+    type :: base_t
+    contains
+        procedure, nopass :: a => a_base
+        procedure, nopass :: b => b_base
+        procedure, nopass :: d => d_base
+    end type base_t
+
+    type, extends(base_t) :: derived_t
+    contains
+        procedure, nopass :: a => a_derived
+        procedure, nopass :: b => b_derived
+        procedure, nopass :: d => d_derived
+    end type derived_t
+
+contains
+
+    function a_base()
+        character(len=6) :: a_base
+        a_base = 'aaaaaa'
+    end function a_base
+
+    function a_derived()
+        character(len=6) :: a_derived
+        a_derived = 'bbbbbb'
+    end function a_derived
+
+    function b_base()
+        integer :: b_base(2)
+        b_base = 0
+    end function b_base
+
+    function b_derived()
+        integer :: b_derived(2)
+        b_derived = 1
+    end function b_derived
+
+    function d_base(y)
+        integer, intent(in) :: y
+        character(len=2*y + 1) :: d_base
+        d_base = ''
+    end function d_base
+
+    function d_derived(y)
+        integer, intent(in) :: y
+        character(len=1 + y*2) :: d_derived
+        d_derived = ''
+    end function d_derived
+
+end module typebound_override_1_valid

--- a/examples/f90/typebound_override_2.f90
+++ b/examples/f90/typebound_override_2.f90
@@ -1,0 +1,37 @@
+! An overriding type-bound procedure must give every dummy argument other than
+! the passed-object dummy the same INTENT as the binding it overrides
+! (F2018 7.5.7.3).
+module typebound_override_2_base
+    implicit none
+
+    type :: foo
+    contains
+        procedure, pass(f) :: bar => base_bar
+    end type foo
+
+contains
+
+    subroutine base_bar(f, j)
+        class(foo), intent(inout) :: f
+        integer, intent(in) :: j
+    end subroutine base_bar
+
+end module typebound_override_2_base
+
+module typebound_override_2
+    use typebound_override_2_base, only: foo
+    implicit none
+
+    type, extends(foo) :: extfoo
+    contains
+        procedure, pass(f) :: bar => ext_bar
+    end type extfoo
+
+contains
+
+    subroutine ext_bar(f, j)
+        class(extfoo), intent(inout) :: f
+        integer, intent(inout) :: j
+    end subroutine ext_bar
+
+end module typebound_override_2

--- a/examples/f90/typebound_override_2_valid.f90
+++ b/examples/f90/typebound_override_2_valid.f90
@@ -1,0 +1,36 @@
+! Corrected neighbour of typebound_override_2.f90: the overriding procedure
+! repeats the INTENT of the overridden binding.
+module typebound_override_2_valid_base
+    implicit none
+
+    type :: foo
+    contains
+        procedure, pass(f) :: bar => base_bar
+    end type foo
+
+contains
+
+    subroutine base_bar(f, j)
+        class(foo), intent(inout) :: f
+        integer, intent(in) :: j
+    end subroutine base_bar
+
+end module typebound_override_2_valid_base
+
+module typebound_override_2_valid
+    use typebound_override_2_valid_base, only: foo
+    implicit none
+
+    type, extends(foo) :: extfoo
+    contains
+        procedure, pass(f) :: bar => ext_bar
+    end type extfoo
+
+contains
+
+    subroutine ext_bar(f, j)
+        class(extfoo), intent(inout) :: f
+        integer, intent(in) :: j
+    end subroutine ext_bar
+
+end module typebound_override_2_valid

--- a/examples/f90/typebound_override_4.f90
+++ b/examples/f90/typebound_override_4.f90
@@ -1,0 +1,37 @@
+! Every dummy argument of an overriding type-bound procedure other than the
+! passed-object dummy must have the same declared type as its counterpart in
+! the overridden binding (F2018 7.5.7.3).
+module typebound_override_4_base
+    implicit none
+
+    type :: base_type
+    contains
+        procedure, pass(map) :: clone => base_clone
+    end type base_type
+
+contains
+
+    subroutine base_clone(map, mapout)
+        class(base_type), intent(inout) :: map
+        class(base_type), intent(inout) :: mapout
+    end subroutine base_clone
+
+end module typebound_override_4_base
+
+module typebound_override_4
+    use typebound_override_4_base, only: base_type
+    implicit none
+
+    type, extends(base_type) :: r_type
+    contains
+        procedure, pass(map) :: clone => r_clone
+    end type r_type
+
+contains
+
+    subroutine r_clone(map, mapout)
+        class(r_type), intent(inout) :: map
+        class(r_type), intent(inout) :: mapout
+    end subroutine r_clone
+
+end module typebound_override_4

--- a/examples/f90/typebound_override_4_valid.f90
+++ b/examples/f90/typebound_override_4_valid.f90
@@ -1,0 +1,36 @@
+! Corrected neighbour of typebound_override_4.f90: only the passed-object
+! dummy narrows to the extending type; the other dummy keeps its declared type.
+module typebound_override_4_valid_base
+    implicit none
+
+    type :: base_type
+    contains
+        procedure, pass(map) :: clone => base_clone
+    end type base_type
+
+contains
+
+    subroutine base_clone(map, mapout)
+        class(base_type), intent(inout) :: map
+        class(base_type), intent(inout) :: mapout
+    end subroutine base_clone
+
+end module typebound_override_4_valid_base
+
+module typebound_override_4_valid
+    use typebound_override_4_valid_base, only: base_type
+    implicit none
+
+    type, extends(base_type) :: r_type
+    contains
+        procedure, pass(map) :: clone => r_clone
+    end type r_type
+
+contains
+
+    subroutine r_clone(map, mapout)
+        class(r_type), intent(inout) :: map
+        class(base_type), intent(inout) :: mapout
+    end subroutine r_clone
+
+end module typebound_override_4_valid

--- a/examples/f90/typebound_override_5.f90
+++ b/examples/f90/typebound_override_5.f90
@@ -1,0 +1,41 @@
+! A dummy argument of an overriding type-bound procedure may not change to an
+! unrelated type. Here the second dummy goes from CLASS(base_type) to INTEGER
+! (F2018 7.5.7.3).
+module typebound_override_5_base
+    implicit none
+
+    type :: base_type
+        integer :: kind_id
+    contains
+        procedure, pass(map) :: clone => base_clone
+    end type base_type
+
+contains
+
+    subroutine base_clone(map, mapout, info)
+        class(base_type), intent(inout) :: map
+        class(base_type), intent(inout) :: mapout
+        integer, intent(inout) :: info
+    end subroutine base_clone
+
+end module typebound_override_5_base
+
+module typebound_override_5
+    use typebound_override_5_base, only: base_type
+    implicit none
+
+    type, extends(base_type) :: r_type
+        real :: dat
+    contains
+        procedure, pass(map) :: clone => r_clone
+    end type r_type
+
+contains
+
+    subroutine r_clone(map, mapout, info)
+        class(r_type), intent(inout) :: map
+        integer, intent(inout) :: mapout
+        integer, intent(inout) :: info
+    end subroutine r_clone
+
+end module typebound_override_5

--- a/src/semantic/analyzers/README.md
+++ b/src/semantic/analyzers/README.md
@@ -75,7 +75,11 @@ For complete semantic analysis concepts including type inference, scope manageme
 | semantic_pure_dummy_validation.f90 | Enforce PURE dummy-argument rules: no polymorphic INTENT(OUT) dummy, dummy procedures must be PURE, PURE FUNCTION dummies are not definable |
 | semantic_bind_c_validation.f90 | Enforce BIND(C) interoperability constraints on derived-type components and procedure dummies (F2003 15.3.2) |
 | semantic_elemental_validation.f90 | Enforce ELEMENTAL scalar-dummy restriction (no array dummies) |
-| semantic_type_hierarchy_validation.f90 | Register derived types and EXTENDS parents into the inheritance hierarchy; report unknown-parent EXTENDS |
+| semantic_type_hierarchy_validation.f90 | Register derived types and EXTENDS parents into the inheritance hierarchy; report unknown-parent EXTENDS; drive the FINAL and override signature rules |
+| semantic_procedure_signature.f90 | Reduce a procedure definition to the dummy argument and function result facts the FINAL and override rules compare |
+| semantic_final_validation.f90 | Enforce the FINAL subroutine dummy argument rules (single data object, nonpolymorphic, F2018 C789/C790) |
+| semantic_tbp_override_validation.f90 | Enforce dummy argument type and INTENT agreement between an overriding type-bound procedure and the binding it overrides (F2018 7.5.7.3) |
+| semantic_tbp_override_result.f90 | Enforce function result rank and constant character length agreement for an overriding type-bound procedure |
 | semantic_implied_do_validation.f90 | Enforce implied-DO index locality in array constructors (no self-reference in bounds, no shadowing nested index) |
 | semantic_declaration_utils.f90 | Declaration processing utilities |
 

--- a/src/semantic/analyzers/semantic_final_validation.f90
+++ b/src/semantic/analyzers/semantic_final_validation.f90
@@ -1,0 +1,132 @@
+module semantic_final_validation
+    ! Validates FINAL subroutines of a derived type against F2018 C789/C790
+    ! (F2003 C476/C477): a final subroutine has exactly one dummy argument, and
+    ! that argument is a nonpointer, nonallocatable, nonpolymorphic variable of
+    ! the type being finalized. An alternate return indicator is not a data
+    ! object and therefore cannot be that argument.
+    !
+    ! Only the two narrow rules above are enforced. Rank, kind and length type
+    ! parameter agreement between distinct final subroutines of one type is not
+    ! checked here.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_data, only: derived_type_node, type_binding_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use semantic_procedure_signature, only: procedure_signature_t, &
+        build_procedure_signature, find_procedure_definition
+    use string_utils_mod, only: int_to_string
+    implicit none
+    private
+
+    public :: validate_final_procedures
+
+contains
+
+    ! Walk every derived type in the arena and check its FINAL bindings.
+    subroutine validate_final_procedures(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i, b
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (derived_type_node)
+                if (.not. allocated(node%binding_indices)) cycle
+                if (.not. allocated(node%name)) cycle
+                do b = 1, size(node%binding_indices)
+                    call check_binding(arena, node%binding_indices(b), &
+                        node%name, errors)
+                end do
+            end select
+        end do
+    end subroutine validate_final_procedures
+
+    ! Check one type binding; non-FINAL bindings are ignored.
+    subroutine check_binding(arena, binding_index, type_name, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: binding_index
+        character(len=*), intent(in) :: type_name
+        type(error_collection_t), intent(inout) :: errors
+        type(procedure_signature_t) :: sig
+        integer :: proc_index
+
+        if (binding_index <= 0) return
+        if (.not. arena%has_node_at(binding_index)) return
+
+        select type (binding => arena%entries(binding_index)%node)
+            type is (type_binding_node)
+            if (.not. binding%is_final) return
+            if (.not. allocated(binding%binding_name)) return
+            proc_index = find_procedure_definition(arena, binding%binding_name)
+            if (proc_index <= 0) return
+            sig = build_procedure_signature(arena, proc_index)
+            if (.not. sig%found) return
+            if (sig%is_function) return
+            if (.not. allocated(sig%dummies)) return
+            call check_signature(sig, binding%binding_name, type_name, &
+                binding%line, binding%column, errors)
+        end select
+    end subroutine check_binding
+
+    ! Apply the two enforced FINAL rules to a resolved signature.
+    subroutine check_signature(sig, proc_name, type_name, line, column, errors)
+        type(procedure_signature_t), intent(in) :: sig
+        character(len=*), intent(in) :: proc_name, type_name
+        integer, intent(in) :: line, column
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        do i = 1, size(sig%dummies)
+            if (.not. allocated(sig%dummies(i)%name)) cycle
+            if (sig%dummies(i)%name /= '*') cycle
+            call report(errors, 'Argument of FINAL procedure '''// &
+                trim(proc_name)//''' must be a data object, not an '// &
+                'alternate return indicator', &
+                'give the final subroutine a single nonpolymorphic dummy '// &
+                'argument of type '''//trim(type_name)//'''', line, column)
+            return
+        end do
+
+        if (size(sig%dummies) /= 1) then
+            call report(errors, 'FINAL procedure '''//trim(proc_name)// &
+                ''' must have exactly one dummy argument but has '// &
+                int_to_string(size(sig%dummies)), &
+                'declare the final subroutine with a single dummy argument '// &
+                'of type '''//trim(type_name)//'''', line, column)
+            return
+        end if
+
+        if (.not. sig%dummies(1)%category_known) return
+        if (.not. is_polymorphic(sig%dummies(1)%category)) return
+        call report(errors, 'Argument of FINAL procedure '''//trim(proc_name)// &
+            ''' must be of type '''//trim(type_name)//''' and nonpolymorphic', &
+            'declare the dummy argument as TYPE('//trim(type_name)// &
+            ') instead of CLASS('//trim(type_name)//')', line, column)
+    end subroutine check_signature
+
+    ! Whether a type category produced by type_category names a CLASS entity.
+    function is_polymorphic(category) result(polymorphic)
+        character(len=*), intent(in) :: category
+        logical :: polymorphic
+
+        polymorphic = .false.
+        if (len(category) < 6) return
+        polymorphic = category(1:6) == 'class:'
+    end function is_polymorphic
+
+    subroutine report(errors, message, suggestion, line, column)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: message, suggestion
+        integer, intent(in) :: line, column
+
+        call errors%add_error( &
+            message=message, &
+            code=ERROR_SEMANTIC, &
+            component='semantic_final_validation', &
+            context='line '//int_to_string(line)//', column '// &
+            int_to_string(column), &
+            suggestion=suggestion, line=line, column=column, &
+            end_line=line, end_column=column + 1)
+    end subroutine report
+
+end module semantic_final_validation

--- a/src/semantic/analyzers/semantic_procedure_signature.f90
+++ b/src/semantic/analyzers/semantic_procedure_signature.f90
@@ -1,0 +1,327 @@
+module semantic_procedure_signature
+    ! Reads a procedure definition out of the AST arena and reduces it to the
+    ! small amount of signature information the F2003 type-bound-procedure
+    ! override rules and the FINAL procedure rules need to compare: the dummy
+    ! argument names, their declared type category and INTENT, and (for
+    ! functions) the shape and character length of the result.
+    !
+    ! Only facts that are actually present in the AST are recorded. Every
+    ! "known" flag stays .false. when the declaration could not be located, so
+    ! callers can stay silent rather than guess. This matters because a wrong
+    ! rejection makes a valid program uncompilable.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: identifier_node
+    use ast_nodes_data, only: declaration_node, parameter_declaration_node, &
+        INTENT_IN, INTENT_OUT, INTENT_INOUT
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+    use string_utils_mod, only: to_lower
+    implicit none
+    private
+
+    public :: dummy_info_t, procedure_signature_t
+    public :: find_procedure_definition, build_procedure_signature
+    public :: type_category
+
+    type :: dummy_info_t
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: category
+        character(len=:), allocatable :: intent_text
+        logical :: category_known = .false.
+        logical :: has_intent = .false.
+        logical :: is_array = .false.
+    end type dummy_info_t
+
+    type :: procedure_signature_t
+        logical :: found = .false.
+        logical :: is_function = .false.
+        character(len=:), allocatable :: name
+        type(dummy_info_t), allocatable :: dummies(:)
+        logical :: result_known = .false.
+        character(len=:), allocatable :: result_category
+        logical :: result_is_array = .false.
+        logical :: result_has_char_len = .false.
+        character(len=:), allocatable :: result_char_len
+        integer :: line = 0
+        integer :: column = 0
+    end type procedure_signature_t
+
+contains
+
+    ! Locate the arena index of a FUNCTION or SUBROUTINE definition by name.
+    ! Returns 0 when the name is not defined in this arena, and also 0 when the
+    ! name is defined more than once, because an ambiguous match cannot be
+    ! compared safely.
+    function find_procedure_definition(arena, name) result(proc_index)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: proc_index
+        character(len=:), allocatable :: wanted
+        integer :: i, matches
+
+        proc_index = 0
+        matches = 0
+        if (len_trim(name) == 0) return
+        wanted = to_lower(trim(name))
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (function_def_node)
+                if (.not. allocated(node%name)) cycle
+                if (to_lower(trim(node%name)) /= wanted) cycle
+                matches = matches + 1
+                proc_index = i
+                type is (subroutine_def_node)
+                if (.not. allocated(node%name)) cycle
+                if (to_lower(trim(node%name)) /= wanted) cycle
+                matches = matches + 1
+                proc_index = i
+            end select
+        end do
+
+        if (matches /= 1) proc_index = 0
+    end function find_procedure_definition
+
+    ! Reduce the procedure at proc_index to a comparable signature.
+    function build_procedure_signature(arena, proc_index) result(sig)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_index
+        type(procedure_signature_t) :: sig
+
+        if (proc_index <= 0) return
+        if (.not. arena%has_node_at(proc_index)) return
+
+        select type (node => arena%entries(proc_index)%node)
+            type is (function_def_node)
+            sig%found = .true.
+            sig%is_function = .true.
+            if (allocated(node%name)) sig%name = trim(node%name)
+            sig%line = node%line
+            sig%column = node%column
+            call collect_dummies(arena, node%param_indices, node%body_indices, &
+                sig%dummies)
+            call collect_result(arena, node, sig)
+            type is (subroutine_def_node)
+            sig%found = .true.
+            sig%is_function = .false.
+            if (allocated(node%name)) sig%name = trim(node%name)
+            sig%line = node%line
+            sig%column = node%column
+            call collect_dummies(arena, node%param_indices, node%body_indices, &
+                sig%dummies)
+        end select
+    end function build_procedure_signature
+
+    ! Build one dummy_info_t per dummy argument. Type and INTENT come from the
+    ! parameter node itself when the parser produced an inline declaration, and
+    ! otherwise from the matching declaration in the procedure body.
+    subroutine collect_dummies(arena, param_indices, body_indices, dummies)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: param_indices(:)
+        integer, allocatable, intent(in) :: body_indices(:)
+        type(dummy_info_t), allocatable, intent(out) :: dummies(:)
+        integer :: i, decl_index
+
+        if (.not. allocated(param_indices)) then
+            allocate (dummies(0))
+            return
+        end if
+
+        allocate (dummies(size(param_indices)))
+        do i = 1, size(param_indices)
+            dummies(i)%name = param_name(arena, param_indices(i))
+            call describe_from_node(arena, param_indices(i), dummies(i))
+            if (dummies(i)%category_known) cycle
+            if (len_trim(dummies(i)%name) == 0) cycle
+            if (.not. allocated(body_indices)) cycle
+            decl_index = find_declaration(arena, body_indices, dummies(i)%name)
+            if (decl_index <= 0) cycle
+            call describe_from_node(arena, decl_index, dummies(i))
+        end do
+    end subroutine collect_dummies
+
+    ! Record type category, INTENT and rank from a declaration-carrying node.
+    subroutine describe_from_node(arena, node_index, info)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(dummy_info_t), intent(inout) :: info
+
+        if (node_index <= 0) return
+        if (.not. arena%has_node_at(node_index)) return
+
+        select type (node => arena%entries(node_index)%node)
+            type is (declaration_node)
+            if (allocated(node%type_name)) then
+                info%category = type_category(node%type_name)
+                info%category_known = len_trim(info%category) > 0
+            end if
+            info%is_array = node%is_array
+            if (node%has_intent) then
+                if (allocated(node%intent)) then
+                    info%intent_text = to_lower(trim(node%intent))
+                    info%has_intent = len_trim(info%intent_text) > 0
+                end if
+            end if
+            type is (parameter_declaration_node)
+            if (allocated(node%type_name)) then
+                info%category = type_category(node%type_name)
+                info%category_known = len_trim(info%category) > 0
+            end if
+            info%is_array = node%is_array
+            select case (node%intent_type)
+            case (INTENT_IN)
+                info%intent_text = 'in'
+                info%has_intent = .true.
+            case (INTENT_OUT)
+                info%intent_text = 'out'
+                info%has_intent = .true.
+            case (INTENT_INOUT)
+                info%intent_text = 'inout'
+                info%has_intent = .true.
+            end select
+        end select
+    end subroutine describe_from_node
+
+    ! Describe the function result: the declaration of the RESULT variable, or
+    ! of the function name when no RESULT clause is present.
+    subroutine collect_result(arena, node, sig)
+        type(ast_arena_t), intent(in) :: arena
+        type(function_def_node), intent(in) :: node
+        type(procedure_signature_t), intent(inout) :: sig
+        character(len=:), allocatable :: result_name
+        integer :: decl_index
+
+        ! The parser allocates result_variable to an empty string when the
+        ! function header carries no RESULT clause; the result is then declared
+        ! under the function's own name.
+        result_name = ''
+        if (allocated(node%result_variable)) result_name = trim(node%result_variable)
+        if (len_trim(result_name) == 0) then
+            if (.not. allocated(node%name)) return
+            result_name = trim(node%name)
+        end if
+        if (len_trim(result_name) == 0) return
+        if (.not. allocated(node%body_indices)) return
+
+        decl_index = find_declaration(arena, node%body_indices, result_name)
+        if (decl_index <= 0) return
+        if (.not. arena%has_node_at(decl_index)) return
+
+        select type (decl => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            if (.not. allocated(decl%type_name)) return
+            sig%result_category = type_category(decl%type_name)
+            sig%result_known = len_trim(sig%result_category) > 0
+            sig%result_is_array = decl%is_array
+            sig%result_has_char_len = decl%has_character_length
+            if (allocated(decl%character_length_expr)) then
+                sig%result_char_len = trim(decl%character_length_expr)
+            end if
+        end select
+    end subroutine collect_result
+
+    ! Reduce a declared type specification to the part the override rules care
+    ! about. Kind and length selectors are dropped so that `integer` and
+    ! `integer(4)` compare equal; TYPE and CLASS keep the derived type name so
+    ! that `class(base_t)` and `class(r_t)` compare unequal.
+    function type_category(type_name) result(category)
+        character(len=*), intent(in) :: type_name
+        character(len=:), allocatable :: category
+        character(len=:), allocatable :: lowered, base, inner
+        integer :: paren
+
+        category = ''
+        lowered = to_lower(trim(adjustl(type_name)))
+        if (len_trim(lowered) == 0) return
+
+        paren = index(lowered, '(')
+        if (paren <= 0) then
+            category = squeeze(lowered)
+            return
+        end if
+
+        base = squeeze(lowered(1:paren - 1))
+        if (base /= 'type' .and. base /= 'class') then
+            category = base
+            return
+        end if
+
+        inner = lowered(paren + 1:)
+        paren = index(inner, ')', back=.true.)
+        if (paren > 0) inner = inner(1:paren - 1)
+        paren = index(inner, '(')
+        if (paren > 0) inner = inner(1:paren - 1)
+        paren = index(inner, ',')
+        if (paren > 0) inner = inner(1:paren - 1)
+        category = base//':'//squeeze(inner)
+    end function type_category
+
+    ! Remove every blank from text so that spacing differences in a declared
+    ! type specification do not produce a spurious mismatch.
+    function squeeze(text) result(packed)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: packed
+        integer :: i
+
+        packed = ''
+        do i = 1, len(text)
+            if (text(i:i) == ' ') cycle
+            packed = packed//text(i:i)
+        end do
+    end function squeeze
+
+    ! Extract the dummy argument name from a parameter node.
+    function param_name(arena, param_index) result(name)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_index
+        character(len=:), allocatable :: name
+
+        name = ''
+        if (param_index <= 0) return
+        if (.not. arena%has_node_at(param_index)) return
+
+        select type (node => arena%entries(param_index)%node)
+            type is (identifier_node)
+            if (allocated(node%name)) name = trim(node%name)
+            type is (declaration_node)
+            if (allocated(node%var_name)) name = trim(node%var_name)
+            type is (parameter_declaration_node)
+            if (allocated(node%name)) name = trim(node%name)
+        end select
+    end function param_name
+
+    ! Find the body declaration that declares var_name, if any.
+    function find_declaration(arena, body_indices, var_name) result(decl_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: var_name
+        integer :: decl_index
+        character(len=:), allocatable :: wanted
+        integer :: i, j
+
+        decl_index = 0
+        wanted = to_lower(trim(var_name))
+        if (len_trim(wanted) == 0) return
+
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (node => arena%entries(body_indices(i))%node)
+                type is (declaration_node)
+                if (allocated(node%var_name)) then
+                    if (to_lower(trim(node%var_name)) == wanted) then
+                        decl_index = body_indices(i)
+                        return
+                    end if
+                end if
+                if (.not. allocated(node%var_names)) cycle
+                do j = 1, size(node%var_names)
+                    if (to_lower(trim(node%var_names(j))) == wanted) then
+                        decl_index = body_indices(i)
+                        return
+                    end if
+                end do
+            end select
+        end do
+    end function find_declaration
+
+end module semantic_procedure_signature

--- a/src/semantic/analyzers/semantic_tbp_override_result.f90
+++ b/src/semantic/analyzers/semantic_tbp_override_result.f90
@@ -1,0 +1,148 @@
+module semantic_tbp_override_result
+    ! Function result half of the F2003 type-bound procedure override rules
+    ! (F2018 7.5.7.3): the result of an overriding function must have the same
+    ! rank as the result of the overridden function, and when the overridden
+    ! result has a constant character length the overriding result must have
+    ! the same constant character length.
+    !
+    ! A nonconstant character length on the overridden result is left alone.
+    ! Deciding whether two specification expressions such as `2*x` and `1+x*2`
+    ! denote the same length needs symbolic evaluation the frontend does not
+    ! have, and gfortran only warns there, so rejecting would be over-eager.
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use semantic_procedure_signature, only: procedure_signature_t
+    use string_utils_mod, only: int_to_string
+    implicit none
+    private
+
+    public :: compare_function_results
+
+contains
+
+    ! Compare the results of an overriding and an overridden function binding.
+    subroutine compare_function_results(child_sig, parent_sig, binding_name, &
+            line, column, errors)
+        type(procedure_signature_t), intent(in) :: child_sig, parent_sig
+        character(len=*), intent(in) :: binding_name
+        integer, intent(in) :: line, column
+        type(error_collection_t), intent(inout) :: errors
+
+        if (.not. child_sig%is_function) return
+        if (.not. parent_sig%is_function) return
+        if (.not. child_sig%result_known) return
+        if (.not. parent_sig%result_known) return
+
+        if (child_sig%result_is_array .neqv. parent_sig%result_is_array) then
+            call report(errors, 'Rank mismatch in function result of '// &
+                'overriding type-bound procedure '''//trim(binding_name)// &
+                ''': overridden result is '// &
+                rank_word(parent_sig%result_is_array)//' but the overriding '// &
+                'result is '//rank_word(child_sig%result_is_array), &
+                'give the overriding function result the same rank as the '// &
+                'overridden function result', line, column)
+            return
+        end if
+
+        if (child_sig%result_category /= 'character') return
+        if (parent_sig%result_category /= 'character') return
+        call compare_character_length(child_sig, parent_sig, binding_name, &
+            line, column, errors)
+    end subroutine compare_function_results
+
+    ! Character length half of the result comparison.
+    subroutine compare_character_length(child_sig, parent_sig, binding_name, &
+            line, column, errors)
+        type(procedure_signature_t), intent(in) :: child_sig, parent_sig
+        character(len=*), intent(in) :: binding_name
+        integer, intent(in) :: line, column
+        type(error_collection_t), intent(inout) :: errors
+        integer :: parent_length, child_length
+        logical :: parent_constant, child_constant
+
+        if (.not. parent_sig%result_has_char_len) return
+        if (.not. child_sig%result_has_char_len) return
+        if (.not. allocated(parent_sig%result_char_len)) return
+        if (.not. allocated(child_sig%result_char_len)) return
+
+        call constant_length(parent_sig%result_char_len, parent_constant, &
+            parent_length)
+        if (.not. parent_constant) return
+
+        call constant_length(child_sig%result_char_len, child_constant, &
+            child_length)
+        if (.not. child_constant) then
+            call report(errors, 'Overridden type-bound function '''// &
+                trim(binding_name)//''' is declared with a constant '// &
+                'character length of '//int_to_string(parent_length)// &
+                ', so the overriding function result must be too', &
+                'declare the overriding function result as character(len='// &
+                int_to_string(parent_length)//')', line, column)
+            return
+        end if
+
+        if (child_length == parent_length) return
+        call report(errors, 'Character length mismatch in function result of '// &
+            'overriding type-bound procedure '''//trim(binding_name)// &
+            ''': overridden result has length '//int_to_string(parent_length)// &
+            ' but the overriding result has length '// &
+            int_to_string(child_length), &
+            'declare the overriding function result as character(len='// &
+            int_to_string(parent_length)//')', line, column)
+    end subroutine compare_character_length
+
+    ! Decide whether a character length specification is a plain nonnegative
+    ! integer literal, and if so return its value. Anything else, including an
+    ! assumed length `*` and any specification expression, is not constant for
+    ! the purposes of this rule.
+    subroutine constant_length(text, is_constant, length)
+        character(len=*), intent(in) :: text
+        logical, intent(out) :: is_constant
+        integer, intent(out) :: length
+        character(len=:), allocatable :: trimmed
+        integer :: i, status
+
+        is_constant = .false.
+        length = 0
+        trimmed = trim(adjustl(text))
+        if (len(trimmed) == 0) return
+
+        do i = 1, len(trimmed)
+            if (trimmed(i:i) < '0') return
+            if (trimmed(i:i) > '9') return
+        end do
+
+        read (trimmed, *, iostat=status) length
+        if (status /= 0) then
+            length = 0
+            return
+        end if
+        is_constant = .true.
+    end subroutine constant_length
+
+    function rank_word(is_array) result(word)
+        logical, intent(in) :: is_array
+        character(len=:), allocatable :: word
+
+        if (is_array) then
+            word = 'an array'
+        else
+            word = 'a scalar'
+        end if
+    end function rank_word
+
+    subroutine report(errors, message, suggestion, line, column)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: message, suggestion
+        integer, intent(in) :: line, column
+
+        call errors%add_error( &
+            message=message, &
+            code=ERROR_SEMANTIC, &
+            component='semantic_tbp_override_validation', &
+            context='line '//int_to_string(line)//', column '// &
+            int_to_string(column), &
+            suggestion=suggestion, line=line, column=column, &
+            end_line=line, end_column=column + 1)
+    end subroutine report
+
+end module semantic_tbp_override_result

--- a/src/semantic/analyzers/semantic_tbp_override_validation.f90
+++ b/src/semantic/analyzers/semantic_tbp_override_validation.f90
@@ -1,0 +1,329 @@
+module semantic_tbp_override_validation
+    ! Validates a type-bound procedure that overrides an inherited binding
+    ! against F2018 C1526/7.5.7.3 (F2003 C468/4.5.7.3). An overriding binding
+    ! and the binding it overrides must agree in everything except the
+    ! passed-object dummy argument: the other dummy arguments must have the
+    ! same declared type and INTENT, and a function result must have the same
+    ! rank and, when the overridden result has a constant character length, the
+    ! same constant character length.
+    !
+    ! The comparison is deliberately conservative. A rule fires only when both
+    ! sides of the comparison are known from the AST, so an unresolved
+    ! procedure or an undeclared dummy leaves the program accepted.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_data, only: derived_type_node, type_binding_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use semantic_procedure_signature, only: procedure_signature_t, &
+        build_procedure_signature, find_procedure_definition
+    use semantic_tbp_override_result, only: compare_function_results
+    use string_utils_mod, only: int_to_string, to_lower
+    implicit none
+    private
+
+    integer, parameter :: MAX_ANCESTOR_DEPTH = 64
+
+    public :: validate_type_bound_overrides
+
+contains
+
+    ! Walk every extending derived type and compare each of its concrete
+    ! bindings with the binding of the same name inherited from an ancestor.
+    subroutine validate_type_bound_overrides(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i, b
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (derived_type_node)
+                if (.not. allocated(node%extends_parent)) cycle
+                if (.not. allocated(node%binding_indices)) cycle
+                do b = 1, size(node%binding_indices)
+                    call check_binding(arena, node%binding_indices(b), &
+                        node%extends_parent, errors)
+                end do
+            end select
+        end do
+    end subroutine validate_type_bound_overrides
+
+    ! Compare one binding of an extending type with its overridden counterpart.
+    subroutine check_binding(arena, binding_index, parent_type, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: binding_index
+        character(len=*), intent(in) :: parent_type
+        type(error_collection_t), intent(inout) :: errors
+        type(procedure_signature_t) :: child_sig, parent_sig
+        integer :: parent_binding
+
+        if (binding_index <= 0) return
+        if (.not. arena%has_node_at(binding_index)) return
+
+        select type (binding => arena%entries(binding_index)%node)
+            type is (type_binding_node)
+            if (binding%is_final) return
+            if (binding%is_generic) return
+            if (binding%is_deferred) return
+            if (.not. allocated(binding%binding_name)) return
+            parent_binding = find_inherited_binding(arena, parent_type, &
+                binding%binding_name)
+            if (parent_binding <= 0) return
+            child_sig = signature_of_binding(arena, binding_index)
+            parent_sig = signature_of_binding(arena, parent_binding)
+            if (.not. child_sig%found) return
+            if (.not. parent_sig%found) return
+            if (child_sig%is_function .neqv. parent_sig%is_function) return
+            call compare_dummies(arena, binding_index, child_sig, parent_sig, &
+                binding%binding_name, binding%line, binding%column, errors)
+            call compare_function_results(child_sig, parent_sig, &
+                binding%binding_name, binding%line, binding%column, errors)
+        end select
+    end subroutine check_binding
+
+    ! Resolve the procedure a binding names and reduce it to a signature.
+    function signature_of_binding(arena, binding_index) result(sig)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: binding_index
+        type(procedure_signature_t) :: sig
+        integer :: proc_index
+
+        if (.not. arena%has_node_at(binding_index)) return
+        select type (binding => arena%entries(binding_index)%node)
+            type is (type_binding_node)
+            if (allocated(binding%implementation)) then
+                proc_index = find_procedure_definition(arena, &
+                    binding%implementation)
+            else if (allocated(binding%binding_name)) then
+                proc_index = find_procedure_definition(arena, &
+                    binding%binding_name)
+            else
+                proc_index = 0
+            end if
+            if (proc_index > 0) sig = build_procedure_signature(arena, proc_index)
+        end select
+    end function signature_of_binding
+
+    ! Search the ancestor chain of type_name for a concrete binding called
+    ! binding_name and return its arena index, or 0.
+    function find_inherited_binding(arena, type_name, binding_name) &
+            result(found_index)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: type_name, binding_name
+        integer :: found_index
+        character(len=:), allocatable :: current
+        integer :: type_index, depth
+
+        found_index = 0
+        current = trim(type_name)
+        do depth = 1, MAX_ANCESTOR_DEPTH
+            type_index = find_derived_type(arena, current)
+            if (type_index <= 0) return
+            found_index = binding_in_type(arena, type_index, binding_name)
+            if (found_index > 0) return
+            select type (node => arena%entries(type_index)%node)
+                type is (derived_type_node)
+                if (.not. allocated(node%extends_parent)) return
+                current = trim(node%extends_parent)
+            class default
+                return
+            end select
+        end do
+    end function find_inherited_binding
+
+    ! Arena index of the derived type definition called type_name, or 0 when it
+    ! is absent or defined more than once.
+    function find_derived_type(arena, type_name) result(type_index)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: type_name
+        integer :: type_index
+        character(len=:), allocatable :: wanted
+        integer :: i, matches
+
+        type_index = 0
+        matches = 0
+        wanted = to_lower(trim(type_name))
+        if (len_trim(wanted) == 0) return
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (derived_type_node)
+                if (.not. allocated(node%name)) cycle
+                if (to_lower(trim(node%name)) /= wanted) cycle
+                matches = matches + 1
+                type_index = i
+            end select
+        end do
+
+        if (matches /= 1) type_index = 0
+    end function find_derived_type
+
+    ! Arena index of the concrete binding called binding_name declared directly
+    ! in the derived type at type_index, or 0.
+    function binding_in_type(arena, type_index, binding_name) result(found_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: type_index
+        character(len=*), intent(in) :: binding_name
+        integer :: found_index
+        character(len=:), allocatable :: wanted
+        integer :: b
+
+        found_index = 0
+        wanted = to_lower(trim(binding_name))
+        select type (node => arena%entries(type_index)%node)
+            type is (derived_type_node)
+            if (.not. allocated(node%binding_indices)) return
+            do b = 1, size(node%binding_indices)
+                if (.not. arena%has_node_at(node%binding_indices(b))) cycle
+                select type (binding => arena%entries(node%binding_indices(b))%node)
+                    type is (type_binding_node)
+                    if (binding%is_final) cycle
+                    if (binding%is_generic) cycle
+                    if (.not. allocated(binding%binding_name)) cycle
+                    if (to_lower(trim(binding%binding_name)) /= wanted) cycle
+                    found_index = node%binding_indices(b)
+                    return
+                end select
+            end do
+        end select
+    end function binding_in_type
+
+    ! Compare every dummy argument except the passed-object dummy. Both sides
+    ! must be known before a mismatch is reported.
+    subroutine compare_dummies(arena, binding_index, child_sig, parent_sig, &
+            binding_name, line, column, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: binding_index
+        type(procedure_signature_t), intent(in) :: child_sig, parent_sig
+        character(len=*), intent(in) :: binding_name
+        integer, intent(in) :: line, column
+        type(error_collection_t), intent(inout) :: errors
+        integer :: passed_position, i
+
+        if (.not. allocated(child_sig%dummies)) return
+        if (.not. allocated(parent_sig%dummies)) return
+        if (size(child_sig%dummies) /= size(parent_sig%dummies)) return
+
+        passed_position = passed_object_position(arena, binding_index, child_sig)
+        do i = 1, size(child_sig%dummies)
+            if (i == passed_position) cycle
+            call compare_one_dummy(child_sig%dummies(i), parent_sig%dummies(i), &
+                binding_name, line, column, errors)
+        end do
+    end subroutine compare_dummies
+
+    ! Report a declared-type or INTENT mismatch for a single dummy argument.
+    subroutine compare_one_dummy(child, parent, binding_name, line, column, errors)
+        use semantic_procedure_signature, only: dummy_info_t
+        type(dummy_info_t), intent(in) :: child, parent
+        character(len=*), intent(in) :: binding_name
+        integer, intent(in) :: line, column
+        type(error_collection_t), intent(inout) :: errors
+        character(len=:), allocatable :: label
+
+        label = 'argument'
+        if (allocated(child%name)) then
+            if (len_trim(child%name) > 0) label = 'argument '''//child%name//''''
+        end if
+
+        if (child%category_known) then
+            if (parent%category_known) then
+                if (child%category /= parent%category) then
+                    call report(errors, 'Type mismatch in '//label// &
+                        ' of overriding type-bound procedure '''// &
+                        trim(binding_name)//''': overridden binding declares '// &
+                        spell_category(parent%category)// &
+                        ' but the override declares '// &
+                        spell_category(child%category), &
+                        'declare the overriding dummy argument with the same '// &
+                        'type as the overridden binding', line, column)
+                    return
+                end if
+            end if
+        end if
+
+        if (.not. child%has_intent) return
+        if (.not. parent%has_intent) return
+        if (child%intent_text == parent%intent_text) return
+        call report(errors, 'INTENT mismatch in '//label// &
+            ' of overriding type-bound procedure '''//trim(binding_name)// &
+            ''': overridden binding declares INTENT('//parent%intent_text// &
+            ') but the override declares INTENT('//child%intent_text//')', &
+            'give the overriding dummy argument the same INTENT as the '// &
+            'overridden binding', line, column)
+    end subroutine compare_one_dummy
+
+    ! Render an internal type category back as Fortran source spelling, so the
+    ! diagnostic reads `CLASS(base_type)` rather than `class:base_type`.
+    function spell_category(category) result(spelled)
+        character(len=*), intent(in) :: category
+        character(len=:), allocatable :: spelled
+        integer :: colon
+
+        colon = index(category, ':')
+        if (colon <= 0) then
+            spelled = upper(category)
+            return
+        end if
+        spelled = upper(category(1:colon - 1))//'('//category(colon + 1:)//')'
+    end function spell_category
+
+    function upper(text) result(uppered)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: uppered
+        integer :: i, code
+
+        uppered = text
+        do i = 1, len(uppered)
+            code = iachar(uppered(i:i))
+            if (code < iachar('a')) cycle
+            if (code > iachar('z')) cycle
+            uppered(i:i) = achar(code - 32)
+        end do
+    end function upper
+
+    ! Position of the passed-object dummy in the overriding procedure, or 0 for
+    ! a NOPASS binding.
+    function passed_object_position(arena, binding_index, sig) result(position)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: binding_index
+        type(procedure_signature_t), intent(in) :: sig
+        integer :: position
+        integer :: i
+
+        position = 0
+        select type (binding => arena%entries(binding_index)%node)
+            type is (type_binding_node)
+            if (.not. binding%pass_arg) return
+            if (.not. allocated(binding%pass_name)) then
+                position = 1
+                return
+            end if
+            if (.not. allocated(sig%dummies)) return
+            do i = 1, size(sig%dummies)
+                if (.not. allocated(sig%dummies(i)%name)) cycle
+                if (to_lower(sig%dummies(i)%name) /= &
+                    to_lower(trim(binding%pass_name))) cycle
+                position = i
+                return
+            end do
+            position = 1
+        end select
+    end function passed_object_position
+
+    subroutine report(errors, message, suggestion, line, column)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: message, suggestion
+        integer, intent(in) :: line, column
+
+        call errors%add_error( &
+            message=message, &
+            code=ERROR_SEMANTIC, &
+            component='semantic_tbp_override_validation', &
+            context='line '//int_to_string(line)//', column '// &
+            int_to_string(column), &
+            suggestion=suggestion, line=line, column=column, &
+            end_line=line, end_column=column + 1)
+    end subroutine report
+
+end module semantic_tbp_override_validation

--- a/src/semantic/analyzers/semantic_type_hierarchy_validation.f90
+++ b/src/semantic/analyzers/semantic_type_hierarchy_validation.f90
@@ -11,6 +11,8 @@ module semantic_type_hierarchy_validation
     use ast_nodes_misc, only: use_statement_node
     use type_hierarchy, only: type_hierarchy_t
     use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use semantic_final_validation, only: validate_final_procedures
+    use semantic_tbp_override_validation, only: validate_type_bound_overrides
     use string_utils_mod, only: int_to_string
     implicit none
     private
@@ -55,6 +57,12 @@ contains
         if (.not. arena_has_use_statement(arena)) then
             call report_unresolved_parents(arena, registered, errors)
         end if
+
+        ! With the hierarchy populated, the signature rules that relate a
+        ! binding to the binding it overrides, and a FINAL binding to the type
+        ! it finalizes, can be checked.
+        call validate_final_procedures(arena, errors)
+        call validate_type_bound_overrides(arena, errors)
     end subroutine populate_type_hierarchy
 
     ! Detect whether the arena contains any USE statement, in which case a

--- a/test/api/test_reject_tbp_01_diagnostics.f90
+++ b/test/api/test_reject_tbp_01_diagnostics.f90
@@ -1,0 +1,121 @@
+program test_reject_tbp_01_diagnostics
+    ! Issue #2881: fortfront must reject a FINAL subroutine whose dummy argument
+    ! is not a nonpolymorphic data object of the finalized type, and a
+    ! type-bound procedure whose signature disagrees with the binding it
+    ! overrides. Each negative fixture must produce the diagnostic of its own
+    ! rule, and the corrected neighbour of each rule must stay accepted.
+    use frontend_compiler_api, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    implicit none
+
+    integer :: test_count, pass_count
+
+    test_count = 0
+    pass_count = 0
+
+    call expect_rejected('examples/f90/finalize_22.f90', &
+        'Argument of FINAL procedure')
+    call expect_rejected('examples/f90/pr104572.f90', &
+        'alternate return indicator')
+    call expect_rejected('examples/f90/typebound_override_1.f90', &
+        'Character length mismatch in function result')
+    call expect_rejected('examples/f90/typebound_override_1.f90', &
+        'Rank mismatch in function result')
+    call expect_rejected('examples/f90/typebound_override_1.f90', &
+        'declared with a constant character length')
+    call expect_rejected('examples/f90/typebound_override_2.f90', &
+        'INTENT mismatch in argument')
+    call expect_rejected('examples/f90/typebound_override_4.f90', &
+        'Type mismatch in argument')
+    call expect_rejected('examples/f90/typebound_override_5.f90', &
+        'Type mismatch in argument')
+
+    call expect_accepted('examples/f90/finalize_22_valid.f90')
+    call expect_accepted('examples/f90/pr104572_valid.f90')
+    call expect_accepted('examples/f90/typebound_override_1_valid.f90')
+    call expect_accepted('examples/f90/typebound_override_2_valid.f90')
+    call expect_accepted('examples/f90/typebound_override_4_valid.f90')
+
+    write (*, '(A,I0,A,I0,A)') 'Passed ', pass_count, ' out of ', &
+        test_count, ' tests.'
+    if (pass_count /= test_count) then
+        write (error_unit, '(A)') 'FAIL'
+        stop 1
+    end if
+
+contains
+
+    include '../common/read_example.inc'
+
+    ! The fixture must be rejected, and the diagnostic text must name the rule
+    ! that rejected it rather than any diagnostic at all.
+    subroutine expect_rejected(fixture, expected_fragment)
+        character(len=*), intent(in) :: fixture
+        character(len=*), intent(in) :: expected_fragment
+        type(compiler_frontend_result_t) :: outcome
+        character(len=:), allocatable :: diagnostics
+
+        test_count = test_count + 1
+        call analyze(fixture, outcome)
+        diagnostics = ''
+        if (allocated(outcome%diagnostic_text)) diagnostics = outcome%diagnostic_text
+
+        if (.not. outcome%parse_ok) then
+            write (*, '(A)') 'FAIL: '//fixture//' did not parse'
+            return
+        end if
+        if (outcome%semantic_ok) then
+            write (*, '(A)') 'FAIL: '//fixture//' was accepted'
+            return
+        end if
+        if (index(diagnostics, expected_fragment) == 0) then
+            write (*, '(A)') 'FAIL: '//fixture// &
+                ' rejected without the expected diagnostic'
+            write (*, '(A)') '  expected fragment: '//expected_fragment
+            write (*, '(A)') '  diagnostics: '//diagnostics
+            return
+        end if
+
+        pass_count = pass_count + 1
+        write (*, '(A)') 'PASS: '//fixture//' rejected with '//expected_fragment
+    end subroutine expect_rejected
+
+    ! The corrected neighbour must still compile: a check that is too eager is
+    ! worse than a missing one.
+    subroutine expect_accepted(fixture)
+        character(len=*), intent(in) :: fixture
+        type(compiler_frontend_result_t) :: outcome
+        character(len=:), allocatable :: diagnostics
+
+        test_count = test_count + 1
+        call analyze(fixture, outcome)
+        diagnostics = ''
+        if (allocated(outcome%diagnostic_text)) diagnostics = outcome%diagnostic_text
+
+        if (.not. outcome%parse_ok) then
+            write (*, '(A)') 'FAIL: '//fixture//' did not parse'
+            return
+        end if
+        if (.not. outcome%semantic_ok) then
+            write (*, '(A)') 'FAIL: '//fixture//' was rejected'
+            write (*, '(A)') '  diagnostics: '//diagnostics
+            return
+        end if
+
+        pass_count = pass_count + 1
+        write (*, '(A)') 'PASS: '//fixture//' accepted'
+    end subroutine expect_accepted
+
+    subroutine analyze(fixture, outcome)
+        character(len=*), intent(in) :: fixture
+        type(compiler_frontend_result_t), intent(out) :: outcome
+        type(compiler_frontend_options_t) :: options
+        character(len=:), allocatable :: source
+
+        call read_example(fixture, source)
+        options%run_semantics = .true.
+        call compile_frontend_from_string(source, outcome, options)
+    end subroutine analyze
+
+end program test_reject_tbp_01_diagnostics


### PR DESCRIPTION
Closes #2881 (partially — see "Not covered" below).

Fortfront accepted derived-type definitions whose FINAL binding or whose
overriding type-bound procedure had a signature the standard forbids. Both
families are now rejected with a rule-specific source diagnostic, and a
corrected neighbour of every rule is added and stays accepted.

## Rules enforced

FINAL subroutines (F2018 C789/C790), `src/semantic/analyzers/semantic_final_validation.f90`:

- the single dummy argument must be a data object, not an alternate return
  indicator (`pr104572.f90`)
- a final subroutine must have exactly one dummy argument
- the dummy argument must be nonpolymorphic (`finalize_22.f90`)

Type-bound procedure overrides (F2018 7.5.7.3),
`src/semantic/analyzers/semantic_tbp_override_validation.f90` and
`semantic_tbp_override_result.f90`:

- a dummy argument other than the passed-object dummy may not change its
  declared type (`typebound_override_4.f90`, `typebound_override_5.f90`)
- a dummy argument other than the passed-object dummy may not change its
  INTENT (`typebound_override_2.f90`)
- a function result may not change rank (`typebound_override_1.f90`)
- a function result whose overridden counterpart has a constant character
  length must have the same constant character length
  (`typebound_override_1.f90`, both the unequal-constant and the
  constant-versus-specification-expression form)

`semantic_procedure_signature.f90` reduces a procedure definition to the
dummy argument and result facts both families compare;
`semantic_type_hierarchy_validation.f90` drives them once the hierarchy is
populated.

## Guarding against over-rejection

A rejection that is too eager makes correct programs uncompilable, so every
rule stays silent when either side of the comparison is unknown:

- an unresolved or ambiguously named procedure is skipped entirely
- dummy arguments are compared only when both procedures declare the same
  number of them and both declarations were located
- type comparison works on categories, not raw declaration text: kind and
  length selectors are dropped so `integer` and `integer(4)` still agree,
  while `CLASS(base_t)` and `CLASS(r_t)` do not
- a nonconstant character length on the overridden result is left alone;
  deciding whether `2*x` and `1+x*2` denote the same length needs symbolic
  evaluation the frontend does not have, and gfortran only warns there

Corrected neighbours are committed alongside each negative fixture and are
asserted to compile: `finalize_22_valid.f90`, `pr104572_valid.f90`,
`typebound_override_1_valid.f90` (including the accepted commutative
nonconstant-length pair), `typebound_override_2_valid.f90`,
`typebound_override_4_valid.f90`.

## Not covered: the defined-I/O half

`dtio_6.f90` and `dtio_11.f90` are not implemented. Their rules all key off
the defined-I/O generic binding, and the parser currently drops it: for

```fortran
generic :: write(formatted) => pwf
```

`read_generic_target_list` expects `=>` immediately after the binding name,
sees `(` instead, and abandons the binding, so nothing in the AST records
that `pwf` is a DTIO procedure or which form it is. Round-tripping the input
above emits only `procedure :: pwf`. Enforcing the DTIO dummy argument rules
therefore needs parser work in
`src/parser/declarations/parser_declarations_derived_module.f90` to retain the
generic spec, which is outside the files #2881 names and is a change large
enough to deserve its own issue. Widening some other rule to cover the DTIO
fixtures would have been the wrong trade.

## Verification

- `fo test test_reject_tbp_01_diagnostics` passes; the test asserts eight
  rejections with their own diagnostic text and five acceptances.
- Every assertion was proved by negative control: each rule was disabled in
  turn and the test failed on exactly the fixtures that rule covers, then
  passed again once restored.
- `fo` full pipeline green.
- `make check-duplication` reports the single pre-existing violation in
  `test/api/test_compiler_statement_queries.f90` (#2910) and no warnings,
  matching the baseline.
