### PR TITLE
[api-unit-01] expose program-unit and declaration queries

### DIFF
--- a/src/fortfront.f90
+++ b/src/fortfront.f90
@@ -55,7 +55,18 @@ module fortfront
         get_function_body_info, &
         get_subroutine_body_info, &
         get_used_modules, get_defined_module, &
-        used_module_t, defined_module_t
+        used_module_t, defined_module_t, &
+        program_unit_query_t, declaration_query_t, &
+        derived_type_query_t, type_binding_query_t, &
+        use_statement_query_t, interface_query_t, visibility_query_t, &
+        namelist_query_t, data_statement_query_t, common_block_query_t, &
+        enum_query_t, statement_function_query_t, block_data_query_t, &
+        query_program_units, query_program_unit, query_declarations, &
+        query_declaration, query_derived_type, query_type_binding, &
+        query_use_statement, query_use_statements, query_interface, &
+        query_visibility, query_namelist, query_data_statement, &
+        query_common_block, query_enum, query_statement_function, &
+        query_block_data
     use frontend_compiler_resolution, only: declaration_binding_t, &
                                             get_scope_bindings, resolve_name_in_scope, &
                                      resolve_name_at_node, resolve_identifier_binding, &

--- a/src/fortfront_compiler.f90
+++ b/src/fortfront_compiler.f90
@@ -24,6 +24,17 @@ module fortfront_compiler
         get_subroutine_body_info, &
         get_used_modules, get_defined_module, &
         used_module_t, defined_module_t, &
+        program_unit_query_t, declaration_query_t, &
+        derived_type_query_t, type_binding_query_t, &
+        use_statement_query_t, interface_query_t, visibility_query_t, &
+        namelist_query_t, data_statement_query_t, common_block_query_t, &
+        enum_query_t, statement_function_query_t, block_data_query_t, &
+        query_program_units, query_program_unit, query_declarations, &
+        query_declaration, query_derived_type, query_type_binding, &
+        query_use_statement, query_use_statements, query_interface, &
+        query_visibility, query_namelist, query_data_statement, &
+        query_common_block, query_enum, query_statement_function, &
+        query_block_data, &
         array_slice_query_t, array_bounds_query_t, &
         range_expression_query_t, component_access_query_t, &
         array_literal_query_t, pointer_assignment_query_t, nullify_query_t, &

--- a/src/frontend/frontend_compiler_queries.f90
+++ b/src/frontend/frontend_compiler_queries.f90
@@ -10,10 +10,13 @@ module frontend_compiler_queries
         range_expression_node
     use ast_nodes_transfer, only: nullify_node
     use ast_nodes_data, only: declaration_node, derived_type_node, &
-        parameter_declaration_node, module_node, &
-        submodule_node
+        parameter_declaration_node, module_node, block_data_node, &
+        submodule_node, multi_unit_container_node, type_binding_node
     use ast_nodes_misc, only: interface_block_node, import_statement_node, &
-        use_statement_node
+        use_statement_node, visibility_statement_node, &
+        namelist_statement_node, data_statement_node, &
+        statement_function_node
+    use ast_nodes_legacy, only: common_block_node, enum_node
     use ast_nodes_conditional, only: select_case_node, case_block_node, &
         case_default_node, case_range_node, &
         select_type_node, type_guard_block_node
@@ -51,6 +54,19 @@ module frontend_compiler_queries
     public :: get_defined_module
     public :: used_module_t
     public :: defined_module_t
+    public :: program_unit_query_t, declaration_query_t
+    public :: derived_type_query_t, type_binding_query_t
+    public :: use_statement_query_t, interface_query_t
+    public :: visibility_query_t, namelist_query_t, data_statement_query_t
+    public :: common_block_query_t, enum_query_t
+    public :: statement_function_query_t, block_data_query_t
+    public :: query_program_units, query_program_unit
+    public :: query_declarations, query_declaration
+    public :: query_derived_type, query_type_binding
+    public :: query_use_statement, query_use_statements
+    public :: query_interface, query_visibility, query_namelist
+    public :: query_data_statement, query_common_block, query_enum
+    public :: query_statement_function, query_block_data
     public :: array_slice_query_t, array_bounds_query_t, range_expression_query_t
     public :: component_access_query_t, array_literal_query_t
     public :: pointer_assignment_query_t, nullify_query_t
@@ -108,6 +124,200 @@ module frontend_compiler_queries
         logical :: is_submodule = .false.
         character(len=:), allocatable :: parent_identifier
     end type defined_module_t
+
+    ! Compiler-facing records contain values and indices copied out of the
+    ! arena. They deliberately do not expose the concrete AST node types.
+    type :: program_unit_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: parent_node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: unit_kind
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: parent_identifier
+        character(len=:), allocatable :: result_name
+        character(len=:), allocatable :: return_type
+        character(len=:), allocatable :: bind_c_clause
+        character(len=:), allocatable :: header_label
+        character(len=:), allocatable :: end_label
+        logical :: has_contains = .false.
+        logical :: is_abstract = .false.
+        logical :: is_recursive = .false.
+        integer, allocatable :: declaration_indices(:)
+        integer, allocatable :: procedure_indices(:)
+        integer, allocatable :: parameter_indices(:)
+        integer, allocatable :: body_indices(:)
+        integer, allocatable :: statement_indices(:)
+    end type program_unit_query_t
+
+    type :: declaration_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: names(:)
+        character(len=:), allocatable :: type_name
+        character(len=:), allocatable :: character_length_expr
+        character(len=:), allocatable :: intent
+        character(len=:), allocatable :: accessibility
+        character(len=:), allocatable :: bind_name
+        integer :: kind_value = 0
+        integer :: intent_type = 0
+        integer :: initializer_index = 0
+        logical :: is_parameter_declaration = .false.
+        logical :: has_kind = .false.
+        logical :: has_character_length = .false.
+        logical :: has_intent = .false.
+        logical :: has_initializer = .false.
+        logical :: is_optional = .false.
+        logical :: is_array = .false.
+        logical :: is_allocatable = .false.
+        logical :: is_pointer = .false.
+        logical :: is_target = .false.
+        logical :: is_external = .false.
+        logical :: is_parameter = .false.
+        logical :: is_save = .false.
+        logical :: is_volatile = .false.
+        logical :: is_protected = .false.
+        logical :: is_asynchronous = .false.
+        logical :: is_contiguous = .false.
+        logical :: is_value = .false.
+        logical :: is_bind_c = .false.
+        logical :: is_inferred = .false.
+        integer, allocatable :: dimension_indices(:)
+    end type declaration_query_t
+
+    type :: derived_type_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: extends_parent
+        character(len=:), allocatable :: attribute_clause
+        logical :: has_attributes = .false.
+        logical :: has_parameters = .false.
+        logical :: has_contains = .false.
+        integer, allocatable :: component_indices(:)
+        integer, allocatable :: parameter_indices(:)
+        integer, allocatable :: binding_indices(:)
+    end type derived_type_query_t
+
+    type :: type_binding_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: binding_name
+        character(len=:), allocatable :: implementation
+        character(len=:), allocatable :: interface_name
+        character(len=:), allocatable :: pass_name
+        character(len=:), allocatable :: accessibility
+        logical :: is_generic = .false.
+        logical :: is_final = .false.
+        logical :: is_deferred = .false.
+        logical :: pass_arg = .true.
+        character(len=:), allocatable :: generic_names(:)
+    end type type_binding_query_t
+
+    type :: use_statement_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: module_name
+        character(len=:), allocatable :: url_spec
+        character(len=:), allocatable :: only_list(:)
+        character(len=:), allocatable :: rename_list(:)
+        logical :: has_only = .false.
+        logical :: has_double_colon = .false.
+        logical :: is_intrinsic = .false.
+        logical :: is_non_intrinsic = .false.
+    end type use_statement_query_t
+
+    type :: interface_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: kind
+        character(len=:), allocatable :: operator
+        logical :: is_abstract = .false.
+        integer, allocatable :: procedure_indices(:)
+    end type interface_query_t
+
+    type :: visibility_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        logical :: is_private = .false.
+        logical :: has_list = .false.
+        logical :: has_double_colon = .false.
+        character(len=:), allocatable :: names(:)
+    end type visibility_query_t
+
+    type :: namelist_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: group_name
+        character(len=:), allocatable :: variable_names(:)
+    end type namelist_query_t
+
+    type :: data_statement_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        integer, allocatable :: object_indices(:)
+        integer, allocatable :: value_indices(:)
+    end type data_statement_query_t
+
+    type :: common_block_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: block_names(:)
+        character(len=:), allocatable :: member_names(:)
+        integer, allocatable :: member_block(:)
+    end type common_block_query_t
+
+    type :: enum_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        logical :: is_bind_c = .false.
+        character(len=:), allocatable :: enumerator_names(:)
+        integer, allocatable :: enumerator_values(:)
+    end type enum_query_t
+
+    type :: statement_function_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: argument_names(:)
+        integer :: body_expression_index = 0
+    end type statement_function_query_t
+
+    type :: block_data_query_t
+        logical :: found = .false.
+        integer :: node_index = 0
+        integer :: line = 0
+        integer :: column = 0
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: header_label
+        character(len=:), allocatable :: end_label
+        integer, allocatable :: statement_indices(:)
+    end type block_data_query_t
 
 contains
 
@@ -960,6 +1170,737 @@ contains
 
         error_msg = 'no module or submodule definition found in arena'
     end subroutine get_defined_module
+
+    recursive function query_program_units(arena, root_index) result(units)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in), optional :: root_index
+        type(program_unit_query_t), allocatable :: units(:)
+
+        integer, allocatable :: indices(:)
+        integer :: i, count, k
+        logical :: selected_root
+
+        allocate (indices(0))
+        selected_root = .false.
+
+        if (present(root_index)) then
+            if (.not. arena%has_node_at(root_index)) then
+                allocate (units(0))
+                return
+            end if
+            selected_root = .true.
+            select type (root => arena%entries(root_index)%node)
+                type is (multi_unit_container_node)
+                if (allocated(root%body_indices)) then
+                    count = count_program_units(arena, root%body_indices)
+                    if (allocated(indices)) deallocate (indices)
+                    allocate (indices(count))
+                    k = 0
+                    do i = 1, size(root%body_indices)
+                        if (.not. is_program_unit_node(arena, &
+                            root%body_indices(i))) cycle
+                        k = k + 1
+                        indices(k) = root%body_indices(i)
+                    end do
+                end if
+            class default
+                if (is_program_unit_node(arena, root_index)) then
+                    if (allocated(indices)) deallocate (indices)
+                    allocate (indices(1))
+                    indices(1) = root_index
+                end if
+            end select
+        end if
+
+        if (.not. selected_root) then
+            do i = 1, arena%size
+                if (.not. arena%has_node_at(i)) cycle
+                if (arena%entries(i)%parent_index /= 0) cycle
+                select type (root => arena%entries(i)%node)
+                    type is (multi_unit_container_node)
+                    units = query_program_units(arena, i)
+                    return
+                end select
+            end do
+            count = 0
+            do i = 1, arena%size
+                if (.not. arena%has_node_at(i)) cycle
+                if (arena%entries(i)%parent_index /= 0) cycle
+                if (is_program_unit_node(arena, i)) count = count + 1
+            end do
+            if (allocated(indices)) deallocate (indices)
+            allocate (indices(count))
+            k = 0
+            do i = 1, arena%size
+                if (.not. arena%has_node_at(i)) cycle
+                if (arena%entries(i)%parent_index /= 0) cycle
+                if (.not. is_program_unit_node(arena, i)) cycle
+                k = k + 1
+                indices(k) = i
+            end do
+        end if
+
+        allocate (units(size(indices)))
+        do i = 1, size(indices)
+            units(i) = query_program_unit(arena, indices(i))
+        end do
+    end function query_program_units
+
+    function query_program_unit(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(program_unit_query_t) :: query
+
+        call initialize_program_unit_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+
+        query%node_index = node_index
+        query%parent_node_index = arena%entries(node_index)%parent_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+
+        select type (node => arena%entries(node_index)%node)
+            type is (program_node)
+            query%found = .true.
+            query%unit_kind = 'program'
+            if (allocated(node%name)) query%name = node%name
+            call copy_integer_array(node%body_indices, query%body_indices)
+            type is (module_node)
+            query%found = .true.
+            query%unit_kind = 'module'
+            if (allocated(node%name)) query%name = node%name
+            query%has_contains = node%has_contains
+            call copy_integer_array(node%declaration_indices, &
+                query%declaration_indices)
+            call copy_integer_array(node%procedure_indices, query%procedure_indices)
+            type is (submodule_node)
+            query%found = .true.
+            query%unit_kind = 'submodule'
+            if (allocated(node%name)) query%name = node%name
+            if (allocated(node%parent_identifier)) then
+                query%parent_identifier = node%parent_identifier
+            end if
+            query%has_contains = node%has_contains
+            call copy_integer_array(node%declaration_indices, &
+                query%declaration_indices)
+            call copy_integer_array(node%procedure_indices, query%procedure_indices)
+            type is (block_data_node)
+            query%found = .true.
+            query%unit_kind = 'block_data'
+            if (allocated(node%name)) query%name = node%name
+            if (allocated(node%header_label)) query%header_label = node%header_label
+            if (allocated(node%end_label)) query%end_label = node%end_label
+            call copy_integer_array(node%statement_indices, &
+                query%statement_indices)
+            type is (function_def_node)
+            query%found = .true.
+            query%unit_kind = 'function'
+            if (allocated(node%name)) query%name = node%name
+            if (allocated(node%result_variable)) query%result_name = &
+                node%result_variable
+            if (allocated(node%return_type)) query%return_type = node%return_type
+            if (allocated(node%bind_c_clause)) query%bind_c_clause = &
+                node%bind_c_clause
+            query%is_recursive = node%is_recursive
+            call copy_integer_array(node%param_indices, query%parameter_indices)
+            call copy_integer_array(node%body_indices, query%body_indices)
+            type is (subroutine_def_node)
+            query%found = .true.
+            query%unit_kind = 'subroutine'
+            if (allocated(node%name)) query%name = node%name
+            if (allocated(node%bind_c_clause)) query%bind_c_clause = &
+                node%bind_c_clause
+            query%is_recursive = node%is_recursive
+            call copy_integer_array(node%param_indices, query%parameter_indices)
+            call copy_integer_array(node%body_indices, query%body_indices)
+            type is (interface_block_node)
+            query%found = .true.
+            query%unit_kind = 'interface'
+            if (allocated(node%name)) query%name = node%name
+            query%is_abstract = node%is_abstract
+            call copy_integer_array(node%procedure_indices, &
+                query%procedure_indices)
+            type is (multi_unit_container_node)
+            query%found = .true.
+            query%unit_kind = 'multi_unit_container'
+            call copy_integer_array(node%body_indices, query%body_indices)
+        end select
+    end function query_program_unit
+
+    function query_declarations(arena, parent_index) result(queries)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: parent_index
+        type(declaration_query_t), allocatable :: queries(:)
+
+        integer, allocatable :: children(:)
+        integer :: i, count, k
+
+        children = arena%get_children(parent_index)
+        if (size(children) > 0) then
+            count = 0
+            do i = 1, size(children)
+                if (is_declaration_query_node(arena, children(i))) count = count + 1
+            end do
+
+            allocate (queries(count))
+            k = 0
+            do i = 1, size(children)
+                if (.not. is_declaration_query_node(arena, children(i))) cycle
+                k = k + 1
+                queries(k) = query_declaration(arena, children(i))
+            end do
+            return
+        end if
+
+        count = 0
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            if (arena%entries(i)%parent_index /= parent_index) cycle
+            if (is_declaration_query_node(arena, i)) count = count + 1
+        end do
+        allocate (queries(count))
+        k = 0
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            if (arena%entries(i)%parent_index /= parent_index) cycle
+            if (.not. is_declaration_query_node(arena, i)) cycle
+            k = k + 1
+            queries(k) = query_declaration(arena, i)
+        end do
+    end function query_declarations
+
+    function query_declaration(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(declaration_query_t) :: query
+
+        call initialize_declaration_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (declaration_node)
+            query%found = .true.
+            if (allocated(node%var_name)) query%name = node%var_name
+            if (allocated(node%var_names)) then
+                query%names = node%var_names
+            else
+                call copy_single_name(query%name, query%names)
+            end if
+            if (allocated(node%type_name)) query%type_name = node%type_name
+            if (allocated(node%character_length_expr)) then
+                query%character_length_expr = node%character_length_expr
+            end if
+            if (allocated(node%intent)) query%intent = node%intent
+            if (allocated(node%accessibility)) query%accessibility = &
+                node%accessibility
+            if (allocated(node%bind_name)) query%bind_name = node%bind_name
+            query%kind_value = node%kind_value
+            query%has_kind = node%has_kind
+            query%has_character_length = node%has_character_length
+            query%has_intent = node%has_intent
+            query%initializer_index = node%initializer_index
+            query%has_initializer = node%has_initializer
+            query%is_optional = node%is_optional
+            query%is_array = node%is_array
+            query%is_allocatable = node%is_allocatable
+            query%is_pointer = node%is_pointer
+            query%is_target = node%is_target
+            query%is_external = node%is_external
+            query%is_parameter = node%is_parameter
+            query%is_save = node%is_save
+            query%is_volatile = node%is_volatile
+            query%is_protected = node%is_protected
+            query%is_asynchronous = node%is_asynchronous
+            query%is_contiguous = node%is_contiguous
+            query%is_value = node%is_value
+            query%is_bind_c = node%is_bind_c
+            query%is_inferred = node%is_inferred
+            call copy_integer_array(node%dimension_indices, &
+                query%dimension_indices)
+            type is (parameter_declaration_node)
+            query%found = .true.
+            query%is_parameter_declaration = .true.
+            if (allocated(node%name)) query%name = node%name
+            call copy_single_name(query%name, query%names)
+            if (allocated(node%type_name)) query%type_name = node%type_name
+            if (allocated(node%character_length_expr)) then
+                query%character_length_expr = node%character_length_expr
+            end if
+            query%kind_value = node%kind_value
+            query%intent_type = node%intent_type
+            query%has_kind = node%has_kind
+            query%has_character_length = node%has_character_length
+            query%is_optional = node%is_optional
+            query%is_array = node%is_array
+            query%is_target = node%is_target
+            query%is_value = .false.
+            call copy_integer_array(node%dimension_indices, &
+                query%dimension_indices)
+        end select
+    end function query_declaration
+
+    function query_derived_type(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(derived_type_query_t) :: query
+
+        call initialize_derived_type_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (derived_type_node)
+            query%found = .true.
+            if (allocated(node%name)) query%name = node%name
+            if (allocated(node%extends_parent)) query%extends_parent = &
+                node%extends_parent
+            if (allocated(node%attribute_clause)) query%attribute_clause = &
+                node%attribute_clause
+            query%has_attributes = node%has_attributes
+            query%has_parameters = node%has_parameters
+            query%has_contains = node%has_contains
+            call copy_integer_array(node%component_indices, query%component_indices)
+            call copy_integer_array(node%param_indices, query%parameter_indices)
+            call copy_integer_array(node%binding_indices, query%binding_indices)
+        end select
+    end function query_derived_type
+
+    function query_type_binding(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(type_binding_query_t) :: query
+
+        call initialize_type_binding_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (type_binding_node)
+            query%found = .true.
+            if (allocated(node%binding_name)) query%binding_name = &
+                node%binding_name
+            if (allocated(node%implementation)) query%implementation = &
+                node%implementation
+            if (allocated(node%interface_name)) query%interface_name = &
+                node%interface_name
+            if (allocated(node%pass_name)) query%pass_name = node%pass_name
+            if (allocated(node%accessibility)) query%accessibility = &
+                node%accessibility
+            query%is_generic = node%is_generic
+            query%is_final = node%is_final
+            query%is_deferred = node%is_deferred
+            query%pass_arg = node%pass_arg
+            call copy_string_t_array(node%generic_list, query%generic_names)
+        end select
+    end function query_type_binding
+
+    function query_use_statement(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(use_statement_query_t) :: query
+
+        call initialize_use_statement_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (use_statement_node)
+            query%found = .true.
+            if (allocated(node%module_name)) query%module_name = node%module_name
+            if (allocated(node%url_spec)) query%url_spec = node%url_spec
+            query%has_only = node%has_only
+            query%has_double_colon = node%has_double_colon
+            query%is_intrinsic = node%is_intrinsic
+            query%is_non_intrinsic = node%is_non_intrinsic
+            call copy_string_t_array(node%only_list, query%only_list)
+            call copy_string_t_array(node%rename_list, query%rename_list)
+        end select
+    end function query_use_statement
+
+    function query_use_statements(arena) result(queries)
+        type(ast_arena_t), intent(in) :: arena
+        type(use_statement_query_t), allocatable :: queries(:)
+
+        integer :: i, count, k
+
+        count = 0
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (use_statement_node)
+                count = count + 1
+            end select
+        end do
+        allocate (queries(count))
+        k = 0
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (use_statement_node)
+                k = k + 1
+                queries(k) = query_use_statement(arena, i)
+            end select
+        end do
+    end function query_use_statements
+
+    function query_interface(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(interface_query_t) :: query
+
+        call initialize_interface_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (interface_block_node)
+            query%found = .true.
+            if (allocated(node%name)) query%name = node%name
+            if (allocated(node%kind)) query%kind = node%kind
+            if (allocated(node%operator)) query%operator = node%operator
+            query%is_abstract = node%is_abstract
+            call copy_integer_array(node%procedure_indices, &
+                query%procedure_indices)
+        end select
+    end function query_interface
+
+    function query_visibility(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(visibility_query_t) :: query
+
+        call initialize_visibility_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (visibility_statement_node)
+            query%found = .true.
+            query%is_private = node%is_private
+            query%has_list = node%has_list
+            query%has_double_colon = node%has_double_colon
+            call copy_string_t_array(node%names, query%names)
+        end select
+    end function query_visibility
+
+    function query_namelist(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(namelist_query_t) :: query
+
+        call initialize_namelist_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (namelist_statement_node)
+            query%found = .true.
+            if (allocated(node%group_name)) query%group_name = node%group_name
+            call copy_string_t_array(node%variable_names, query%variable_names)
+        end select
+    end function query_namelist
+
+    function query_data_statement(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(data_statement_query_t) :: query
+
+        call initialize_data_statement_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (data_statement_node)
+            query%found = .true.
+            call copy_integer_array(node%object_indices, query%object_indices)
+            call copy_integer_array(node%value_indices, query%value_indices)
+        end select
+    end function query_data_statement
+
+    function query_common_block(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(common_block_query_t) :: query
+
+        call initialize_common_block_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (common_block_node)
+            query%found = .true.
+            call copy_string_t_array(node%block_names, query%block_names)
+            call copy_string_t_array(node%member_names, query%member_names)
+            call copy_integer_array(node%member_block, query%member_block)
+        end select
+    end function query_common_block
+
+    function query_enum(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(enum_query_t) :: query
+
+        call initialize_enum_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (enum_node)
+            query%found = .true.
+            query%is_bind_c = node%is_bind_c
+            call copy_string_t_array(node%enumerator_names, &
+                query%enumerator_names)
+            call copy_integer_array(node%enumerator_values, &
+                query%enumerator_values)
+        end select
+    end function query_enum
+
+    function query_statement_function(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(statement_function_query_t) :: query
+
+        call initialize_statement_function_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (statement_function_node)
+            query%found = .true.
+            if (allocated(node%name)) query%name = node%name
+            if (allocated(node%arg_names)) query%argument_names = node%arg_names
+            query%body_expression_index = node%body_expr_index
+        end select
+    end function query_statement_function
+
+    function query_block_data(arena, node_index) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(block_data_query_t) :: query
+
+        call initialize_block_data_query(query)
+        if (.not. arena%has_node_at(node_index)) return
+        query%node_index = node_index
+        query%line = arena%get_node_line(node_index)
+        query%column = arena%get_node_column(node_index)
+        select type (node => arena%entries(node_index)%node)
+            type is (block_data_node)
+            query%found = .true.
+            if (allocated(node%name)) query%name = node%name
+            if (allocated(node%header_label)) query%header_label = node%header_label
+            if (allocated(node%end_label)) query%end_label = node%end_label
+            call copy_integer_array(node%statement_indices, query%statement_indices)
+        end select
+    end function query_block_data
+
+    logical function is_program_unit_node(arena, node_index) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+
+        found = .false.
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (program_node)
+            found = .true.
+            type is (module_node)
+            found = .true.
+            type is (submodule_node)
+            found = .true.
+            type is (block_data_node)
+            found = .true.
+            type is (function_def_node)
+            found = .true.
+            type is (subroutine_def_node)
+            found = .true.
+            type is (interface_block_node)
+            found = .true.
+            type is (multi_unit_container_node)
+            found = .true.
+        end select
+    end function is_program_unit_node
+
+    logical function is_declaration_query_node(arena, node_index) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+
+        found = .false.
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (declaration_node)
+            found = .true.
+            type is (parameter_declaration_node)
+            found = .true.
+        end select
+    end function is_declaration_query_node
+
+    integer function count_program_units(arena, indices) result(count)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        integer :: i
+
+        count = 0
+        do i = 1, size(indices)
+            if (is_program_unit_node(arena, indices(i))) count = count + 1
+        end do
+    end function count_program_units
+
+    subroutine initialize_program_unit_query(query)
+        type(program_unit_query_t), intent(out) :: query
+
+        call set_empty(query%unit_kind)
+        call set_empty(query%name)
+        call set_empty(query%parent_identifier)
+        call set_empty(query%result_name)
+        call set_empty(query%return_type)
+        call set_empty(query%bind_c_clause)
+        call set_empty(query%header_label)
+        call set_empty(query%end_label)
+        allocate (query%declaration_indices(0))
+        allocate (query%procedure_indices(0))
+        allocate (query%parameter_indices(0))
+        allocate (query%body_indices(0))
+        allocate (query%statement_indices(0))
+    end subroutine initialize_program_unit_query
+
+    subroutine initialize_declaration_query(query)
+        type(declaration_query_t), intent(out) :: query
+
+        call set_empty(query%name)
+        call set_empty(query%type_name)
+        call set_empty(query%character_length_expr)
+        call set_empty(query%intent)
+        call set_empty(query%accessibility)
+        call set_empty(query%bind_name)
+        allocate (character(len=1) :: query%names(0))
+        allocate (query%dimension_indices(0))
+    end subroutine initialize_declaration_query
+
+    subroutine initialize_derived_type_query(query)
+        type(derived_type_query_t), intent(out) :: query
+
+        call set_empty(query%name)
+        call set_empty(query%extends_parent)
+        call set_empty(query%attribute_clause)
+        allocate (query%component_indices(0))
+        allocate (query%parameter_indices(0))
+        allocate (query%binding_indices(0))
+    end subroutine initialize_derived_type_query
+
+    subroutine initialize_type_binding_query(query)
+        type(type_binding_query_t), intent(out) :: query
+
+        call set_empty(query%binding_name)
+        call set_empty(query%implementation)
+        call set_empty(query%interface_name)
+        call set_empty(query%pass_name)
+        call set_empty(query%accessibility)
+        allocate (character(len=1) :: query%generic_names(0))
+    end subroutine initialize_type_binding_query
+
+    subroutine initialize_use_statement_query(query)
+        type(use_statement_query_t), intent(out) :: query
+
+        call set_empty(query%module_name)
+        call set_empty(query%url_spec)
+        allocate (character(len=1) :: query%only_list(0))
+        allocate (character(len=1) :: query%rename_list(0))
+    end subroutine initialize_use_statement_query
+
+    subroutine initialize_interface_query(query)
+        type(interface_query_t), intent(out) :: query
+
+        call set_empty(query%name)
+        call set_empty(query%kind)
+        call set_empty(query%operator)
+        allocate (query%procedure_indices(0))
+    end subroutine initialize_interface_query
+
+    subroutine initialize_visibility_query(query)
+        type(visibility_query_t), intent(out) :: query
+
+        allocate (character(len=1) :: query%names(0))
+    end subroutine initialize_visibility_query
+
+    subroutine initialize_namelist_query(query)
+        type(namelist_query_t), intent(out) :: query
+
+        call set_empty(query%group_name)
+        allocate (character(len=1) :: query%variable_names(0))
+    end subroutine initialize_namelist_query
+
+    subroutine initialize_data_statement_query(query)
+        type(data_statement_query_t), intent(out) :: query
+
+        allocate (query%object_indices(0))
+        allocate (query%value_indices(0))
+    end subroutine initialize_data_statement_query
+
+    subroutine initialize_common_block_query(query)
+        type(common_block_query_t), intent(out) :: query
+
+        allocate (character(len=1) :: query%block_names(0))
+        allocate (character(len=1) :: query%member_names(0))
+        allocate (query%member_block(0))
+    end subroutine initialize_common_block_query
+
+    subroutine initialize_enum_query(query)
+        type(enum_query_t), intent(out) :: query
+
+        allocate (character(len=1) :: query%enumerator_names(0))
+        allocate (query%enumerator_values(0))
+    end subroutine initialize_enum_query
+
+    subroutine initialize_statement_function_query(query)
+        type(statement_function_query_t), intent(out) :: query
+
+        call set_empty(query%name)
+        allocate (character(len=1) :: query%argument_names(0))
+    end subroutine initialize_statement_function_query
+
+    subroutine initialize_block_data_query(query)
+        type(block_data_query_t), intent(out) :: query
+
+        call set_empty(query%name)
+        call set_empty(query%header_label)
+        call set_empty(query%end_label)
+        allocate (query%statement_indices(0))
+    end subroutine initialize_block_data_query
+
+    subroutine copy_integer_array(src, dst)
+        integer, allocatable, intent(in) :: src(:)
+        integer, allocatable, intent(out) :: dst(:)
+
+        if (allocated(src)) then
+            dst = src
+        else
+            allocate (dst(0))
+        end if
+    end subroutine copy_integer_array
+
+    subroutine copy_single_name(name, names)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable, intent(out) :: names(:)
+
+        if (len_trim(name) == 0) then
+            allocate (character(len=1) :: names(0))
+        else
+            allocate (character(len=len(name)) :: names(1))
+            names(1) = name
+        end if
+    end subroutine copy_single_name
 
     subroutine copy_string_t_array(src, dst)
         type(string_t), allocatable, intent(in) :: src(:)

--- a/test/api/test_compiler_program_unit_queries.f90
+++ b/test/api/test_compiler_program_unit_queries.f90
@@ -1,0 +1,356 @@
+program test_compiler_program_unit_queries
+    use, intrinsic :: iso_fortran_env, only: error_unit, output_unit
+    use fortfront_compiler, only: ast_arena_t, &
+        compiler_frontend_options_t, compiler_frontend_result_t, &
+        compile_frontend_from_string, INPUT_MODE_STANDARD, &
+        program_unit_query_t, declaration_query_t, derived_type_query_t, &
+        type_binding_query_t, use_statement_query_t, interface_query_t, &
+        visibility_query_t, namelist_query_t, data_statement_query_t, &
+        common_block_query_t, enum_query_t, statement_function_query_t, &
+        block_data_query_t, query_program_units, query_program_unit, &
+        query_declarations, query_declaration, query_derived_type, &
+        query_type_binding, query_use_statements, query_interface, &
+        query_visibility, query_namelist, query_data_statement, &
+        query_common_block, query_enum, query_statement_function, &
+        query_block_data
+    implicit none
+
+    call test_program_units_and_declarations()
+    call test_construct_queries()
+    call test_block_data_query()
+    call test_wrong_kind_and_parse_diagnostic()
+
+    write (output_unit, '(a)') 'PASS: compiler program-unit queries'
+
+contains
+
+    subroutine test_program_units_and_declarations()
+        type(compiler_frontend_result_t) :: result
+        type(program_unit_query_t), allocatable :: units(:)
+        type(declaration_query_t), allocatable :: declarations(:)
+        type(derived_type_query_t) :: derived
+        type(type_binding_query_t) :: binding
+        type(use_statement_query_t), allocatable :: uses(:)
+        character(len=:), allocatable :: source
+        integer :: i
+
+        source = 'module m'//new_line('a')// &
+            '  use dep, only: local => remote'//new_line('a')// &
+            '  private'//new_line('a')// &
+            '  integer, parameter :: n = 2'//new_line('a')// &
+            '  type :: pair'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  contains'//new_line('a')// &
+            '    procedure :: show'//new_line('a')// &
+            '  end type pair'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  subroutine show(self)'//new_line('a')// &
+            '    type(pair) :: self'//new_line('a')// &
+            '  end subroutine show'//new_line('a')// &
+            'end module m'//new_line('a')// &
+            'program p'//new_line('a')// &
+            '  use m'//new_line('a')// &
+            'end program p'
+        call compile_parse_only(source, result, 'module and program')
+
+        units = query_program_units(result%arena, result%root_index)
+        call require(size(units) == 2, 'two top-level units in source order')
+        units = query_program_units(result%arena)
+        call require(size(units) == 2, 'implicit root query preserves unit order')
+        call require(trim(units(1)%unit_kind) == 'module', 'first unit is module')
+        call require(trim(units(1)%name) == 'm', 'module name')
+        call require(trim(units(2)%unit_kind) == 'program', 'second unit is program')
+        call require(trim(units(2)%name) == 'p', 'program name')
+        call require(units(1)%line > 0 .and. units(1)%column > 0, &
+            'program-unit source location')
+        call require(size(units(1)%declaration_indices) > 0, &
+            'module declaration indices')
+
+        declarations = query_declarations(result%arena, units(1)%node_index)
+        call require(size(declarations) >= 1, 'module declarations are queryable')
+        do i = 1, size(declarations)
+            if (trim(declarations(i)%name) == 'n') exit
+        end do
+        call require(i <= size(declarations), 'parameter declaration is present')
+        call require(declarations(i)%is_parameter, 'parameter attribute is copied')
+        call require(declarations(i)%has_initializer, 'initializer attribute is copied')
+        call require(declarations(i)%initializer_index > 0, &
+            'initializer child index is copied')
+
+        derived = find_derived_type(result%arena)
+        call require(derived%found, 'derived type query finds pair')
+        call require(trim(derived%name) == 'pair', 'derived type name')
+        call require(derived%has_contains, 'derived type contains attribute')
+        call require(size(derived%component_indices) == 1, &
+            'derived type component order')
+        call require(size(derived%binding_indices) == 1, &
+            'derived type binding order')
+
+        binding = find_type_binding(result%arena)
+        call require(binding%found, 'type binding query finds show')
+        call require(trim(binding%binding_name) == 'show', 'type binding name')
+
+        uses = query_use_statements(result%arena)
+        call require(size(uses) == 2, 'all USE statements are queryable')
+        call require(trim(uses(1)%module_name) == 'dep', 'USE module name')
+        call require(uses(1)%has_only, 'USE ONLY attribute')
+        call require(size(uses(1)%rename_list) == 2, 'USE rename pair')
+        call require(trim(uses(1)%rename_list(1)) == 'local', &
+            'USE local rename is first')
+        call require(trim(uses(1)%rename_list(2)) == 'remote', &
+            'USE remote rename is second')
+    end subroutine test_program_units_and_declarations
+
+    subroutine test_construct_queries()
+        type(compiler_frontend_result_t) :: result
+        type(interface_query_t) :: interface_query
+        type(visibility_query_t) :: visibility_query
+        type(namelist_query_t) :: namelist_query
+        type(data_statement_query_t) :: data_query
+        type(common_block_query_t) :: common_query
+        type(enum_query_t) :: enum_query
+        type(statement_function_query_t) :: statement_query
+        character(len=:), allocatable :: source
+
+        source = 'program legacy'//new_line('a')// &
+            '  integer :: a, b'//new_line('a')// &
+            '  common /blk/ a, b'//new_line('a')// &
+            '  namelist /group/ a, b'//new_line('a')// &
+            '  data a, b /1, 2/'//new_line('a')// &
+            '  enum, bind(c)'//new_line('a')// &
+            '    enumerator :: red = 1, blue'//new_line('a')// &
+            '  end enum'//new_line('a')// &
+            'end program legacy'
+        call compile_parse_only(source, result, 'legacy constructs')
+
+        common_query = find_common_block(result%arena)
+        call require(common_query%found, 'COMMON query finds block')
+        call require(size(common_query%block_names) == 1, 'COMMON block count')
+        call require(trim(common_query%block_names(1)) == 'blk', 'COMMON block name')
+        call require(size(common_query%member_names) == 2, 'COMMON member order')
+        call require(all(common_query%member_block == 1), 'COMMON member ownership')
+
+        namelist_query = find_namelist(result%arena)
+        call require(namelist_query%found, 'NAMELIST query finds group')
+        call require(trim(namelist_query%group_name) == 'group', 'NAMELIST group name')
+        call require(size(namelist_query%variable_names) == 2, &
+            'NAMELIST variable order')
+
+        data_query = find_data_statement(result%arena)
+        call require(data_query%found, 'DATA query finds statement')
+        call require(size(data_query%object_indices) == 2, 'DATA object order')
+        call require(size(data_query%value_indices) == 2, 'DATA value order')
+
+        enum_query = find_enum(result%arena)
+        call require(enum_query%found, 'ENUM query finds construct')
+        call require(enum_query%is_bind_c, 'ENUM BIND(C) attribute')
+        call require(size(enum_query%enumerator_names) == 2, 'ENUM name order')
+        call require(enum_query%enumerator_values(1) == 1, 'ENUM explicit value')
+        call require(enum_query%enumerator_values(2) == 2, 'ENUM implicit value')
+
+        source = 'f(x) = x + 1'//new_line('a')//'end'
+        call compile_parse_only(source, result, 'statement function')
+        statement_query = find_statement_function(result%arena)
+        call require(statement_query%found, 'statement-function query finds f')
+        call require(trim(statement_query%name) == 'f', 'statement-function name')
+        call require(size(statement_query%argument_names) == 1, &
+            'statement-function argument count')
+        call require(statement_query%body_expression_index > 0, &
+            'statement-function body index')
+
+        source = 'module visible'//new_line('a')// &
+            '  private'//new_line('a')// &
+            '  public :: x'//new_line('a')// &
+            '  integer :: x'//new_line('a')// &
+            'end module visible'
+        call compile_parse_only(source, result, 'visibility statements')
+        visibility_query = find_visibility(result%arena)
+        call require(visibility_query%found, 'visibility query finds PRIVATE')
+        call require(visibility_query%is_private, 'PRIVATE attribute')
+    end subroutine test_construct_queries
+
+    subroutine test_block_data_query()
+        type(compiler_frontend_result_t) :: result
+        type(program_unit_query_t), allocatable :: units(:)
+        type(block_data_query_t) :: block_data_query
+        character(len=:), allocatable :: source
+
+        source = 'block data init'//new_line('a')// &
+            '  integer :: a, b'//new_line('a')// &
+            '  common /shared/ a, b'//new_line('a')// &
+            '  data a, b /1, 2/'//new_line('a')// &
+            'end block data init'
+        call compile_parse_only(source, result, 'BLOCK DATA')
+        units = query_program_units(result%arena, result%root_index)
+        call require(size(units) == 1, 'one BLOCK DATA unit')
+        call require(trim(units(1)%unit_kind) == 'block_data', 'BLOCK DATA kind')
+        call require(trim(units(1)%name) == 'init', 'BLOCK DATA name')
+        call require(size(units(1)%statement_indices) >= 3, &
+            'BLOCK DATA statement order')
+        block_data_query = query_block_data(result%arena, units(1)%node_index)
+        call require(block_data_query%found, 'BLOCK DATA record query')
+        call require(size(block_data_query%statement_indices) == &
+            size(units(1)%statement_indices), 'BLOCK DATA record matches unit')
+    end subroutine test_block_data_query
+
+    subroutine test_wrong_kind_and_parse_diagnostic()
+        type(compiler_frontend_result_t) :: result
+        type(program_unit_query_t), allocatable :: units(:)
+        type(declaration_query_t) :: declaration
+        type(interface_query_t) :: interface_result
+
+        call compile_parse_only( &
+            'interface g'//new_line('a')// &
+            '  subroutine s(x)'//new_line('a')// &
+            '    integer :: x'//new_line('a')// &
+            '  end subroutine s'//new_line('a')// &
+            'end interface g', result, 'interface')
+        declaration = query_declaration(result%arena, result%root_index)
+        call require(.not. declaration%found, 'wrong-kind declaration is not invented')
+        call require(declaration%node_index == result%root_index, &
+            'wrong-kind declaration retains queried index')
+        interface_result = find_interface(result%arena)
+        call require(interface_result%found, 'interface query finds named interface')
+
+        call compile_frontend_from_string( &
+            'program broken'//new_line('a')// &
+            '  value = identity{integer'//new_line('a')// &
+            'end program broken', result)
+        call require(.not. result%parse_ok, 'malformed source returns parse diagnostic')
+        units = query_program_units(result%arena, result%root_index)
+        call require(size(units) == 0, 'malformed source has no invented units')
+    end subroutine test_wrong_kind_and_parse_diagnostic
+
+    subroutine compile_parse_only(source, result, label)
+        character(len=*), intent(in) :: source, label
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: options
+
+        options = compiler_frontend_options_t()
+        options%input_mode = INPUT_MODE_STANDARD
+        options%run_semantics = .false.
+        call compile_frontend_from_string(source, result, options)
+        if (result%parse_ok) return
+        write (error_unit, '(2a)') 'FAIL: parse failed for ', trim(label)
+        if (allocated(result%error_msg)) write (error_unit, '(a)') result%error_msg
+        error stop 1
+    end subroutine compile_parse_only
+
+    function find_derived_type(arena) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        type(derived_type_query_t) :: query
+        integer :: i
+
+        query = query_derived_type(arena, 0)
+        do i = 1, arena%size
+            query = query_derived_type(arena, i)
+            if (query%found) return
+        end do
+    end function find_derived_type
+
+    function find_type_binding(arena) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        type(type_binding_query_t) :: query
+        integer :: i
+
+        query = query_type_binding(arena, 0)
+        do i = 1, arena%size
+            query = query_type_binding(arena, i)
+            if (query%found) return
+        end do
+    end function find_type_binding
+
+    function find_common_block(arena) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        type(common_block_query_t) :: query
+        integer :: i
+
+        query = query_common_block(arena, 0)
+        do i = 1, arena%size
+            query = query_common_block(arena, i)
+            if (query%found) return
+        end do
+    end function find_common_block
+
+    function find_namelist(arena) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        type(namelist_query_t) :: query
+        integer :: i
+
+        query = query_namelist(arena, 0)
+        do i = 1, arena%size
+            query = query_namelist(arena, i)
+            if (query%found) return
+        end do
+    end function find_namelist
+
+    function find_data_statement(arena) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        type(data_statement_query_t) :: query
+        integer :: i
+
+        query = query_data_statement(arena, 0)
+        do i = 1, arena%size
+            query = query_data_statement(arena, i)
+            if (query%found) return
+        end do
+    end function find_data_statement
+
+    function find_enum(arena) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        type(enum_query_t) :: query
+        integer :: i
+
+        query = query_enum(arena, 0)
+        do i = 1, arena%size
+            query = query_enum(arena, i)
+            if (query%found) return
+        end do
+    end function find_enum
+
+    function find_statement_function(arena) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        type(statement_function_query_t) :: query
+        integer :: i
+
+        query = query_statement_function(arena, 0)
+        do i = 1, arena%size
+            query = query_statement_function(arena, i)
+            if (query%found) return
+        end do
+    end function find_statement_function
+
+    function find_visibility(arena) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        type(visibility_query_t) :: query
+        integer :: i
+
+        query = query_visibility(arena, 0)
+        do i = 1, arena%size
+            query = query_visibility(arena, i)
+            if (query%found) return
+        end do
+    end function find_visibility
+
+    function find_interface(arena) result(query)
+        type(ast_arena_t), intent(in) :: arena
+        type(interface_query_t) :: query
+        integer :: i
+
+        query = query_interface(arena, 0)
+        do i = 1, arena%size
+            query = query_interface(arena, i)
+            if (query%found) return
+        end do
+    end function find_interface
+
+    subroutine require(condition, message)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: message
+
+        if (condition) return
+        write (error_unit, '(2a)') 'FAIL: ', trim(message)
+        error stop 1
+    end subroutine require
+
+end program test_compiler_program_unit_queries


### PR DESCRIPTION
## Summary
- expose immutable-copy query records for program units, declarations, and the requested declaration-level constructs
- provide source-order query helpers through the public `fortfront` and `fortfront_compiler` facades
- add independent API tests covering multi-unit programs, USE/visibility/declarations, derived types and bindings, legacy declarations, statement functions, BLOCK DATA, wrong-kind queries, and malformed input diagnostics

Closes #2879.

## Verification
- `FO_TEST_TIMEOUT=120 FO_BUILD_TIMEOUT=120 fo test test_compiler_program_unit_queries test_compiler_facing_queries test_compiler_node_queries test_compiler_scope_resolution`
- `FO_TEST_TIMEOUT=600 FO_BUILD_TIMEOUT=120 fo`
- `git diff --check`
