### PR TITLE
[reject-label-01] reject invalid statement labels (#2889)

### DIFF
--- a/src/frontend/frontend_statement_token_parsing.f90
+++ b/src/frontend/frontend_statement_token_parsing.f90
@@ -8,6 +8,8 @@ module frontend_statement_token_parsing
     use parser_prefix_buffer_module, only: parser_prefix_buffer_t
     use ast_arena_modern, only: ast_arena_t
     use error_reporting, only: error_collection_t
+    use parser_label_validation_module, only: validate_label_context, &
+        is_statement_label_text
 
     implicit none
     private
@@ -63,6 +65,7 @@ contains
             return
         end if
 
+        call check_label_separator(tokens, stmt_start, stmt_end)
         effective_start = compute_effective_statement_start(tokens, stmt_start, &
             stmt_end)
         call build_statement_tokens(tokens, effective_start, stmt_end, stmt_tokens)
@@ -76,6 +79,34 @@ contains
         body_indices = [body_indices, stmt_index]
         call append_additional_indices_from_dispatcher(body_indices)
     end subroutine process_regular_statement
+
+    ! A free-form statement label is separated from the statement by blanks;
+    ! a digit string used as a construct name (`10: a=10`) is invalid.
+    subroutine check_label_separator(tokens, stmt_start, stmt_end)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: stmt_start
+        integer, intent(in) :: stmt_end
+        integer :: i, label_idx
+
+        label_idx = 0
+        do i = stmt_start, stmt_end
+            if (tokens(i)%kind == TK_WHITESPACE) cycle
+            if (tokens(i)%kind == TK_NUMBER) label_idx = i
+            exit
+        end do
+
+        if (label_idx == 0) return
+        if (.not. is_statement_label_text(tokens(label_idx)%text)) return
+
+        do i = label_idx + 1, stmt_end
+            if (tokens(i)%kind == TK_WHITESPACE) cycle
+            if (tokens(i)%kind /= TK_OPERATOR) return
+            if (tokens(i)%text /= ":") return
+            call validate_label_context(tokens(label_idx)%text, .true., .true., &
+                tokens(label_idx)%line, tokens(label_idx)%column)
+            return
+        end do
+    end subroutine check_label_separator
 
     integer function compute_effective_statement_start(tokens, stmt_start, stmt_end) &
             result(effective_start)
@@ -159,6 +190,7 @@ contains
         end do
 
         if (label_end_idx > 0) then
+            call check_statement_label(stmt_tokens, label_end_idx, stmt_label)
             allocate (tokens_without_label(size(stmt_tokens) - label_end_idx))
             tokens_without_label = stmt_tokens(label_end_idx + 1:size(stmt_tokens))
             call move_alloc(tokens_without_label, stmt_tokens)
@@ -174,6 +206,30 @@ contains
             end if
         end if
     end subroutine parse_statement_tokens_with_optional_label
+
+    ! Validate the digits of a leading statement label and require that the
+    ! label is attached to a statement.
+    subroutine check_statement_label(stmt_tokens, label_end_idx, stmt_label)
+        type(token_t), intent(in) :: stmt_tokens(:)
+        integer, intent(in) :: label_end_idx
+        character(len=*), intent(in) :: stmt_label
+        logical :: has_statement
+        integer :: i
+
+        has_statement = .false.
+        do i = label_end_idx + 1, size(stmt_tokens)
+            select case (stmt_tokens(i)%kind)
+            case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT, TK_EOF)
+                cycle
+            case default
+                has_statement = .true.
+                exit
+            end select
+        end do
+
+        call validate_label_context(stmt_label, has_statement, .false., &
+            stmt_tokens(label_end_idx)%line, stmt_tokens(label_end_idx)%column)
+    end subroutine check_statement_label
 
     subroutine append_additional_indices_from_dispatcher(body_indices)
         integer, allocatable, intent(inout) :: body_indices(:)

--- a/src/frontend_parsing.f90
+++ b/src/frontend_parsing.f90
@@ -45,6 +45,8 @@ module frontend_parsing
         reset_nested_internal_procedure_error, &
         has_nested_internal_procedure_error, &
         get_nested_internal_procedure_message
+    use parser_label_validation_module, only: reset_statement_label_error, &
+        has_statement_label_error, get_statement_label_message
     use frontend_program_unit_scanner, only: detect_explicit_program_unit, &
         is_inside_module, is_program_unit_start, &
         unit_has_meaningful_content, &
@@ -105,6 +107,7 @@ contains
         error_msg = ""
         prog_index = 0
         call reset_nested_internal_procedure_error()
+        call reset_statement_label_error()
         call clear_parser_errors()
         call ensure_if_do_registration()
 
@@ -116,6 +119,10 @@ contains
         if (should_use_mixed_constructs(tokens_local, mixed_result)) then
             call parse_mixed_construct_file(tokens_local, arena, mixed_result, &
                 prog_index, error_msg, diagnostics)
+            if (has_statement_label_error()) then
+                error_msg = get_statement_label_message()
+                prog_index = 0
+            end if
             call export_parser_errors(diagnostics, parser_errors)
             return
         end if
@@ -131,6 +138,13 @@ contains
                 call export_parser_errors(diagnostics, parser_errors)
                 return
             end if
+        end if
+
+        if (has_statement_label_error()) then
+            error_msg = get_statement_label_message()
+            prog_index = 0
+            call export_parser_errors(diagnostics, parser_errors)
+            return
         end if
 
         if (has_nested_internal_procedure_error()) then

--- a/src/parser/statements/parser_execution_statements.f90
+++ b/src/parser/statements/parser_execution_statements.f90
@@ -6,6 +6,7 @@ module parser_execution_statements_module
     use lexer_token_types, only: TK_IDENTIFIER, TK_OPERATOR, TK_NUMBER, &
         TK_STRING, TK_NEWLINE, TK_KEYWORD
     use parser_state_module, only: parser_state_t
+    use parser_label_validation_module, only: validate_label_context
     use parser_declarations, only: parse_declaration, parse_multi_declaration, &
         parse_derived_type_def, parser_is_at_type_definition
     use parser_definition_statements_module, only: parse_function_definition, &

--- a/src/parser/statements/parser_execution_statements_module.inc
+++ b/src/parser/statements/parser_execution_statements_module.inc
@@ -53,6 +53,7 @@
         type(ast_arena_t), intent(inout) :: arena
         integer, allocatable, intent(inout) :: body_indices(:)
         type(token_t) :: token
+        type(token_t) :: label_token
         type(parser_prefix_buffer_t) :: prefix_buffer
         character(len=16), allocatable :: pending_prefixes(:)
         character(len=:), allocatable :: lowered
@@ -92,8 +93,9 @@
                 ! Save the label text
                 stmt_label = trim(token%text)
                 ! Consume the label and get next token
-                token = parser%consume()
+                label_token = parser%consume()
                 token = parser%peek()
+                call validate_program_body_label(stmt_label, label_token, token)
                 if (token%kind == TK_KEYWORD) then
                     lowered = trim(to_lower(token%text))
                 else
@@ -900,6 +902,29 @@
             end if
         end subroutine append_statement
     end subroutine parse_program_body
+
+    ! Reject invalid statement labels found in an explicit program body.
+    subroutine validate_program_body_label(label_text, label_token, next_token)
+        character(len=*), intent(in) :: label_text
+        type(token_t), intent(in) :: label_token
+        type(token_t), intent(in) :: next_token
+        logical :: has_statement
+        logical :: colon_follows
+
+        has_statement = .true.
+        select case (next_token%kind)
+        case (TK_NEWLINE, TK_EOF, TK_COMMENT)
+            has_statement = .false.
+        end select
+
+        colon_follows = .false.
+        if (next_token%kind == TK_OPERATOR) then
+            if (allocated(next_token%text)) colon_follows = next_token%text == ":"
+        end if
+
+        call validate_label_context(label_text, has_statement, colon_follows, &
+            label_token%line, label_token%column)
+    end subroutine validate_program_body_label
 
     ! Handle single vs multi-variable declarations (duplicate of dispatcher logic)
     subroutine handle_variable_declaration(parser, arena, stmt_index)

--- a/src/parser/statements/parser_label_validation.f90
+++ b/src/parser/statements/parser_label_validation.f90
@@ -1,0 +1,139 @@
+module parser_label_validation_module
+    ! Statement label validation (Fortran 2003 R313 / C304).
+    !
+    ! A statement label is one to five digits, at least one of them nonzero,
+    ! and in free form it is separated from the statement by blanks.  A label
+    ! must be attached to a statement.  Violations are recorded here and
+    ! surfaced by the parsing driver as a source diagnostic.
+    implicit none
+    private
+
+    public :: validate_statement_label
+    public :: validate_label_context
+    public :: record_statement_label_error
+    public :: is_statement_label_text
+    public :: reset_statement_label_error
+    public :: has_statement_label_error
+    public :: get_statement_label_message
+
+    logical :: statement_label_error = .false.
+    character(len=:), allocatable :: statement_label_message
+
+contains
+
+    ! Check the digits of a statement label. Returns .true. when valid,
+    ! otherwise .false. and an allocated rule-specific message.
+    logical function validate_statement_label(label_text, message) result(valid)
+        character(len=*), intent(in) :: label_text
+        character(len=:), allocatable, intent(out) :: message
+        character(len=:), allocatable :: digits
+        integer :: i
+
+        valid = .true.
+        digits = trim(adjustl(label_text))
+
+        do i = 1, len(digits)
+            if (digits(i:i) < '0' .or. digits(i:i) > '9') then
+                valid = .false.
+                message = "Invalid statement label '"//digits// &
+                    "': statement labels consist of digits only"
+                return
+            end if
+        end do
+
+        if (len(digits) == 0) return
+
+        if (len(digits) > 5) then
+            valid = .false.
+            message = "Too many digits in statement label '"//digits// &
+                "': at most five digits are allowed"
+            return
+        end if
+
+        if (verify(digits, '0') == 0) then
+            valid = .false.
+            message = "Zero is not a valid statement label"
+        end if
+    end function validate_statement_label
+
+    ! True when the token text can only be a statement label (digits only).
+    logical function is_statement_label_text(text) result(is_label)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: digits
+        integer :: i
+
+        digits = trim(adjustl(text))
+        is_label = len(digits) > 0
+        if (.not. is_label) return
+        do i = 1, len(digits)
+            if (digits(i:i) < '0' .or. digits(i:i) > '9') then
+                is_label = .false.
+                return
+            end if
+        end do
+    end function is_statement_label_text
+
+    ! Validate a label token together with what follows it. `has_statement`
+    ! reports whether a statement is attached, `colon_follows` whether the
+    ! label is directly followed by a colon (an invalid separator).
+    subroutine validate_label_context(label_text, has_statement, colon_follows, &
+            line, column)
+        character(len=*), intent(in) :: label_text
+        logical, intent(in) :: has_statement
+        logical, intent(in) :: colon_follows
+        integer, intent(in) :: line
+        integer, intent(in) :: column
+        character(len=:), allocatable :: message
+
+        if (.not. is_statement_label_text(label_text)) return
+
+        if (.not. validate_statement_label(label_text, message)) then
+            call record_statement_label_error(message, line, column)
+            return
+        end if
+
+        if (colon_follows) then
+            call record_statement_label_error( &
+                "Invalid character ':' after statement label '"// &
+                trim(adjustl(label_text))//"'", line, column)
+            return
+        end if
+
+        if (.not. has_statement) then
+            call record_statement_label_error( &
+                "Statement label without statement", line, column)
+        end if
+    end subroutine validate_label_context
+
+    subroutine record_statement_label_error(message, line, column)
+        character(len=*), intent(in) :: message
+        integer, intent(in) :: line
+        integer, intent(in) :: column
+        character(len=32) :: position_text
+
+        if (statement_label_error) return
+        statement_label_error = .true.
+        write (position_text, '(I0,A,I0)') line, ':', column
+        statement_label_message = trim(position_text)//": error: "//trim(message)
+    end subroutine record_statement_label_error
+
+    subroutine reset_statement_label_error()
+        statement_label_error = .false.
+        if (allocated(statement_label_message)) deallocate (statement_label_message)
+    end subroutine reset_statement_label_error
+
+    logical function has_statement_label_error() result(has_error)
+        has_error = statement_label_error
+    end function has_statement_label_error
+
+    function get_statement_label_message() result(message)
+        character(len=:), allocatable :: message
+
+        if (allocated(statement_label_message)) then
+            message = statement_label_message
+        else
+            message = "Invalid statement label"
+        end if
+    end function get_statement_label_message
+
+end module parser_label_validation_module

--- a/test/api/test_reject_label_01_diagnostics.f90
+++ b/test/api/test_reject_label_01_diagnostics.f90
@@ -1,0 +1,134 @@
+program test_reject_label_01_diagnostics
+    ! Issue #2889 [reject-label-01]: invalid statement labels must be rejected
+    ! with a source diagnostic, while the corrected neighbouring form still
+    ! compiles.
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use fortfront_compiler, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=1), parameter :: nl = new_line('a')
+    integer :: failures
+
+    failures = 0
+
+    ! gfortran.dg/empty_label.f90: statement label without a statement
+    call expect_rejected('empty_label.f90', &
+        'program p'//nl// &
+        '100'//nl// &
+        'end program p', failures)
+    call expect_accepted('empty_label corrected neighbour', &
+        'program p'//nl// &
+        '100 continue'//nl// &
+        'end program p', failures)
+
+    ! gfortran.dg/label_1.f90: too many digits, and a zero label
+    call expect_rejected('label_1.f90 too many digits', &
+        'program a'//nl// &
+        '0056780 continue'//nl// &
+        'end program a', failures)
+    call expect_rejected('label_1.f90 zero label', &
+        'program a'//nl// &
+        '0 continue'//nl// &
+        'end program a', failures)
+    call expect_accepted('label_1 corrected neighbour', &
+        'program a'//nl// &
+        '56780 continue'//nl// &
+        '1 continue'//nl// &
+        'end program a', failures)
+
+    ! gfortran.dg/label_2.f90: invalid character directly after the label
+    call expect_rejected('label_2.f90', &
+        'program pr24640'//nl// &
+        '   integer :: a'//nl// &
+        '10: a=10'//nl// &
+        'end program pr24640', failures)
+    call expect_accepted('label_2 corrected neighbour', &
+        'program pr24640'//nl// &
+        '   integer :: a'//nl// &
+        '10 a=10'//nl// &
+        '   print *, a'//nl// &
+        'end program pr24640', failures)
+
+    ! Named construct labels keep working: they are identifiers, not labels.
+    call expect_accepted('named construct label', &
+        'program named'//nl// &
+        '   integer :: i'//nl// &
+        '   loop: do i = 1, 3'//nl// &
+        '      print *, i'//nl// &
+        '   end do loop'//nl// &
+        'end program named', failures)
+
+    if (failures /= 0) then
+        write (error_unit, '(A,I0,A)') 'FAIL: ', failures, ' case(s) failed'
+        stop 1
+    end if
+    print *, 'PASS: reject-label-01 diagnostics'
+
+contains
+
+    subroutine compile_case(source, result)
+        character(len=*), intent(in) :: source
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: opts
+
+        opts%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(source, result, opts)
+    end subroutine compile_case
+
+    subroutine expect_rejected(label, source, failure_count)
+        character(len=*), intent(in) :: label
+        character(len=*), intent(in) :: source
+        integer, intent(inout) :: failure_count
+        type(compiler_frontend_result_t) :: result
+        logical :: reported
+
+        call compile_case(source, result)
+        reported = .not. result%success()
+        if (reported) reported = allocated(result%error_msg)
+        if (reported) reported = len_trim(result%error_msg) > 0
+        if (reported) reported = index(to_lower(result%error_msg), 'label') > 0
+
+        if (reported) then
+            print *, 'PASS: rejected ', label
+        else
+            failure_count = failure_count + 1
+            write (error_unit, '(A,A)') 'FAIL: not rejected: ', label
+        end if
+    end subroutine expect_rejected
+
+    subroutine expect_accepted(label, source, failure_count)
+        character(len=*), intent(in) :: label
+        character(len=*), intent(in) :: source
+        integer, intent(inout) :: failure_count
+        type(compiler_frontend_result_t) :: result
+
+        call compile_case(source, result)
+        if (result%success()) then
+            print *, 'PASS: accepted ', label
+        else
+            failure_count = failure_count + 1
+            write (error_unit, '(A,A)') 'FAIL: wrongly rejected: ', label
+            if (allocated(result%error_msg)) then
+                write (error_unit, '(A,A)') '  error: ', result%error_msg
+            end if
+        end if
+    end subroutine expect_accepted
+
+    function to_lower(text) result(lowered)
+        character(len=*), intent(in) :: text
+        character(len=len(text)) :: lowered
+        integer :: i, code
+
+        do i = 1, len(text)
+            code = iachar(text(i:i))
+            if (code >= iachar('A') .and. code <= iachar('Z')) then
+                lowered(i:i) = achar(code + 32)
+            else
+                lowered(i:i) = text(i:i)
+            end if
+        end do
+    end function to_lower
+
+end program test_reject_label_01_diagnostics


### PR DESCRIPTION
Closes #2889.

## Preserved compiler invariant

A statement label is one to five digits with at least one nonzero digit
(F2003 R313/C304), it is separated from the statement by blanks in free
form, and it must be attached to a statement. Fortfront previously
accepted every leading digit string as a label and silently dropped the
invalid ones. Now the label is validated where it is recognized
(explicit program bodies and the token-level statement path) and any
violation aborts the parse with a source diagnostic carrying line and
column.

Covers the gfortran.dg fixtures named in the issue:
- `empty_label.f90` -> "Statement label without statement"
- `label_1.f90` -> "Too many digits in statement label", "Zero is not a valid statement label"
- `label_2.f90` -> "Invalid character ':' after statement label"

Validation is on the typed token/label data, not on filenames or message
text. Named construct labels (identifiers before `:`) are untouched.

## Red evidence

`fo test test_reject_label_01_diagnostics` on unmodified main:

```
FAIL: not rejected: empty_label.f90
FAIL: not rejected: label_1.f90 too many digits
FAIL: not rejected: label_1.f90 zero label
FAIL: not rejected: label_2.f90
FAIL: 4 case(s) failed
```
(the four corrected-neighbour cases already passed)

## Green evidence

```
test_reject_label_01_diagnostics           PASS
```
Full local pipeline after rebase onto origin/main: `Static: OK`, `Build: OK`, `Tests: OK`, `Lint: OK`, `All stages passed`.