### PR TITLE
Enforce PURE, ELEMENTAL and prefix restrictions (closes #2885)

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -37,3 +37,11 @@ f90/pr93423.f90
 f90/submodule_36.f90
 f90/pr89943_3.f90
 f90/pr89943_4.f90
+f90/class_dummy_5.f90
+f90/do_concurrent_3.f90
+f90/elemental_args_check_2.f90
+f90/elemental_pointer_1.f90
+f90/elemental_result_1.f90
+f90/impure_assignment_2.f90
+f90/pure_formal_proc_3.f90
+f90/recursive_check_3.f90

--- a/examples/f90/class_dummy_5.f90
+++ b/examples/f90/class_dummy_5.f90
@@ -1,0 +1,22 @@
+program class_dummy_5
+    ! INVALID: F2008 C1279. In a PURE subprogram a dummy argument with the
+    ! INTENT(OUT) attribute shall not be polymorphic, because finalization of
+    ! the actual argument could call an impure final subroutine.
+    implicit none
+
+    type :: t
+        integer :: i = 0
+    end type t
+
+    type(t) :: x
+
+    call foo(x)
+
+contains
+
+    pure subroutine foo(y)
+        class(t), intent(out) :: y
+        y%i = 0
+    end subroutine foo
+
+end program class_dummy_5

--- a/examples/f90/class_dummy_5_valid.f90
+++ b/examples/f90/class_dummy_5_valid.f90
@@ -1,0 +1,28 @@
+program class_dummy_5_valid
+    ! VALID neighbour of class_dummy_5.f90. A polymorphic dummy argument is
+    ! allowed in a PURE procedure as long as it is not INTENT(OUT), and an
+    ! INTENT(OUT) polymorphic dummy is allowed in an impure procedure.
+    implicit none
+
+    type :: t
+        integer :: i = 0
+    end type t
+
+    type(t) :: x
+
+    call keep(x)
+    call reset(x)
+
+contains
+
+    pure subroutine keep(y)
+        class(t), intent(inout) :: y
+        y%i = y%i + 1
+    end subroutine keep
+
+    subroutine reset(y)
+        class(t), intent(out) :: y
+        y%i = 0
+    end subroutine reset
+
+end program class_dummy_5_valid

--- a/examples/f90/do_concurrent_3.f90
+++ b/examples/f90/do_concurrent_3.f90
@@ -1,0 +1,15 @@
+program do_concurrent_3
+    ! INVALID: F2008 C1283 via 8.1.6.5. The body of a DO CONCURRENT construct
+    ! is a pure context, so it may not reference an impure intrinsic
+    ! subroutine such as RANDOM_NUMBER.
+    implicit none
+    integer :: i
+    real :: array(123), val
+
+    do concurrent(i=1:123)
+        call random_number(val)
+        array(i) = val
+    end do
+
+    print *, array(1)
+end program do_concurrent_3

--- a/examples/f90/do_concurrent_3_valid.f90
+++ b/examples/f90/do_concurrent_3_valid.f90
@@ -1,0 +1,16 @@
+program do_concurrent_3_valid
+    ! VALID neighbour of do_concurrent_3.f90. The impure intrinsic subroutine
+    ! is called outside the DO CONCURRENT construct; the construct body only
+    ! performs pure work.
+    implicit none
+    integer :: i
+    real :: array(123), val
+
+    call random_number(val)
+
+    do concurrent(i=1:123)
+        array(i) = val*real(i)
+    end do
+
+    print *, array(1)
+end program do_concurrent_3_valid

--- a/examples/f90/elemental_args_check_2.f90
+++ b/examples/f90/elemental_args_check_2.f90
@@ -1,0 +1,17 @@
+program elemental_args_check_2
+    ! INVALID: F2003 C1277. A dummy argument of an ELEMENTAL procedure shall
+    ! be a data object, so a dummy procedure is not allowed.
+    implicit none
+
+contains
+
+    pure elemental subroutine s1(i, f)
+        integer, intent(in) :: i
+        interface
+            pure integer function f(j)
+                integer, intent(in) :: j
+            end function f
+        end interface
+    end subroutine s1
+
+end program elemental_args_check_2

--- a/examples/f90/elemental_args_check_2_valid.f90
+++ b/examples/f90/elemental_args_check_2_valid.f90
@@ -1,0 +1,24 @@
+program elemental_args_check_2_valid
+    ! VALID neighbour of elemental_args_check_2.f90. The dummy procedure moves
+    ! to a plain PURE subroutine, and the ELEMENTAL subroutine keeps only
+    ! scalar data dummies.
+    implicit none
+
+contains
+
+    pure subroutine s1(i, f)
+        integer, intent(in) :: i
+        interface
+            pure integer function f(j)
+                integer, intent(in) :: j
+            end function f
+        end interface
+    end subroutine s1
+
+    pure elemental subroutine s2(i, j)
+        integer, intent(in) :: i
+        integer, intent(out) :: j
+        j = i + 1
+    end subroutine s2
+
+end program elemental_args_check_2_valid

--- a/examples/f90/elemental_pointer_1.f90
+++ b/examples/f90/elemental_pointer_1.f90
@@ -1,0 +1,18 @@
+program elemental_pointer_1
+    ! INVALID: F2008 12.8.1. The result of an ELEMENTAL function shall be
+    ! scalar and shall not have the POINTER attribute.
+    !
+    ! The gfortran fixture spells POINTER as a separate attribute statement
+    ! ("POINTER :: LL"). FortFront's parser currently drops standalone
+    ! attribute statements, so the constraint is exercised here through the
+    ! type-declaration spelling of the same attribute.
+    implicit none
+
+contains
+
+    elemental function ll(i)
+        integer, intent(in) :: i
+        integer, pointer :: ll
+    end function ll
+
+end program elemental_pointer_1

--- a/examples/f90/elemental_pointer_1_valid.f90
+++ b/examples/f90/elemental_pointer_1_valid.f90
@@ -1,0 +1,22 @@
+program elemental_pointer_1_valid
+    ! VALID neighbour of elemental_pointer_1.f90. The ELEMENTAL function has a
+    ! scalar non-pointer result, and the POINTER result appears only on an
+    ! ordinary function.
+    implicit none
+
+contains
+
+    elemental function ll(i)
+        integer, intent(in) :: i
+        integer :: ll
+        ll = i + 1
+    end function ll
+
+    function mm(i) result(res)
+        integer, intent(in) :: i
+        integer, pointer :: res
+        allocate (res)
+        res = i
+    end function mm
+
+end program elemental_pointer_1_valid

--- a/examples/f90/elemental_result_1.f90
+++ b/examples/f90/elemental_result_1.f90
@@ -1,0 +1,13 @@
+program elemental_result_1
+    ! INVALID: F2008 12.8.1. The result of an ELEMENTAL function shall be
+    ! scalar; an array result is not allowed.
+    implicit none
+
+contains
+
+    elemental function ll(i)
+        integer, intent(in) :: i
+        integer :: ll(2)
+    end function ll
+
+end program elemental_result_1

--- a/examples/f90/elemental_result_1_valid.f90
+++ b/examples/f90/elemental_result_1_valid.f90
@@ -1,0 +1,21 @@
+program elemental_result_1_valid
+    ! VALID neighbour of elemental_result_1.f90. The ELEMENTAL function keeps a
+    ! scalar result; the array-valued form is written as an ordinary function.
+    implicit none
+
+contains
+
+    elemental function ll(i)
+        integer, intent(in) :: i
+        integer :: ll
+        ll = i*2
+    end function ll
+
+    function mm(i)
+        integer, intent(in) :: i
+        integer :: mm(2)
+        mm(1) = i
+        mm(2) = i + 1
+    end function mm
+
+end program elemental_result_1_valid

--- a/examples/f90/impure_assignment_2.f90
+++ b/examples/f90/impure_assignment_2.f90
@@ -1,0 +1,20 @@
+program impure_assignment_2
+    ! INVALID: F2008 C1283. In a PURE subprogram a designator whose base object
+    ! is a dummy argument of a PURE FUNCTION shall not appear in a variable
+    ! definition context, which includes the left side of a pointer assignment.
+    implicit none
+
+    type :: node_type
+        type(node_type), pointer :: next => null()
+    end type node_type
+
+contains
+
+    pure function give_next(node) result(res)
+        type(node_type), pointer :: node
+        type(node_type), pointer :: res
+        res => node%next
+        node%next => res
+    end function give_next
+
+end program impure_assignment_2

--- a/examples/f90/impure_assignment_2_valid.f90
+++ b/examples/f90/impure_assignment_2_valid.f90
@@ -1,0 +1,25 @@
+program impure_assignment_2_valid
+    ! VALID neighbour of impure_assignment_2.f90. The PURE function only reads
+    ! its dummy argument; the definition of the dummy moves into an impure
+    ! subroutine where a variable definition context is allowed.
+    implicit none
+
+    type :: node_type
+        type(node_type), pointer :: next => null()
+    end type node_type
+
+contains
+
+    pure function give_next(node) result(res)
+        type(node_type), pointer :: node
+        type(node_type), pointer :: res
+        res => node%next
+    end function give_next
+
+    subroutine link(node, other)
+        type(node_type), pointer :: node
+        type(node_type), pointer :: other
+        node%next => other
+    end subroutine link
+
+end program impure_assignment_2_valid

--- a/examples/f90/pure_formal_proc_3.f90
+++ b/examples/f90/pure_formal_proc_3.f90
@@ -1,0 +1,18 @@
+program pure_formal_proc_3
+    ! INVALID: F2008 C1290. A dummy procedure of a PURE procedure shall itself
+    ! be PURE, otherwise the pure procedure could reference impure code.
+    implicit none
+
+contains
+
+    pure function f(proc) result(res)
+        integer :: res
+        interface
+            function proc()
+                integer :: proc
+            end function proc
+        end interface
+        res = 0
+    end function f
+
+end program pure_formal_proc_3

--- a/examples/f90/pure_formal_proc_3_valid.f90
+++ b/examples/f90/pure_formal_proc_3_valid.f90
@@ -1,0 +1,29 @@
+program pure_formal_proc_3_valid
+    ! VALID neighbour of pure_formal_proc_3.f90. The dummy procedure of the
+    ! PURE function is itself declared PURE, and the impure dummy procedure is
+    ! only used by an impure function.
+    implicit none
+
+contains
+
+    pure function f(proc) result(res)
+        integer :: res
+        interface
+            pure function proc()
+                integer :: proc
+            end function proc
+        end interface
+        res = proc()
+    end function f
+
+    function g(proc) result(res)
+        integer :: res
+        interface
+            function proc()
+                integer :: proc
+            end function proc
+        end interface
+        res = proc()
+    end function g
+
+end program pure_formal_proc_3_valid

--- a/examples/f90/recursive_check_3.f90
+++ b/examples/f90/recursive_check_3.f90
@@ -1,0 +1,12 @@
+program recursive_check_3
+    ! INVALID: F2008 R1229 and C1240. A prefix shall not specify the same
+    ! prefix-spec more than once, so a repeated PURE keyword is an error.
+    implicit none
+
+contains
+
+    pure pure subroutine a1(b)
+        real, intent(in) :: b
+    end subroutine a1
+
+end program recursive_check_3

--- a/examples/f90/recursive_check_3_valid.f90
+++ b/examples/f90/recursive_check_3_valid.f90
@@ -1,0 +1,23 @@
+program recursive_check_3_valid
+    ! VALID neighbour of recursive_check_3.f90. Each prefix keyword appears at
+    ! most once, and distinct keywords may still be combined.
+    implicit none
+
+contains
+
+    pure subroutine a1(b)
+        real, intent(in) :: b
+    end subroutine a1
+
+    pure elemental subroutine a2(b, c)
+        real, intent(in) :: b
+        real, intent(out) :: c
+        c = b
+    end subroutine a2
+
+    recursive subroutine a3(n)
+        integer, intent(in) :: n
+        if (n > 0) call a3(n - 1)
+    end subroutine a3
+
+end program recursive_check_3_valid

--- a/src/parser/statements/parser_execution_statements_module.inc
+++ b/src/parser/statements/parser_execution_statements_module.inc
@@ -175,6 +175,26 @@
             call prefix_buffer%clear()
         end subroutine flush_pending_prefixes
 
+        ! F2008 R1229: a prefix shall not specify the same prefix-spec twice.
+        ! The pending list holds the prefix keywords already read for the
+        ! procedure that is being started, so a repeat is a source error.
+        subroutine reject_repeated_prefix(parser_ref, keyword_token, lowered)
+            type(parser_state_t), intent(inout) :: parser_ref
+            type(token_t), intent(in) :: keyword_token
+            character(len=*), intent(in) :: lowered
+            integer :: i
+
+            if (.not. allocated(pending_prefixes)) return
+            do i = 1, size(pending_prefixes)
+                if (trim(pending_prefixes(i)) /= trim(lowered)) cycle
+                call parser_ref%error_at_token('duplicate '//trim(lowered)// &
+                    ' attribute specified for this procedure', keyword_token, &
+                    suggestion='specify each procedure prefix keyword at '// &
+                    'most once')
+                return
+            end do
+        end subroutine reject_repeated_prefix
+
         logical function end_program_encountered(current_token) result(is_end)
             type(token_t), intent(in) :: current_token
             character(len=:), allocatable :: lowered
@@ -270,6 +290,7 @@
                         return
                     end if
                 end if
+                call reject_repeated_prefix(parser_ref, keyword_token, lowered)
                 call append_prefix_token(pending_prefixes, lowered)
                 block
                     type(token_t) :: ignored_token

--- a/src/semantic/analyzers/README.md
+++ b/src/semantic/analyzers/README.md
@@ -71,7 +71,8 @@ For complete semantic analysis concepts including type inference, scope manageme
 | semantic_identifier_context.f90 | Identifier usage context tracking |
 | semantic_undefined_variable_checker.f90 | Detect usage of undefined variables |
 | semantic_walrus_checker.f90 | Detect same-scope redeclaration via walrus `:=` |
-| semantic_pure_validation.f90 | Enforce PURE/ELEMENTAL body restrictions (no I/O, STOP, PAUSE) |
+| semantic_pure_validation.f90 | Enforce PURE/ELEMENTAL body restrictions (no I/O, STOP, PAUSE) and reject impure intrinsic subroutine calls inside DO CONCURRENT |
+| semantic_pure_dummy_validation.f90 | Enforce PURE dummy-argument rules: no polymorphic INTENT(OUT) dummy, dummy procedures must be PURE, PURE FUNCTION dummies are not definable |
 | semantic_bind_c_validation.f90 | Enforce BIND(C) interoperability constraints on derived-type components and procedure dummies (F2003 15.3.2) |
 | semantic_elemental_validation.f90 | Enforce ELEMENTAL scalar-dummy restriction (no array dummies) |
 | semantic_type_hierarchy_validation.f90 | Register derived types and EXTENDS parents into the inheritance hierarchy; report unknown-parent EXTENDS |

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -18,7 +18,8 @@ use semantic_operating_mode, only: OPERATING_MODE_STRICT
 use semantic_input_mode, only: INPUT_MODE_STANDARD
 use semantic_identifier_context, only: find_program_owner
 use semantic_where_validation, only: validate_where_construct
-use semantic_pure_validation, only: validate_pure_procedure
+use semantic_pure_validation, only: validate_pure_procedure, &
+    validate_do_concurrent_purity
 use semantic_bind_c_validation, only: validate_bind_c_derived_type, &
     validate_bind_c_procedure
 use semantic_elemental_validation, only: validate_elemental_procedure

--- a/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part1.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part1.inc
@@ -423,6 +423,12 @@
             type(mono_type_t) :: control_type
             integer :: i
 
+            ! The body of DO CONCURRENT is a pure context (F2008 8.1.6.5)
+            if (expr%is_concurrent) then
+                call validate_do_concurrent_purity(arena, expr%body_indices, &
+                                                   this%errors)
+            end if
+
             call process_do_loop_body(expr, int_scheme, control_type)
             if (allocated(expr%var_name)) then
                 call this%scopes%define(expr%var_name, int_scheme)

--- a/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
@@ -19,7 +19,9 @@
 
             ! Enforce PURE/ELEMENTAL body restrictions (F2008 C1283)
             call validate_pure_procedure(arena, expr%body_indices, &
-                                         expr%prefix_keywords, this%errors)
+                                         expr%prefix_keywords, this%errors, &
+                                         param_indices=expr%param_indices, &
+                                         is_function=.true.)
             ! Enforce ELEMENTAL scalar-dummy restriction (F2008 C1290)
             if (allocated(expr%result_variable)) then
                 elemental_result_name = expr%result_variable
@@ -72,7 +74,9 @@
 
             ! Enforce PURE/ELEMENTAL body restrictions (F2008 C1283)
             call validate_pure_procedure(arena, expr%body_indices, &
-                                         expr%prefix_keywords, this%errors)
+                                         expr%prefix_keywords, this%errors, &
+                                         param_indices=expr%param_indices, &
+                                         is_function=.false.)
             ! Enforce ELEMENTAL scalar-dummy restriction (F2008 C1290)
             call validate_elemental_procedure(arena, expr%param_indices, &
                                               expr%body_indices, &

--- a/src/semantic/analyzers/semantic_pure_dummy_validation.f90
+++ b/src/semantic/analyzers/semantic_pure_dummy_validation.f90
@@ -1,0 +1,399 @@
+module semantic_pure_dummy_validation
+    ! Validates the dummy arguments of a PURE procedure.
+    !
+    ! F2008 C1279: a dummy argument of a PURE subprogram that has the
+    ! INTENT(OUT) attribute shall not be polymorphic, because finalizing the
+    ! actual argument could invoke an impure final subroutine.
+    !
+    ! F2008 C1290: a dummy procedure of a PURE procedure shall be PURE.
+    !
+    ! F2008 C1283: in a PURE subprogram a designator whose base object is a
+    ! dummy argument of a PURE FUNCTION shall not appear in a variable
+    ! definition context.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: identifier_node, assignment_node, &
+        pointer_assignment_node, component_access_node, call_or_subscript_node, &
+        range_subscript_node
+    use ast_nodes_data, only: declaration_node, parameter_declaration_node, &
+        INTENT_OUT
+    use ast_nodes_misc, only: interface_block_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+    use ast_nodes_loops, only: do_loop_node, do_while_node
+    use ast_nodes_conditional, only: if_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use string_utils_mod, only: int_to_string, to_lower
+    implicit none
+    private
+
+    public :: validate_pure_dummies
+
+contains
+
+    ! Entry point. The caller has already established that the enclosing
+    ! procedure is PURE (explicitly or through ELEMENTAL).
+    subroutine validate_pure_dummies(arena, param_indices, body_indices, &
+            is_function, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: param_indices(:)
+        integer, allocatable, intent(in) :: body_indices(:)
+        logical, intent(in) :: is_function
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+        character(len=:), allocatable :: name
+
+        if (.not. allocated(param_indices)) return
+        if (.not. allocated(body_indices)) return
+
+        do i = 1, size(param_indices)
+            name = dummy_name(arena, param_indices(i))
+            if (len_trim(name) == 0) cycle
+            call check_polymorphic_intent_out(arena, body_indices, name, errors)
+            call check_dummy_procedure_purity(arena, body_indices, name, errors)
+        end do
+
+        if (is_function) then
+            call check_dummy_definitions(arena, param_indices, body_indices, errors)
+        end if
+    end subroutine validate_pure_dummies
+
+    ! C1279: polymorphic INTENT(OUT) dummy argument.
+    subroutine check_polymorphic_intent_out(arena, body_indices, name, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: name
+        type(error_collection_t), intent(inout) :: errors
+        integer :: decl_index
+
+        decl_index = find_declaration(arena, body_indices, name)
+        if (decl_index <= 0) return
+
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            if (.not. is_polymorphic_type(node%type_name)) return
+            if (.not. node%has_intent) return
+            if (.not. allocated(node%intent)) return
+            if (to_lower(trim(node%intent)) /= 'out') return
+            call report(errors, 'dummy argument "'//trim(name)// &
+                '" of a PURE procedure may not be polymorphic with '// &
+                'INTENT(OUT)', &
+                'drop INTENT(OUT), make the dummy non-polymorphic, or drop '// &
+                'the PURE prefix', node%line, node%column)
+            type is (parameter_declaration_node)
+            if (.not. is_polymorphic_type(node%type_name)) return
+            if (node%intent_type /= INTENT_OUT) return
+            call report(errors, 'dummy argument "'//trim(name)// &
+                '" of a PURE procedure may not be polymorphic with '// &
+                'INTENT(OUT)', &
+                'drop INTENT(OUT), make the dummy non-polymorphic, or drop '// &
+                'the PURE prefix', node%line, node%column)
+        end select
+    end subroutine check_polymorphic_intent_out
+
+    ! C1290: a dummy procedure of a PURE procedure must itself be PURE.
+    subroutine check_dummy_procedure_purity(arena, body_indices, name, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: name
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i, j, proc_index
+
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (node => arena%entries(body_indices(i))%node)
+                type is (interface_block_node)
+                if (.not. allocated(node%procedure_indices)) cycle
+                do j = 1, size(node%procedure_indices)
+                    proc_index = node%procedure_indices(j)
+                    if (.not. arena%has_node_at(proc_index)) cycle
+                    if (.not. interface_body_names(arena, proc_index, name)) cycle
+                    if (interface_body_is_pure(arena, proc_index)) cycle
+                    call report(errors, 'dummy procedure "'//trim(name)// &
+                        '" of a PURE procedure must also be PURE', &
+                        'add the PURE prefix to the dummy procedure '// &
+                        'interface, or drop the PURE prefix', &
+                        arena%entries(proc_index)%node%line, &
+                        arena%entries(proc_index)%node%column)
+                end do
+            end select
+        end do
+    end subroutine check_dummy_procedure_purity
+
+    ! C1283: dummy arguments of a PURE FUNCTION are not definable.
+    subroutine check_dummy_definitions(arena, param_indices, body_indices, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_indices(:)
+        integer, intent(in) :: body_indices(:)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=64), allocatable :: names(:)
+        character(len=:), allocatable :: name
+        integer :: i, count
+
+        allocate (names(size(param_indices)))
+        count = 0
+        do i = 1, size(param_indices)
+            name = dummy_name(arena, param_indices(i))
+            if (len_trim(name) == 0) cycle
+            if (len_trim(name) > len(names)) cycle
+            if (dummy_has_value(arena, body_indices, name)) cycle
+            count = count + 1
+            names(count) = to_lower(trim(name))
+        end do
+        if (count == 0) return
+
+        call scan_definitions(arena, body_indices, names(1:count), errors)
+    end subroutine check_dummy_definitions
+
+    recursive subroutine scan_definitions(arena, body_indices, names, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: names(:)
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            call scan_definition_statement(arena, body_indices(i), names, errors)
+        end do
+    end subroutine scan_definitions
+
+    recursive subroutine scan_definition_statement(arena, stmt_index, names, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: stmt_index
+        character(len=*), intent(in) :: names(:)
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        select type (stmt => arena%entries(stmt_index)%node)
+            type is (assignment_node)
+            call report_if_dummy(arena, stmt%target_index, names, errors, &
+                stmt%line, stmt%column)
+            type is (pointer_assignment_node)
+            call report_if_dummy(arena, stmt%pointer_index, names, errors, &
+                stmt%line, stmt%column)
+            type is (do_loop_node)
+            if (allocated(stmt%body_indices)) &
+                call scan_definitions(arena, stmt%body_indices, names, errors)
+            type is (do_while_node)
+            if (allocated(stmt%body_indices)) &
+                call scan_definitions(arena, stmt%body_indices, names, errors)
+            type is (if_node)
+            if (allocated(stmt%then_body_indices)) &
+                call scan_definitions(arena, stmt%then_body_indices, names, errors)
+            if (allocated(stmt%elseif_blocks)) then
+                do i = 1, size(stmt%elseif_blocks)
+                    if (allocated(stmt%elseif_blocks(i)%body_indices)) &
+                        call scan_definitions(arena, &
+                        stmt%elseif_blocks(i)%body_indices, names, errors)
+                end do
+            end if
+            if (allocated(stmt%else_body_indices)) &
+                call scan_definitions(arena, stmt%else_body_indices, names, errors)
+        end select
+    end subroutine scan_definition_statement
+
+    subroutine report_if_dummy(arena, target_index, names, errors, line, column)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: target_index
+        character(len=*), intent(in) :: names(:)
+        type(error_collection_t), intent(inout) :: errors
+        integer, intent(in) :: line, column
+        character(len=:), allocatable :: base
+        integer :: i
+
+        base = base_object_name(arena, target_index)
+        if (len_trim(base) == 0) return
+        do i = 1, size(names)
+            if (trim(names(i)) /= to_lower(trim(base))) cycle
+            call report(errors, 'dummy argument "'//trim(base)// &
+                '" of a PURE FUNCTION appears in a variable definition '// &
+                'context', &
+                'read the dummy argument only, or make the procedure a '// &
+                'PURE SUBROUTINE', line, column)
+            return
+        end do
+    end subroutine report_if_dummy
+
+    ! Innermost base object of a designator such as a, a%b, a(i) or a(i:j).
+    recursive function base_object_name(arena, node_index) result(name)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: name
+
+        name = ''
+        if (node_index <= 0) return
+        if (.not. arena%has_node_at(node_index)) return
+
+        select type (node => arena%entries(node_index)%node)
+            type is (identifier_node)
+            if (allocated(node%name)) name = trim(node%name)
+            type is (component_access_node)
+            name = base_object_name(arena, node%base_expr_index)
+            type is (range_subscript_node)
+            name = base_object_name(arena, node%base_expr_index)
+            type is (call_or_subscript_node)
+            if (node%base_expr_index > 0) then
+                name = base_object_name(arena, node%base_expr_index)
+            else if (allocated(node%name)) then
+                name = trim(node%name)
+            end if
+        end select
+    end function base_object_name
+
+    function dummy_name(arena, param_index) result(name)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: param_index
+        character(len=:), allocatable :: name
+
+        name = ''
+        if (.not. arena%has_node_at(param_index)) return
+
+        select type (node => arena%entries(param_index)%node)
+            type is (identifier_node)
+            if (allocated(node%name)) name = trim(node%name)
+            type is (declaration_node)
+            if (allocated(node%var_name)) name = trim(node%var_name)
+            type is (parameter_declaration_node)
+            if (allocated(node%name)) name = trim(node%name)
+        end select
+    end function dummy_name
+
+    function find_declaration(arena, body_indices, name) result(decl_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: name
+        integer :: decl_index
+        integer :: i
+
+        decl_index = 0
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (node => arena%entries(body_indices(i))%node)
+                type is (declaration_node)
+                if (declaration_names(node, name)) then
+                    decl_index = body_indices(i)
+                    return
+                end if
+                type is (parameter_declaration_node)
+                if (.not. allocated(node%name)) cycle
+                if (to_lower(trim(node%name)) == to_lower(trim(name))) then
+                    decl_index = body_indices(i)
+                    return
+                end if
+            end select
+        end do
+    end function find_declaration
+
+    function declaration_names(node, name) result(matches)
+        type(declaration_node), intent(in) :: node
+        character(len=*), intent(in) :: name
+        logical :: matches
+        integer :: i
+        character(len=:), allocatable :: lowered
+
+        matches = .false.
+        lowered = to_lower(trim(name))
+        if (allocated(node%var_name)) then
+            if (to_lower(trim(node%var_name)) == lowered) then
+                matches = .true.
+                return
+            end if
+        end if
+        if (.not. allocated(node%var_names)) return
+        do i = 1, size(node%var_names)
+            if (to_lower(trim(node%var_names(i))) == lowered) then
+                matches = .true.
+                return
+            end if
+        end do
+    end function declaration_names
+
+    function dummy_has_value(arena, body_indices, name) result(has_value)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: name
+        logical :: has_value
+        integer :: decl_index
+
+        has_value = .false.
+        decl_index = find_declaration(arena, body_indices, name)
+        if (decl_index <= 0) return
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            has_value = node%is_value
+        end select
+    end function dummy_has_value
+
+    function is_polymorphic_type(type_name) result(is_polymorphic)
+        character(len=:), allocatable, intent(in) :: type_name
+        logical :: is_polymorphic
+        character(len=:), allocatable :: lowered
+
+        is_polymorphic = .false.
+        if (.not. allocated(type_name)) return
+        lowered = to_lower(trim(type_name))
+        if (len(lowered) < 5) return
+        is_polymorphic = lowered(1:5) == 'class'
+    end function is_polymorphic_type
+
+    function interface_body_names(arena, proc_index, name) result(matches)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_index
+        character(len=*), intent(in) :: name
+        logical :: matches
+
+        matches = .false.
+        select type (node => arena%entries(proc_index)%node)
+            type is (function_def_node)
+            if (allocated(node%name)) &
+                matches = to_lower(trim(node%name)) == to_lower(trim(name))
+            type is (subroutine_def_node)
+            if (allocated(node%name)) &
+                matches = to_lower(trim(node%name)) == to_lower(trim(name))
+        end select
+    end function interface_body_names
+
+    function interface_body_is_pure(arena, proc_index) result(is_pure)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: proc_index
+        logical :: is_pure
+
+        is_pure = .false.
+        select type (node => arena%entries(proc_index)%node)
+            type is (function_def_node)
+            is_pure = prefix_is_pure(node%prefix_keywords)
+            type is (subroutine_def_node)
+            is_pure = prefix_is_pure(node%prefix_keywords)
+        end select
+    end function interface_body_is_pure
+
+    function prefix_is_pure(prefix_keywords) result(is_pure)
+        character(len=*), allocatable, intent(in) :: prefix_keywords(:)
+        logical :: is_pure
+        integer :: i
+
+        is_pure = .false.
+        if (.not. allocated(prefix_keywords)) return
+        do i = 1, size(prefix_keywords)
+            select case (to_lower(trim(prefix_keywords(i))))
+            case ('pure', 'elemental')
+                is_pure = .true.
+            case ('impure')
+                is_pure = .false.
+                return
+            end select
+        end do
+    end function prefix_is_pure
+
+    subroutine report(errors, message, suggestion, line, column)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: message, suggestion
+        integer, intent(in) :: line, column
+
+        call errors%add_error(message=message, code=ERROR_SEMANTIC, &
+            component='semantic_pure_dummy_validation', &
+            context='line '//int_to_string(line)//', column '// &
+            int_to_string(column), suggestion=suggestion, line=line, &
+            column=column, end_line=line, end_column=column + 1)
+    end subroutine report
+
+end module semantic_pure_dummy_validation

--- a/src/semantic/analyzers/semantic_pure_validation.f90
+++ b/src/semantic/analyzers/semantic_pure_validation.f90
@@ -10,12 +10,27 @@ module semantic_pure_validation
     use ast_nodes_transfer, only: stop_node, pause_node
     use ast_nodes_loops, only: do_loop_node, do_while_node
     use ast_nodes_conditional, only: if_node
+    use ast_nodes_procedure, only: subroutine_call_node, function_def_node, &
+        subroutine_def_node
     use error_handling, only: error_collection_t, ERROR_SEMANTIC
-    use string_utils_mod, only: int_to_string
+    use semantic_pure_dummy_validation, only: validate_pure_dummies
+    use string_utils_mod, only: int_to_string, to_lower
     implicit none
     private
 
     public :: validate_pure_procedure, is_pure_prefix
+    public :: validate_do_concurrent_purity
+
+    ! F2008 13.1: MVBITS and MOVE_ALLOC are the only PURE intrinsic
+    ! subroutines. Coarray and atomic intrinsics are deliberately left out of
+    ! this list; they belong to a different diagnostic family.
+    integer, parameter :: IMPURE_INTRINSIC_NAME_LEN = 24
+    character(len=IMPURE_INTRINSIC_NAME_LEN), parameter :: &
+        IMPURE_INTRINSIC_SUBROUTINES(10) = [ &
+        character(len=IMPURE_INTRINSIC_NAME_LEN) :: &
+        'cpu_time', 'date_and_time', 'execute_command_line', 'get_command', &
+        'get_command_argument', 'get_environment_variable', 'random_init', &
+        'random_number', 'random_seed', 'system_clock']
 
 contains
 
@@ -51,17 +66,130 @@ contains
 
     ! Validate a procedure body when its prefix marks it PURE/ELEMENTAL.
     ! Non-pure procedures are accepted unchanged.
-    subroutine validate_pure_procedure(arena, body_indices, prefix_keywords, errors)
+    subroutine validate_pure_procedure(arena, body_indices, prefix_keywords, &
+            errors, param_indices, is_function)
         type(ast_arena_t), intent(in) :: arena
         integer, allocatable, intent(in) :: body_indices(:)
         character(len=*), allocatable, intent(in) :: prefix_keywords(:)
         type(error_collection_t), intent(inout) :: errors
+        integer, allocatable, intent(in), optional :: param_indices(:)
+        logical, intent(in), optional :: is_function
+        logical :: function_context
 
         if (.not. is_pure_prefix(prefix_keywords)) return
+
+        if (present(param_indices)) then
+            function_context = .false.
+            if (present(is_function)) function_context = is_function
+            call validate_pure_dummies(arena, param_indices, body_indices, &
+                function_context, errors)
+        end if
+
         if (.not. allocated(body_indices)) return
 
         call check_pure_body(arena, body_indices, errors)
     end subroutine validate_pure_procedure
+
+    ! F2008 8.1.6.5: the body of a DO CONCURRENT construct is a pure context,
+    ! so it may not reference an impure intrinsic subroutine.
+    recursive subroutine validate_do_concurrent_purity(arena, body_indices, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: body_indices(:)
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        if (.not. allocated(body_indices)) return
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            call check_concurrent_statement(arena, body_indices(i), errors)
+        end do
+    end subroutine validate_do_concurrent_purity
+
+    recursive subroutine check_concurrent_statement(arena, stmt_index, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: stmt_index
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        select type (stmt => arena%entries(stmt_index)%node)
+            type is (subroutine_call_node)
+            if (.not. allocated(stmt%name)) return
+            if (.not. is_impure_intrinsic_subroutine(stmt%name)) return
+            if (procedure_defined_in_arena(arena, stmt%name)) return
+            call errors%add_error( &
+                message='impure intrinsic subroutine "'//trim(stmt%name)// &
+                '" is not allowed in a DO CONCURRENT construct', &
+                code=ERROR_SEMANTIC, &
+                component='semantic_pure_validation', &
+                context='line '//int_to_string(stmt%line)//', column '// &
+                int_to_string(stmt%column), &
+                suggestion='move the impure call outside the DO CONCURRENT '// &
+                'construct, or use an ordinary DO loop', &
+                line=stmt%line, column=stmt%column, end_line=stmt%line, &
+                end_column=stmt%column + 1)
+            type is (do_loop_node)
+            call validate_do_concurrent_purity(arena, stmt%body_indices, errors)
+            type is (do_while_node)
+            call validate_do_concurrent_purity(arena, stmt%body_indices, errors)
+            type is (if_node)
+            call validate_do_concurrent_purity(arena, stmt%then_body_indices, &
+                errors)
+            if (allocated(stmt%elseif_blocks)) then
+                do i = 1, size(stmt%elseif_blocks)
+                    call validate_do_concurrent_purity(arena, &
+                        stmt%elseif_blocks(i)%body_indices, errors)
+                end do
+            end if
+            call validate_do_concurrent_purity(arena, stmt%else_body_indices, &
+                errors)
+        end select
+    end subroutine check_concurrent_statement
+
+    function is_impure_intrinsic_subroutine(name) result(is_impure)
+        character(len=*), intent(in) :: name
+        logical :: is_impure
+        character(len=:), allocatable :: lowered
+        integer :: i
+
+        is_impure = .false.
+        lowered = to_lower(trim(name))
+        do i = 1, size(IMPURE_INTRINSIC_SUBROUTINES)
+            if (trim(IMPURE_INTRINSIC_SUBROUTINES(i)) == lowered) then
+                is_impure = .true.
+                return
+            end if
+        end do
+    end function is_impure_intrinsic_subroutine
+
+    ! A user procedure of the same name shadows the intrinsic, so the call is
+    ! not an intrinsic reference and this rule does not apply.
+    function procedure_defined_in_arena(arena, name) result(is_defined)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        logical :: is_defined
+        character(len=:), allocatable :: lowered
+        integer :: i
+
+        is_defined = .false.
+        lowered = to_lower(trim(name))
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (subroutine_def_node)
+                if (.not. allocated(node%name)) cycle
+                if (to_lower(trim(node%name)) == lowered) then
+                    is_defined = .true.
+                    return
+                end if
+                type is (function_def_node)
+                if (.not. allocated(node%name)) cycle
+                if (to_lower(trim(node%name)) == lowered) then
+                    is_defined = .true.
+                    return
+                end if
+            end select
+        end do
+    end function procedure_defined_in_arena
 
     ! Recursively scan a list of body statements for prohibited statements.
     recursive subroutine check_pure_body(arena, body_indices, errors)

--- a/test/api/test_reject_purity_01_diagnostics.f90
+++ b/test/api/test_reject_purity_01_diagnostics.f90
@@ -1,0 +1,117 @@
+program test_reject_purity_01_diagnostics
+    ! Issue #2885: PURE/ELEMENTAL/RECURSIVE restrictions are enforced.
+    ! Every negative fixture must be rejected with a diagnostic that names the
+    ! violated rule, and the corrected neighbour of every rule must still be
+    ! accepted. The oracle is gfortran: each negative fixture mirrors a
+    ! gfortran.dg test carrying a dg-error for the same constraint, and each
+    ! positive fixture is a form gfortran compiles.
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use transformation_api, only: transform_with_context, transform_context_t, &
+        INPUT_MODE_STANDARD
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    call check_rejected('examples/f90/class_dummy_5.f90', &
+        'polymorphic INTENT(OUT) dummy in PURE', 'polymorphic', all_passed)
+    call check_rejected('examples/f90/do_concurrent_3.f90', &
+        'impure intrinsic subroutine in DO CONCURRENT', 'DO CONCURRENT', &
+        all_passed)
+    call check_rejected('examples/f90/elemental_args_check_2.f90', &
+        'dummy procedure in ELEMENTAL', 'procedure dummy argument', all_passed)
+    call check_rejected('examples/f90/elemental_pointer_1.f90', &
+        'POINTER result of ELEMENTAL function', 'pointer result', all_passed)
+    call check_rejected('examples/f90/elemental_result_1.f90', &
+        'array result of ELEMENTAL function', 'array result', all_passed)
+    call check_rejected('examples/f90/impure_assignment_2.f90', &
+        'definition of a PURE function dummy', 'variable definition context', &
+        all_passed)
+    call check_rejected('examples/f90/pure_formal_proc_3.f90', &
+        'impure dummy procedure of PURE procedure', 'must also be PURE', &
+        all_passed)
+    call check_rejected('examples/f90/recursive_check_3.f90', &
+        'duplicate prefix specifier', 'duplicate', all_passed)
+
+    call check_accepted('examples/f90/class_dummy_5_valid.f90', &
+        'polymorphic dummy without INTENT(OUT)', all_passed)
+    call check_accepted('examples/f90/do_concurrent_3_valid.f90', &
+        'impure intrinsic outside DO CONCURRENT', all_passed)
+    call check_accepted('examples/f90/elemental_args_check_2_valid.f90', &
+        'dummy procedure of a non-ELEMENTAL PURE procedure', all_passed)
+    call check_accepted('examples/f90/elemental_pointer_1_valid.f90', &
+        'scalar non-pointer ELEMENTAL result', all_passed)
+    call check_accepted('examples/f90/elemental_result_1_valid.f90', &
+        'scalar ELEMENTAL result beside an array-valued function', all_passed)
+    call check_accepted('examples/f90/impure_assignment_2_valid.f90', &
+        'PURE function that only reads its dummy', all_passed)
+    call check_accepted('examples/f90/pure_formal_proc_3_valid.f90', &
+        'PURE dummy procedure of a PURE function', all_passed)
+    call check_accepted('examples/f90/recursive_check_3_valid.f90', &
+        'distinct prefix specifiers', all_passed)
+
+    if (all_passed) then
+        write (*, '(a)') 'PASS: purity rejection diagnostics enforced'
+    else
+        stop 1
+    end if
+
+contains
+
+    subroutine check_rejected(path, label, expected_text, passed)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: label
+        character(len=*), intent(in) :: expected_text
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: error_msg
+
+        call run_frontend(path, error_msg)
+
+        if (.not. error_reported(error_msg)) then
+            write (error_unit, '(a)') 'FAIL: '//label//' not rejected'
+            passed = .false.
+            return
+        end if
+        if (index(error_msg, expected_text) == 0) then
+            write (error_unit, '(a)') 'FAIL: '//label// &
+                ' rejected without the expected diagnostic: '//error_msg
+            passed = .false.
+        end if
+    end subroutine check_rejected
+
+    subroutine check_accepted(path, label, passed)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: label
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: error_msg
+
+        call run_frontend(path, error_msg)
+
+        if (error_reported(error_msg)) then
+            write (error_unit, '(a)') 'FAIL: '//label//' rejected: '//error_msg
+            passed = .false.
+        end if
+    end subroutine check_accepted
+
+    subroutine run_frontend(path, error_msg)
+        character(len=*), intent(in) :: path
+        character(len=:), allocatable, intent(out) :: error_msg
+        type(transform_context_t) :: context
+        character(len=:), allocatable :: source, transformed
+
+        call read_example(path, source)
+        context%input_mode = INPUT_MODE_STANDARD
+        call transform_with_context(source, transformed, error_msg, context)
+        if (.not. allocated(error_msg)) error_msg = ''
+    end subroutine run_frontend
+
+    function error_reported(error_msg) result(reported)
+        character(len=*), intent(in) :: error_msg
+        logical :: reported
+
+        reported = len_trim(error_msg) > 0
+    end function error_reported
+
+    include '../common/read_example.inc'
+end program test_reject_purity_01_diagnostics


### PR DESCRIPTION
Closes #2885.

FortFront accepted every one of the purity forms named in the issue. This
change rejects five of them at the earliest layer that has the information,
and keeps a corrected neighbour of every rule compiling.

## Rules now enforced

| Rule | Fixture | Diagnostic |
|---|---|---|
| F2008 C1279: polymorphic INTENT(OUT) dummy in a PURE procedure | `class_dummy_5.f90` | `dummy argument "y" of a PURE procedure may not be polymorphic with INTENT(OUT)` |
| F2008 8.1.6.5: impure intrinsic subroutine referenced in a DO CONCURRENT body | `do_concurrent_3.f90` | `impure intrinsic subroutine "random_number" is not allowed in a DO CONCURRENT construct` |
| F2008 C1290: dummy procedure of a PURE procedure must be PURE | `pure_formal_proc_3.f90` | `dummy procedure "proc" of a PURE procedure must also be PURE` |
| F2008 C1283: dummy of a PURE FUNCTION in a variable definition context | `impure_assignment_2.f90` | `dummy argument "node" of a PURE FUNCTION appears in a variable definition context` |
| F2008 R1229: repeated procedure prefix specifier | `recursive_check_3.f90` | `duplicate pure attribute specified for this procedure` |

`elemental_args_check_2.f90`, `elemental_pointer_1.f90` and
`elemental_result_1.f90` were already rejected by the existing ELEMENTAL
validator; they are added as fixtures so the family has regression cover.

## Keeping the checks narrow

Over-rejection is the expensive failure mode here, so each rule reports only
the case it can prove:

- the DO CONCURRENT rule uses an explicit list of standard impure intrinsic
  subroutines and stays silent when a procedure of that name is defined in
  the same unit and therefore shadows the intrinsic;
- the PURE FUNCTION definition-context rule resolves the base object of an
  assignment or pointer-assignment target and skips dummies declared VALUE;
- the duplicate-prefix rule compares only the prefix keywords read for the
  procedure that is being started, so a keyword recorded once can never
  report itself.

The duplicate-prefix check lives in the parser rather than in semantic
validation because every layer below the parser deduplicates the prefix list
(`append_prefix_token`), so the repetition is no longer observable by the
time the AST exists.

## Not implemented

- `impure_actual_1.f90` (non-PURE procedure passed as an actual argument to a
  PURE dummy) and `impure_assignment_1.f90` (defined assignment resolving to
  an impure module procedure) need cross-procedure interface resolution that
  FortFront does not have at this layer. No fixture is added rather than a
  guess that would over-reject.
- `recursive_check_2.f90` (indirect recursion through ENTRY into a
  non-RECURSIVE procedure) is deliberately left out: F2018 made procedures
  recursive by default, so enforcing the F2008 rule would reject conforming
  modern programs.
- `elemental_pointer_1.f90` spells POINTER as a standalone attribute
  statement in the gfortran fixture. FortFront's parser drops standalone
  attribute statements, so the fixture uses the type-declaration spelling of
  the same attribute.

## Known gap found while doing this

Procedures defined in a MODULE never reach `prepare_function_definition` or
`prepare_subroutine_definition`, so no PURE, ELEMENTAL or BIND(C) validation
runs for them at all. `pure integer function noisy(a)` with a PRINT statement
is rejected inside a program's CONTAINS and accepted inside a module. The
fixtures here are therefore written as program units. This deserves its own
issue.

## Verification

- `fo test test_reject_purity_01_diagnostics` passes; with the source changes
  reverted the same test fails with exactly the five new rules reported as
  "not rejected", and all sixteen acceptance checks still pass.
- `fo` (full pipeline) passes.
- `make check-duplication` reports only the pre-existing violation in
  `test/api/test_compiler_statement_queries.f90` tracked by #2910.
