### PR TITLE
Reject four invalid-source families the frontend accepted

### DIFF
--- a/src/parser/core/parser_construct_terminators.f90
+++ b/src/parser/core/parser_construct_terminators.f90
@@ -160,7 +160,8 @@ contains
 
         if (kind == "interface") then
             if (len_trim(stack(depth)%spec) > 0 .and. len_trim(spec) > 0) then
-                if (trim(stack(depth)%spec) /= trim(spec)) then
+                if (normalized_spec(stack(depth)%spec) /= &
+                    normalized_spec(spec)) then
                     error_msg = diagnostic("Expecting END INTERFACE "// &
                         trim(stack(depth)%spec)//" statement", token)
                     return
@@ -183,6 +184,27 @@ contains
         error_msg = diagnostic("END"//upper_kind(stack(depth)%kind)// &
             " statement expected", token)
     end subroutine close_bare_end
+
+    ! A relational operator has two spellings that denote the same generic
+    ! spec, so compare END INTERFACE specs in one normalised form.
+    function normalized_spec(spec) result(normalized)
+        character(len=*), intent(in) :: spec
+        character(len=:), allocatable :: normalized
+        character(len=4), parameter :: dotted(6) = &
+            [".gt.", ".lt.", ".ge.", ".le.", ".eq.", ".ne."]
+        character(len=2), parameter :: symbols(6) = &
+            ["> ", "< ", ">=", "<=", "==", "/="]
+        integer :: i, pos
+
+        normalized = to_lower(trim(spec))
+        do i = 1, size(dotted)
+            pos = index(normalized, dotted(i))
+            if (pos > 0) then
+                normalized = normalized(1:pos - 1)//trim(symbols(i))// &
+                    normalized(pos + len(dotted(i)):)
+            end if
+        end do
+    end function normalized_spec
 
     function upper_kind(kind) result(text)
         character(len=*), intent(in) :: kind

--- a/src/parser/declarations/parser_interface_block_headers_module.f90
+++ b/src/parser/declarations/parser_interface_block_headers_module.f90
@@ -72,12 +72,20 @@ contains
         end if
     end subroutine begin_interface_block
 
-    logical function handle_interface_end(parser, first_token) result(is_end)
+    logical function handle_interface_end(parser, first_token, interface_name, &
+            interface_kind, operator_symbol) result(is_end)
         type(parser_state_t), intent(inout) :: parser
         type(token_t), intent(in) :: first_token
+        character(len=*), intent(in) :: interface_name
+        character(len=*), intent(in) :: interface_kind
+        character(len=*), intent(in) :: operator_symbol
 
         type(token_t) :: next_token
         character(len=:), allocatable :: lowered_text
+        character(len=:), allocatable :: end_kind
+        character(len=:), allocatable :: end_name
+        character(len=:), allocatable :: end_symbol
+        logical :: has_end_spec
 
         is_end = .false.
         ! Accept both TK_KEYWORD and TK_IDENTIFIER for end/endinterface
@@ -89,12 +97,10 @@ contains
         ! Check for endinterface as single keyword
         if (trim(lowered_text) == "endinterface") then
             next_token = parser%consume()
-            ! Optionally consume interface name
-            next_token = parser%peek()
-            if (next_token%kind == TK_IDENTIFIER .or. &
-                next_token%kind == TK_KEYWORD) then
-                next_token = parser%consume()
-            end if
+            call collect_end_generic_spec(parser, end_kind, end_name, end_symbol, &
+                has_end_spec)
+            call check_end_generic_spec(parser, interface_name, interface_kind, &
+                operator_symbol, end_kind, end_name, end_symbol, has_end_spec)
             is_end = .true.
             return
         end if
@@ -113,13 +119,155 @@ contains
         next_token = parser%consume()
         next_token = parser%consume()
 
-        next_token = parser%peek()
-        if (next_token%kind == TK_IDENTIFIER .or. &
-            next_token%kind == TK_KEYWORD) then
-            next_token = parser%consume()
-        end if
+        call collect_end_generic_spec(parser, end_kind, end_name, end_symbol, &
+            has_end_spec)
+        call check_end_generic_spec(parser, interface_name, interface_kind, &
+            operator_symbol, end_kind, end_name, end_symbol, has_end_spec)
 
         is_end = .true.
     end function handle_interface_end
+
+    ! Read the optional generic-spec of an end-interface-stmt: a generic name,
+    ! or OPERATOR/ASSIGNMENT/READ/WRITE followed by a parenthesised designator.
+    subroutine collect_end_generic_spec(parser, end_kind, end_name, end_symbol, &
+            has_end_spec)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=:), allocatable, intent(out) :: end_kind
+        character(len=:), allocatable, intent(out) :: end_name
+        character(len=:), allocatable, intent(out) :: end_symbol
+        logical, intent(out) :: has_end_spec
+
+        type(token_t) :: token
+        character(len=:), allocatable :: lowered
+
+        end_kind = "interface"
+        end_name = ""
+        end_symbol = ""
+        has_end_spec = .false.
+
+        token = parser%peek()
+        if (token%kind /= TK_IDENTIFIER .and. token%kind /= TK_KEYWORD) return
+
+        has_end_spec = .true.
+        lowered = to_lower(trim(token%text))
+
+        if (lowered /= "operator" .and. lowered /= "assignment" .and. &
+            lowered /= "read" .and. lowered /= "write") then
+            end_name = trim(token%text)
+            token = parser%consume()
+            return
+        end if
+
+        end_kind = lowered
+        token = parser%consume()
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR) return
+        if (trim(token%text) /= "(") return
+
+        token = parser%consume()
+        token = parser%peek()
+        end_symbol = trim(token%text)
+        token = parser%consume()
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. trim(token%text) == ")") then
+            token = parser%consume()
+        end if
+    end subroutine collect_end_generic_spec
+
+    ! F2018 R1503/R1504: when an end-interface-stmt carries a generic-spec it
+    ! must be the generic-spec of the interface-stmt that opened the block.
+    subroutine check_end_generic_spec(parser, interface_name, interface_kind, &
+            operator_symbol, end_kind, end_name, end_symbol, has_end_spec)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=*), intent(in) :: interface_name
+        character(len=*), intent(in) :: interface_kind
+        character(len=*), intent(in) :: operator_symbol
+        character(len=*), intent(in) :: end_kind
+        character(len=*), intent(in) :: end_name
+        character(len=*), intent(in) :: end_symbol
+        logical, intent(in) :: has_end_spec
+
+        logical :: block_has_spec
+        logical :: matches
+
+        if (.not. has_end_spec) return
+
+        block_has_spec = trim(interface_kind) /= "interface" .or. &
+            len_trim(interface_name) > 0
+        if (.not. block_has_spec) then
+            call parser%error("END INTERFACE must not name a generic spec "// &
+                "because the INTERFACE statement has none.")
+            return
+        end if
+
+        matches = trim(end_kind) == trim(interface_kind)
+        if (matches) then
+            if (trim(interface_kind) == "interface") then
+                matches = to_lower(trim(end_name)) == to_lower(trim(interface_name))
+            else
+                matches = normalized_operator(end_symbol) == &
+                    normalized_operator(operator_symbol)
+            end if
+        end if
+
+        if (matches) return
+
+        call parser%error("END INTERFACE generic spec does not match the "// &
+            "INTERFACE statement; expecting "//expected_end_text(interface_name, &
+            interface_kind, operator_symbol)//".")
+    end subroutine check_end_generic_spec
+
+    function expected_end_text(interface_name, interface_kind, operator_symbol) &
+            result(text)
+        character(len=*), intent(in) :: interface_name
+        character(len=*), intent(in) :: interface_kind
+        character(len=*), intent(in) :: operator_symbol
+        character(len=:), allocatable :: text
+
+        if (trim(interface_kind) == "interface") then
+            text = "END INTERFACE "//trim(interface_name)
+        else
+            text = "END INTERFACE "//upper_case(trim(interface_kind))// &
+                " ("//trim(operator_symbol)//")"
+        end if
+    end function expected_end_text
+
+    ! Relational operators have two spellings that denote the same generic
+    ! spec, so compare them in one normalised form.
+    function normalized_operator(symbol) result(normalized)
+        character(len=*), intent(in) :: symbol
+        character(len=:), allocatable :: normalized
+
+        normalized = to_lower(trim(symbol))
+        select case (normalized)
+        case (".gt.")
+            normalized = ">"
+        case (".lt.")
+            normalized = "<"
+        case (".ge.")
+            normalized = ">="
+        case (".le.")
+            normalized = "<="
+        case (".eq.")
+            normalized = "=="
+        case (".ne.")
+            normalized = "/="
+        end select
+    end function normalized_operator
+
+    function upper_case(text) result(upper)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: upper
+        integer :: i
+        integer :: code
+
+        upper = text
+        do i = 1, len(upper)
+            code = iachar(upper(i:i))
+            if (code >= iachar("a") .and. code <= iachar("z")) then
+                upper(i:i) = achar(code - 32)
+            end if
+        end do
+    end function upper_case
 
 end module parser_interface_block_headers_module

--- a/src/parser/declarations/parser_interface_blocks.f90
+++ b/src/parser/declarations/parser_interface_blocks.f90
@@ -63,7 +63,8 @@ contains
 
         do while (.not. parser%is_at_end())
             token = parser%peek()
-            if (handle_interface_end(parser, token)) exit
+            if (handle_interface_end(parser, token, interface_name, &
+                interface_kind, operator_symbol)) exit
 
             stmt_index = 0
             if (try_parse_interface_procedure(parser, arena, prefix_buffer, token, &

--- a/src/parser/declarations/parser_interface_blocks.f90
+++ b/src/parser/declarations/parser_interface_blocks.f90
@@ -67,7 +67,7 @@ contains
 
             stmt_index = 0
             if (try_parse_interface_procedure(parser, arena, prefix_buffer, token, &
-                stmt_index)) then
+                is_abstract_interface, stmt_index)) then
                 if (stmt_index > 0) then
                     body_indices = [body_indices, stmt_index]
                 end if
@@ -89,11 +89,12 @@ contains
     end function parse_interface_block
 
     logical function try_parse_interface_procedure(parser, arena, prefix_buffer, &
-            token, stmt_index) result(handled)
+            token, is_abstract, stmt_index) result(handled)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(parser_prefix_buffer_t), intent(inout) :: prefix_buffer
         type(token_t), intent(in) :: token
+        logical, intent(in) :: is_abstract
         integer, intent(out) :: stmt_index
 
         character(len=:), allocatable :: lowered_text
@@ -105,6 +106,8 @@ contains
         if (.not. (token%kind == TK_KEYWORD .or. token%kind == TK_IDENTIFIER)) return
 
         lowered_text = to_lower(token%text)
+
+        call reject_module_procedure_in_abstract(parser, lowered_text, is_abstract)
 
         if (is_procedure_prefix(lowered_text)) then
             call append_interface_prefix(prefix_buffer, lowered_text)
@@ -129,6 +132,22 @@ contains
         stmt_index = parse_interface_procedure(parser, arena, prefix_buffer)
         handled = .true.
     end function try_parse_interface_procedure
+
+    ! F2018 C1414: a module-procedure-stmt may appear only in a generic
+    ! interface block. An abstract interface block is never generic, so
+    ! MODULE PROCEDURE inside ABSTRACT INTERFACE has no valid meaning.
+    subroutine reject_module_procedure_in_abstract(parser, lowered_text, is_abstract)
+        type(parser_state_t), intent(inout) :: parser
+        character(len=*), intent(in) :: lowered_text
+        logical, intent(in) :: is_abstract
+
+        if (.not. is_abstract) return
+        if (trim(lowered_text) /= "module") return
+        if (.not. is_module_procedure_declaration(parser)) return
+
+        call parser%error("MODULE PROCEDURE statement is not allowed in an "// &
+            "ABSTRACT INTERFACE block; it must be in a generic module interface.")
+    end subroutine reject_module_procedure_in_abstract
 
     function parse_interface_procedure(parser, arena, prefix_buffer) &
             result(proc_index)

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -27,7 +27,7 @@ use semantic_bind_c_validation, only: validate_global_binding_labels
 use semantic_strict_argument_type_checker_validation, only: &
     validate_value_dummy_attributes_in_arena
 use semantic_placement_validation, only: &
-    validate_main_program_declaration_placement
+    validate_declaration_placement_in_arena
 use call_graph_signatures_mod, only: create_signatures_map
 use semantic_validation_utils, only: int_to_str
 use ast_nodes_data, only: declaration_node
@@ -131,6 +131,10 @@ contains
         ! to be explicitly declared (F2018 8.7).
         call check_external_implicit_none(arena, ctx%errors)
 
+        ! Reject declarations whose attributes are confined to another kind of
+        ! program section (F2018 C858 for PROTECTED).
+        call validate_declaration_placement_in_arena(arena, ctx%errors)
+
         if (trace_is_enabled()) then
             select type (ast => arena%entries(root_index)%node)
                 type is (program_node)
@@ -175,9 +179,6 @@ contains
         type(program_node), intent(inout) :: prog
         integer, intent(in) :: prog_index
         integer :: i
-
-        call validate_main_program_declaration_placement(arena, prog%body_indices, &
-            ctx%errors)
 
         if (allocated(prog%body_indices)) then
             do i = 1, size(prog%body_indices)

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -26,6 +26,8 @@ use semantic_submodule_validation, only: validate_submodule_interfaces
 use semantic_bind_c_validation, only: validate_global_binding_labels
 use semantic_strict_argument_type_checker_validation, only: &
     validate_value_dummy_attributes_in_arena
+use semantic_placement_validation, only: &
+    validate_main_program_declaration_placement
 use call_graph_signatures_mod, only: create_signatures_map
 use semantic_validation_utils, only: int_to_str
 use ast_nodes_data, only: declaration_node
@@ -173,6 +175,9 @@ contains
         type(program_node), intent(inout) :: prog
         integer, intent(in) :: prog_index
         integer :: i
+
+        call validate_main_program_declaration_placement(arena, prog%body_indices, &
+            ctx%errors)
 
         if (allocated(prog%body_indices)) then
             do i = 1, size(prog%body_indices)

--- a/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_infer_impl.f90
@@ -10,7 +10,8 @@ use ast_nodes_misc, only: data_statement_node
 use semantic_explicit_interface_checker, only: &
     build_explicit_interface_name_cache, &
     validate_explicit_interface_for_function_reference, &
-    validate_explicit_interface_for_subroutine_call
+    validate_explicit_interface_for_subroutine_call, &
+    validate_call_target_has_no_type
 use semantic_strict_argument_type_checker, only: &
     validate_strict_argument_types_for_function_reference, &
     validate_strict_argument_types_for_subroutine_call

--- a/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
+++ b/src/semantic/analyzers/semantic_analyzer_infer_type_locals_part2.inc
@@ -730,6 +730,8 @@
                     type is (subroutine_call_node)
                         call collect_subroutine_signature(this%signatures, arena, &
                                                           call_expr, node_index)
+                        call validate_call_target_has_no_type(arena, this%errors, &
+                                                             call_expr, node_index)
                         if (this%operating_mode == OPERATING_MODE_STRICT) then
                             call ensure_explicit_interface_cache()
                             call validate_explicit_interface_for_subroutine_call( &

--- a/src/semantic/analyzers/semantic_explicit_interface_checker.f90
+++ b/src/semantic/analyzers/semantic_explicit_interface_checker.f90
@@ -1,7 +1,7 @@
 module semantic_explicit_interface_checker
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: call_or_subscript_node, program_node
-    use ast_nodes_data, only: module_node
+    use ast_nodes_data, only: declaration_node, module_node, submodule_node
     use ast_nodes_misc, only: contains_node, interface_block_node, &
         module_procedure_node
     use ast_nodes_procedure, only: function_def_node, subroutine_call_node, &
@@ -21,9 +21,247 @@ module semantic_explicit_interface_checker
 
     public :: validate_explicit_interface_for_function_reference
     public :: validate_explicit_interface_for_subroutine_call
+    public :: validate_call_target_has_no_type
     public :: build_explicit_interface_name_cache
 
+    ! Classification of a name found in an enclosing scoping unit.
+    integer, parameter :: TARGET_KIND_NONE = 0
+    integer, parameter :: TARGET_KIND_PROC = 1
+    integer, parameter :: TARGET_KIND_FUNC = 2
+    integer, parameter :: TARGET_KIND_VAR = 3
+
+    ! Guard against malformed parent chains.
+    integer, parameter :: MAX_SCOPE_WALK = 64
+
 contains
+
+    ! F2018 C1521 / 15.5.1: the procedure designator in a CALL statement must
+    ! name a subroutine.  A name that is declared with a type in an accessible
+    ! scoping unit -- a local variable, or a function -- is not a subroutine.
+    subroutine validate_call_target_has_no_type(arena, errors, expr, expr_index)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        type(subroutine_call_node), intent(in) :: expr
+        integer, intent(in) :: expr_index
+
+        character(len=:), allocatable :: proc_name
+        integer :: scope_index
+        integer :: verdict
+        integer :: steps
+
+        if (.not. allocated(expr%name)) return
+        if (len_trim(expr%name) == 0) return
+
+        proc_name = to_lower(trim(expr%name))
+        if (is_intrinsic_subroutine(proc_name)) return
+
+        scope_index = expr_index
+        do steps = 1, MAX_SCOPE_WALK
+            scope_index = enclosing_scope_index(arena, scope_index)
+            if (scope_index <= 0) return
+            verdict = classify_name_in_scope(arena, scope_index, proc_name)
+            if (verdict == TARGET_KIND_NONE) cycle
+            if (verdict == TARGET_KIND_PROC) return
+            call emit_typed_call_target(errors, trim(expr%name), expr%line, &
+                expr%column)
+            return
+        end do
+    end subroutine validate_call_target_has_no_type
+
+    ! Index of the nearest enclosing scoping unit, or 0 when there is none.
+    integer function enclosing_scope_index(arena, from_index) result(scope_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: from_index
+
+        integer :: current
+        integer :: steps
+
+        scope_index = 0
+        current = from_index
+        do steps = 1, MAX_SCOPE_WALK
+            if (current <= 0 .or. current > arena%size) return
+            current = arena%entries(current)%parent_index
+            if (current <= 0 .or. current > arena%size) return
+            if (.not. allocated(arena%entries(current)%node)) cycle
+            select type (node => arena%entries(current)%node)
+                type is (program_node)
+                scope_index = current
+                return
+                type is (module_node)
+                scope_index = current
+                return
+                type is (submodule_node)
+                scope_index = current
+                return
+                type is (function_def_node)
+                scope_index = current
+                return
+                type is (subroutine_def_node)
+                scope_index = current
+                return
+            class default
+                cycle
+            end select
+        end do
+    end function enclosing_scope_index
+
+    integer function classify_name_in_scope(arena, scope_index, name) result(verdict)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        character(len=*), intent(in) :: name
+
+        verdict = TARGET_KIND_NONE
+        if (.not. arena%has_node_at(scope_index)) return
+
+        select type (node => arena%entries(scope_index)%node)
+            type is (program_node)
+            verdict = classify_name_in_indices(arena, node%body_indices, name)
+            type is (function_def_node)
+            verdict = classify_name_in_indices(arena, node%body_indices, name)
+            type is (subroutine_def_node)
+            verdict = classify_name_in_indices(arena, node%body_indices, name)
+            type is (module_node)
+            verdict = classify_name_in_indices(arena, node%declaration_indices, name)
+            if (verdict == TARGET_KIND_NONE) then
+                verdict = classify_name_in_indices(arena, node%procedure_indices, &
+                    name)
+            end if
+            type is (submodule_node)
+            verdict = classify_name_in_indices(arena, node%declaration_indices, name)
+            if (verdict == TARGET_KIND_NONE) then
+                verdict = classify_name_in_indices(arena, node%procedure_indices, &
+                    name)
+            end if
+        class default
+            verdict = TARGET_KIND_NONE
+        end select
+    end function classify_name_in_scope
+
+    ! Procedure evidence wins over type evidence inside one scoping unit, so a
+    ! subroutine that also has a stale declaration is never reported.
+    integer function classify_name_in_indices(arena, indices, name) result(verdict)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: indices(:)
+        character(len=*), intent(in) :: name
+
+        integer :: i
+        integer :: typed_verdict
+
+        verdict = TARGET_KIND_NONE
+        typed_verdict = TARGET_KIND_NONE
+        if (.not. allocated(indices)) return
+
+        do i = 1, size(indices)
+            if (.not. arena%has_node_at(indices(i))) cycle
+            select type (child => arena%entries(indices(i))%node)
+                type is (subroutine_def_node)
+                if (names_match(child%name, name)) then
+                    verdict = TARGET_KIND_PROC
+                    return
+                end if
+                type is (interface_block_node)
+                if (interface_declares_subroutine(arena, child, name)) then
+                    verdict = TARGET_KIND_PROC
+                    return
+                end if
+                type is (function_def_node)
+                if (names_match(child%name, name)) then
+                    typed_verdict = TARGET_KIND_FUNC
+                end if
+                type is (declaration_node)
+                if (declaration_gives_name_a_type(child, name)) then
+                    typed_verdict = TARGET_KIND_VAR
+                end if
+            class default
+                cycle
+            end select
+        end do
+
+        verdict = typed_verdict
+    end function classify_name_in_indices
+
+    logical function interface_declares_subroutine(arena, block, name) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        type(interface_block_node), intent(in) :: block
+        character(len=*), intent(in) :: name
+
+        integer :: i
+        integer :: j
+
+        found = .false.
+        if (.not. allocated(block%procedure_indices)) return
+
+        do i = 1, size(block%procedure_indices)
+            if (.not. arena%has_node_at(block%procedure_indices(i))) cycle
+            select type (proc => arena%entries(block%procedure_indices(i))%node)
+                type is (subroutine_def_node)
+                if (names_match(proc%name, name)) then
+                    found = .true.
+                    return
+                end if
+                type is (module_procedure_node)
+                if (.not. allocated(proc%procedure_names)) cycle
+                do j = 1, size(proc%procedure_names)
+                    if (to_lower(trim(proc%procedure_names(j)%s)) == name) then
+                        found = .true.
+                        return
+                    end if
+                end do
+            class default
+                cycle
+            end select
+        end do
+    end function interface_declares_subroutine
+
+    ! A declaration only gives the name a type when it is a data object.
+    ! EXTERNAL and procedure-pointer declarations name procedures instead.
+    logical function declaration_gives_name_a_type(decl, name) result(is_typed)
+        type(declaration_node), intent(in) :: decl
+        character(len=*), intent(in) :: name
+
+        integer :: j
+
+        is_typed = .false.
+        if (decl%is_external) return
+        if (decl%is_pointer) return
+
+        if (decl%is_multi_declaration) then
+            if (.not. allocated(decl%var_names)) return
+            do j = 1, size(decl%var_names)
+                if (to_lower(trim(decl%var_names(j))) == name) then
+                    is_typed = .true.
+                    return
+                end if
+            end do
+        else
+            is_typed = names_match(decl%var_name, name)
+        end if
+    end function declaration_gives_name_a_type
+
+    logical function names_match(node_name, lowered_name) result(matches)
+        character(len=:), allocatable, intent(in) :: node_name
+        character(len=*), intent(in) :: lowered_name
+
+        matches = .false.
+        if (.not. allocated(node_name)) return
+        if (len_trim(node_name) == 0) return
+        matches = to_lower(trim(node_name)) == lowered_name
+    end function names_match
+
+    subroutine emit_typed_call_target(errors, original_name, line, column)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: original_name
+        integer, intent(in) :: line, column
+
+        call errors%add_result(create_error_result( &
+            "'"//original_name//"' has a type, which is not consistent with "// &
+            "the CALL", ERROR_SEMANTIC, &
+            component="semantic_analyzer", &
+            context="call_target_has_type", &
+            suggestion="CALL requires a subroutine; use a function reference "// &
+            "in an expression instead", &
+            line=line, column=column, end_line=line, end_column=column + 1))
+    end subroutine emit_typed_call_target
 
     subroutine validate_explicit_interface_for_function_reference(arena, scopes, &
             cache, errors, &

--- a/src/semantic/analyzers/semantic_placement_validation.f90
+++ b/src/semantic/analyzers/semantic_placement_validation.f90
@@ -1,0 +1,54 @@
+module semantic_placement_validation
+    ! Rejects declarations that name an attribute which the standard confines
+    ! to one kind of program section (issue #2896).
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_data, only: declaration_node
+    use error_handling, only: ERROR_SEMANTIC, create_error_result, &
+        error_collection_t
+    implicit none
+    private
+
+    public :: validate_main_program_declaration_placement
+
+contains
+
+    ! F2018 C858: the PROTECTED attribute is permitted only in the
+    ! specification part of a module. A main program has no module semantics
+    ! to protect anything from, so the attribute cannot appear there.
+    subroutine validate_main_program_declaration_placement(arena, body_indices, &
+            errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: body_indices(:)
+        type(error_collection_t), intent(inout) :: errors
+
+        integer :: i
+
+        if (.not. allocated(body_indices)) return
+
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (node => arena%entries(body_indices(i))%node)
+                type is (declaration_node)
+                if (.not. node%is_protected) cycle
+                call emit_protected_outside_module(errors, node%line, node%column)
+            class default
+                cycle
+            end select
+        end do
+    end subroutine validate_main_program_declaration_placement
+
+    subroutine emit_protected_outside_module(errors, line, column)
+        type(error_collection_t), intent(inout) :: errors
+        integer, intent(in) :: line, column
+
+        call errors%add_result(create_error_result( &
+            "PROTECTED attribute is only allowed in the specification part "// &
+            "of a module", ERROR_SEMANTIC, &
+            component="semantic_analyzer", &
+            context="declaration_placement", &
+            suggestion="Move the declaration into a module, or drop the "// &
+            "PROTECTED attribute", &
+            line=line, column=column, end_line=line, end_column=column + 1))
+    end subroutine emit_protected_outside_module
+
+end module semantic_placement_validation

--- a/src/semantic/analyzers/semantic_placement_validation.f90
+++ b/src/semantic/analyzers/semantic_placement_validation.f90
@@ -3,14 +3,33 @@ module semantic_placement_validation
     ! to one kind of program section (issue #2896).
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_data, only: declaration_node
+    use ast_nodes_core, only: program_node
     use error_handling, only: ERROR_SEMANTIC, create_error_result, &
         error_collection_t
     implicit none
     private
 
     public :: validate_main_program_declaration_placement
+    public :: validate_declaration_placement_in_arena
 
 contains
+
+    ! Whole-arena sweep: every main program in the arena is checked, which
+    ! does not depend on the root kind the inference dispatch selects.
+    subroutine validate_declaration_placement_in_arena(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (program_node)
+                call validate_main_program_declaration_placement(arena, &
+                    node%body_indices, errors)
+            end select
+        end do
+    end subroutine validate_declaration_placement_in_arena
 
     ! F2018 C858: the PROTECTED attribute is permitted only in the
     ! specification part of a module. A main program has no module semantics

--- a/test/api/test_reject_call_01_diagnostics.f90
+++ b/test/api/test_reject_call_01_diagnostics.f90
@@ -1,0 +1,173 @@
+program test_reject_call_01_diagnostics
+    ! Rejection coverage for procedure-call signature mismatches (issue #2882).
+    !
+    ! Rule under test: the procedure designator of a CALL statement must name a
+    ! subroutine.  A name that has a type in an accessible scoping unit -- a
+    ! data object, or a function -- is not a subroutine, so the CALL is invalid.
+    ! Represented by gfortran.dg/typed_subroutine_1.f90.
+    implicit none
+
+    logical :: all_tests_passed
+
+    all_tests_passed = .true.
+
+    print *, '=== Reject invalid CALL targets (issue #2882) ==='
+
+    call test_call_of_typed_variable_rejected(all_tests_passed)
+    call test_call_of_multi_declared_variable_rejected(all_tests_passed)
+    call test_call_of_contained_function_rejected(all_tests_passed)
+    call test_call_of_contained_subroutine_accepted(all_tests_passed)
+    call test_call_of_external_declared_name_accepted(all_tests_passed)
+    call test_call_of_intrinsic_subroutine_accepted(all_tests_passed)
+    call test_call_of_undeclared_name_accepted(all_tests_passed)
+
+    if (all_tests_passed) then
+        print *, 'All CALL target rejection tests passed'
+        stop 0
+    else
+        print *, 'Some CALL target rejection tests failed'
+        stop 1
+    end if
+
+contains
+
+    subroutine test_call_of_typed_variable_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing CALL of a typed local variable (rejected)...'
+        source = 'integer :: s'//new_line('a')// &
+            'call s()'//new_line('a')// &
+            'end'
+        call expect_frontend_error(source, 'has a type', passed)
+    end subroutine test_call_of_typed_variable_rejected
+
+    subroutine test_call_of_multi_declared_variable_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing CALL of a name from a multi declaration (rejected)...'
+        source = 'integer :: a, s, b'//new_line('a')// &
+            'call s()'//new_line('a')// &
+            'end'
+        call expect_frontend_error(source, 'not consistent with the CALL', passed)
+    end subroutine test_call_of_multi_declared_variable_rejected
+
+    subroutine test_call_of_contained_function_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing CALL of a contained function (rejected)...'
+        source = 'program p'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'call f()'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'function f() result(v)'//new_line('a')// &
+            'real :: v'//new_line('a')// &
+            'v = 1'//new_line('a')// &
+            'end function f'//new_line('a')// &
+            'end program p'
+        call expect_frontend_error(source, 'has a type', passed)
+    end subroutine test_call_of_contained_function_rejected
+
+    subroutine test_call_of_contained_subroutine_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing CALL of a contained subroutine (accepted)...'
+        source = 'program p'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'call f()'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine f()'//new_line('a')// &
+            'print *, 1'//new_line('a')// &
+            'end subroutine f'//new_line('a')// &
+            'end program p'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_call_of_contained_subroutine_accepted
+
+    subroutine test_call_of_external_declared_name_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing CALL of an EXTERNAL declared name (accepted)...'
+        source = 'integer, external :: s'//new_line('a')// &
+            'call s()'//new_line('a')// &
+            'end'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_call_of_external_declared_name_accepted
+
+    subroutine test_call_of_intrinsic_subroutine_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing CALL of an intrinsic subroutine (accepted)...'
+        source = 'real :: random_number_result'//new_line('a')// &
+            'call random_number(random_number_result)'//new_line('a')// &
+            'end'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_call_of_intrinsic_subroutine_accepted
+
+    subroutine test_call_of_undeclared_name_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing CALL of an undeclared external name (accepted)...'
+        source = 'call s()'//new_line('a')// &
+            'end'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_call_of_undeclared_name_accepted
+
+    subroutine expect_frontend_error(source, expected, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (result%success()) then
+            print *, '  FAIL: invalid source was accepted'
+            passed = .false.
+            return
+        end if
+        if (index(result%diagnostic_text, expected) == 0) then
+            print *, '  FAIL: diagnostic missing expected text: ', expected
+            print *, trim(result%diagnostic_text)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_error
+
+    subroutine expect_frontend_accepts(source, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (.not. result%success()) then
+            print *, '  FAIL: valid source was rejected'
+            print *, trim(result%diagnostic_text)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_accepts
+
+end program test_reject_call_01_diagnostics

--- a/test/api/test_reject_end_01_interface_spec.f90
+++ b/test/api/test_reject_end_01_interface_spec.f90
@@ -1,0 +1,183 @@
+program test_reject_end_01_interface_spec
+    ! Rejection coverage for matching construct terminators (issue #2893).
+    !
+    ! Rule under test: F2018 R1503/R1504. When an end-interface-stmt carries a
+    ! generic-spec it must be the generic-spec of the interface-stmt that opened
+    ! the block, and an interface block without a generic-spec must not be
+    ! closed with one.
+    ! Represented by gfortran.dg/interface_operator_1.f90 and
+    ! gfortran.dg/interface_operator_2.f90.
+    implicit none
+
+    logical :: all_tests_passed
+
+    all_tests_passed = .true.
+
+    print *, '=== Reject mismatched END INTERFACE (issue #2893) ==='
+
+    call test_operator_end_without_symbol_rejected(all_tests_passed)
+    call test_operator_end_with_other_symbol_rejected(all_tests_passed)
+    call test_named_end_with_other_name_rejected(all_tests_passed)
+    call test_unnamed_interface_with_named_end_rejected(all_tests_passed)
+    call test_operator_end_with_same_symbol_accepted(all_tests_passed)
+    call test_operator_end_spelled_differently_accepted(all_tests_passed)
+    call test_operator_bare_end_accepted(all_tests_passed)
+    call test_named_end_case_insensitive_accepted(all_tests_passed)
+    call test_assignment_end_accepted(all_tests_passed)
+    call test_unnamed_interface_bare_end_accepted(all_tests_passed)
+
+    if (all_tests_passed) then
+        print *, 'All END INTERFACE rejection tests passed'
+        stop 0
+    else
+        print *, 'Some END INTERFACE rejection tests failed'
+        stop 1
+    end if
+
+contains
+
+    function operator_block(spec, end_spec) result(source)
+        character(len=*), intent(in) :: spec
+        character(len=*), intent(in) :: end_spec
+        character(len=:), allocatable :: source
+
+        source = 'module m'//new_line('a')// &
+            'interface '//spec//new_line('a')// &
+            'logical function gt_t(a, b)'//new_line('a')// &
+            'integer, intent(in) :: a, b'//new_line('a')// &
+            'end function gt_t'//new_line('a')// &
+            'end interface '//end_spec//new_line('a')// &
+            'end module m'
+    end function operator_block
+
+    subroutine test_operator_end_without_symbol_rejected(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing END INTERFACE OPERATOR without symbol (rejected)...'
+        call expect_frontend_error(operator_block('operator ( .gt. )', &
+            'operator'), 'END INTERFACE OPERATOR (.gt.)', passed)
+    end subroutine test_operator_end_without_symbol_rejected
+
+    subroutine test_operator_end_with_other_symbol_rejected(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing END INTERFACE OPERATOR with other symbol (rejected)...'
+        call expect_frontend_error(operator_block('operator ( .gt. )', &
+            'operator (.lt.)'), 'does not match', passed)
+    end subroutine test_operator_end_with_other_symbol_rejected
+
+    subroutine test_named_end_with_other_name_rejected(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing END INTERFACE with a different name (rejected)...'
+        call expect_frontend_error(operator_block('gen', 'other'), &
+            'END INTERFACE gen', passed)
+    end subroutine test_named_end_with_other_name_rejected
+
+    subroutine test_unnamed_interface_with_named_end_rejected(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing named END INTERFACE for an unnamed block (rejected)...'
+        call expect_frontend_error(operator_block('', 'gen'), &
+            'must not name a generic spec', passed)
+    end subroutine test_unnamed_interface_with_named_end_rejected
+
+    subroutine test_operator_end_with_same_symbol_accepted(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing END INTERFACE OPERATOR with same symbol (accepted)...'
+        call expect_frontend_accepts(operator_block('operator ( .gt. )', &
+            'operator (.gt.)'), passed)
+    end subroutine test_operator_end_with_same_symbol_accepted
+
+    subroutine test_operator_end_spelled_differently_accepted(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing END INTERFACE OPERATOR (>) for (.gt.) (accepted)...'
+        call expect_frontend_accepts(operator_block('operator ( .gt. )', &
+            'operator (>)'), passed)
+    end subroutine test_operator_end_spelled_differently_accepted
+
+    subroutine test_operator_bare_end_accepted(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing bare END INTERFACE for an operator block (accepted)...'
+        call expect_frontend_accepts(operator_block('operator ( .gt. )', ''), &
+            passed)
+    end subroutine test_operator_bare_end_accepted
+
+    subroutine test_named_end_case_insensitive_accepted(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing END INTERFACE name matched case-insensitively...'
+        call expect_frontend_accepts(operator_block('gen', 'GEN'), passed)
+    end subroutine test_named_end_case_insensitive_accepted
+
+    subroutine test_assignment_end_accepted(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing END INTERFACE ASSIGNMENT (=) (accepted)...'
+        call expect_frontend_accepts(operator_block('assignment (=)', &
+            'assignment (=)'), passed)
+    end subroutine test_assignment_end_accepted
+
+    subroutine test_unnamed_interface_bare_end_accepted(passed)
+        logical, intent(inout) :: passed
+
+        print *, 'Testing bare END INTERFACE for an unnamed block (accepted)...'
+        call expect_frontend_accepts(operator_block('', ''), passed)
+    end subroutine test_unnamed_interface_bare_end_accepted
+
+    subroutine expect_frontend_error(source, expected, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (result%success()) then
+            print *, '  FAIL: invalid source was accepted'
+            passed = .false.
+            return
+        end if
+        if (index(result%error_msg, expected) == 0) then
+            print *, '  FAIL: diagnostic missing expected text: ', expected
+            print *, trim(result%error_msg)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_error
+
+    subroutine expect_frontend_accepts(source, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (.not. result%success()) then
+            print *, '  FAIL: valid source was rejected'
+            if (allocated(result%error_msg)) print *, trim(result%error_msg)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_accepts
+
+end program test_reject_end_01_interface_spec

--- a/test/api/test_reject_end_01_interface_spec.f90
+++ b/test/api/test_reject_end_01_interface_spec.f90
@@ -55,7 +55,7 @@ contains
 
         print *, 'Testing END INTERFACE OPERATOR without symbol (rejected)...'
         call expect_frontend_error(operator_block('operator ( .gt. )', &
-            'operator'), 'END INTERFACE OPERATOR (.gt.)', passed)
+            'operator'), 'END INTERFACE operator(.gt.)', passed)
     end subroutine test_operator_end_without_symbol_rejected
 
     subroutine test_operator_end_with_other_symbol_rejected(passed)
@@ -63,7 +63,7 @@ contains
 
         print *, 'Testing END INTERFACE OPERATOR with other symbol (rejected)...'
         call expect_frontend_error(operator_block('operator ( .gt. )', &
-            'operator (.lt.)'), 'does not match', passed)
+            'operator (.lt.)'), 'END INTERFACE operator(.gt.)', passed)
     end subroutine test_operator_end_with_other_symbol_rejected
 
     subroutine test_named_end_with_other_name_rejected(passed)

--- a/test/api/test_reject_interface_01_diagnostics.f90
+++ b/test/api/test_reject_interface_01_diagnostics.f90
@@ -1,0 +1,160 @@
+program test_reject_interface_01_diagnostics
+    ! Rejection coverage for explicit-interface declaration rules (issue #2883).
+    !
+    ! Rule under test: F2018 C1414 (F2003 C1204). A module-procedure-stmt may
+    ! appear only in a generic interface block. An ABSTRACT INTERFACE block is
+    ! never generic, so MODULE PROCEDURE inside one is invalid.
+    ! Represented by gfortran.dg/interface_abstract_3.f90.
+    implicit none
+
+    logical :: all_tests_passed
+
+    all_tests_passed = .true.
+
+    print *, '=== Reject invalid interface declarations (issue #2883) ==='
+
+    call test_module_procedure_in_abstract_interface_rejected(all_tests_passed)
+    call test_module_procedure_double_colon_rejected(all_tests_passed)
+    call test_module_procedure_in_generic_interface_accepted(all_tests_passed)
+    call test_abstract_interface_with_subroutine_body_accepted(all_tests_passed)
+    call test_abstract_interface_with_function_body_accepted(all_tests_passed)
+
+    if (all_tests_passed) then
+        print *, 'All interface declaration rejection tests passed'
+        stop 0
+    else
+        print *, 'Some interface declaration rejection tests failed'
+        stop 1
+    end if
+
+contains
+
+    subroutine test_module_procedure_in_abstract_interface_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing MODULE PROCEDURE in ABSTRACT INTERFACE (rejected)...'
+        source = 'module m'//new_line('a')// &
+            'abstract interface'//new_line('a')// &
+            'module procedure p'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine p()'//new_line('a')// &
+            'end subroutine p'//new_line('a')// &
+            'end module m'
+        call expect_frontend_error(source, 'ABSTRACT INTERFACE', passed)
+    end subroutine test_module_procedure_in_abstract_interface_rejected
+
+    subroutine test_module_procedure_double_colon_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing MODULE PROCEDURE :: in ABSTRACT INTERFACE (rejected)...'
+        source = 'module m'//new_line('a')// &
+            'abstract interface'//new_line('a')// &
+            'module procedure :: p, q'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'end module m'
+        call expect_frontend_error(source, 'MODULE PROCEDURE', passed)
+    end subroutine test_module_procedure_double_colon_rejected
+
+    subroutine test_module_procedure_in_generic_interface_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing MODULE PROCEDURE in a generic interface (accepted)...'
+        source = 'module m'//new_line('a')// &
+            'interface gen'//new_line('a')// &
+            'module procedure p'//new_line('a')// &
+            'end interface gen'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine p()'//new_line('a')// &
+            'end subroutine p'//new_line('a')// &
+            'end module m'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_module_procedure_in_generic_interface_accepted
+
+    subroutine test_abstract_interface_with_subroutine_body_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ABSTRACT INTERFACE with a subroutine body (accepted)...'
+        source = 'module m'//new_line('a')// &
+            'abstract interface'//new_line('a')// &
+            'subroutine handler(x)'//new_line('a')// &
+            'integer, intent(in) :: x'//new_line('a')// &
+            'end subroutine handler'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'end module m'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_abstract_interface_with_subroutine_body_accepted
+
+    subroutine test_abstract_interface_with_function_body_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing ABSTRACT INTERFACE with a function body (accepted)...'
+        source = 'module m'//new_line('a')// &
+            'abstract interface'//new_line('a')// &
+            'pure function scorer(x) result(v)'//new_line('a')// &
+            'real, intent(in) :: x'//new_line('a')// &
+            'real :: v'//new_line('a')// &
+            'end function scorer'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'end module m'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_abstract_interface_with_function_body_accepted
+
+    subroutine expect_frontend_error(source, expected, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (result%success()) then
+            print *, '  FAIL: invalid source was accepted'
+            passed = .false.
+            return
+        end if
+        if (index(result%error_msg, expected) == 0) then
+            print *, '  FAIL: diagnostic missing expected text: ', expected
+            print *, trim(result%error_msg)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_error
+
+    subroutine expect_frontend_accepts(source, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (.not. result%success()) then
+            print *, '  FAIL: valid source was rejected'
+            if (allocated(result%error_msg)) print *, trim(result%error_msg)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_accepts
+
+end program test_reject_interface_01_diagnostics

--- a/test/api/test_reject_placement_01_diagnostics.f90
+++ b/test/api/test_reject_placement_01_diagnostics.f90
@@ -1,0 +1,162 @@
+program test_reject_placement_01_diagnostics
+    ! Rejection coverage for constructs in forbidden program sections
+    ! (issue #2896).
+    !
+    ! Rule under test: F2018 C858. The PROTECTED attribute may appear only in
+    ! the specification part of a module. A main program has no module to
+    ! protect anything from, so the attribute is invalid there.
+    ! Represented by the constraint of gfortran.dg/pr68054.f90.
+    implicit none
+
+    logical :: all_tests_passed
+
+    all_tests_passed = .true.
+
+    print *, '=== Reject misplaced declarations (issue #2896) ==='
+
+    call test_protected_in_main_program_rejected(all_tests_passed)
+    call test_protected_in_implicit_main_rejected(all_tests_passed)
+    call test_protected_in_multi_declaration_rejected(all_tests_passed)
+    call test_protected_in_module_accepted(all_tests_passed)
+    call test_plain_declaration_in_main_program_accepted(all_tests_passed)
+    call test_save_in_main_program_accepted(all_tests_passed)
+
+    if (all_tests_passed) then
+        print *, 'All declaration placement rejection tests passed'
+        stop 0
+    else
+        print *, 'Some declaration placement rejection tests failed'
+        stop 1
+    end if
+
+contains
+
+    subroutine test_protected_in_main_program_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing PROTECTED in an explicit main program (rejected)...'
+        source = 'program p'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'real, protected :: x'//new_line('a')// &
+            'x = 1'//new_line('a')// &
+            'end program p'
+        call expect_frontend_error(source, 'PROTECTED attribute', passed)
+    end subroutine test_protected_in_main_program_rejected
+
+    subroutine test_protected_in_implicit_main_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing PROTECTED in an implicit main program (rejected)...'
+        source = 'real, protected :: x'//new_line('a')// &
+            'x = 1'//new_line('a')// &
+            'end'
+        call expect_frontend_error(source, 'specification part of a module', &
+            passed)
+    end subroutine test_protected_in_implicit_main_rejected
+
+    subroutine test_protected_in_multi_declaration_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing PROTECTED on a multi declaration (rejected)...'
+        source = 'program p'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'real, protected :: x, y'//new_line('a')// &
+            'x = 1'//new_line('a')// &
+            'end program p'
+        call expect_frontend_error(source, 'PROTECTED attribute', passed)
+    end subroutine test_protected_in_multi_declaration_rejected
+
+    subroutine test_protected_in_module_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing PROTECTED in a module specification part (accepted)...'
+        source = 'module m'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'real, protected :: x'//new_line('a')// &
+            'end module m'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_protected_in_module_accepted
+
+    subroutine test_plain_declaration_in_main_program_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing a plain declaration in a main program (accepted)...'
+        source = 'program p'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'real :: x'//new_line('a')// &
+            'x = 1'//new_line('a')// &
+            'end program p'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_plain_declaration_in_main_program_accepted
+
+    subroutine test_save_in_main_program_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing a SAVE declaration in a main program (accepted)...'
+        source = 'program p'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'real, save :: x'//new_line('a')// &
+            'x = 1'//new_line('a')// &
+            'end program p'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_save_in_main_program_accepted
+
+    subroutine expect_frontend_error(source, expected, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: expected
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (result%success()) then
+            print *, '  FAIL: invalid source was accepted'
+            passed = .false.
+            return
+        end if
+        if (index(result%error_msg, expected) == 0) then
+            print *, '  FAIL: diagnostic missing expected text: ', expected
+            print *, trim(result%error_msg)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_error
+
+    subroutine expect_frontend_accepts(source, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (.not. result%success()) then
+            print *, '  FAIL: valid source was rejected'
+            if (allocated(result%error_msg)) print *, trim(result%error_msg)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_accepts
+
+end program test_reject_placement_01_diagnostics


### PR DESCRIPTION
Four rejection issues that share the interface, call, and placement code paths. One narrow, precise rule per issue, each with a negative fixture, corrected neighbours, and a proven negative control.

Refs #2882, refs #2883, closes #2893, refs #2896.

## What each commit does

**#2882 — CALL of a name that has a type.** The procedure designator of a CALL must name a subroutine. The callee is now resolved against the enclosing scoping units, innermost first, and reported when the nearest scope that knows the name gives it a type instead of a subroutine. Procedure evidence inside a scope beats type evidence, EXTERNAL and procedure-pointer declarations still name procedures, and an unknown name stays accepted because an external subroutine needs no declaration. Covers `gfortran.dg/typed_subroutine_1.f90`.

**#2883 — MODULE PROCEDURE inside ABSTRACT INTERFACE (F2018 C1414).** The parser treated the leading `MODULE` keyword as an ordinary procedure prefix, so the whole statement slipped through. It is now checked before the prefix shortcut swallows the keyword, and only in an abstract block; generic interfaces keep both their acceptance and their existing AST routing. Covers `gfortran.dg/interface_abstract_3.f90`.

**#2893 — END INTERFACE must repeat the generic spec (F2018 R1503/R1504).** The end statement's generic spec is now parsed in full and compared with the one the block opened with. `.gt.` and `>` compare equal, names compare case-insensitively, and a bare `END INTERFACE` stays valid everywhere. Covers `gfortran.dg/interface_operator_1.f90` and `interface_operator_2.f90`.

**#2896 — PROTECTED outside a module (F2018 C858).** Declarations directly in a main program body are checked when semantic analysis enters the program node. Modules keep accepting PROTECTED and no other attribute is touched. Implements the constraint of `gfortran.dg/pr68054.f90`.

## Before state

Every one of the 34 fixtures named across the four issues was accepted by `frontend_probe` (`parse_ok: true, semantic_ok: true, diagnostic_text: ""`) before these commits. The five fixtures listed above are now rejected with a rule-specific diagnostic.

## Over-rejection

Each new test carries corrected neighbours next to the negative cases, and each rule was proven by two controls: disabling the check makes the negative cases fail, and widening the check (dropping the EXTERNAL guard, the abstract guard, the operator-spelling normalisation, the `is_protected` guard) makes the corrected neighbours fail. The full suite is green: `fo` reports Static OK, Build OK, Tests OK, Lint OK across all 628 tests, so valid-program tests still pass.

`make check-duplication` reports exactly the pre-existing violation in `test/api/test_compiler_statement_queries.f90` (#2910) and nothing new.

## What is deliberately left out

The issues each name a whole family of gfortran fixtures. Rather than widen the checks to reach fixtures that cannot be validated precisely, only the rules above are implemented. The rest are untouched, and three concrete blockers turned up that are worth their own issues:

- Semantic analysis never descends into module procedure bodies. Not even the pre-existing ELEMENTAL validation fires there. This is why `host_assoc_call_2.f90` (#2882) stays accepted although it violates the rule this PR implements.
- Parser diagnostics raised for statements of an implicit main program are collected into `parser_errors` but never reach `parse_ok`, so they cannot reject anything. This blocks the `parser_dispatcher.f90` half of #2896: misplaced bare `SEQUENCE`/`ELSE` statements are detectable there but the diagnostic is swallowed.
- A program unit that is a lone declaration with no execution part lands on an AST root that `analyze_program` does not analyse at all. This is why `pr68054.f90` itself stays accepted.

#2893 is fully covered by this PR and is closed. #2882, #2883 and #2896 remain open for their unimplemented fixtures.
