### PR TITLE
Reject invalid statement labels

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -8,3 +8,6 @@ f90/issue_2562_where_invalid_if.f90
 f90/issue_2591_unsigned_mixing_error.f90
 lf/issue_2816_walrus_redeclaration.lf
 f90/issue_2819_pure_with_print.f90
+f90/empty_label.f90
+f90/label_1.f90
+f90/label_2.f90

--- a/examples/f90/empty_label.f90
+++ b/examples/f90/empty_label.f90
@@ -1,0 +1,4 @@
+! INVALID: a statement label must be attached to a statement.
+! Fortran 2023 clause 6.3.2.3; gfortran.dg/empty_label.f90.
+100
+end

--- a/examples/f90/empty_label_corrected.f90
+++ b/examples/f90/empty_label_corrected.f90
@@ -1,0 +1,3 @@
+! Corrected neighbour of empty_label.f90: the label now carries a statement.
+100 continue
+end

--- a/examples/f90/label_1.f90
+++ b/examples/f90/label_1.f90
@@ -1,0 +1,6 @@
+! INVALID: a statement label is one to five digits and at least one of them
+! must be nonzero. Fortran 2023 clause 6.2.5; gfortran.dg/label_1.f90.
+program label_1
+    0056780 continue
+    0 continue
+end program label_1

--- a/examples/f90/label_1_corrected.f90
+++ b/examples/f90/label_1_corrected.f90
@@ -1,0 +1,5 @@
+! Corrected neighbour of label_1.f90: five digits or fewer, nonzero value.
+program label_1_corrected
+    56780 continue
+    1 continue
+end program label_1_corrected

--- a/examples/f90/label_2.f90
+++ b/examples/f90/label_2.f90
@@ -1,0 +1,5 @@
+! INVALID: in free source form a statement label must be separated from the
+! statement it labels. Fortran 2023 clause 6.3.2.3; gfortran.dg/label_2.f90.
+program label_2
+    10: a = 10
+end program label_2

--- a/examples/f90/label_2_corrected.f90
+++ b/examples/f90/label_2_corrected.f90
@@ -1,0 +1,6 @@
+! Corrected neighbour of label_2.f90: a blank separates label and statement.
+program label_2_corrected
+    integer :: a
+    10  a = 10
+    print *, a
+end program label_2_corrected

--- a/src/frontend/frontend_program_units.f90
+++ b/src/frontend/frontend_program_units.f90
@@ -15,6 +15,8 @@ module frontend_program_units
     use mixed_construct_detector, only: function_follows_type_spec
     use frontend_statement_processing, only: parse_all_statements, &
         parse_explicit_program_unit
+    use frontend_statement_token_parsing, only: clear_statement_label_error, &
+        get_statement_label_error
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_program
     use frontend_utilities, only: is_type_start
@@ -287,6 +289,9 @@ contains
         type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
         integer :: prog_index
         character(len=:), allocatable :: errors
+        character(len=:), allocatable :: label_error
+
+        call clear_statement_label_error()
 
         ! Check for meaningful content that should become an implicit main
         if (has_any_non_comment_content(tokens)) then
@@ -304,6 +309,13 @@ contains
 
         ! Extract parser errors if requested (implicit main can have parse errors too)
         if (present(error_msg)) then
+            ! Invalid statement labels are hard errors even when a diagnostic
+            ! sink collects them, so report them through error_msg as well.
+            label_error = get_statement_label_error()
+            if (len_trim(label_error) > 0) then
+                error_msg = label_error
+                return
+            end if
             if (present(diagnostic_sink)) return
             errors = get_last_parser_errors()
             if (len_trim(errors) > 0) then

--- a/src/frontend/frontend_statement_token_parsing.f90
+++ b/src/frontend/frontend_statement_token_parsing.f90
@@ -6,6 +6,7 @@ module frontend_statement_token_parsing
         clear_additional_indices, &
         get_last_parser_errors
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t
+    use parser_statement_label_module, only: validate_statement_label
     use ast_arena_modern, only: ast_arena_t
     use error_reporting, only: error_collection_t
 
@@ -16,8 +17,11 @@ module frontend_statement_token_parsing
     public :: process_comment_statement
     public :: process_regular_statement
     public :: is_prefix_only_statement
+    public :: clear_statement_label_error
+    public :: get_statement_label_error
 
     character(len=:), allocatable :: captured_trailing_comment
+    character(len=:), allocatable :: statement_label_error
 
 contains
 
@@ -63,6 +67,8 @@ contains
             return
         end if
 
+        call validate_leading_statement_label(tokens, stmt_start, stmt_end, &
+            diagnostic_sink)
         effective_start = compute_effective_statement_start(tokens, stmt_start, &
             stmt_end)
         call build_statement_tokens(tokens, effective_start, stmt_end, stmt_tokens)
@@ -76,6 +82,63 @@ contains
         body_indices = [body_indices, stmt_index]
         call append_additional_indices_from_dispatcher(body_indices)
     end subroutine process_regular_statement
+
+    subroutine clear_statement_label_error()
+        if (allocated(statement_label_error)) deallocate (statement_label_error)
+    end subroutine clear_statement_label_error
+
+    function get_statement_label_error() result(message)
+        character(len=:), allocatable :: message
+
+        if (allocated(statement_label_error)) then
+            message = statement_label_error
+        else
+            message = ""
+        end if
+    end function get_statement_label_error
+
+    ! Reject an invalid statement label before the statement is dispatched.
+    ! The raw token range is used because later stages drop the label tokens.
+    subroutine validate_leading_statement_label(tokens, stmt_start, stmt_end, &
+            diagnostic_sink)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: stmt_start, stmt_end
+        type(error_collection_t), target, intent(inout), optional :: diagnostic_sink
+        character(len=:), allocatable :: message
+        type(token_t) :: next_token
+        character(len=64) :: location
+        integer :: label_idx
+
+        label_idx = stmt_start
+        do while (label_idx <= stmt_end)
+            if (tokens(label_idx)%kind /= TK_WHITESPACE) exit
+            label_idx = label_idx + 1
+        end do
+        if (label_idx > stmt_end) return
+        if (tokens(label_idx)%kind /= TK_NUMBER) return
+
+        if (label_idx < stmt_end) then
+            next_token = tokens(label_idx + 1)
+        else
+            next_token%kind = TK_EOF
+            next_token%text = ""
+            next_token%line = tokens(label_idx)%line
+            next_token%column = tokens(label_idx)%column + &
+                len_trim(tokens(label_idx)%text)
+        end if
+
+        call validate_statement_label(tokens(label_idx), next_token, message)
+        if (.not. allocated(message)) return
+
+        write (location, '(A,I0,A,I0,A)') "ERROR at line ", &
+            tokens(label_idx)%line, ", column ", tokens(label_idx)%column, ":"
+        if (.not. allocated(statement_label_error)) then
+            statement_label_error = trim(location)//" "//message
+        end if
+        if (present(diagnostic_sink)) then
+            call diagnostic_sink%add_error_with_token(message, tokens(label_idx))
+        end if
+    end subroutine validate_leading_statement_label
 
     integer function compute_effective_statement_start(tokens, stmt_start, stmt_end) &
             result(effective_start)

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -63,6 +63,7 @@ module parser_execution_statements_module
     use parser_common_statement_module, only: parse_common_statement
     use parser_enum_statement_module, only: parse_enum_construct
     use parser_trailing_comment_module, only: capture_trailing_comment
+    use parser_statement_label_module, only: validate_statement_label
     implicit none
     private
 

--- a/src/parser/statements/parser_execution_statements_module.inc
+++ b/src/parser/statements/parser_execution_statements_module.inc
@@ -57,6 +57,8 @@
         character(len=16), allocatable :: pending_prefixes(:)
         character(len=:), allocatable :: lowered
         character(len=:), allocatable :: stmt_label
+        character(len=:), allocatable :: label_error
+        type(token_t) :: label_token
         integer :: stmt_index
         integer :: last_position
 
@@ -92,8 +94,13 @@
                 ! Save the label text
                 stmt_label = trim(token%text)
                 ! Consume the label and get next token
+                label_token = token
                 token = parser%consume()
                 token = parser%peek()
+                call validate_statement_label(label_token, token, label_error)
+                if (allocated(label_error)) then
+                    call parser%error_at_token(label_error, label_token)
+                end if
                 if (token%kind == TK_KEYWORD) then
                     lowered = trim(to_lower(token%text))
                 else

--- a/src/parser/statements/parser_statement_label.f90
+++ b/src/parser/statements/parser_statement_label.f90
@@ -1,0 +1,108 @@
+module parser_statement_label_module
+    ! Statement label validation for free source form.
+    !
+    ! Fortran 2023 clause 6.2.5: a statement label is a sequence of one to five
+    ! digits, at least one of which is nonzero.  Clause 6.3.2.3 requires the
+    ! label to be followed, on the same line, by the statement it labels, and
+    ! the label must be separated from that statement by a blank.
+    use lexer_core, only: token_t, TK_EOF, TK_NEWLINE, TK_COMMENT, TK_OPERATOR
+    implicit none
+    private
+
+    integer, parameter, public :: MAX_STATEMENT_LABEL_DIGITS = 5
+
+    public :: validate_statement_label
+
+contains
+
+    ! Validate the leading numeric token of a statement as a statement label.
+    ! next_token is the token that directly follows the label in the raw token
+    ! stream; a TK_EOF, TK_NEWLINE or TK_COMMENT there means the label has no
+    ! statement.  message is allocated only when the label is invalid, so an
+    ! unallocated message means "accept".
+    subroutine validate_statement_label(label_token, next_token, message)
+        type(token_t), intent(in) :: label_token
+        type(token_t), intent(in) :: next_token
+        character(len=:), allocatable, intent(out) :: message
+        character(len=:), allocatable :: digits
+
+        if (.not. allocated(label_token%text)) return
+        digits = trim(label_token%text)
+        if (.not. is_digit_string(digits)) return
+
+        if (len(digits) > MAX_STATEMENT_LABEL_DIGITS) then
+            message = "Too many digits in statement label '"//digits//"'"
+            return
+        end if
+
+        if (is_all_zero(digits)) then
+            message = "Zero is not a valid statement label"
+            return
+        end if
+
+        if (terminates_statement(next_token)) then
+            message = "Statement label without statement"
+            return
+        end if
+
+        if (label_runs_into_next_token(label_token, next_token, len(digits))) then
+            message = "Invalid character in statement label field"
+        end if
+    end subroutine validate_statement_label
+
+    ! A label candidate is a nonempty run of decimal digits.  Anything else
+    ! (real literals, kind suffixes, signs) is not a label and is left alone.
+    logical function is_digit_string(text) result(is_digits)
+        character(len=*), intent(in) :: text
+        integer :: i
+
+        is_digits = .false.
+        if (len(text) == 0) return
+        do i = 1, len(text)
+            if (text(i:i) < '0') return
+            if (text(i:i) > '9') return
+        end do
+        is_digits = .true.
+    end function is_digit_string
+
+    logical function is_all_zero(digits) result(all_zero)
+        character(len=*), intent(in) :: digits
+        integer :: i
+
+        all_zero = .true.
+        do i = 1, len(digits)
+            if (digits(i:i) /= '0') then
+                all_zero = .false.
+                return
+            end if
+        end do
+    end function is_all_zero
+
+    logical function terminates_statement(next_token) result(terminates)
+        type(token_t), intent(in) :: next_token
+
+        select case (next_token%kind)
+        case (TK_EOF, TK_NEWLINE, TK_COMMENT)
+            terminates = .true.
+        case default
+            terminates = .false.
+        end select
+    end function terminates_statement
+
+    ! Free source form demands a blank between the label and the statement.
+    ! Only the narrow case of an operator glued to the label is rejected here:
+    ! that is what `10: a = 10` produces, and it cannot be a valid statement.
+    logical function label_runs_into_next_token(label_token, next_token, &
+            digit_count) result(runs_into)
+        type(token_t), intent(in) :: label_token
+        type(token_t), intent(in) :: next_token
+        integer, intent(in) :: digit_count
+
+        runs_into = .false.
+        if (next_token%kind /= TK_OPERATOR) return
+        if (next_token%line /= label_token%line) return
+        if (next_token%column /= label_token%column + digit_count) return
+        runs_into = .true.
+    end function label_runs_into_next_token
+
+end module parser_statement_label_module

--- a/test/api/test_reject_label_01_diagnostics.f90
+++ b/test/api/test_reject_label_01_diagnostics.f90
@@ -1,0 +1,97 @@
+program test_reject_label_01_diagnostics
+    ! Issue #2889: fortfront must reject invalid statement labels.
+    !
+    ! Rules covered (Fortran 2023 clauses 6.2.5 and 6.3.2.3):
+    !   - a label carries at most five digits
+    !   - a label has at least one nonzero digit
+    !   - a label must be followed by the statement it labels
+    !   - in free source form a blank must separate label and statement
+    !
+    ! Every negative fixture has a corrected neighbour that must still parse,
+    ! so an over-eager check fails this test too.
+    use, intrinsic :: iso_fortran_env, only: output_unit, error_unit
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use lexer_core, only: token_t
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    call assert_rejected('examples/f90/empty_label.f90', &
+        'Statement label without statement')
+    call assert_rejected('examples/f90/label_1.f90', &
+        'Too many digits in statement label')
+    call assert_rejected('examples/f90/label_1.f90', &
+        'Zero is not a valid statement label')
+    call assert_rejected('examples/f90/label_2.f90', &
+        'Invalid character in statement label field')
+
+    call assert_accepted('examples/f90/empty_label_corrected.f90')
+    call assert_accepted('examples/f90/label_1_corrected.f90')
+    call assert_accepted('examples/f90/label_2_corrected.f90')
+
+    if (failures /= 0) then
+        write (error_unit, '(A,I0,A)') 'FAIL: ', failures, ' label check(s) failed'
+        error stop 1
+    end if
+    write (output_unit, '(A)') 'PASS: invalid statement labels rejected'
+
+contains
+
+    subroutine parse_example(filepath, parse_error)
+        character(len=*), intent(in) :: filepath
+        character(len=*), intent(out) :: parse_error
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: lex_error
+        type(ast_arena_t) :: arena
+        type(token_t), allocatable :: tokens(:)
+        integer :: root_index
+
+        call read_example(filepath, source)
+        arena = create_ast_arena()
+        call lex_source(source, tokens, lex_error)
+        if (allocated(lex_error)) then
+            if (len_trim(lex_error) > 0) then
+                write (error_unit, '(A)') 'FAIL: lexing error in '//filepath
+                error stop 1
+            end if
+        end if
+        call parse_tokens(tokens, arena, root_index, parse_error)
+    end subroutine parse_example
+
+    subroutine assert_rejected(filepath, expected_message)
+        character(len=*), intent(in) :: filepath
+        character(len=*), intent(in) :: expected_message
+        character(len=5000) :: parse_error
+
+        call parse_example(filepath, parse_error)
+        if (index(parse_error, expected_message) > 0) then
+            write (output_unit, '(A)') 'PASS: '//filepath//' -> '//expected_message
+            return
+        end if
+        failures = failures + 1
+        write (error_unit, '(A)') 'FAIL: '//filepath// &
+            ' did not report: '//expected_message
+        write (error_unit, '(A)') '  got: '//trim(parse_error)
+    end subroutine assert_rejected
+
+    subroutine assert_accepted(filepath)
+        character(len=*), intent(in) :: filepath
+        character(len=5000) :: parse_error
+
+        call parse_example(filepath, parse_error)
+        if (len_trim(parse_error) == 0) then
+            write (output_unit, '(A)') 'PASS: '//filepath//' still accepted'
+            return
+        end if
+        failures = failures + 1
+        write (error_unit, '(A)') 'FAIL: '//filepath//' was rejected'
+        write (error_unit, '(A)') '  got: '//trim(parse_error)
+    end subroutine assert_accepted
+
+    include '../common/read_example.inc'
+
+end program test_reject_label_01_diagnostics


### PR DESCRIPTION
Closes #2889.

## What was wrong

fortfront accepted all three gfortran.dg label fixtures with exit code 0:

| fixture | before | after |
|---|---|---|
| `empty_label.f90` | accepted, label dropped | `ERROR at line 3, column 1: Statement label without statement` |
| `label_1.f90` | accepted, `0056780 continue` / `0 continue` emitted verbatim | `Too many digits in statement label '0056780'` and `Zero is not a valid statement label` |
| `label_2.f90` | accepted, `10:` silently dropped, emitted `a = 10` | `Invalid character in statement label field` |

gfortran rejects all three; it accepts all three corrected neighbours.

## Rules implemented

Fortran 2023 clause 6.2.5 (one to five digits, at least one nonzero) and
6.3.2.3 (the label must be followed by the statement it labels, separated by
a blank in free source form).

`src/parser/statements/parser_statement_label.f90` holds the validator. It is
called from the two sites that consume a leading numeric token as a label:
`src/frontend/frontend_statement_token_parsing.f90` (implicit main) and
`src/parser/statements/parser_execution_statements_module.inc` (explicit
program body). `src/frontend/frontend_program_units.f90` surfaces the
frontend-side diagnostic through `error_msg` so the driver exits nonzero.

## Over-rejection guard

The "no blank after the label" rule fires only when a `TK_OPERATOR` begins at
the exact column where the label ends. That is precisely the `10: a = 10`
shape from `label_2.f90`. Any adjacent non-operator token is left alone
rather than guessed at.

Deliberately left out: labels on statements inside procedure bodies
(`parser_procedure_definition_bodies.f90`) are not validated. That site has
no `error_msg` path, only a diagnostic sink, so wiring it up is a separate
change. This is a coverage gap, not a source of false rejections.

## Verification

- Negative fixtures: `examples/f90/{empty_label,label_1,label_2}.f90`,
  registered in `examples/expected_diagnostics.txt`, each exits nonzero.
- Corrected neighbours: `examples/f90/{empty_label,label_1,label_2}_corrected.f90`,
  each compiles under gfortran and still parses cleanly here.
- `test/api/test_reject_label_01_diagnostics.f90` reads every fixture via
  `read_example` and asserts both directions.
- Five negative controls, each rebuilt and rerun: disabling the digit-count,
  zero, no-statement, and adjacency rules individually makes the matching
  rejection assertion fail; tightening the digit limit to four makes the
  `label_1_corrected` acceptance assertion fail.
- `fo` green: 483 tests pass, including `test_all_examples`, so valid-program
  acceptance is unchanged.
- `make check-duplication` reports only the pre-existing
  `test/api/test_compiler_statement_queries.f90` violation (#2910).