### PR TITLE
Reject invalid ENUM definitions

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -8,3 +8,8 @@ f90/issue_2562_where_invalid_if.f90
 f90/issue_2591_unsigned_mixing_error.f90
 lf/issue_2816_walrus_redeclaration.lf
 f90/issue_2819_pure_with_print.f90
+f90/enum_2.f90
+f90/enum_3.f90
+f90/enum_6.f90
+f90/enum_7.f90
+f90/enum_8.f90

--- a/examples/f90/enum_2.f90
+++ b/examples/f90/enum_2.f90
@@ -1,0 +1,12 @@
+! Invalid: an ENUM body may contain only ENUMERATOR statements (F2003 R460),
+! and an enumerator initializer requires the "::" separator.
+program enum_2
+    implicit none
+
+    enum, bind(c)
+        enumerator :: red, black
+        integer :: x
+        enumerator blue = 1
+    end enum
+
+end program enum_2

--- a/examples/f90/enum_2_valid.f90
+++ b/examples/f90/enum_2_valid.f90
@@ -1,0 +1,15 @@
+! Valid neighbor of enum_2: the ENUM body holds only ENUMERATOR statements and
+! the initialized enumerator uses the required "::" separator.
+program enum_2_valid
+    implicit none
+    integer :: x
+
+    enum, bind(c)
+        enumerator :: red, black
+        enumerator green, yellow
+        enumerator :: blue = 1
+    end enum
+
+    x = 0
+    print *, x
+end program enum_2_valid

--- a/examples/f90/enum_3.f90
+++ b/examples/f90/enum_3.f90
@@ -1,0 +1,11 @@
+! Invalid: an enumerator must be initialized with an integer expression
+! (F2003 4.6). A real or character initializer is not allowed.
+program enum_3
+    implicit none
+
+    enum, bind(c)
+        enumerator :: red, black = 2.2
+        enumerator :: blue = "x"
+    end enum
+
+end program enum_3

--- a/examples/f90/enum_3_valid.f90
+++ b/examples/f90/enum_3_valid.f90
@@ -1,0 +1,13 @@
+! Valid neighbor of enum_3: enumerators initialized with integer expressions,
+! including a signed literal and a kind-suffixed literal.
+program enum_3_valid
+    implicit none
+
+    enum, bind(c)
+        enumerator :: red, black = 2
+        enumerator :: blue = -3
+        enumerator :: white = 7_4
+    end enum
+
+    print *, "ok"
+end program enum_3_valid

--- a/examples/f90/enum_6.f90
+++ b/examples/f90/enum_6.f90
@@ -1,0 +1,13 @@
+! Invalid: an assignment statement is not an ENUM definition statement, so it
+! may not appear inside an ENUM body (F2003 R460).
+program enum_6
+    implicit none
+    integer :: i = 1
+
+    enum, bind(c)
+        enumerator :: sun, mon = 2
+        i = 2
+        enumerator :: wed = 1
+    end enum
+
+end program enum_6

--- a/examples/f90/enum_6_valid.f90
+++ b/examples/f90/enum_6_valid.f90
@@ -1,0 +1,14 @@
+! Valid neighbor of enum_6: the assignment lives in the executable part instead
+! of inside the ENUM body.
+program enum_6_valid
+    implicit none
+    integer :: i
+
+    enum, bind(c)
+        enumerator :: sun, mon = 2
+        enumerator :: wed = 1
+    end enum
+
+    i = 2
+    print *, i
+end program enum_6_valid

--- a/examples/f90/enum_7.f90
+++ b/examples/f90/enum_7.f90
@@ -1,0 +1,14 @@
+! Invalid: an ENUM definition may not be nested inside another ENUM body
+! (F2003 R460 admits only enumerator-def-stmt between ENUM and END ENUM).
+program enum_7
+    implicit none
+
+    enum, bind(c)
+        enumerator :: sun, mon = 2
+        enum, bind(c)
+            enumerator :: apple, mango
+        end enum
+        enumerator :: wed = 1
+    end enum
+
+end program enum_7

--- a/examples/f90/enum_7_valid.f90
+++ b/examples/f90/enum_7_valid.f90
@@ -1,0 +1,16 @@
+! Valid neighbor of enum_7: two ENUM definitions in sequence rather than one
+! nested inside the other.
+program enum_7_valid
+    implicit none
+
+    enum, bind(c)
+        enumerator :: sun, mon = 2
+        enumerator :: wed = 1
+    end enum
+
+    enum, bind(c)
+        enumerator :: apple, mango
+    end enum
+
+    print *, "ok"
+end program enum_7_valid

--- a/examples/f90/enum_8.f90
+++ b/examples/f90/enum_8.f90
@@ -1,0 +1,14 @@
+! Invalid: an enumerator value must fit the kind of the enumeration, which for
+! a bind(c) enumeration is the C int kind (F2003 4.6).
+program enum_8
+    implicit none
+
+    enum, bind(c)
+        enumerator :: pp, qq = 4294967295, rr
+    end enum
+
+    enum, bind(c)
+        enumerator :: p, q = 4294967299_8, r
+    end enum
+
+end program enum_8

--- a/examples/f90/enum_8_valid.f90
+++ b/examples/f90/enum_8_valid.f90
@@ -1,0 +1,15 @@
+! Valid neighbor of enum_8: enumerator values that fit the C int kind, taken at
+! both ends of the range.
+program enum_8_valid
+    implicit none
+
+    enum, bind(c)
+        enumerator :: pp, qq = 2147483646, rr
+    end enum
+
+    enum, bind(c)
+        enumerator :: p, q = -2147483647, r
+    end enum
+
+    print *, "ok"
+end program enum_8_valid

--- a/src/ast/factory/ast_factory_statements.f90
+++ b/src/ast/factory/ast_factory_statements.f90
@@ -211,12 +211,16 @@ contains
     end function push_common_block
 
     function push_enum(arena, enumerator_names, enumerator_values, is_bind_c, &
-            line, column, parent_index) result(enum_index)
+            line, column, parent_index, violation_messages, violation_lines, &
+            violation_columns) result(enum_index)
         type(ast_arena_t), intent(inout) :: arena
         type(string_t), intent(in) :: enumerator_names(:)
         integer, intent(in) :: enumerator_values(:)
         logical, intent(in) :: is_bind_c
         integer, intent(in), optional :: line, column, parent_index
+        type(string_t), intent(in), optional :: violation_messages(:)
+        integer, intent(in), optional :: violation_lines(:)
+        integer, intent(in), optional :: violation_columns(:)
         integer :: enum_index
         type(enum_node) :: node
 
@@ -224,6 +228,9 @@ contains
         node%enumerator_names = enumerator_names
         node%enumerator_values = enumerator_values
         node%is_bind_c = is_bind_c
+        if (present(violation_messages)) node%violation_messages = violation_messages
+        if (present(violation_lines)) node%violation_lines = violation_lines
+        if (present(violation_columns)) node%violation_columns = violation_columns
         if (present(line)) node%line = line
         if (present(column)) node%column = column
         call arena%push(node, "enum", parent_index)

--- a/src/ast/nodes/ast_nodes_legacy.f90
+++ b/src/ast/nodes/ast_nodes_legacy.f90
@@ -25,6 +25,12 @@ module ast_nodes_legacy
         logical :: is_bind_c = .false.
         type(string_t), allocatable :: enumerator_names(:)
         integer, allocatable :: enumerator_values(:)
+        ! Constraint violations found while parsing the ENUM body. The parser
+        ! records them here instead of failing the parse so that the semantic
+        ! layer reports them as source diagnostics with their own location.
+        type(string_t), allocatable :: violation_messages(:)
+        integer, allocatable :: violation_lines(:)
+        integer, allocatable :: violation_columns(:)
     contains
         procedure :: accept => enum_accept
         procedure :: assign => enum_assign
@@ -96,6 +102,21 @@ contains
             lhs%enumerator_values = rhs%enumerator_values
         else if (allocated(lhs%enumerator_values)) then
             deallocate (lhs%enumerator_values)
+        end if
+        if (allocated(rhs%violation_messages)) then
+            lhs%violation_messages = rhs%violation_messages
+        else if (allocated(lhs%violation_messages)) then
+            deallocate (lhs%violation_messages)
+        end if
+        if (allocated(rhs%violation_lines)) then
+            lhs%violation_lines = rhs%violation_lines
+        else if (allocated(lhs%violation_lines)) then
+            deallocate (lhs%violation_lines)
+        end if
+        if (allocated(rhs%violation_columns)) then
+            lhs%violation_columns = rhs%violation_columns
+        else if (allocated(lhs%violation_columns)) then
+            deallocate (lhs%violation_columns)
         end if
     end subroutine enum_assign
 

--- a/src/parser/declarations/parser_enum_statement.f90
+++ b/src/parser/declarations/parser_enum_statement.f90
@@ -5,16 +5,45 @@ module parser_enum_statement_module
     !   end enum
     ! Enumerator values follow F2003 4.6: an explicit value sets the counter;
     ! an implicit value is the previous value plus one, starting at zero.
+    !
+    ! The body of an enum-def (F2003 R460) admits nothing but
+    ! enumerator-def-stmt between ENUM and END ENUM, an initialized enumerator
+    ! requires the "::" separator, and an enumerator value must be an integer
+    ! within the kind of the enumeration. Violations are recorded on the node
+    ! and reported by semantic_enum_validation; the parser keeps parsing so a
+    ! single malformed enumerator does not swallow the rest of the unit.
     use lexer_core, only: token_t, TK_EOF, TK_IDENTIFIER, TK_KEYWORD, TK_NEWLINE, &
-        TK_COMMENT, TK_WHITESPACE, TK_OPERATOR, TK_NUMBER, to_lower
+        TK_COMMENT, TK_WHITESPACE, TK_OPERATOR, TK_NUMBER, TK_STRING, to_lower
     use parser_state_module, only: parser_state_t
     use ast_arena_modern, only: ast_arena_t
     use ast_base, only: string_t
     use ast_factory, only: push_enum
+    use semantic_constant_values, only: integer_literal_fits_default_kind
     implicit none
     private
 
     public :: parse_enum_construct
+
+    character(len=*), parameter :: MSG_UNEXPECTED_STATEMENT = &
+        "Unexpected statement in ENUM definition: only ENUMERATOR statements "// &
+        "may appear between ENUM and END ENUM"
+    character(len=*), parameter :: MSG_NESTED_ENUM = &
+        "Unexpected ENUM statement: an ENUM definition may not be nested "// &
+        "inside another ENUM definition"
+    character(len=*), parameter :: MSG_MISSING_COLONS = &
+        "Syntax error in ENUMERATOR definition: '::' is required before an "// &
+        "initialized enumerator"
+    character(len=*), parameter :: MSG_NON_INTEGER_VALUE = &
+        "ENUMERATOR must be initialized with an integer expression"
+    character(len=*), parameter :: MSG_VALUE_TOO_BIG = &
+        "ENUMERATOR value is too big for its kind"
+
+    ! Constraint violations collected while parsing one ENUM body.
+    type :: enum_violations_t
+        type(string_t), allocatable :: messages(:)
+        integer, allocatable :: lines(:)
+        integer, allocatable :: columns(:)
+    end type enum_violations_t
 
 contains
 
@@ -24,11 +53,13 @@ contains
         type(token_t) :: token
         type(string_t), allocatable :: names(:)
         integer, allocatable :: values(:)
+        type(enum_violations_t) :: violations
         logical :: is_bind_c
         integer :: line, column, next_value
 
         allocate (names(0))
         allocate (values(0))
+        call init_violations(violations)
         is_bind_c = .false.
         next_value = 0
 
@@ -47,17 +78,51 @@ contains
                 call consume_end_enum(parser)
                 exit
             end if
-            if ((token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER) .and. &
-                to_lower(trim(token%text)) == "enumerator") then
-                call parse_enumerator_line(parser, names, values, next_value)
+            if (is_word(token, "enumerator")) then
+                call parse_enumerator_line(parser, names, values, next_value, &
+                    violations)
+            else if (is_word(token, "enum")) then
+                call add_violation(violations, MSG_NESTED_ENUM, token)
+                call skip_nested_enum(parser)
             else
-                token = parser%consume()
+                call add_violation(violations, MSG_UNEXPECTED_STATEMENT, token)
+                call skip_rest_of_line(parser)
             end if
         end do
 
         stmt_index = push_enum(arena, names, values, is_bind_c, &
-            line=line, column=column)
+            line=line, column=column, &
+            violation_messages=violations%messages, &
+            violation_lines=violations%lines, &
+            violation_columns=violations%columns)
     end function parse_enum_construct
+
+    subroutine init_violations(violations)
+        type(enum_violations_t), intent(out) :: violations
+
+        allocate (violations%messages(0))
+        allocate (violations%lines(0))
+        allocate (violations%columns(0))
+    end subroutine init_violations
+
+    subroutine add_violation(violations, message, token)
+        type(enum_violations_t), intent(inout) :: violations
+        character(len=*), intent(in) :: message
+        type(token_t), intent(in) :: token
+
+        violations%messages = [violations%messages, string_t(message)]
+        violations%lines = [violations%lines, token%line]
+        violations%columns = [violations%columns, token%column]
+    end subroutine add_violation
+
+    logical function is_word(token, word) result(matches)
+        type(token_t), intent(in) :: token
+        character(len=*), intent(in) :: word
+
+        matches = .false.
+        if (token%kind /= TK_KEYWORD .and. token%kind /= TK_IDENTIFIER) return
+        matches = to_lower(trim(token%text)) == word
+    end function is_word
 
     logical function consume_enum_header(parser) result(is_bind_c)
         ! Consume the rest of the "enum[, bind(c)]" header line.
@@ -75,16 +140,52 @@ contains
         end do
     end function consume_enum_header
 
-    subroutine parse_enumerator_line(parser, names, values, next_value)
+    subroutine skip_rest_of_line(parser)
+        ! Discard the remainder of a statement that does not belong in an ENUM
+        ! body, so the ENUMERATOR statements that follow it still parse.
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%kind == TK_EOF) exit
+            token = parser%consume()
+            if (token%kind == TK_NEWLINE) exit
+        end do
+    end subroutine skip_rest_of_line
+
+    subroutine skip_nested_enum(parser)
+        ! Discard a nested enum-def, including its END ENUM, so that the inner
+        ! END ENUM does not terminate the enclosing definition.
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        call skip_rest_of_line(parser)
+        do while (.not. parser%is_at_end())
+            call skip_trivia_and_newlines(parser)
+            if (parser%is_at_end()) exit
+            if (is_end_enum(parser)) then
+                call consume_end_enum(parser)
+                exit
+            end if
+            token = parser%peek()
+            if (token%kind == TK_EOF) exit
+            call skip_rest_of_line(parser)
+        end do
+    end subroutine skip_nested_enum
+
+    subroutine parse_enumerator_line(parser, names, values, next_value, violations)
         type(parser_state_t), intent(inout) :: parser
         type(string_t), allocatable, intent(inout) :: names(:)
         integer, allocatable, intent(inout) :: values(:)
         integer, intent(inout) :: next_value
+        type(enum_violations_t), intent(inout) :: violations
         type(token_t) :: token
         integer :: this_value
+        logical :: has_colons
 
         token = parser%consume() ! consume "enumerator"
-        call skip_separator_tokens(parser) ! optional "::"
+        has_colons = consume_separator_tokens(parser)
 
         do while (.not. parser%is_at_end())
             call skip_inline_trivia(parser)
@@ -97,8 +198,11 @@ contains
                 call skip_inline_trivia(parser)
                 token = parser%peek()
                 if (token%kind == TK_OPERATOR .and. trim(token%text) == "=") then
+                    if (.not. has_colons) then
+                        call add_violation(violations, MSG_MISSING_COLONS, token)
+                    end if
                     token = parser%consume()
-                    this_value = parse_int_value(parser)
+                    this_value = parse_int_value(parser, violations)
                 end if
                 values = [values, this_value]
                 next_value = this_value + 1
@@ -108,10 +212,12 @@ contains
         end do
     end subroutine parse_enumerator_line
 
-    integer function parse_int_value(parser) result(value)
+    integer function parse_int_value(parser, violations) result(value)
         type(parser_state_t), intent(inout) :: parser
+        type(enum_violations_t), intent(inout) :: violations
         type(token_t) :: token
-        integer :: sign_factor, ios
+        integer :: sign_factor, magnitude
+        logical :: fits, is_integer
 
         value = 0
         sign_factor = 1
@@ -127,13 +233,40 @@ contains
             call skip_inline_trivia(parser)
             token = parser%peek()
         end if
-        if (token%kind == TK_NUMBER) then
-            read (token%text, *, iostat=ios) value
-            if (ios /= 0) value = 0
-            value = sign_factor * value
+        if (token%kind == TK_STRING) then
+            call add_violation(violations, MSG_NON_INTEGER_VALUE, token)
             token = parser%consume()
+            return
         end if
+        if (token%kind /= TK_NUMBER) return
+        if (is_real_literal_text(trim(token%text))) then
+            call add_violation(violations, MSG_NON_INTEGER_VALUE, token)
+            token = parser%consume()
+            return
+        end if
+        fits = integer_literal_fits_default_kind(trim(token%text), magnitude, &
+            is_integer_literal=is_integer)
+        if (is_integer .and. .not. fits) then
+            call add_violation(violations, MSG_VALUE_TOO_BIG, token)
+        end if
+        if (fits) value = sign_factor * magnitude
+        token = parser%consume()
     end function parse_int_value
+
+    logical function is_real_literal_text(text) result(is_real)
+        ! A numeric literal is real when it carries a decimal point or a real
+        ! exponent letter. Kind-suffixed integers such as 42_8 are not real.
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: lowered
+        integer :: underscore_pos
+
+        lowered = to_lower(text)
+        underscore_pos = index(lowered, '_')
+        if (underscore_pos > 0) lowered = lowered(1:underscore_pos - 1)
+        is_real = index(lowered, '.') > 0
+        if (.not. is_real) is_real = index(lowered, 'e') > 0
+        if (.not. is_real) is_real = index(lowered, 'd') > 0
+    end function is_real_literal_text
 
     logical function is_end_enum(parser) result(at_end)
         type(parser_state_t), intent(inout) :: parser
@@ -169,17 +302,19 @@ contains
         end if
     end subroutine consume_end_enum
 
-    subroutine skip_separator_tokens(parser)
+    logical function consume_separator_tokens(parser) result(has_colons)
         ! Skip whitespace and an optional "::" before the enumerator name list.
         type(parser_state_t), intent(inout) :: parser
         type(token_t) :: token
 
+        has_colons = .false.
         call skip_inline_trivia(parser)
         token = parser%peek()
         if (token%kind == TK_OPERATOR .and. trim(token%text) == "::") then
             token = parser%consume()
+            has_colons = .true.
         end if
-    end subroutine skip_separator_tokens
+    end function consume_separator_tokens
 
     subroutine skip_inline_trivia(parser)
         type(parser_state_t), intent(inout) :: parser

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -16,6 +16,7 @@ use constant_transformation, only: fold_constants_in_arena
 use error_handling, only: create_error_collection
 use type_hierarchy, only: create_type_hierarchy
 use semantic_type_hierarchy_validation, only: populate_type_hierarchy
+use semantic_enum_validation, only: validate_enum_definitions
 use call_graph_signatures_mod, only: create_signatures_map
 use semantic_validation_utils, only: int_to_str
 use ast_nodes_data, only: declaration_node
@@ -87,6 +88,10 @@ contains
         ! Register derived types and their EXTENDS parents so polymorphic
         ! resolution can consult the (now populated) inheritance hierarchy.
         call populate_type_hierarchy(arena, ctx%type_hierarchy, ctx%errors)
+
+        ! Report ENUM constraint violations recorded by the parser. The sweep
+        ! is arena-wide so module-level enumerations are covered too.
+        call validate_enum_definitions(arena, ctx%errors)
 
         if (trace_is_enabled()) then
             select type (ast => arena%entries(root_index)%node)

--- a/src/semantic/analyzers/semantic_constant_values.f90
+++ b/src/semantic/analyzers/semantic_constant_values.f90
@@ -1,4 +1,5 @@
 module semantic_constant_values
+    use, intrinsic :: iso_fortran_env, only: int32, int64
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: literal_node
     use ast_base, only: LITERAL_INTEGER
@@ -7,8 +8,54 @@ module semantic_constant_values
 
     public :: get_constant_integer_value
     public :: parse_literal_integer_value
+    public :: integer_literal_fits_default_kind
 
 contains
+
+    ! Decide whether an integer literal, written with or without a kind
+    ! parameter, denotes a value representable in the default integer kind.
+    ! An ENUM with BIND(C) is limited to that range because its kind is the
+    ! companion C processor's int (F2003 4.6), so a value outside it is an
+    ! error rather than a silently widened constant.
+    logical function integer_literal_fits_default_kind(raw_text, value, &
+            is_integer_literal) result(fits)
+        character(len=*), intent(in) :: raw_text
+        integer, intent(out) :: value
+        logical, intent(out), optional :: is_integer_literal
+        character(len=:), allocatable :: cleaned
+        integer(int64) :: wide_value
+        integer :: underscore_pos, ios, i, digit_count
+
+        fits = .false.
+        value = 0
+        if (present(is_integer_literal)) is_integer_literal = .false.
+
+        cleaned = trim(adjustl(raw_text))
+        underscore_pos = index(cleaned, '_')
+        if (underscore_pos > 0) cleaned = cleaned(1:underscore_pos - 1)
+        if (len(cleaned) == 0) return
+
+        ! Only plain decimal digits with an optional sign are handled here;
+        ! anything else is not an integer literal and is not this rule's case.
+        digit_count = 0
+        do i = 1, len(cleaned)
+            if (i == 1) then
+                if (cleaned(i:i) == '+' .or. cleaned(i:i) == '-') cycle
+            end if
+            if (cleaned(i:i) < '0' .or. cleaned(i:i) > '9') return
+            digit_count = digit_count + 1
+        end do
+        if (digit_count == 0) return
+        if (present(is_integer_literal)) is_integer_literal = .true.
+
+        read (cleaned, *, iostat=ios) wide_value
+        if (ios /= 0) return
+        if (wide_value > int(huge(0_int32), int64)) return
+        if (wide_value < -int(huge(0_int32), int64) - 1_int64) return
+
+        value = int(wide_value)
+        fits = .true.
+    end function integer_literal_fits_default_kind
 
     logical function get_constant_integer_value(arena, expr_index, value) &
             result(found)

--- a/src/semantic/analyzers/semantic_enum_validation.f90
+++ b/src/semantic/analyzers/semantic_enum_validation.f90
@@ -1,0 +1,58 @@
+module semantic_enum_validation
+    ! Report the ENUM constraint violations that the parser recorded on
+    ! enum_node (F2003 R460 and 4.6): only ENUMERATOR statements may appear in
+    ! an enum-def body, an initialized enumerator needs the "::" separator, and
+    ! an enumerator value must be an integer within the kind of the
+    ! enumeration. The sweep runs over the whole arena so that enumerations in
+    ! programs, modules, and multi-unit files are all covered.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_legacy, only: enum_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    implicit none
+    private
+
+    public :: validate_enum_definitions
+
+contains
+
+    subroutine validate_enum_definitions(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (enum_node)
+                call report_enum_violations(node, errors)
+            end select
+        end do
+    end subroutine validate_enum_definitions
+
+    subroutine report_enum_violations(node, errors)
+        type(enum_node), intent(in) :: node
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i, violation_line, violation_column
+
+        if (.not. allocated(node%violation_messages)) return
+
+        do i = 1, size(node%violation_messages)
+            violation_line = node%line
+            violation_column = node%column
+            if (allocated(node%violation_lines)) then
+                if (i <= size(node%violation_lines)) then
+                    violation_line = node%violation_lines(i)
+                end if
+            end if
+            if (allocated(node%violation_columns)) then
+                if (i <= size(node%violation_columns)) then
+                    violation_column = node%violation_columns(i)
+                end if
+            end if
+            call errors%add_error(node%violation_messages(i)%s, &
+                code=ERROR_SEMANTIC, component="semantic_enum_validation", &
+                line=violation_line, column=violation_column)
+        end do
+    end subroutine report_enum_violations
+
+end module semantic_enum_validation

--- a/test/api/test_reject_enum_01_diagnostics.f90
+++ b/test/api/test_reject_enum_01_diagnostics.f90
@@ -1,0 +1,97 @@
+program test_reject_enum_01_diagnostics
+    ! Issue #2899: ENUM grammar and value constraints (F2003 R460 and 4.6).
+    ! Each invalid form must produce a rule-specific source diagnostic, and the
+    ! corrected neighbour of every rule must still be accepted.
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use semantic_operating_mode, only: OPERATING_MODE_STRICT
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    print *, "=== Issue #2899: ENUM rejection diagnostics ==="
+
+    call expect_rejected('enum_2', 'only ENUMERATOR statements')
+    call expect_rejected('enum_2', "'::' is required")
+    call expect_rejected('enum_3', 'integer expression')
+    call expect_rejected('enum_6', 'only ENUMERATOR statements')
+    call expect_rejected('enum_7', 'may not be nested')
+    call expect_rejected('enum_8', 'too big for its kind')
+
+    call expect_accepted('enum_2_valid')
+    call expect_accepted('enum_3_valid')
+    call expect_accepted('enum_6_valid')
+    call expect_accepted('enum_7_valid')
+    call expect_accepted('enum_8_valid')
+
+    if (failures > 0) then
+        print *, 'FAIL: ', failures, ' ENUM diagnostic checks failed'
+        error stop 1
+    end if
+    print *, 'PASS: ENUM constraint diagnostics'
+
+contains
+
+    subroutine compile_example(name, error_msg, output_code)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable, intent(out) :: output_code
+        character(len=:), allocatable :: input_code
+        type(transform_context_t) :: context
+
+        call read_example('examples/f90/'//name//'.f90', input_code)
+
+        context%input_mode = INPUT_MODE_STANDARD
+        context%operating_mode = OPERATING_MODE_STRICT
+        context%has_filename = .true.
+        context%source_name = name
+
+        call transform_with_context(input_code, output_code, error_msg, context)
+    end subroutine compile_example
+
+    subroutine expect_rejected(name, expected_fragment)
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: expected_fragment
+        character(len=:), allocatable :: error_msg, output_code
+
+        call compile_example(name, error_msg, output_code)
+
+        if (len_trim(error_msg) == 0) then
+            print *, 'FAIL: ', name, ' was accepted but must be rejected'
+            failures = failures + 1
+            return
+        end if
+        if (index(error_msg, expected_fragment) == 0) then
+            print *, 'FAIL: ', name, ' diagnostic lacks "', expected_fragment, '"'
+            print *, 'Error: ', trim(error_msg)
+            failures = failures + 1
+            return
+        end if
+        print *, 'PASS: ', name, ' rejected with "', expected_fragment, '"'
+    end subroutine expect_rejected
+
+    subroutine expect_accepted(name)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: error_msg, output_code
+
+        call compile_example(name, error_msg, output_code)
+
+        if (len_trim(error_msg) /= 0) then
+            print *, 'FAIL: ', name, ' is valid but was rejected'
+            print *, 'Error: ', trim(error_msg)
+            failures = failures + 1
+            return
+        end if
+        if (index(output_code, 'enumerator') == 0) then
+            print *, 'FAIL: ', name, ' lost its ENUM definition'
+            print *, 'Output: ', trim(output_code)
+            failures = failures + 1
+            return
+        end if
+        print *, 'PASS: ', name, ' accepted'
+    end subroutine expect_accepted
+
+    include '../common/read_example.inc'
+end program test_reject_enum_01_diagnostics


### PR DESCRIPTION
Closes #2899.

Fortfront accepted every ENUM form that the gfortran.dg fixtures `enum_2`,
`enum_3`, `enum_6`, `enum_7`, and `enum_8` reject, and silently changed the
program while doing so: a stray declaration or assignment inside an ENUM body
was dropped, a nested ENUM closed the outer definition, a real or character
initializer became zero, and a value past the C int range became zero too.

## What is enforced

- Only ENUMERATOR statements may appear between ENUM and END ENUM (F2003 R460).
- An ENUM definition may not be nested inside another one.
- An initialized enumerator requires the `::` separator.
- An enumerator initializer may not be a real or character literal.
- An enumerator value must fit the default integer kind, which for a `bind(c)`
  enumeration is the companion C `int` (F2003 4.6). `4294967295` and
  `4294967299_8` are both rejected.

## How it works

The parser records violations on `enum_node` rather than discarding the
offending tokens, so a malformed enumerator no longer swallows the rest of the
unit. `semantic_enum_validation` sweeps the arena and turns each record into a
diagnostic with its own line and column, which makes the compile exit nonzero
through the normal semantic-error path and covers enumerations in programs,
modules, and multi-unit files alike. The literal range rule lives in
`semantic_constant_values` because it is a property of the literal.

## Deliberately not enforced

Statement ordering (an ENUM after the executable part, `enum_6`'s second
enumeration), assignment to an enumerator name, and a bare ENUMERATOR statement
outside any ENUM. Each of those is a different rule family; widening this check
to cover them by proximity would risk rejecting valid programs. Every listed
fixture is still rejected by the rules above.

## Verification

- `fo test test_reject_enum_01_diagnostics` passes.
- Negative controls: dropping the recorded violations makes all six rejection
  assertions fail; making the range check accept any magnitude makes only the
  `enum_8` assertion fail; reporting a violation for every enumerator statement
  makes all five corrected-neighbour assertions fail. No assertion is vacuous.
- Valid-program coverage: the five corrected neighbours are accepted and still
  emit their enumerations, and `test_all_examples` (which transforms and
  compiles every example) passes.
- `make check-duplication` reports only the pre-existing violation in
  `test/api/test_compiler_statement_queries.f90` tracked by #2910.