### PR TITLE
[reject-lex-01] reject invalid source and identifier characters (#2890)

### DIFF
--- a/src/frontend_core.f90
+++ b/src/frontend_core.f90
@@ -6,6 +6,7 @@ module frontend_core
     use fortfront_constants, only: MAX_FRONTEND_ERROR_LEN
     use string_builder_mod, only: join_strings
     use lexer_core, only: token_t, tokenize_core, &
+        validate_source_characters, &
         TK_COMMENT, TK_NEWLINE, TK_OPERATOR, TK_IDENTIFIER, &
         TK_NUMBER, TK_STRING, TK_UNKNOWN, TK_WHITESPACE, &
         to_lower
@@ -172,12 +173,16 @@ contains
         type(token_t), allocatable, intent(out) :: tokens(:)
         character(len=:), allocatable, intent(out) :: error_msg
 
+        call validate_source_characters(source_code, error_msg)
+        if (len_trim(error_msg) > 0) then
+            allocate (tokens(0))
+            return
+        end if
+
         call tokenize_core(source_code, tokens)
         if (.not. allocated(tokens)) then
-            allocate (character(len=22) :: error_msg)
             error_msg = "Failed to tokenize source"
         else
-            allocate (character(len=0) :: error_msg)
             error_msg = ""
             call normalize_line_continuations(tokens)
         end if

--- a/src/lexer/lexer_core.f90
+++ b/src/lexer/lexer_core.f90
@@ -32,6 +32,9 @@ module lexer_core
     ! Re-export utilities
     public :: to_lower, resize_tokens, resize_trivia_buffer
 
+    ! Source character validation
+    public :: validate_source_characters
+
 contains
 
     pure function normalize_line_endings(source) result(normalized)
@@ -72,6 +75,119 @@ contains
             normalized = buffer(1:write_pos)
         end if
     end function normalize_line_endings
+
+    ! Reject characters that cannot appear in free-form Fortran source and
+    ! names that do not start with a letter. Comments and character literals
+    ! may carry any byte, so they are skipped. Returns an empty message when
+    ! the source is lexically valid.
+    subroutine validate_source_characters(source, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable, intent(out) :: error_msg
+        character(len=:), allocatable :: src
+        character :: c, quote, prev, prev_adj
+        integer :: pos, line_num, col_num, src_len
+        logical :: in_string, in_comment
+
+        error_msg = ""
+        src = normalize_line_endings(source)
+        src_len = len(src)
+
+        pos = 1
+        line_num = 1
+        col_num = 1
+        in_string = .false.
+        in_comment = .false.
+        quote = ' '
+        prev = ' '
+        prev_adj = ' '
+
+        do while (pos <= src_len)
+            c = src(pos:pos)
+
+            if (c == char(10)) then
+                in_string = .false.
+                in_comment = .false.
+                prev = ' '
+                prev_adj = ' '
+                line_num = line_num + 1
+                col_num = 1
+                pos = pos + 1
+                cycle
+            end if
+
+            if (in_comment) then
+                pos = pos + 1
+                col_num = col_num + 1
+                cycle
+            end if
+
+            if (in_string) then
+                if (c == quote) in_string = .false.
+                pos = pos + 1
+                col_num = col_num + 1
+                cycle
+            end if
+
+            if (.not. is_legal_source_char(c)) then
+                error_msg = invalid_char_message(c, line_num, col_num)
+                return
+            end if
+
+            select case (c)
+            case ('!', '#')
+                in_comment = .true.
+            case ('''', '"')
+                in_string = .true.
+                quote = c
+            case ('_')
+                ! A name must start with a letter, so a leading underscore is
+                ! only valid when it continues the immediately preceding name.
+                if (.not. is_name_body_char(prev_adj)) then
+                    error_msg = name_char_message(line_num, col_num)
+                    return
+                end if
+            case ('%')
+                if (.not. is_percent_prefix_char(prev)) then
+                    error_msg = invalid_char_message(c, line_num, col_num)
+                    return
+                end if
+            end select
+
+            ! Blanks and continuation markers do not change the significant
+            ! predecessor used by the part-reference rule.
+            select case (c)
+            case (' ', char(9), '&')
+                continue
+            case default
+                prev = c
+            end select
+            prev_adj = c
+
+            pos = pos + 1
+            col_num = col_num + 1
+        end do
+    end subroutine validate_source_characters
+
+    pure function invalid_char_message(c, line_num, col_num) result(msg)
+        character, intent(in) :: c
+        integer, intent(in) :: line_num, col_num
+        character(len=:), allocatable :: msg
+        character(len=64) :: buffer
+
+        write (buffer, '(A,Z2.2,A,I0,A,I0)') "Invalid character 0x", &
+            iachar(c), " at line ", line_num, ", column ", col_num
+        msg = trim(buffer)
+    end function invalid_char_message
+
+    pure function name_char_message(line_num, col_num) result(msg)
+        integer, intent(in) :: line_num, col_num
+        character(len=:), allocatable :: msg
+        character(len=64) :: buffer
+
+        write (buffer, '(A,I0,A,I0)') "Invalid character in name at line ", &
+            line_num, ", column ", col_num
+        msg = trim(buffer)
+    end function name_char_message
 
     ! Main tokenization function with error handling
     function tokenize_safe(source) result(tokenize_res)

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -12,6 +12,9 @@ module lexer_scanners
         scan_identifier_safe
     public :: scan_operator_safe, scan_logical_token_safe
 
+    ! Public source character classification (F2018 6.1 character set)
+    public :: is_legal_source_char, is_name_body_char, is_percent_prefix_char
+
 contains
 
     ! Scan a number token (including Hollerith constants like 2Hab)
@@ -594,6 +597,43 @@ contains
         end select
     end function is_logical_constant
 
-    ! Helper function to convert string to lowercase
+    ! True for characters that may appear in free-form source text outside of
+    ! comments and character literals: printable ASCII plus tab/newline/CR.
+    pure logical function is_legal_source_char(c) result(legal)
+        character, intent(in) :: c
+        integer :: code
+
+        code = iachar(c)
+        legal = .false.
+        if (code >= 32 .and. code <= 126) legal = .true.
+        if (code == 9) legal = .true.
+        if (code == 10) legal = .true.
+        if (code == 13) legal = .true.
+    end function is_legal_source_char
+
+    ! True for characters that may continue a Fortran name.
+    pure logical function is_name_body_char(c) result(is_body)
+        character, intent(in) :: c
+
+        select case (c)
+        case ('a':'z', 'A':'Z', '0':'9', '_')
+            is_body = .true.
+        case default
+            is_body = .false.
+        end select
+    end function is_name_body_char
+
+    ! True for characters that may legally precede a '%' part-reference or
+    ! type-parameter inquiry separator.
+    pure logical function is_percent_prefix_char(c) result(is_prefix)
+        character, intent(in) :: c
+
+        select case (c)
+        case ('a':'z', 'A':'Z', '0':'9', '_', ')', ']')
+            is_prefix = .true.
+        case default
+            is_prefix = .false.
+        end select
+    end function is_percent_prefix_char
 
 end module lexer_scanners

--- a/test/api/test_reject_lex_01_diagnostics.f90
+++ b/test/api/test_reject_lex_01_diagnostics.f90
@@ -1,0 +1,124 @@
+program test_reject_lex_01_diagnostics
+    ! Issue #2890 [reject-lex-01]: invalid source characters and invalid
+    ! identifier characters must be rejected with a source diagnostic, while
+    ! the corrected neighbouring form still compiles.
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use fortfront_compiler, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=1), parameter :: nl = new_line('a')
+    integer :: failures
+
+    failures = 0
+
+    ! gfortran.dg/illegal_char.f90
+    call expect_rejected('illegal_char.f90', &
+        'program main'//nl// &
+        '  tmp ='//achar(200)//'   1.0'//nl// &
+        '  print *,tmp'//nl// &
+        'end', failures)
+    call expect_accepted('illegal_char corrected neighbour', &
+        'program main'//nl// &
+        '  tmp =   1.0'//nl// &
+        '  print *,tmp'//nl// &
+        'end', failures)
+
+    ! gfortran.dg/invalid_name.f90
+    call expect_rejected('invalid_name.f90', &
+        'SUBROUTINE _foo'//nl// &
+        'END', failures)
+    call expect_accepted('invalid_name corrected neighbour', &
+        'SUBROUTINE foo'//nl// &
+        'END', failures)
+
+    ! gfortran.dg/pr91959.f90
+    call expect_rejected('pr91959.f90', &
+        'program p'//nl// &
+        '   implicit none'//nl// &
+        '   integer :: %a'//nl// &
+        '   print *, 1'//nl// &
+        'end', failures)
+    call expect_accepted('pr91959 corrected neighbour', &
+        'program p'//nl// &
+        '   implicit none'//nl// &
+        '   integer :: a'//nl// &
+        '   a = 1'//nl// &
+        '   print *, a'//nl// &
+        'end', failures)
+
+    ! Invalid bytes inside comments and character literals stay legal.
+    call expect_accepted('non-ascii byte in comment and literal', &
+        'program q'//nl// &
+        '  ! caf'//achar(200)//' comment'//nl// &
+        '  print *, "caf'//achar(200)//'"'//nl// &
+        'end', failures)
+
+    ! Legitimate component selection keeps working.
+    call expect_accepted('component selector', &
+        'program r'//nl// &
+        '  type :: point_t'//nl// &
+        '    real :: x'//nl// &
+        '  end type point_t'//nl// &
+        '  type(point_t) :: p'//nl// &
+        '  p%x = 1.0'//nl// &
+        '  print *, p%x'//nl// &
+        'end program r', failures)
+
+    if (failures /= 0) then
+        write (error_unit, '(A,I0,A)') 'FAIL: ', failures, ' case(s) failed'
+        stop 1
+    end if
+    print *, 'PASS: reject-lex-01 diagnostics'
+
+contains
+
+    subroutine compile_case(source, result)
+        character(len=*), intent(in) :: source
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: opts
+
+        opts%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(source, result, opts)
+    end subroutine compile_case
+
+    subroutine expect_rejected(label, source, failure_count)
+        character(len=*), intent(in) :: label
+        character(len=*), intent(in) :: source
+        integer, intent(inout) :: failure_count
+        type(compiler_frontend_result_t) :: result
+        logical :: reported
+
+        call compile_case(source, result)
+        reported = .not. result%success()
+        if (reported) reported = allocated(result%error_msg)
+        if (reported) reported = len_trim(result%error_msg) > 0
+
+        if (reported) then
+            print *, 'PASS: rejected ', label
+        else
+            failure_count = failure_count + 1
+            write (error_unit, '(A,A)') 'FAIL: not rejected: ', label
+        end if
+    end subroutine expect_rejected
+
+    subroutine expect_accepted(label, source, failure_count)
+        character(len=*), intent(in) :: label
+        character(len=*), intent(in) :: source
+        integer, intent(inout) :: failure_count
+        type(compiler_frontend_result_t) :: result
+
+        call compile_case(source, result)
+        if (result%success()) then
+            print *, 'PASS: accepted ', label
+        else
+            failure_count = failure_count + 1
+            write (error_unit, '(A,A)') 'FAIL: wrongly rejected: ', label
+            if (allocated(result%error_msg)) then
+                write (error_unit, '(A,A)') '  error: ', result%error_msg
+            end if
+        end if
+    end subroutine expect_accepted
+
+end program test_reject_lex_01_diagnostics


### PR DESCRIPTION
Closes #2890.

## Preserved compiler invariant

Free-form source text is validated before tokenization. Outside comments and character literals, only the Fortran character set is accepted, a name must start with a letter (a leading `_` is rejected), and `%` must follow a part-reference (name, `)`, `]`). Previously the lexer silently skipped unknown bytes, so `gfortran.dg/illegal_char.f90`, `invalid_name.f90` and `pr91959.f90` compiled clean.

- `src/lexer/lexer_scanners.f90`: `is_legal_source_char`, `is_name_body_char`, `is_percent_prefix_char`.
- `src/lexer/lexer_core.f90`: `validate_source_characters` producing a located diagnostic.
- `src/frontend_core.f90`: `lex_source` reports it before tokenizing.
- NEW `test/api/test_reject_lex_01_diagnostics.f90`.

## Red evidence (before the fix)

```
test_reject_lex_01_diagnostics             FAIL
FAIL: not rejected: illegal_char.f90
FAIL: not rejected: invalid_name.f90
FAIL: not rejected: pr91959.f90
```

## Green evidence

```
test_reject_lex_01_diagnostics             PASS
Summary: 1 passed, 0 failed, 0 skipped
```

Corrected neighbours all stay accepted, as do non-ASCII bytes inside comments and character literals and ordinary `p%x` component selection.

Full `fo`: Build OK, Static OK, 482/483 tests pass. The single failure is `test_all_examples`, which fails identically on unmodified `origin/main` (verified in a clean detached worktree) and is unrelated to this change.