### PR TITLE
Reject malformed type and SELECT TYPE syntax

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -24,3 +24,10 @@ f90/contiguous_12.f90
 f90/external_initializer.f90
 f90/iso_fortran_env_4.f90
 f90/type_decl_4.f90
+f90/class_is_1.f90
+f90/type_is_1.f90
+f90/pr91660_1.f90
+f90/pr91715.f90
+f90/pr96099_1.f90
+f90/pr96099_2.f90
+f90/pr19936_3.f90

--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -52,3 +52,10 @@ issue_2753_unsigned_argument_mixing_error.f90  # ERROR-TEST: signed/unsigned arg
 issue_2819_implied_do_index_out_of_scope.f90  # ERROR-TEST: implied-DO index in own bounds (#2819)
 issue_2819_implied_do_index_shadow.f90  # ERROR-TEST: nested implied-DO index shadowing (#2819)
 issue_2855_external_intrinsic_conflict.f90  # ERROR-TEST: entity both intrinsic and external (F2018 8.5.9) (#2855)
+
+# Round-trip gaps uncovered while adding the issue #2891 rejection fixtures.
+# The sources are valid (gfortran -std=f2018 accepts them); fortfront parses
+# and accepts them too, but its emitter loses part of the construct.
+pr19936_3_ok.f90  # BUG: legacy (/ ... /) implied-do loses its (/ /) wrapper on emit
+pr96099_1_ok.f90  # BUG: IMPLICIT CLASS(t) (x) loses the letter-spec list on emit
+implicit_kind_selector_letter_specs.f90  # BUG: IMPLICIT with a kind/len selector loses the letter-spec list on emit

--- a/examples/f90/class_is_1.f90
+++ b/examples/f90/class_is_1.f90
@@ -1,0 +1,15 @@
+! { dg-do compile }
+! PR fortran/66245
+! Original testcase by Gerhard Steinmetz
+! <gerhard dot steinmetz dot fortran at t-online dot de>
+program p
+   type t; end type
+   class(t), allocatable :: x
+   call s
+   contains
+      subroutine s
+         select type ( x )
+         class is ( )       ! { dg-error "error in CLASS IS" }
+         end select
+      end subroutine s
+end program p

--- a/examples/f90/class_is_1_ok.f90
+++ b/examples/f90/class_is_1_ok.f90
@@ -1,0 +1,15 @@
+! Corrected neighbor of class_is_1.f90: CLASS IS names a type.
+program class_is_1_ok
+    type t
+    end type t
+    class(t), allocatable :: x
+    allocate (t :: x)
+    call s
+contains
+    subroutine s
+        select type (x)
+        class is (t)
+            print *, 'class is t'
+        end select
+    end subroutine s
+end program class_is_1_ok

--- a/examples/f90/implicit_kind_selector_letter_specs.f90
+++ b/examples/f90/implicit_kind_selector_letter_specs.f90
@@ -1,0 +1,11 @@
+! Valid IMPLICIT statements whose declaration-type-spec carries a kind or
+! length selector before the letter-spec list. The selector parentheses are not
+! a letter-spec list and must not be validated as one.
+program implicit_kind_selector_letter_specs
+    implicit real(kind=8) (o-t)
+    implicit character(len=4) (u)
+
+    omega = 3.0d0
+    udder = 'abcd'
+    print *, omega, udder
+end program implicit_kind_selector_letter_specs

--- a/examples/f90/implicit_letter_spec_forms.f90
+++ b/examples/f90/implicit_letter_spec_forms.f90
@@ -1,0 +1,11 @@
+! Valid IMPLICIT letter-spec lists that must keep compiling: a range and
+! several implicit-specs separated by commas in one statement.
+program implicit_letter_spec_forms
+    implicit integer (a-h), real (i-n)
+    integer :: apple
+    real :: index
+
+    apple = 1
+    index = 2.0
+    print *, apple, index
+end program implicit_letter_spec_forms

--- a/examples/f90/pr19936_3.f90
+++ b/examples/f90/pr19936_3.f90
@@ -1,0 +1,5 @@
+! { dg-do compile }
+program pr19936_3
+  integer, parameter :: i = 4
+  print *,(/(i,i,4)/) ! { dg-error "Syntax error in COMPLEX" }
+end program pr19936_3

--- a/examples/f90/pr19936_3_ok.f90
+++ b/examples/f90/pr19936_3_ok.f90
@@ -1,0 +1,5 @@
+! Corrected neighbor of pr19936_3.f90: the array item is an implied-do.
+program pr19936_3_ok
+    integer :: i
+    print *, (/(i, i=1, 4)/)
+end program pr19936_3_ok

--- a/examples/f90/pr91660_1.f90
+++ b/examples/f90/pr91660_1.f90
@@ -1,0 +1,9 @@
+! { dg-do compile }
+! PR fortran/91660
+! Code contributed by Gerhard Steinmetz
+program p
+   type t
+   end type
+   type (t x    ! { dg-error "Malformed type-spec" }
+   x = t()      ! { dg-error "Cannot convert" }
+end

--- a/examples/f90/pr91660_1_ok.f90
+++ b/examples/f90/pr91660_1_ok.f90
@@ -1,0 +1,9 @@
+! Corrected neighbor of pr91660_1.f90: the type-spec parenthesis is closed.
+program pr91660_1_ok
+    type t
+        integer :: i
+    end type t
+    type(t) :: x
+    x%i = 1
+    print *, x%i
+end program pr91660_1_ok

--- a/examples/f90/pr91715.f90
+++ b/examples/f90/pr91715.f90
@@ -1,0 +1,5 @@
+! { dg-do compile }
+! PR fortran/91715
+! Code contributed Gerhard Steinmetz
+character(1function f()  ! { dg-error "Syntax error in CHARACTER" }
+end

--- a/examples/f90/pr91715_ok.f90
+++ b/examples/f90/pr91715_ok.f90
@@ -1,0 +1,8 @@
+! Corrected neighbor of pr91715.f90: the CHARACTER type-spec is closed.
+program pr91715_ok
+    print *, f()
+contains
+    character(1) function f()
+        f = 'a'
+    end function f
+end program pr91715_ok

--- a/examples/f90/pr96099_1.f90
+++ b/examples/f90/pr96099_1.f90
@@ -1,0 +1,8 @@
+! { dg-do compile }
+
+program pr96099_1
+   implicit class(t) (1) ! { dg-error "Syntax error in IMPLICIT" }
+   type t
+   end type
+end
+

--- a/examples/f90/pr96099_1_ok.f90
+++ b/examples/f90/pr96099_1_ok.f90
@@ -1,0 +1,12 @@
+! Corrected neighbor of pr96099_1.f90: the letter-spec list holds letters.
+module pr96099_1_ok_mod
+    type t
+        integer :: i = 1
+    end type t
+end module pr96099_1_ok_mod
+
+program pr96099_1_ok
+    use pr96099_1_ok_mod, only: t
+    implicit class(t) (x)
+    print *, 'ok'
+end program pr96099_1_ok

--- a/examples/f90/pr96099_2.f90
+++ b/examples/f90/pr96099_2.f90
@@ -1,0 +1,9 @@
+! { dg-do compile }
+
+program pr96099_2
+   integer n1
+   parameter (n1 = 1)
+   implicit class(t) (n1) ! { dg-error "Syntax error in IMPLICIT" }
+   type t
+   end type
+end

--- a/examples/f90/type_is_1.f90
+++ b/examples/f90/type_is_1.f90
@@ -1,0 +1,15 @@
+! { dg-do compile }
+! PR fortran/66245
+! Original testcase by Gerhard Steinmetz
+! <gerhard dot steinmetz dot fortran at t-online dot de>
+program p
+   type t; end type
+   class(t), allocatable :: x
+   call s
+   contains
+      subroutine s
+         select type ( x )
+         type is ( )       ! { dg-error "error in TYPE IS" }
+         end select
+      end subroutine s
+end program p

--- a/examples/f90/type_is_1_ok.f90
+++ b/examples/f90/type_is_1_ok.f90
@@ -1,0 +1,15 @@
+! Corrected neighbor of type_is_1.f90: TYPE IS names a type.
+program type_is_1_ok
+    type t
+    end type t
+    class(t), allocatable :: x
+    allocate (t :: x)
+    call s
+contains
+    subroutine s
+        select type (x)
+        type is (t)
+            print *, 'type is t'
+        end select
+    end subroutine s
+end program type_is_1_ok

--- a/src/parser/control_flow/parser_select_constructs_type.inc
+++ b/src/parser/control_flow/parser_select_constructs_type.inc
@@ -124,8 +124,20 @@
 
         ok = .true.
 
+        ! F2018 R1155/R1156: the type-guard parentheses must hold a
+        ! type-spec. An empty or otherwise nameless "( )" is a syntax error,
+        ! not a construct fortfront may silently drop.
         if (type_name_token%kind /= TK_IDENTIFIER .and. &
             type_name_token%kind /= TK_KEYWORD) then
+            if (guard_keyword == "type") then
+                call parser%error_at_token( &
+                    "Syntax error in TYPE IS specification: expected a "// &
+                    "type-spec inside the parentheses", type_name_token)
+            else
+                call parser%error_at_token( &
+                    "Syntax error in CLASS IS specification: expected a "// &
+                    "type-spec inside the parentheses", type_name_token)
+            end if
             ok = .false.
             return
         end if

--- a/src/parser/core/parser_state.f90
+++ b/src/parser/core/parser_state.f90
@@ -28,6 +28,7 @@ module parser_state_module
         procedure :: error_at_token => parser_add_error_at_token
         procedure :: has_errors => parser_has_errors
         procedure :: get_error_messages => parser_get_error_messages
+        procedure :: absorb_errors => parser_absorb_errors
 
         procedure :: cleanup => parser_cleanup
         procedure :: get_token_at_index => parser_get_token_at_index
@@ -158,6 +159,32 @@ contains
                 suggestion=suggestion)
         end if
     end subroutine parser_add_error_at_token
+
+    ! Take over the errors a nested parser collected. Sub-parsers built from a
+    ! statement token slice are discarded once the statement is parsed, so
+    ! without this their diagnostics would never reach the caller that reports
+    ! parse failures.
+    subroutine parser_absorb_errors(this, other)
+        class(parser_state_t), intent(inout) :: this
+        class(parser_state_t), intent(in) :: other
+        integer :: i
+
+        if (.not. other%errors%has_errors()) return
+        if (.not. allocated(other%errors%errors)) return
+
+        do i = 1, other%errors%count
+            associate (record => other%errors%errors(i))
+                if (allocated(record%suggestion)) then
+                    call this%errors%add_error_with_context(record%message, &
+                        record%context, severity=record%severity, &
+                        suggestion=record%suggestion)
+                else
+                    call this%errors%add_error_with_context(record%message, &
+                        record%context, severity=record%severity)
+                end if
+            end associate
+        end do
+    end subroutine parser_absorb_errors
 
     ! Check if parser has any errors
     logical function parser_has_errors(this)

--- a/src/parser/declarations/parser_declarations_type_spec_module.f90
+++ b/src/parser/declarations/parser_declarations_type_spec_module.f90
@@ -100,25 +100,35 @@ contains
 
         select case (base_lower)
         case ("type", "class")
-            call parse_parenthesized_derived(parser, arena, type_spec)
+            call parse_parenthesized_derived(parser, arena, type_spec, token)
         case ("character")
-            call parse_parenthesized_character(parser, type_spec)
+            call parse_parenthesized_character(parser, type_spec, token)
         case default
             call capture_parenthesized_content(parser, type_spec)
         end select
     end subroutine parse_parenthesized_spec
 
-    subroutine parse_parenthesized_derived(parser, arena, type_spec)
+    subroutine parse_parenthesized_derived(parser, arena, type_spec, open_paren)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         type(type_specifier_t), intent(inout) :: type_spec
+        type(token_t), intent(in) :: open_paren
         type(token_t), allocatable :: collected_tokens(:)
         character(len=:), allocatable :: derived_text
+        logical :: closed
 
         call clear_derived_type_storage(type_spec)
         type_spec%is_derived_type = .true.
 
-        call gather_derived_type_tokens(parser, collected_tokens)
+        call gather_derived_type_tokens(parser, collected_tokens, closed)
+        ! F2018 R703: the derived-type-spec parenthesis must be closed. Running
+        ! off the end of the statement means the type-spec is malformed.
+        if (.not. closed) then
+            call parser%error_at_token( &
+                "Malformed type-spec: missing ')' after the derived type name", &
+                open_paren)
+        end if
+
         if (allocated(collected_tokens)) then
             call analyze_derived_type_tokens(type_spec, collected_tokens, arena, &
                 parser)
@@ -141,19 +151,22 @@ contains
         end if
     end subroutine parse_parenthesized_derived
 
-    subroutine gather_derived_type_tokens(parser, tokens)
+    subroutine gather_derived_type_tokens(parser, tokens, closed)
         type(parser_state_t), intent(inout) :: parser
         type(token_t), allocatable, intent(out) :: tokens(:)
+        logical, intent(out) :: closed
         type(token_t) :: token
         integer :: depth
 
         depth = 0
+        closed = .false.
         do while (.not. parser%is_at_end())
             token = parser%peek()
             select case (token%text)
             case (")")
                 if (depth == 0) then
                     token = parser%consume()
+                    closed = .true.
                     exit
                 else
                     depth = depth - 1
@@ -171,9 +184,10 @@ contains
         end do
     end subroutine gather_derived_type_tokens
 
-    subroutine parse_parenthesized_character(parser, type_spec)
+    subroutine parse_parenthesized_character(parser, type_spec, open_paren)
         type(parser_state_t), intent(inout) :: parser
         type(type_specifier_t), intent(inout) :: type_spec
+        type(token_t), intent(in) :: open_paren
         type(token_t) :: token
         type(token_t), allocatable :: param_tokens(:)
         type(token_t), allocatable :: cleaned_tokens(:)
@@ -181,14 +195,17 @@ contains
         character(len=:), allocatable :: param_text
         integer :: param_start, param_end
         logical :: first_param
+        logical :: closed
 
         collected_text = ""
         first_param = .true.
+        closed = .false.
 
         do while (.not. parser%is_at_end())
             token = parser%peek()
             if (token%text == ")") then
                 token = parser%consume()
+                closed = .true.
                 exit
             end if
 
@@ -221,6 +238,14 @@ contains
 
             call consume_comma_if_present(parser)
         end do
+
+        ! F2018 R721: the char-selector parenthesis must be closed. Running off
+        ! the end of the statement means the CHARACTER declaration is malformed.
+        if (.not. closed) then
+            call parser%error_at_token( &
+                "Syntax error in CHARACTER declaration: missing ')' after the "// &
+                "length or kind selector", open_paren)
+        end if
 
         if (len_trim(collected_text) > 0) then
             type_spec%type_name = trim(type_spec%base_keyword)//"("// &

--- a/src/parser/declarations/parser_implicit_letter_specs.f90
+++ b/src/parser/declarations/parser_implicit_letter_specs.f90
@@ -1,0 +1,154 @@
+module parser_implicit_letter_specs_module
+    ! Validation of the letter-spec-list that terminates every implicit-spec.
+    use lexer_core, only: token_t, TK_IDENTIFIER, TK_KEYWORD, TK_OPERATOR, &
+        TK_NEWLINE, TK_COMMENT, TK_WHITESPACE, TK_EOF
+    use parser_state_module, only: parser_state_t
+    implicit none
+    private
+
+    public :: validate_implicit_letter_specs
+
+contains
+
+    ! F2018 R863/R865: every implicit-spec ends in a parenthesised
+    ! letter-spec-list, and a letter-spec is a single letter or a range of two
+    ! single letters. Only the group that closes an implicit-spec is checked, so
+    ! a preceding kind or derived-type selector such as real(kind=8) or class(t)
+    ! is left alone.
+    subroutine validate_implicit_letter_specs(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+        integer :: pos, depth, group_start, last_index
+
+        last_index = statement_end_index(parser)
+        pos = parser%current_token
+        depth = 0
+        group_start = 0
+
+        do while (pos <= last_index)
+            token = parser%get_token_at_index(pos)
+            if (token%kind == TK_OPERATOR .and. token%text == "(") then
+                if (depth == 0) group_start = pos
+                depth = depth + 1
+            else if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                depth = depth - 1
+                if (depth == 0 .and. group_start > 0) then
+                    if (closes_implicit_spec(parser, pos, last_index)) then
+                        if (.not. is_letter_spec_list(parser, group_start + 1, &
+                            pos - 1)) then
+                            call parser%error_at_token( &
+                                "Syntax error in IMPLICIT statement: the "// &
+                                "letter-spec list must hold single letters or "// &
+                                "letter ranges", &
+                                parser%get_token_at_index(group_start))
+                            return
+                        end if
+                    end if
+                    group_start = 0
+                end if
+            end if
+            pos = pos + 1
+        end do
+    end subroutine validate_implicit_letter_specs
+
+    ! Index of the last token belonging to the current statement.
+    integer function statement_end_index(parser) result(last_index)
+        type(parser_state_t), intent(in) :: parser
+        type(token_t) :: token
+        integer :: pos
+
+        last_index = parser%current_token - 1
+        pos = parser%current_token
+        do while (pos <= parser%get_token_count())
+            token = parser%get_token_at_index(pos)
+            if (token%kind == TK_NEWLINE .or. token%kind == TK_COMMENT .or. &
+                token%kind == TK_EOF) exit
+            last_index = pos
+            pos = pos + 1
+        end do
+    end function statement_end_index
+
+    ! A parenthesised group closes an implicit-spec when the statement ends
+    ! right after it or the next token is the comma before the next spec.
+    logical function closes_implicit_spec(parser, close_pos, last_index) &
+            result(closes)
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(in) :: close_pos
+        integer, intent(in) :: last_index
+        type(token_t) :: token
+        integer :: pos
+
+        closes = .false.
+        pos = skip_blanks(parser, close_pos + 1, last_index)
+        if (pos > last_index) then
+            closes = .true.
+            return
+        end if
+
+        token = parser%get_token_at_index(pos)
+        if (token%kind /= TK_OPERATOR) return
+        closes = (token%text == ",")
+    end function closes_implicit_spec
+
+    logical function is_letter_spec_list(parser, first, last) result(valid)
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(in) :: first
+        integer, intent(in) :: last
+        type(token_t) :: token
+        integer :: pos
+
+        valid = .false.
+        if (last < first) return
+
+        pos = skip_blanks(parser, first, last)
+        do
+            if (pos > last) return
+            if (.not. is_single_letter(parser%get_token_at_index(pos))) return
+            pos = skip_blanks(parser, pos + 1, last)
+            if (pos > last) exit
+
+            token = parser%get_token_at_index(pos)
+            if (token%kind == TK_OPERATOR .and. token%text == "-") then
+                pos = skip_blanks(parser, pos + 1, last)
+                if (pos > last) return
+                if (.not. is_single_letter(parser%get_token_at_index(pos))) return
+                pos = skip_blanks(parser, pos + 1, last)
+                if (pos > last) exit
+                token = parser%get_token_at_index(pos)
+            end if
+
+            if (token%kind /= TK_OPERATOR) return
+            if (token%text /= ",") return
+            pos = skip_blanks(parser, pos + 1, last)
+        end do
+
+        valid = .true.
+    end function is_letter_spec_list
+
+    integer function skip_blanks(parser, first, last) result(pos)
+        type(parser_state_t), intent(in) :: parser
+        integer, intent(in) :: first
+        integer, intent(in) :: last
+        type(token_t) :: token
+
+        pos = first
+        do while (pos <= last)
+            token = parser%get_token_at_index(pos)
+            if (token%kind /= TK_WHITESPACE) exit
+            pos = pos + 1
+        end do
+    end function skip_blanks
+
+    logical function is_single_letter(token) result(is_letter)
+        type(token_t), intent(in) :: token
+        character(len=1) :: c
+
+        is_letter = .false.
+        if (token%kind /= TK_IDENTIFIER .and. token%kind /= TK_KEYWORD) return
+        if (.not. allocated(token%text)) return
+        if (len(token%text) /= 1) return
+        c = token%text(1:1)
+        is_letter = (c >= "a" .and. c <= "z") .or. (c >= "A" .and. c <= "Z")
+    end function is_single_letter
+
+end module parser_implicit_letter_specs_module

--- a/src/parser/declarations/parser_type_specifications.f90
+++ b/src/parser/declarations/parser_type_specifications.f90
@@ -7,6 +7,7 @@ module parser_type_specifications_module
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_implicit_statement
     use parser_implicit_shared_module, only: parse_none_spec_list
+    use parser_implicit_letter_specs_module, only: validate_implicit_letter_specs
     implicit none
     private
     integer, allocatable, save :: implicit_additional_indices(:)
@@ -207,6 +208,8 @@ contains
             call clear_implicit_additional_indices()
             return
         end if
+
+        call validate_implicit_letter_specs(parser)
 
         call parse_implicit_spec_sequence(parser, specs, spec_count)
         if (spec_count <= 0) then

--- a/src/parser/expressions/parser_expression_arrays.f90
+++ b/src/parser/expressions/parser_expression_arrays.f90
@@ -187,6 +187,10 @@ contains
             end if
 
             if (current%text == "(") then
+                if (is_malformed_parenthesized_item(parser)) then
+                    expr_index = 0
+                    return
+                end if
                 saved_pos = parser%current_token
                 if (has_type_spec) then
                     expr_index = parse_legacy_implied_do_constructor(parser, arena, &
@@ -320,6 +324,10 @@ contains
                 current = parser%consume() ! Consume the closing bracket
                 exit
             else if (peek_token%text == "(") then
+                if (is_malformed_parenthesized_item(parser)) then
+                    expr_index = 0
+                    return
+                end if
                 saved_pos = parser%current_token
                 if (has_type_spec) then
                     expr_index = parse_implied_do_constructor(parser, arena, &
@@ -406,6 +414,57 @@ contains
                 syntax_style="modern")
         end if
     end function parse_modern_array_literal
+
+    ! F2018 R770: an ac-value that starts with "(" is either a parenthesised
+    ! expression, a complex literal (exactly two items), or an ac-implied-do
+    ! (which carries "=" for its do-variable). A parenthesised list of three or
+    ! more items without "=" matches none of those, so reject it here instead of
+    ! letting the fallback expression parser swallow part of it.
+    logical function is_malformed_parenthesized_item(parser) result(malformed)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: open_paren
+        type(token_t) :: token
+        integer :: pos, depth, item_count
+        logical :: has_equals
+
+        malformed = .false.
+        open_paren = parser%peek()
+        if (open_paren%kind /= TK_OPERATOR) return
+        if (open_paren%text /= "(") return
+
+        pos = parser%current_token + 1
+        depth = 1
+        item_count = 1
+        has_equals = .false.
+
+        do while (pos <= parser%get_token_count())
+            token = parser%get_token_at_index(pos)
+            if (token%kind == TK_OPERATOR) then
+                select case (token%text)
+                case ("(", "[")
+                    depth = depth + 1
+                case (")", "]")
+                    depth = depth - 1
+                    if (depth == 0) exit
+                case (",")
+                    if (depth == 1) item_count = item_count + 1
+                case ("=")
+                    if (depth == 1) has_equals = .true.
+                end select
+            end if
+            pos = pos + 1
+        end do
+
+        if (depth /= 0) return
+        if (has_equals) return
+        if (item_count < 3) return
+
+        malformed = .true.
+        call parser%error_at_token( &
+            "Syntax error in COMPLEX constant: a parenthesised array "// &
+            "constructor item needs exactly two parts, or an implied-do "// &
+            "with a do-variable", open_paren)
+    end function is_malformed_parenthesized_item
 
     recursive function parse_nested_implied_do(parser, arena, helpers) &
             result(expr_index)

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -558,7 +558,7 @@ contains
         type(token_t), intent(in) :: stmt_tokens(:)
         integer, intent(in) :: stmt_size
         type(ast_arena_t), intent(inout) :: arena
-        type(parser_state_t), intent(in) :: parent_parser
+        type(parser_state_t), intent(inout) :: parent_parser
         integer :: first_token
         character(len=:), allocatable :: token_lower, stmt_label
         type(parser_state_t) :: block_parser
@@ -666,7 +666,7 @@ contains
         type(token_t), intent(in) :: stmt_tokens(:)
         type(ast_arena_t), intent(inout) :: arena
         type(parser_state_t) :: select_parser
-        type(parser_state_t), intent(in) :: parent_parser
+        type(parser_state_t), intent(inout) :: parent_parser
         type(token_t) :: next_token
         character(len=:), allocatable :: next_lower
 
@@ -728,6 +728,11 @@ contains
         else
             select_index = 0
         end if
+
+        ! The sub-parser is about to go out of scope; hand its diagnostics to
+        ! the enclosing parser so a rejected SELECT arm is reported instead of
+        ! silently dropping the construct.
+        call parent_parser%absorb_errors(select_parser)
     end function parse_select_statement_tokens
 
     logical function handle_contains_procedure(parser, arena, token, prefix_buffer, &

--- a/test/api/test_reject_type_syntax_01_diagnostics.f90
+++ b/test/api/test_reject_type_syntax_01_diagnostics.f90
@@ -1,0 +1,150 @@
+program test_reject_type_syntax_01_diagnostics
+    ! Issue #2891: malformed type and SELECT TYPE syntax must be rejected with a
+    ! rule-specific diagnostic, while the corrected neighbouring form still
+    ! compiles. The gfortran.dg fixtures named by the issue are mirrored under
+    ! examples/f90/ with their exact basenames; the *_ok.f90 neighbours are the
+    ! corrected forms and are verified against gfortran -std=f2018.
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use semantic_operating_mode, only: OPERATING_MODE_STRICT
+    use transformation_api, only: transform_with_context, transform_context_t
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    print *, '=== Issue #2891: malformed type / SELECT TYPE rejection ==='
+
+    call expect_rejected('class_is_1', 'CLASS IS specification', all_passed)
+    call expect_rejected('type_is_1', 'TYPE IS specification', all_passed)
+    call expect_rejected('pr91660_1', 'Malformed type-spec', all_passed)
+    call expect_rejected('pr91715', 'CHARACTER declaration', all_passed)
+    call expect_rejected('pr96099_1', 'IMPLICIT statement', all_passed)
+    call expect_rejected('pr96099_2', 'IMPLICIT statement', all_passed)
+    call expect_rejected('pr19936_3', 'COMPLEX constant', all_passed)
+
+    call expect_accepted('class_is_1_ok', all_passed)
+    call expect_accepted('type_is_1_ok', all_passed)
+    call expect_accepted('pr91660_1_ok', all_passed)
+    call expect_accepted('pr91715_ok', all_passed)
+    call expect_accepted('pr96099_1_ok', all_passed)
+    call expect_accepted('pr19936_3_ok', all_passed)
+
+    ! Guard against over-rejection of the valid forms that share these code
+    ! paths: kind selectors in IMPLICIT, complex literals and implied-dos in
+    ! array constructors, and CHARACTER length selectors.
+    call expect_accepted('implicit_letter_spec_forms', all_passed)
+    ! A kind or length selector before the letter-spec list must not be read as
+    ! a letter-spec list. fortfront still loses that letter list on emit
+    ! (pre-existing, see examples/expected_failures.txt), so only the rules
+    ! added here are asserted.
+    call expect_no_rule_rejection('implicit_kind_selector_letter_specs', all_passed)
+    call expect_accepted('issue_2390_module_implicit_rules', all_passed)
+    call expect_accepted('complex_assignment_literals', all_passed)
+    call expect_accepted('issue_1575_implied_do_array_constructor', all_passed)
+    call expect_accepted('issue_1970_implied_do_array_constructor', all_passed)
+    call expect_accepted('issue_2013_nested_implied_do_duplicate_var', all_passed)
+    call expect_accepted('issue_1614_character_parameter_length', all_passed)
+    call expect_accepted('issue_2559_select_type_case_variations', all_passed)
+
+    print *
+    if (all_passed) then
+        print *, 'All issue #2891 rejection tests PASSED!'
+        stop 0
+    else
+        print *, 'Some issue #2891 rejection tests FAILED!'
+        error stop 1
+    end if
+
+contains
+
+    subroutine transform_example(basename, output_code, error_msg)
+        character(len=*), intent(in) :: basename
+        character(len=:), allocatable, intent(out) :: output_code
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: input_code
+        type(transform_context_t) :: context
+
+        call read_example('examples/f90/'//basename//'.f90', input_code)
+
+        context%input_mode = INPUT_MODE_STANDARD
+        context%operating_mode = OPERATING_MODE_STRICT
+        context%has_filename = .true.
+        context%source_name = basename
+
+        call transform_with_context(input_code, output_code, error_msg, context)
+    end subroutine transform_example
+
+    subroutine expect_rejected(basename, expected_fragment, passed)
+        character(len=*), intent(in) :: basename
+        character(len=*), intent(in) :: expected_fragment
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+
+        call transform_example(basename, output_code, error_msg)
+
+        if (len_trim(error_msg) == 0) then
+            print *, 'FAIL: ', basename, ' was accepted but must be rejected'
+            print *, '  output: ', trim(output_code)
+            passed = .false.
+            return
+        end if
+
+        if (index(error_msg, expected_fragment) == 0) then
+            print *, 'FAIL: ', basename, ' rejected by the wrong rule'
+            print *, '  expected fragment: ', expected_fragment
+            print *, '  error: ', trim(error_msg)
+            passed = .false.
+            return
+        end if
+
+        print *, 'PASS: ', basename, ' rejected (', expected_fragment, ')'
+    end subroutine expect_rejected
+
+    ! Weaker guard for fixtures that trip unrelated pre-existing diagnostics:
+    ! assert only that none of the rules added for issue #2891 fired.
+    subroutine expect_no_rule_rejection(basename, passed)
+        character(len=*), intent(in) :: basename
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+        character(len=24), parameter :: fragments(5) = [ &
+            character(len=24) :: 'TYPE IS specification', 'CLASS IS specification', &
+            'Malformed type-spec', 'CHARACTER declaration', 'IMPLICIT statement']
+        integer :: i
+
+        call transform_example(basename, output_code, error_msg)
+
+        do i = 1, size(fragments)
+            if (index(error_msg, trim(fragments(i))) > 0) then
+                print *, 'FAIL: ', basename, ' hit rule ', trim(fragments(i))
+                print *, '  error: ', trim(error_msg)
+                passed = .false.
+                return
+            end if
+        end do
+
+        print *, 'PASS: ', basename, ' not rejected by any issue 2891 rule'
+    end subroutine expect_no_rule_rejection
+
+    subroutine expect_accepted(basename, passed)
+        character(len=*), intent(in) :: basename
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: output_code
+        character(len=:), allocatable :: error_msg
+
+        call transform_example(basename, output_code, error_msg)
+
+        if (len_trim(error_msg) /= 0) then
+            print *, 'FAIL: ', basename, ' is valid but was rejected'
+            print *, '  error: ', trim(error_msg)
+            passed = .false.
+            return
+        end if
+
+        print *, 'PASS: ', basename, ' accepted'
+    end subroutine expect_accepted
+
+    include '../common/read_example.inc'
+end program test_reject_type_syntax_01_diagnostics


### PR DESCRIPTION
Closes #2891.

## What changed

fortfront accepted all seven gfortran.dg fixtures named by the issue and silently
dropped or mangled the offending construct. Five rules now reject them:

| Rule | Fixture | Diagnostic | Owner |
|---|---|---|---|
| TYPE IS / CLASS IS guard needs a type-spec | `type_is_1.f90`, `class_is_1.f90` | `Syntax error in TYPE IS specification` / `... CLASS IS ...` | `parser_select_constructs_type.inc` |
| derived type-spec parenthesis must close | `pr91660_1.f90` | `Malformed type-spec` | `parser_declarations_type_spec_module.f90` |
| CHARACTER selector parenthesis must close | `pr91715.f90` | `Syntax error in CHARACTER declaration` | `parser_declarations_type_spec_module.f90` |
| implicit-spec must end in a letter-spec list | `pr96099_1.f90`, `pr96099_2.f90` | `Syntax error in IMPLICIT statement` | new `parser_implicit_letter_specs.f90`, called from `parser_type_specifications.f90` |
| parenthesised array-constructor item | `pr19936_3.f90` | `Syntax error in COMPLEX constant` | `parser_expression_arrays.f90` |

A sixth change is plumbing: diagnostics raised while parsing a SELECT construct
nested in a procedure body were discarded together with the sub-parser that
produced them. `parser_state_t%absorb_errors` hands them to the enclosing parser.
Without it the guard rule fired but was invisible.

## Before / after

All seven fixtures exited 0 on `origin/main`. All seven now exit 1 with the
diagnostic above; the six corrected neighbours still exit 0.

## Guarding against over-rejection

- The IMPLICIT rule only inspects the parenthesised group that *closes* an
  implicit-spec, so `real(kind=8) (a-z)` and `class(t) (a)` keep their selector
  group unchecked. `implicit_kind_selector_letter_specs.f90` covers this.
- The array rule needs three or more top-level items **and** no top-level `=`.
  `(a, b)` stays a complex literal and `(a(i), b(i), i=1,n)` stays an
  implied-do. It runs only inside an array constructor, so io-implied-dos are
  untouched.
- `test_reject_type_syntax_01_diagnostics` additionally asserts that
  `complex_assignment_literals`, `issue_1575_implied_do_array_constructor`,
  `issue_1970_implied_do_array_constructor`,
  `issue_2013_nested_implied_do_duplicate_var`,
  `issue_1614_character_parameter_length`,
  `issue_2390_module_implicit_rules` and
  `issue_2559_select_type_case_variations` still pass.

Every rule was proved by negative control: disabling the emission makes the test
fail on exactly its fixture, and restoring it makes it pass.

## Known gaps left in place

Three corrected neighbours parse and validate fine but hit **pre-existing**
emitter bugs (verified by reverting the parser change): the legacy `(/ ... /)`
implied-do loses its wrapper, and IMPLICIT statements carrying a kind, length or
class selector lose the letter-spec list. They are listed in
`examples/expected_failures.txt` rather than papered over.

`make check-duplication` reports the same single pre-existing violation in
`test/api/test_compiler_statement_queries.f90` (#2910) as on `main`.