### PR TITLE
Reject USE module-nature conflicts and local type/variable name collisions

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -22,3 +22,4 @@ f90/pr77583.f90
 f90/protected_9.f90
 f90/contiguous_12.f90
 f90/external_initializer.f90
+f90/iso_fortran_env_4.f90

--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -23,3 +23,4 @@ f90/protected_9.f90
 f90/contiguous_12.f90
 f90/external_initializer.f90
 f90/iso_fortran_env_4.f90
+f90/type_decl_4.f90

--- a/examples/f90/iso_fortran_env_4.f90
+++ b/examples/f90/iso_fortran_env_4.f90
@@ -1,0 +1,16 @@
+! Negative fixture for issue #2887 (reject-use-01).
+! A scoping unit accesses the same module under two different module natures.
+! F2023 14.2.2 / C8102: all USE statements in a scoping unit that reference the
+! same module shall agree on the module nature. Rejected in both orders.
+module iso_fortran_env
+end module iso_fortran_env
+
+program foo
+    use, intrinsic :: iso_fortran_env
+    use, non_intrinsic :: iso_fortran_env
+end program foo
+
+subroutine truc
+    use, non_intrinsic :: iso_fortran_env
+    use, intrinsic :: iso_fortran_env
+end subroutine truc

--- a/examples/f90/iso_fortran_env_4_corrected.f90
+++ b/examples/f90/iso_fortran_env_4_corrected.f90
@@ -1,0 +1,23 @@
+! Corrected neighbour of iso_fortran_env_4.f90 (issue #2887).
+! Two USE statements for the same module with the SAME stated nature are
+! legal, and one scoping unit may state different natures for different
+! modules. Only a disagreement about a single module inside a single scoping
+! unit is an error.
+module use_nature_probe
+    implicit none
+    integer, parameter :: local_marker = 1
+end module use_nature_probe
+
+program foo
+    use, non_intrinsic :: use_nature_probe
+    use, non_intrinsic :: use_nature_probe, only: local_marker
+    implicit none
+    print *, local_marker
+end program foo
+
+subroutine truc
+    use, intrinsic :: iso_fortran_env, only: output_unit
+    use, non_intrinsic :: use_nature_probe, only: local_marker
+    implicit none
+    write (output_unit, '(I0)') local_marker
+end subroutine truc

--- a/examples/f90/type_decl_4.f90
+++ b/examples/f90/type_decl_4.f90
@@ -1,0 +1,10 @@
+! Negative fixture for issue #2888 (reject-scope-02).
+! The name Xx is used as a derived-type name and as a variable name in the
+! same scoping unit. F2023 19.3.1: within a scoping unit a local identifier
+! of class (1) shall not be the same as another class (1) local identifier.
+program main
+    type Xx
+    end type Xx
+    real :: Xx
+
+end program main

--- a/examples/f90/type_decl_4_corrected.f90
+++ b/examples/f90/type_decl_4_corrected.f90
@@ -1,0 +1,15 @@
+! Corrected neighbour of type_decl_4.f90 (issue #2888).
+! Declaring a variable OF a derived type in the scoping unit that defines the
+! type is legal; only reusing the type name itself as an entity name is not.
+program main
+    implicit none
+    type Xx
+        integer :: i
+    end type Xx
+    type(Xx) :: xx_value
+    real :: yy
+
+    xx_value%i = 3
+    yy = 2.0
+    print *, xx_value%i, yy
+end program main

--- a/src/frontend/frontend_compiler_resolution.f90
+++ b/src/frontend/frontend_compiler_resolution.f90
@@ -44,6 +44,10 @@ module frontend_compiler_resolution
     end type declaration_binding_t
 
     public :: get_scope_bindings
+    ! Scope enumeration primitives, shared with the semantic validators that
+    ! diagnose per-scoping-unit conflicts (issues #2887 and #2888).
+    public :: is_scope_node
+    public :: get_scope_statement_indices
     public :: resolve_name_in_scope
     public :: resolve_name_at_node
     public :: resolve_identifier_binding

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -18,6 +18,7 @@ use type_hierarchy, only: create_type_hierarchy
 use semantic_type_hierarchy_validation, only: populate_type_hierarchy
 use semantic_enum_validation, only: validate_enum_definitions
 use semantic_literal_form_validation, only: validate_literal_forms
+use semantic_use_nature_validation, only: validate_use_module_nature
 use call_graph_signatures_mod, only: create_signatures_map
 use semantic_validation_utils, only: int_to_str
 use ast_nodes_data, only: declaration_node
@@ -97,6 +98,10 @@ contains
         ! Reject malformed or disallowed literal forms before inference runs.
         call validate_literal_forms(arena, ctx%errors, &
                                     ctx%input_mode == INPUT_MODE_STANDARD)
+
+        ! Whole-arena scoping-unit checks. They run for every root kind,
+        ! including a bare module root, which the dispatch below skips.
+        call validate_use_module_nature(arena, ctx%errors)
 
         if (trace_is_enabled()) then
             select type (ast => arena%entries(root_index)%node)

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -19,6 +19,8 @@ use semantic_type_hierarchy_validation, only: populate_type_hierarchy
 use semantic_enum_validation, only: validate_enum_definitions
 use semantic_literal_form_validation, only: validate_literal_forms
 use semantic_use_nature_validation, only: validate_use_module_nature
+use semantic_local_name_collision_validation, only: &
+    validate_local_name_collisions
 use call_graph_signatures_mod, only: create_signatures_map
 use semantic_validation_utils, only: int_to_str
 use ast_nodes_data, only: declaration_node
@@ -102,6 +104,7 @@ contains
         ! Whole-arena scoping-unit checks. They run for every root kind,
         ! including a bare module root, which the dispatch below skips.
         call validate_use_module_nature(arena, ctx%errors)
+        call validate_local_name_collisions(arena, ctx%errors)
 
         if (trace_is_enabled()) then
             select type (ast => arena%entries(root_index)%node)

--- a/src/semantic/analyzers/semantic_local_name_collision_validation.f90
+++ b/src/semantic/analyzers/semantic_local_name_collision_validation.f90
@@ -1,0 +1,122 @@
+module semantic_local_name_collision_validation
+    ! Issue #2888 (reject-scope-02). F2023 19.3.1 puts derived-type names and
+    ! variable names in the same class of local identifier, so within one
+    ! scoping unit a name shall not be both. gfortran.dg/type_decl_4.f90 is the
+    ! reference case ("Symbol 'xx' at (1) also declared as a type at (2)").
+    !
+    ! Only that pairing is diagnosed here: a derived-type definition whose name
+    ! is also the name of a variable or named constant declared in the same
+    ! scoping unit. Declaring an entity OF the type is untouched, and so is any
+    ! collision that involves host or use association rather than two local
+    ! declarations.
+    use ast_arena_modern, only: ast_arena_t
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use frontend_compiler_resolution, only: declaration_binding_t, &
+        get_scope_bindings, is_scope_node, BINDING_DECLARATION, &
+        BINDING_NAMED_CONSTANT, BINDING_DERIVED_TYPE
+    implicit none
+    private
+
+    public :: validate_local_name_collisions
+
+contains
+
+    ! Report every scoping unit that declares one name both as a derived type
+    ! and as a variable or named constant.
+    subroutine validate_local_name_collisions(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            if (.not. is_scope_node(arena, i)) cycle
+            call check_scope(arena, i, errors)
+        end do
+    end subroutine validate_local_name_collisions
+
+    ! Compare the direct bindings of one scoping unit pairwise. At most one
+    ! diagnostic is emitted per entity binding.
+    subroutine check_scope(arena, scope_index, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        type(error_collection_t), intent(inout) :: errors
+        type(declaration_binding_t), allocatable :: bindings(:)
+        character(len=:), allocatable :: error_msg
+        integer :: i, j
+
+        call get_scope_bindings(arena, scope_index, bindings, error_msg)
+        if (len_trim(error_msg) > 0) return
+        do j = 1, size(bindings)
+            if (.not. is_entity_binding(bindings(j))) cycle
+            do i = 1, size(bindings)
+                if (bindings(i)%binding_kind /= BINDING_DERIVED_TYPE) cycle
+                if (.not. same_name(bindings(i)%name, bindings(j)%name)) cycle
+                call report_collision(arena, bindings(j), errors)
+                exit
+            end do
+        end do
+    end subroutine check_scope
+
+    ! Whether a binding names a data entity rather than a type or procedure.
+    logical function is_entity_binding(binding) result(is_entity)
+        type(declaration_binding_t), intent(in) :: binding
+
+        is_entity = binding%binding_kind == BINDING_DECLARATION .or. &
+            binding%binding_kind == BINDING_NAMED_CONSTANT
+    end function is_entity_binding
+
+    subroutine report_collision(arena, binding, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_binding_t), intent(in) :: binding
+        type(error_collection_t), intent(inout) :: errors
+        integer :: line, column
+
+        call binding_position(arena, binding, line, column)
+        call errors%add_error( &
+            "Symbol '"//trim(binding%name)//"' is also declared as a type "// &
+            "in the same scoping unit", &
+            severity=ERROR_SEMANTIC, component="semantic_scope_collision", &
+            line=line, column=column)
+    end subroutine report_collision
+
+    ! Source position of the declaration that carries the colliding name.
+    subroutine binding_position(arena, binding, line, column)
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_binding_t), intent(in) :: binding
+        integer, intent(out) :: line
+        integer, intent(out) :: column
+
+        line = 0
+        column = 0
+        if (.not. arena%has_node_at(binding%declaration_node_index)) return
+        line = arena%entries(binding%declaration_node_index)%node%line
+        column = arena%entries(binding%declaration_node_index)%node%column
+    end subroutine binding_position
+
+    ! Case-insensitive comparison of Fortran names.
+    logical function same_name(lhs, rhs) result(equal)
+        character(len=*), intent(in) :: lhs
+        character(len=*), intent(in) :: rhs
+
+        equal = lowered(trim(lhs)) == lowered(trim(rhs))
+    end function same_name
+
+    function lowered(text) result(out)
+        character(len=*), intent(in) :: text
+        character(len=len(text)) :: out
+        integer :: i, code
+
+        do i = 1, len(text)
+            code = iachar(text(i:i))
+            if (code < iachar('A')) then
+                out(i:i) = text(i:i)
+            else if (code > iachar('Z')) then
+                out(i:i) = text(i:i)
+            else
+                out(i:i) = achar(code + 32)
+            end if
+        end do
+    end function lowered
+
+end module semantic_local_name_collision_validation

--- a/src/semantic/analyzers/semantic_use_nature_validation.f90
+++ b/src/semantic/analyzers/semantic_use_nature_validation.f90
@@ -1,0 +1,145 @@
+module semantic_use_nature_validation
+    ! Issue #2887 (reject-use-01). F2023 14.2.2 lets a USE statement state the
+    ! nature of the module it accesses, but all USE statements of one scoping
+    ! unit that name the same module must agree: a module is either intrinsic
+    ! or non-intrinsic, never both. gfortran.dg/iso_fortran_env_4.f90 is the
+    ! reference case. The rule is checked per scoping unit, so two different
+    ! scoping units are free to disagree, and repeating the same nature is
+    ! accepted.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_misc, only: use_statement_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use frontend_compiler_resolution, only: is_scope_node, &
+        get_scope_statement_indices
+    implicit none
+    private
+
+    public :: validate_use_module_nature
+
+contains
+
+    ! Report every scoping unit that accesses one module under both the
+    ! INTRINSIC and the NON_INTRINSIC nature.
+    subroutine validate_use_module_nature(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            if (.not. is_scope_node(arena, i)) cycle
+            call check_scope(arena, i, errors)
+        end do
+    end subroutine validate_use_module_nature
+
+    ! Compare the module natures of the USE statements directly owned by one
+    ! scoping unit. Only the first conflict per USE statement is reported.
+    subroutine check_scope(arena, scope_index, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        type(error_collection_t), intent(inout) :: errors
+        integer, allocatable :: indices(:)
+        integer :: i, j
+
+        call get_scope_statement_indices(arena, scope_index, indices)
+        do j = 2, size(indices)
+            do i = 1, j - 1
+                if (report_if_conflicting(arena, indices(i), indices(j), &
+                    errors)) exit
+            end do
+        end do
+    end subroutine check_scope
+
+    ! Whether the two arena entries are USE statements of the same module with
+    ! opposite stated natures. Emits the diagnostic when they are.
+    logical function report_if_conflicting(arena, first_index, second_index, &
+            errors) result(conflicting)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: first_index
+        integer, intent(in) :: second_index
+        type(error_collection_t), intent(inout) :: errors
+        character(len=:), allocatable :: first_name, second_name
+        logical :: first_intrinsic, first_non_intrinsic
+        logical :: second_intrinsic, second_non_intrinsic
+        integer :: ignored_line, ignored_column
+        integer :: line, column
+
+        conflicting = .false.
+        call use_facts(arena, first_index, first_name, first_intrinsic, &
+            first_non_intrinsic, ignored_line, ignored_column)
+        if (len_trim(first_name) == 0) return
+        call use_facts(arena, second_index, second_name, second_intrinsic, &
+            second_non_intrinsic, line, column)
+        if (len_trim(second_name) == 0) return
+        if (.not. same_name(first_name, second_name)) return
+
+        if (first_intrinsic .and. second_non_intrinsic) then
+            conflicting = .true.
+        else if (first_non_intrinsic .and. second_intrinsic) then
+            conflicting = .true.
+        end if
+        if (.not. conflicting) return
+
+        call errors%add_error( &
+            "Conflicting module nature for module '"//trim(second_name)// &
+            "': accessed as INTRINSIC and as NON_INTRINSIC in the same "// &
+            "scoping unit", &
+            severity=ERROR_SEMANTIC, component="semantic_use_nature", &
+            line=line, column=column)
+    end function report_if_conflicting
+
+    ! Extract module name, stated nature, and source position from an arena
+    ! entry. A non-USE entry yields an empty name.
+    subroutine use_facts(arena, node_index, module_name, is_intrinsic, &
+            is_non_intrinsic, line, column)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable, intent(out) :: module_name
+        logical, intent(out) :: is_intrinsic
+        logical, intent(out) :: is_non_intrinsic
+        integer, intent(out) :: line
+        integer, intent(out) :: column
+
+        module_name = ''
+        is_intrinsic = .false.
+        is_non_intrinsic = .false.
+        line = 0
+        column = 0
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (use_statement_node)
+            if (.not. allocated(node%module_name)) return
+            module_name = trim(node%module_name)
+            is_intrinsic = node%is_intrinsic
+            is_non_intrinsic = node%is_non_intrinsic
+            line = node%line
+            column = node%column
+        end select
+    end subroutine use_facts
+
+    ! Case-insensitive comparison of Fortran names.
+    logical function same_name(lhs, rhs) result(equal)
+        character(len=*), intent(in) :: lhs
+        character(len=*), intent(in) :: rhs
+
+        equal = lowered(trim(lhs)) == lowered(trim(rhs))
+    end function same_name
+
+    function lowered(text) result(out)
+        character(len=*), intent(in) :: text
+        character(len=len(text)) :: out
+        integer :: i, code
+
+        do i = 1, len(text)
+            code = iachar(text(i:i))
+            if (code < iachar('A')) then
+                out(i:i) = text(i:i)
+            else if (code > iachar('Z')) then
+                out(i:i) = text(i:i)
+            else
+                out(i:i) = achar(code + 32)
+            end if
+        end do
+    end function lowered
+
+end module semantic_use_nature_validation

--- a/test/api/test_reject_scope_02_diagnostics.f90
+++ b/test/api/test_reject_scope_02_diagnostics.f90
@@ -1,0 +1,118 @@
+program test_reject_scope_02_diagnostics
+    ! Issue #2888 (reject-scope-02): a name used both as a derived-type name and
+    ! as an entity name in the same scoping unit must be rejected with a source
+    ! diagnostic, while the corrected neighbour stays accepted.
+    !
+    ! Oracle: gfortran rejects gfortran.dg/type_decl_4.f90 with
+    ! "Symbol 'xx' at (1) also declared as a type at (2)" and accepts a program
+    ! that merely declares a variable OF the type. The expectations below come
+    ! from the standard rule (F2023 19.3.1), not from fortfront's own output.
+    use fortfront, only: compiler_frontend_result_t, &
+        compiler_frontend_options_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== Issue #2888: scope name-collision diagnostics ==='
+
+    all_passed = .true.
+    if (.not. test_type_and_variable_collision_rejected()) all_passed = .false.
+    if (.not. test_corrected_neighbour_accepted()) all_passed = .false.
+
+    if (all_passed) then
+        print *, 'All reject-scope-02 diagnostics tests passed.'
+        stop 0
+    else
+        print *, 'reject-scope-02 diagnostics tests FAILED.'
+        stop 1
+    end if
+
+contains
+
+    logical function test_type_and_variable_collision_rejected() result(ok)
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: text
+
+        ok = .true.
+        call read_example('examples/f90/type_decl_4.f90', source)
+        call compile_standard(source, result)
+
+        if (result%success()) then
+            print *, '  FAIL: type/variable name collision was accepted'
+            ok = .false.
+            return
+        end if
+
+        text = lowered(diagnostic_of(result))
+        if (index(text, 'also declared as a type') == 0) then
+            print *, '  FAIL: diagnostic is not the name-collision rule -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        if (index(text, "'xx'") == 0) then
+            print *, '  FAIL: diagnostic does not name the symbol -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        print *, '  PASS: type/variable name collision rejected'
+    end function test_type_and_variable_collision_rejected
+
+    logical function test_corrected_neighbour_accepted() result(ok)
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: source
+
+        ok = .true.
+        call read_example('examples/f90/type_decl_4_corrected.f90', source)
+        call compile_standard(source, result)
+
+        if (.not. result%success()) then
+            print *, '  FAIL: corrected neighbour rejected -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        print *, '  PASS: corrected neighbour still accepted'
+    end function test_corrected_neighbour_accepted
+
+    subroutine compile_standard(source, result)
+        character(len=*), intent(in) :: source
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: options
+
+        options%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(source, result, options)
+    end subroutine compile_standard
+
+    function diagnostic_of(result) result(text)
+        type(compiler_frontend_result_t), intent(in) :: result
+        character(len=:), allocatable :: text
+
+        if (allocated(result%error_msg)) then
+            text = result%error_msg
+        else
+            text = ''
+        end if
+    end function diagnostic_of
+
+    function lowered(text) result(out)
+        character(len=*), intent(in) :: text
+        character(len=len(text)) :: out
+        integer :: i, code
+
+        do i = 1, len(text)
+            code = iachar(text(i:i))
+            if (code >= iachar('A') .and. code <= iachar('Z')) then
+                out(i:i) = achar(code + 32)
+            else
+                out(i:i) = text(i:i)
+            end if
+        end do
+    end function lowered
+
+    include '../common/read_example.inc'
+
+end program test_reject_scope_02_diagnostics

--- a/test/api/test_reject_use_01_diagnostics.f90
+++ b/test/api/test_reject_use_01_diagnostics.f90
@@ -1,0 +1,118 @@
+program test_reject_use_01_diagnostics
+    ! Issue #2887 (reject-use-01): a scoping unit that accesses the same module
+    ! under two conflicting module natures must be rejected with a source
+    ! diagnostic, while the corrected neighbour stays accepted.
+    !
+    ! Oracle: gfortran rejects gfortran.dg/iso_fortran_env_4.f90 with
+    ! "conflicts with intrinsic module" / "conflicts with non-intrinsic module"
+    ! and accepts the corrected neighbour. The expectations below are derived
+    ! from the standard rule (F2023 14.2.2), not from fortfront's own output.
+    use fortfront, only: compiler_frontend_result_t, &
+        compiler_frontend_options_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
+    implicit none
+
+    logical :: all_passed
+
+    print *, '=== Issue #2887: USE module-nature conflict diagnostics ==='
+
+    all_passed = .true.
+    if (.not. test_conflicting_natures_rejected()) all_passed = .false.
+    if (.not. test_corrected_neighbour_accepted()) all_passed = .false.
+
+    if (all_passed) then
+        print *, 'All reject-use-01 diagnostics tests passed.'
+        stop 0
+    else
+        print *, 'reject-use-01 diagnostics tests FAILED.'
+        stop 1
+    end if
+
+contains
+
+    logical function test_conflicting_natures_rejected() result(ok)
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: text
+
+        ok = .true.
+        call read_example('examples/f90/iso_fortran_env_4.f90', source)
+        call compile_standard(source, result)
+
+        if (result%success()) then
+            print *, '  FAIL: conflicting module natures were accepted'
+            ok = .false.
+            return
+        end if
+
+        text = lowered(diagnostic_of(result))
+        if (index(text, 'module nature') == 0) then
+            print *, '  FAIL: diagnostic is not the module-nature rule -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        if (index(text, 'iso_fortran_env') == 0) then
+            print *, '  FAIL: diagnostic does not name the module -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        print *, '  PASS: conflicting module natures rejected'
+    end function test_conflicting_natures_rejected
+
+    logical function test_corrected_neighbour_accepted() result(ok)
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: source
+
+        ok = .true.
+        call read_example('examples/f90/iso_fortran_env_4_corrected.f90', source)
+        call compile_standard(source, result)
+
+        if (.not. result%success()) then
+            print *, '  FAIL: corrected neighbour rejected -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        print *, '  PASS: corrected neighbour still accepted'
+    end function test_corrected_neighbour_accepted
+
+    subroutine compile_standard(source, result)
+        character(len=*), intent(in) :: source
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: options
+
+        options%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(source, result, options)
+    end subroutine compile_standard
+
+    function diagnostic_of(result) result(text)
+        type(compiler_frontend_result_t), intent(in) :: result
+        character(len=:), allocatable :: text
+
+        if (allocated(result%error_msg)) then
+            text = result%error_msg
+        else
+            text = ''
+        end if
+    end function diagnostic_of
+
+    function lowered(text) result(out)
+        character(len=*), intent(in) :: text
+        character(len=len(text)) :: out
+        integer :: i, code
+
+        do i = 1, len(text)
+            code = iachar(text(i:i))
+            if (code >= iachar('A') .and. code <= iachar('Z')) then
+                out(i:i) = achar(code + 32)
+            else
+                out(i:i) = text(i:i)
+            end if
+        end do
+    end function lowered
+
+    include '../common/read_example.inc'
+
+end program test_reject_use_01_diagnostics


### PR DESCRIPTION
Two rejection rules that share the scope-resolution layer, one commit each.

## What is rejected now

**#2887 — conflicting module natures on USE.** A USE statement may state that
the module it accesses is intrinsic or non-intrinsic. F2023 14.2.2 requires all
USE statements of a scoping unit that name the same module to agree. fortfront
parsed the nature into `use_statement_node` but never compared the statements,
so `use, intrinsic :: iso_fortran_env` followed by
`use, non_intrinsic :: iso_fortran_env` in one program unit was accepted.

**#2888 — a name declared as both a derived type and a variable.** F2023 19.3.1
puts derived-type names and variable names in the same class of local
identifier. A program unit that defined `type Xx` and also declared `real :: Xx`
was accepted; whichever binding a later lookup happened to reach won.

Both checks run as whole-arena passes at the start of semantic analysis, which
is the earliest layer that knows the scoping-unit boundaries. Neither needs new
bookkeeping: the nature flags and the scope binding table already existed.

## Scope, and what is deliberately left out

Each issue lists a family of gfortran.dg fixtures. Most members of those
families need information fortfront does not yet have — cross-module export
lists, operator interface identities, host-association records — and widening
the checks to cover them by guesswork would reject valid programs. So each
commit implements exactly one precise rule and its named fixture:

- #2887 covers `iso_fortran_env_4.f90`. Not covered: `operator_6.f90`,
  `use_9.f90`, `use_19.f90`, `use_iso_c_binding.f90` (symbol/operator not
  exported by the named module — needs module export resolution, including for
  intrinsic modules); `use_15.f90` (module name equals the current program unit
  name); `use_rename_11.f90`, `use_rename_5.f90` (rename target visibility);
  `interface_operator_3.f90`, `function_kinds_2.f90`.
- #2888 covers `type_decl_4.f90`. Not covered: `common_29.f90`,
  `host_assoc_types_1.f90`, `pr96102.f90`, `pr77414.f90`, `pr104351.f90`,
  `pr123375.f90`, `used_types_25.f90` — every one of these is a collision
  across an association boundary (host, use, or COMMON) rather than between two
  local declarations, and the binding table does not yet record enough about
  association to separate them from legal shadowing.

The issues should stay open for the remaining fixtures.

## Evidence

Fixtures were written first and confirmed accepted before the checks existed:

    test_reject_use_01_diagnostics    FAIL  "conflicting module natures were accepted"
    test_reject_scope_02_diagnostics  FAIL  "type/variable name collision was accepted"

Both pass after the change. Each test also asserts a corrected neighbour still
compiles, and those assertions were proved non-vacuous by mutation: making the
nature comparison nature-blind rejects the corrected USE neighbour, and making
the collision comparison name-blind rejects the corrected type neighbour. Both
mutations were reverted.

Full pipeline is green: `fo` reports Static OK, Build OK, Tests OK (483 tests),
Lint OK. `make check-duplication` still reports exactly the pre-existing
violation in `test/api/test_compiler_statement_queries.f90` tracked by #2910.

Refs #2887
Refs #2888
