### PR TITLE
[api-type-02] resolve ISO C kinds and declaration ranks

### DIFF
--- a/src/frontend/frontend_compiler_type_queries.f90
+++ b/src/frontend/frontend_compiler_type_queries.f90
@@ -1,12 +1,12 @@
 module frontend_compiler_type_queries
     use ast_arena_modern, only: ast_arena_t
-    use ast_base, only: ast_node, LITERAL_INTEGER, LITERAL_REAL, &
+    use ast_base, only: ast_node, string_t, LITERAL_INTEGER, LITERAL_REAL, &
         LITERAL_STRING, LITERAL_LOGICAL
     use ast_nodes_core, only: literal_node, identifier_node, binary_op_node, &
         call_or_subscript_node, component_access_node, assignment_node
     use ast_nodes_data, only: declaration_node, parameter_declaration_node, &
         derived_type_node
-    use ast_nodes_misc, only: complex_literal_node
+    use ast_nodes_misc, only: complex_literal_node, use_statement_node
     use ast_nodes_procedure, only: function_def_node
     use frontend_compiler_resolution, only: declaration_binding_t, &
         resolve_name_at_node, resolve_identifier_binding
@@ -803,6 +803,9 @@ contains
             if (kind_value > 0) return
         end if
 
+        if (resolve_iso_c_binding_kind(arena, reference_index, lowered, &
+            kind_value)) return
+
         kind_value = conventional_kind_selector(lowered)
     end function resolve_kind_selector
 
@@ -826,6 +829,109 @@ contains
             kind_value = 0
         end select
     end function conventional_kind_selector
+
+    logical function resolve_iso_c_binding_kind(arena, reference_index, selector, &
+            kind_value) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: reference_index
+        character(len=*), intent(in) :: selector
+        integer, intent(out) :: kind_value
+        integer :: current, child, i
+        logical :: imported
+        character(len=:), allocatable :: canonical_selector, remote_selector
+
+        found = .false.
+        kind_value = 0
+        imported = .false.
+        canonical_selector = compact_lower(selector)
+        current = reference_index
+        do while (current > 0)
+            if (.not. arena%has_node_at(current)) return
+            if (allocated(arena%entries(current)%child_indices)) then
+                do i = 1, arena%entries(current)%child_count
+                    child = arena%entries(current)%child_indices(i)
+                    if (.not. arena%has_node_at(child)) cycle
+                    select type (use_node => arena%entries(child)%node)
+                        type is (use_statement_node)
+                        if (.not. allocated(use_node%module_name)) cycle
+                        if (compact_lower(use_node%module_name) /= &
+                            'iso_c_binding') cycle
+                        if (.not. use_node%has_only) then
+                            imported = .true.
+                        else if (allocated(use_node%only_list)) then
+                            imported = use_list_contains(use_node%only_list, selector)
+                        end if
+                        if (.not. imported .and. allocated(use_node%rename_list)) then
+                            remote_selector = ''
+                            imported = use_rename_contains(use_node%rename_list, &
+                                selector, remote_selector)
+                            if (imported) canonical_selector = remote_selector
+                        end if
+                        if (imported) exit
+                    end select
+                end do
+            end if
+            if (imported) exit
+            current = arena%entries(current)%parent_index
+        end do
+        if (.not. imported) return
+
+        select case (compact_lower(canonical_selector))
+        case ('c_signed_char', 'c_int8_t', 'c_int_least8_t', &
+                'c_int_fast8_t', 'c_bool', 'c_char')
+            kind_value = 1
+        case ('c_short', 'c_int16_t', 'c_int_least16_t', 'c_int_fast16_t')
+            kind_value = 2
+        case ('c_int', 'c_int32_t', 'c_int_least32_t', 'c_int_fast32_t', &
+                'c_float', 'c_float32')
+            kind_value = 4
+        case ('c_long', 'c_long_long', 'c_size_t', 'c_intptr_t', &
+                'c_ptrdiff_t', 'c_intmax_t', 'c_int64_t', 'c_int_least64_t', &
+                'c_int_fast64_t', 'c_double', 'c_float64')
+            kind_value = 8
+        case ('c_long_double', 'c_float128')
+            kind_value = 16
+        case default
+            return
+        end select
+        found = .true.
+    end function resolve_iso_c_binding_kind
+
+    logical function use_list_contains(list, selector) result(found)
+        type(string_t), allocatable, intent(in) :: list(:)
+        character(len=*), intent(in) :: selector
+        integer :: i
+
+        found = .false.
+        do i = 1, size(list)
+            if (.not. allocated(list(i)%s)) cycle
+            if (compact_lower(list(i)%s) == compact_lower(selector)) then
+                found = .true.
+                return
+            end if
+        end do
+    end function use_list_contains
+
+    logical function use_rename_contains(list, selector, remote) result(found)
+        type(string_t), allocatable, intent(in) :: list(:)
+        character(len=*), intent(in) :: selector
+        character(len=:), allocatable, intent(out) :: remote
+        integer :: i
+
+        found = .false.
+        remote = ''
+        i = 1
+        do while (i + 1 <= size(list))
+            if (allocated(list(i)%s)) then
+                if (compact_lower(list(i)%s) == compact_lower(selector)) then
+                    if (allocated(list(i + 1)%s)) remote = list(i + 1)%s
+                    found = .true.
+                    return
+                end if
+            end if
+            i = i + 2
+        end do
+    end function use_rename_contains
 
     recursive subroutine resolve_named_integer_constant(arena, reference_index, &
             name, value, visiting)
@@ -917,11 +1023,78 @@ contains
             case ("**")
                 if (rhs >= 0) value = lhs**rhs
             end select
+            type is (call_or_subscript_node)
+            if (.not. allocated(expr%name)) then
+                visiting(expr_index) = .false.
+                return
+            end if
+            select case (compact_lower(expr%name))
+            case ("selected_real_kind")
+                call evaluate_selected_real_kind(arena, expr, value, visiting)
+            case ("selected_int_kind")
+                call evaluate_selected_int_kind(arena, expr, value, visiting)
+            end select
         class default
             if (expr%is_constant) value = expr%constant_integer
         end select
         visiting(expr_index) = .false.
     end subroutine evaluate_integer_constant
+
+    subroutine evaluate_selected_real_kind(arena, node, value, visiting)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        integer, intent(out) :: value
+        logical, intent(inout) :: visiting(:)
+        integer :: precision, range_value
+
+        value = 0
+        precision = 0
+        range_value = 0
+        if (.not. allocated(node%arg_indices)) return
+        if (size(node%arg_indices) >= 1) then
+            call evaluate_integer_constant(arena, node%arg_indices(1), &
+                precision, visiting)
+        end if
+        if (size(node%arg_indices) >= 2) then
+            call evaluate_integer_constant(arena, node%arg_indices(2), &
+                range_value, visiting)
+        end if
+
+        if (precision <= 6 .and. range_value <= 37) then
+            value = 4
+        else if (precision <= 15 .and. range_value <= 307) then
+            value = 8
+        else if (precision <= 33 .and. range_value <= 4931) then
+            value = 16
+        else
+            value = -1
+        end if
+    end subroutine evaluate_selected_real_kind
+
+    subroutine evaluate_selected_int_kind(arena, node, value, visiting)
+        type(ast_arena_t), intent(in) :: arena
+        type(call_or_subscript_node), intent(in) :: node
+        integer, intent(out) :: value
+        logical, intent(inout) :: visiting(:)
+        integer :: range_value
+
+        value = 0
+        range_value = 0
+        if (.not. allocated(node%arg_indices)) return
+        if (size(node%arg_indices) < 1) return
+        call evaluate_integer_constant(arena, node%arg_indices(1), range_value, visiting)
+        if (range_value <= 2) then
+            value = 1
+        else if (range_value <= 4) then
+            value = 2
+        else if (range_value <= 9) then
+            value = 4
+        else if (range_value <= 18) then
+            value = 8
+        else
+            value = -1
+        end if
+    end subroutine evaluate_selected_int_kind
 
     subroutine real_result_kind_from_argument(arena, node, visiting, kind_value)
         type(ast_arena_t), intent(inout) :: arena

--- a/test/api/test_compiler_resolved_type_query.f90
+++ b/test/api/test_compiler_resolved_type_query.f90
@@ -1,5 +1,6 @@
 program test_compiler_resolved_type_query
     use, intrinsic :: iso_fortran_env, only: error_unit
+    use, intrinsic :: iso_c_binding, only: c_int, c_double, c_size_t
     use fortfront_compiler, only: compiler_frontend_options_t, &
         compiler_frontend_result_t, compile_frontend_from_string, &
         resolved_type_query_t, query_resolved_type, &
@@ -55,6 +56,10 @@ program test_compiler_resolved_type_query
     call require_intrinsic_call_kind('abs', 1, TREAL, 8)
     call require_shadowed_kind_selector()
     call require_renamed_kind_selector()
+    call require_iso_c_binding_kinds()
+    call require_indirect_kind_selectors()
+    call require_array_declaration_ranks()
+    call require_unresolved_kind_remains_unknown()
     call require_unavailable_result()
     call require_unavailable_without_semantics(source)
 
@@ -282,6 +287,143 @@ contains
         end do
         call require(matched, 'renamed dp declaration was not found')
     end subroutine require_renamed_kind_selector
+
+    subroutine require_iso_c_binding_kinds()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  use, intrinsic :: iso_c_binding, only: c_int, c_double, c_size_t'// &
+            new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer(c_int) :: int_value'//new_line('a')// &
+            '  real(c_double) :: real_value'//new_line('a')// &
+            '  integer(c_size_t) :: size_value'//new_line('a')// &
+            'end program main'
+        type(compiler_frontend_result_t) :: iso_result
+
+        call compile_frontend_from_string(source, iso_result, options)
+        call require(iso_result%parse_ok, &
+            'iso_c_binding query source did not parse')
+        call require(iso_result%semantic_ok, &
+            'iso_c_binding query source did not analyze: '// &
+            iso_result%error_msg)
+        call require_result_declaration(iso_result, 'int_value', TINT, c_int, 0)
+        call require_result_declaration(iso_result, 'real_value', TREAL, &
+            c_double, 0)
+        call require_result_declaration(iso_result, 'size_value', TINT, &
+            c_size_t, 0)
+    end subroutine require_iso_c_binding_kinds
+
+    subroutine require_indirect_kind_selectors()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer, parameter :: real_kind = selected_real_kind(12)'// &
+            new_line('a')// &
+            '  real(real_kind) :: value'//new_line('a')// &
+            '  value = 1.0_real_kind'//new_line('a')// &
+            'end program main'
+        type(compiler_frontend_result_t) :: alias_result
+        integer, parameter :: expected_kind = selected_real_kind(12)
+
+        call compile_frontend_from_string(source, alias_result, options)
+        call require(alias_result%parse_ok, &
+            'indirect kind query source did not parse')
+        call require(alias_result%semantic_ok, &
+            'indirect kind query source did not analyze: '// &
+            alias_result%error_msg)
+        call require_result_declaration(alias_result, 'value', TREAL, &
+            expected_kind, 0)
+    end subroutine require_indirect_kind_selectors
+
+    subroutine require_array_declaration_ranks()
+        character(len=*), parameter :: source = &
+            'subroutine array_shapes(explicit_value, assumed_value)'// &
+            new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  integer :: explicit_value(2, 3)'//new_line('a')// &
+            '  integer :: assumed_value(:, :)'//new_line('a')// &
+            '  integer, allocatable :: allocatable_value(:)'//new_line('a')// &
+            '  integer, pointer :: pointer_value(:)'//new_line('a')// &
+            'end subroutine array_shapes'
+        type(compiler_frontend_result_t) :: array_result
+
+        call compile_frontend_from_string(source, array_result, options)
+        call require(array_result%parse_ok, &
+            'array rank query source did not parse')
+        call require(array_result%semantic_ok, &
+            'array rank query source did not analyze: '// &
+            array_result%error_msg)
+        call require_result_declaration(array_result, 'explicit_value', TINT, 4, 2)
+        call require_result_declaration(array_result, 'assumed_value', TINT, 4, 2)
+        call require_result_declaration(array_result, 'allocatable_value', TINT, 4, 1)
+        call require_result_declaration(array_result, 'pointer_value', TINT, 4, 1)
+    end subroutine require_array_declaration_ranks
+
+    subroutine require_unresolved_kind_remains_unknown()
+        character(len=*), parameter :: source = &
+            'program main'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  real(unknown_kind) :: value'//new_line('a')// &
+            'end program main'
+        type(compiler_frontend_result_t) :: unresolved_result
+        type(resolved_type_query_t) :: query
+        character(len=:), allocatable :: name, error_msg
+        logical :: matched
+        integer :: i
+
+        call compile_frontend_from_string(source, unresolved_result, options)
+        call require(unresolved_result%parse_ok, &
+            'unresolved kind query source did not parse')
+        matched = .false.
+        do i = 1, unresolved_result%arena%size
+            if (.not. is_declaration_node(unresolved_result%arena, i)) cycle
+            call get_declaration_var_name(unresolved_result%arena, i, name, error_msg)
+            if (len_trim(error_msg) > 0) cycle
+            if (trim(name) /= 'value') cycle
+            query = query_resolved_type(unresolved_result%arena, i)
+            call require(.not. query%found, &
+                'unresolved kind was guessed instead of rejected')
+            call require(len_trim(query%diagnostic) > 0, &
+                'unresolved kind did not return a diagnostic')
+            matched = .true.
+            exit
+        end do
+        call require(matched, 'unresolved kind declaration was not found')
+    end subroutine require_unresolved_kind_remains_unknown
+
+    subroutine require_result_declaration(result_value, expected_name, &
+            expected_type, expected_kind, expected_rank)
+        type(compiler_frontend_result_t), intent(in) :: result_value
+        character(len=*), intent(in) :: expected_name
+        integer, intent(in) :: expected_type, expected_kind, expected_rank
+        character(len=:), allocatable :: name, error_msg
+        type(resolved_type_query_t) :: query
+        logical :: matched
+        integer :: i, expected_storage_bits
+
+        matched = .false.
+        do i = 1, result_value%arena%size
+            if (.not. is_declaration_node(result_value%arena, i)) cycle
+            call get_declaration_var_name(result_value%arena, i, name, error_msg)
+            if (len_trim(error_msg) > 0) cycle
+            if (trim(name) /= expected_name) cycle
+            query = query_resolved_type(result_value%arena, i)
+            call require(query%found, &
+                'declaration '//expected_name//' did not resolve: '//query%diagnostic)
+            call require(query%type_kind == expected_type, &
+                'declaration '//expected_name//' resolved to the wrong type')
+            call require(query%kind_value == expected_kind, &
+                'declaration '//expected_name//' resolved to the wrong kind')
+            call require(query%rank == expected_rank, &
+                'declaration '//expected_name//' resolved to the wrong rank')
+            expected_storage_bits = 8 * expected_kind
+            call require(query%storage_size_bits == expected_storage_bits, &
+                'declaration '//expected_name//' reported the wrong storage size')
+            matched = .true.
+            exit
+        end do
+        call require(matched, 'resolved declaration not found: '//expected_name)
+    end subroutine require_result_declaration
 
     subroutine require_unavailable_result()
         type(resolved_type_query_t) :: query


### PR DESCRIPTION
## Summary

- resolve `iso_c_binding` kind selectors only when the intrinsic module is visible, including the C integer, logical, character, and real kind families
- evaluate `selected_real_kind` and `selected_int_kind` in constant kind aliases so declarations resolve through indirect parameters
- retain exact unresolved-kind failures instead of guessing, while covering explicit, assumed-shape, allocatable, and pointer declaration ranks

## Behavioral evidence

- the new query cases fail on `main` first: `c_int` is unavailable, then the indirect kind alias is unavailable
- the same cases pass after the change and assert type category, exact kind, storage width, rank, and a nonempty diagnostic for an unknown kind

## Verification

- `FO_TEST_TIMEOUT=120 FO_BUILD_TIMEOUT=120 fo test test_compiler_resolved_type_query`
- `FO_TEST_TIMEOUT=600 FO_BUILD_TIMEOUT=120 fo`
- `fo fmt --check src/frontend/frontend_compiler_type_queries.f90 test/api/test_compiler_resolved_type_query.f90`
- `git diff --check`

Closes #2906.