### PR TITLE
[reject-literal-01] reject malformed or disallowed literal forms

### DIFF
--- a/src/frontend_core.f90
+++ b/src/frontend_core.f90
@@ -7,6 +7,7 @@ module frontend_core
     use string_builder_mod, only: join_strings
     use lexer_core, only: token_t, tokenize_core, &
         validate_source_characters, &
+        find_unterminated_character_constant, &
         TK_COMMENT, TK_NEWLINE, TK_OPERATOR, TK_IDENTIFIER, &
         TK_NUMBER, TK_STRING, TK_UNKNOWN, TK_WHITESPACE, &
         to_lower
@@ -161,11 +162,30 @@ contains
         character(len=*), intent(out) :: error_msg
 
         error_msg = ""
+        call unterminated_character_constant_error(source, error_msg)
+        if (len_trim(error_msg) > 0) return
         call tokenize_core(source, tokens)
         if (allocated(tokens)) then
             call normalize_line_continuations(tokens)
         end if
     end subroutine lex_file
+
+    ! Reject a character literal that is never closed. Leaves error_msg empty
+    ! when every character context on every line is terminated.
+    subroutine unterminated_character_constant_error(source, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=*), intent(out) :: error_msg
+        integer :: bad_line, bad_column
+        character(len=32) :: line_text, column_text
+
+        error_msg = ""
+        if (.not. find_unterminated_character_constant(source, bad_line, &
+                                                       bad_column)) return
+        write (line_text, '(I0)') bad_line
+        write (column_text, '(I0)') bad_column
+        error_msg = "Unterminated character constant at line "// &
+                    trim(line_text)//", column "//trim(column_text)
+    end subroutine unterminated_character_constant_error
 
     ! Simple interface functions for clean pipeline usage
     subroutine lex_source(source_code, tokens, error_msg)
@@ -178,6 +198,17 @@ contains
             allocate (tokens(0))
             return
         end if
+
+        block
+            character(len=MAX_FRONTEND_ERROR_LEN) :: literal_error
+
+            call unterminated_character_constant_error(source_code, literal_error)
+            if (len_trim(literal_error) > 0) then
+                allocate (tokens(0))
+                error_msg = trim(literal_error)
+                return
+            end if
+        end block
 
         call tokenize_core(source_code, tokens)
         if (.not. allocated(tokens)) then

--- a/src/lexer/lexer_core.f90
+++ b/src/lexer/lexer_core.f90
@@ -28,6 +28,7 @@ module lexer_core
     public :: scan_number_safe, scan_comment_safe, scan_string_safe, &
         scan_identifier_safe
     public :: scan_operator_safe, scan_logical_token_safe
+    public :: find_unterminated_character_constant
 
     ! Re-export utilities
     public :: to_lower, resize_tokens, resize_trivia_buffer

--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -11,6 +11,7 @@ module lexer_scanners
     public :: scan_number_safe, scan_comment_safe, scan_string_safe, &
         scan_identifier_safe
     public :: scan_operator_safe, scan_logical_token_safe
+    public :: find_unterminated_character_constant
 
     ! Public source character classification (F2018 6.1 character set)
     public :: is_legal_source_char, is_name_body_char, is_percent_prefix_char
@@ -534,6 +535,128 @@ contains
 
         scan_result%chars_consumed = pos - start_pos
     end subroutine scan_logical_token_safe
+
+    ! Locate the first unterminated character constant in a source text.
+    !
+    ! A character context that is not closed before the end of its line is only
+    ! legal when the line is continued and the next line resumes the constant
+    ! with a leading ampersand (F2018 6.3.2.4). Otherwise the constant runs off
+    ! the end of the line and off the end of the program unit. Returns the line
+    ! and column of the opening delimiter.
+    function find_unterminated_character_constant(source, line_num, col_num) &
+            result(found)
+        character(len=*), intent(in) :: source
+        integer, intent(out) :: line_num, col_num
+        logical :: found
+        integer :: source_len, line_start, line_end, current_line, open_col
+        logical :: quote_open
+
+        found = .false.
+        line_num = 0
+        col_num = 0
+        source_len = len(source)
+        line_start = 1
+        current_line = 1
+
+        do while (line_start <= source_len)
+            line_end = line_start - 1
+            do while (line_end < source_len)
+                if (source(line_end + 1:line_end + 1) == char(10)) exit
+                if (source(line_end + 1:line_end + 1) == char(13)) exit
+                line_end = line_end + 1
+            end do
+
+            call scan_line_quotes(source(line_start:line_end), quote_open, open_col)
+            if (quote_open) then
+                if (line_is_continued(source(line_start:line_end))) then
+                    if (continuation_resumes(source, line_end + 1)) return
+                end if
+                found = .true.
+                line_num = current_line
+                col_num = open_col
+                return
+            end if
+
+            if (line_end >= source_len) return
+            line_start = line_end + 2
+            if (source(line_end + 1:line_end + 1) == char(13)) then
+                if (line_start <= source_len) then
+                    if (source(line_start:line_start) == char(10)) then
+                        line_start = line_start + 1
+                    end if
+                end if
+            end if
+            current_line = current_line + 1
+        end do
+    end function find_unterminated_character_constant
+
+    ! Whether a line ends inside a character context, and where that context
+    ! was opened. A comment delimiter outside a character context ends the line.
+    subroutine scan_line_quotes(line, quote_open, open_col)
+        character(len=*), intent(in) :: line
+        logical, intent(out) :: quote_open
+        integer, intent(out) :: open_col
+        character :: c, quote_char
+        integer :: i
+
+        quote_open = .false.
+        open_col = 0
+        quote_char = ' '
+        i = 1
+        do while (i <= len(line))
+            c = line(i:i)
+            if (quote_open) then
+                if (c == quote_char) then
+                    if (i < len(line)) then
+                        if (line(i + 1:i + 1) == quote_char) then
+                            i = i + 2
+                            cycle
+                        end if
+                    end if
+                    quote_open = .false.
+                end if
+            else
+                if (c == '!') return
+                if (c == "'" .or. c == '"') then
+                    quote_open = .true.
+                    quote_char = c
+                    open_col = i
+                end if
+            end if
+            i = i + 1
+        end do
+    end subroutine scan_line_quotes
+
+    ! Whether a line ends with a continuation ampersand.
+    function line_is_continued(line) result(is_continued)
+        character(len=*), intent(in) :: line
+        logical :: is_continued
+        integer :: trimmed_len
+
+        is_continued = .false.
+        trimmed_len = len_trim(line)
+        if (trimmed_len == 0) return
+        is_continued = line(trimmed_len:trimmed_len) == '&'
+    end function line_is_continued
+
+    ! Whether the text after a continued character context resumes it with the
+    ! mandatory leading ampersand.
+    function continuation_resumes(source, start_pos) result(resumes)
+        character(len=*), intent(in) :: source
+        integer, intent(in) :: start_pos
+        logical :: resumes
+        integer :: i
+        character :: c
+
+        resumes = .false.
+        do i = start_pos, len(source)
+            c = source(i:i)
+            if (c == ' ' .or. c == char(9) .or. c == char(10) .or. &
+                c == char(13)) cycle
+            resumes = c == '&'
+            return
+        end do
+    end function continuation_resumes
 
     ! Helper function to check if a word is a keyword
     function is_keyword(word) result(keyword)

--- a/src/semantic/analyzers/README.md
+++ b/src/semantic/analyzers/README.md
@@ -38,6 +38,7 @@ For complete semantic analysis concepts including type inference, scope manageme
 | semantic_binary_operations.f90 | Binary operator type checking and inference |
 | semantic_binary_ops_core.f90 | Core binary operation semantics |
 | semantic_literal_identifier.f90 | Literal and identifier type inference |
+| semantic_literal_form_validation.f90 | Reject malformed or disallowed literal forms (undefined named kind parameter, non-standard ISO_FORTRAN_ENV import, procedure name as an output list value) |
 | semantic_literal_type_helpers.f90 | Literal type helper functions |
 
 ### Function and Procedure Analysis

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -17,6 +17,7 @@ use error_handling, only: create_error_collection
 use type_hierarchy, only: create_type_hierarchy
 use semantic_type_hierarchy_validation, only: populate_type_hierarchy
 use semantic_enum_validation, only: validate_enum_definitions
+use semantic_literal_form_validation, only: validate_literal_forms
 use call_graph_signatures_mod, only: create_signatures_map
 use semantic_validation_utils, only: int_to_str
 use ast_nodes_data, only: declaration_node
@@ -92,6 +93,10 @@ contains
         ! Report ENUM constraint violations recorded by the parser. The sweep
         ! is arena-wide so module-level enumerations are covered too.
         call validate_enum_definitions(arena, ctx%errors)
+
+        ! Reject malformed or disallowed literal forms before inference runs.
+        call validate_literal_forms(arena, ctx%errors, &
+                                    ctx%input_mode == INPUT_MODE_STANDARD)
 
         if (trace_is_enabled()) then
             select type (ast => arena%entries(root_index)%node)

--- a/src/semantic/analyzers/semantic_literal_form_validation.f90
+++ b/src/semantic/analyzers/semantic_literal_form_validation.f90
@@ -1,0 +1,407 @@
+module semantic_literal_form_validation
+    ! Rejects malformed or disallowed literal forms (issue #2894).
+    !
+    ! One constraint family: a literal constant must denote a value that the
+    ! standard actually allows at that point in the program.
+    !
+    !   * A kind parameter written as a name (`0.0_dp`) must be a named integer
+    !     constant that is available in the compilation unit (F2018 R764,
+    !     C716). An undefined name leaves the literal without a kind.
+    !   * A named constant imported from the intrinsic module ISO_FORTRAN_ENV
+    !     must be an entity that module actually defines. The unsigned kind
+    !     names (`uint8` ... `uint64`) are a vendor extension, not standard.
+    !   * A procedure name is not a constant and not a variable, so it is not a
+    !     valid value in an output list (`print *, (erfc)`).
+    use ast_arena_modern, only: ast_arena_t
+    use ast_base, only: LITERAL_INTEGER, LITERAL_REAL
+    use ast_nodes_core, only: literal_node, identifier_node
+    use ast_nodes_data, only: declaration_node, parameter_declaration_node
+    use ast_nodes_io, only: print_statement_node
+    use ast_nodes_misc, only: use_statement_node
+    use ast_nodes_procedure, only: function_def_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use string_utils_mod, only: int_to_string, to_lower
+    use string_types, only: string_t
+    implicit none
+    private
+
+    public :: validate_literal_forms
+
+contains
+
+    ! Walk the arena once, gathering the names a literal kind parameter could
+    ! refer to together with the nodes each rule has to inspect, then report.
+    subroutine validate_literal_forms(arena, errors, standard_mode)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        logical, intent(in) :: standard_mode
+        type(string_t), allocatable :: available(:)
+        type(string_t), allocatable :: procedures(:)
+        integer, allocatable :: kind_literals(:)
+        integer, allocatable :: output_items(:)
+        integer, allocatable :: imports(:)
+        integer :: available_count, procedure_count
+        integer :: kind_count, output_count, import_count
+        logical :: unrestricted_use
+
+        call scan_arena(arena, available, available_count, procedures, &
+                        procedure_count, kind_literals, kind_count, &
+                        output_items, output_count, imports, import_count, &
+                        unrestricted_use)
+
+        ! Lazy Fortran supplies kind names such as `dp` implicitly, so a named
+        ! kind parameter is only required to be declared in standard input.
+        if (standard_mode .and. .not. unrestricted_use) then
+            call check_kind_parameters(arena, kind_literals, kind_count, &
+                                       available, available_count, errors)
+        end if
+        call check_intrinsic_module_imports(arena, imports, import_count, errors)
+        call check_output_list_items(arena, output_items, output_count, &
+                                     available, available_count, procedures, &
+                                     procedure_count, errors)
+    end subroutine validate_literal_forms
+
+    ! Single arena traversal feeding every rule below.
+    subroutine scan_arena(arena, available, available_count, procedures, &
+                          procedure_count, kind_literals, kind_count, &
+                          output_items, output_count, imports, import_count, &
+                          unrestricted_use)
+        type(ast_arena_t), intent(in) :: arena
+        type(string_t), allocatable, intent(out) :: available(:)
+        integer, intent(out) :: available_count
+        type(string_t), allocatable, intent(out) :: procedures(:)
+        integer, intent(out) :: procedure_count
+        integer, allocatable, intent(out) :: kind_literals(:)
+        integer, intent(out) :: kind_count
+        integer, allocatable, intent(out) :: output_items(:)
+        integer, intent(out) :: output_count
+        integer, allocatable, intent(out) :: imports(:)
+        integer, intent(out) :: import_count
+        logical, intent(out) :: unrestricted_use
+        character(len=:), allocatable :: suffix
+        integer :: i, j
+
+        allocate (available(0))
+        allocate (procedures(0))
+        allocate (kind_literals(0))
+        allocate (output_items(0))
+        allocate (imports(0))
+        available_count = 0
+        procedure_count = 0
+        kind_count = 0
+        output_count = 0
+        import_count = 0
+        unrestricted_use = .false.
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (literal_node)
+                if (.not. allocated(node%value)) cycle
+                if (.not. is_numeric_literal(node%literal_kind)) cycle
+                suffix = kind_suffix(node%value)
+                if (len(suffix) == 0) cycle
+                if (is_digit_string(suffix)) cycle
+                call append_index(kind_literals, kind_count, i)
+                type is (print_statement_node)
+                if (.not. allocated(node%expression_indices)) cycle
+                do j = 1, size(node%expression_indices)
+                    call append_index(output_items, output_count, &
+                                      node%expression_indices(j))
+                end do
+                type is (declaration_node)
+                if (allocated(node%var_name)) then
+                    call append(available, available_count, node%var_name)
+                end if
+                if (allocated(node%var_names)) then
+                    do j = 1, size(node%var_names)
+                        call append(available, available_count, node%var_names(j))
+                    end do
+                end if
+                type is (parameter_declaration_node)
+                if (allocated(node%name)) then
+                    call append(available, available_count, node%name)
+                end if
+                type is (function_def_node)
+                if (allocated(node%name)) then
+                    call append(procedures, procedure_count, node%name)
+                end if
+                type is (use_statement_node)
+                if (.not. node%has_only) unrestricted_use = .true.
+                call append_index(imports, import_count, i)
+                if (allocated(node%only_list)) then
+                    do j = 1, size(node%only_list)
+                        if (.not. allocated(node%only_list(j)%s)) cycle
+                        call append(available, available_count, &
+                                    local_name(node%only_list(j)%s))
+                    end do
+                end if
+                if (allocated(node%rename_list)) then
+                    do j = 1, size(node%rename_list)
+                        if (.not. allocated(node%rename_list(j)%s)) cycle
+                        call append(available, available_count, &
+                                    local_name(node%rename_list(j)%s))
+                    end do
+                end if
+            end select
+        end do
+    end subroutine scan_arena
+
+    ! A named kind parameter must denote a named integer constant in scope.
+    subroutine check_kind_parameters(arena, kind_literals, kind_count, &
+                                     available, available_count, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: kind_literals(:)
+        integer, intent(in) :: kind_count
+        type(string_t), intent(in) :: available(:)
+        integer, intent(in) :: available_count
+        type(error_collection_t), intent(inout) :: errors
+        character(len=:), allocatable :: suffix
+        integer :: i
+
+        do i = 1, kind_count
+            select type (node => arena%entries(kind_literals(i))%node)
+                type is (literal_node)
+                suffix = kind_suffix(node%value)
+                if (name_present(available, available_count, suffix)) cycle
+                call report(errors, 'Missing kind-parameter: '//suffix// &
+                            ' in literal constant '//node%value// &
+                            ' is not a named integer constant', &
+                            node%line, node%column, &
+                            'declare the kind as an integer parameter before use')
+            end select
+        end do
+    end subroutine check_kind_parameters
+
+    ! ONLY-list names taken from ISO_FORTRAN_ENV must exist in that module.
+    subroutine check_intrinsic_module_imports(arena, imports, import_count, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: imports(:)
+        integer, intent(in) :: import_count
+        type(error_collection_t), intent(inout) :: errors
+        character(len=:), allocatable :: imported
+        integer :: i, j
+
+        do i = 1, import_count
+            select type (node => arena%entries(imports(i))%node)
+                type is (use_statement_node)
+                if (.not. allocated(node%module_name)) cycle
+                if (to_lower(node%module_name) /= 'iso_fortran_env') cycle
+                if (.not. allocated(node%only_list)) cycle
+                do j = 1, size(node%only_list)
+                    if (.not. allocated(node%only_list(j)%s)) cycle
+                    imported = remote_name(node%only_list(j)%s)
+                    if (len(imported) == 0) cycle
+                    if (is_iso_fortran_env_entity(imported)) cycle
+                    call report(errors, 'Invalid literal kind import: '// &
+                                imported//' is not an entity of the intrinsic '// &
+                                'module ISO_FORTRAN_ENV in the selected standard', &
+                                node%line, node%column, &
+                                'use a standard kind such as int32 or real64')
+                end do
+            end select
+        end do
+    end subroutine check_intrinsic_module_imports
+
+    ! A bare procedure name is neither a constant nor a variable, so it cannot
+    ! appear as an output list item.
+    subroutine check_output_list_items(arena, output_items, output_count, &
+                                       available, available_count, procedures, &
+                                       procedure_count, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: output_items(:)
+        integer, intent(in) :: output_count
+        type(string_t), intent(in) :: available(:)
+        integer, intent(in) :: available_count
+        type(string_t), intent(in) :: procedures(:)
+        integer, intent(in) :: procedure_count
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i, item_index
+
+        if (procedure_count == 0) return
+
+        do i = 1, output_count
+            item_index = output_items(i)
+            if (item_index <= 0) cycle
+            if (.not. arena%has_node_at(item_index)) cycle
+            select type (item => arena%entries(item_index)%node)
+                type is (identifier_node)
+                if (.not. allocated(item%name)) cycle
+                if (name_present(available, available_count, item%name)) cycle
+                if (.not. name_present(procedures, procedure_count, &
+                                       item%name)) cycle
+                call report(errors, 'Invalid constant in output list: '// &
+                            item%name//' is a procedure name, not a floating '// &
+                            'constant or variable', item%line, item%column, &
+                            'call the procedure with an argument list, for '// &
+                            'example '//item%name//'()')
+            end select
+        end do
+    end subroutine check_output_list_items
+
+    ! Append an arena index with geometric growth.
+    subroutine append_index(indices, count, value)
+        integer, allocatable, intent(inout) :: indices(:)
+        integer, intent(inout) :: count
+        integer, intent(in) :: value
+        integer, allocatable :: grown(:)
+        integer :: capacity
+
+        capacity = size(indices)
+        if (count >= capacity) then
+            allocate (grown(max(16, 2*capacity)))
+            if (count > 0) grown(1:count) = indices(1:count)
+            call move_alloc(grown, indices)
+        end if
+        count = count + 1
+        indices(count) = value
+    end subroutine append_index
+
+    ! Add one diagnostic of this rule family.
+    subroutine report(errors, message, line, column, suggestion)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: message
+        integer, intent(in) :: line, column
+        character(len=*), intent(in) :: suggestion
+
+        call errors%add_error( &
+            message=message, &
+            code=ERROR_SEMANTIC, &
+            component='semantic_literal_form_validation', &
+            context='line '//int_to_string(line)//', column '// &
+            int_to_string(column), &
+            suggestion=suggestion, line=line, column=column, &
+            end_line=line, end_column=column + 1)
+    end subroutine report
+
+    ! The kind suffix of a numeric literal, empty when there is none.
+    function kind_suffix(value) result(suffix)
+        character(len=*), intent(in) :: value
+        character(len=:), allocatable :: suffix
+        integer :: i
+
+        suffix = ''
+        do i = 1, len(value)
+            if (value(i:i) == '_') then
+                if (i < len(value)) suffix = value(i + 1:)
+                return
+            end if
+        end do
+    end function kind_suffix
+
+    ! Whether a literal carries a numeric type that admits a kind parameter.
+    function is_numeric_literal(literal_kind) result(is_numeric)
+        integer, intent(in) :: literal_kind
+        logical :: is_numeric
+
+        is_numeric = literal_kind == LITERAL_REAL .or. &
+            literal_kind == LITERAL_INTEGER
+    end function is_numeric_literal
+
+    function is_digit_string(text) result(all_digits)
+        character(len=*), intent(in) :: text
+        logical :: all_digits
+        integer :: i
+
+        all_digits = len(text) > 0
+        do i = 1, len(text)
+            if (text(i:i) < '0' .or. text(i:i) > '9') then
+                all_digits = .false.
+                return
+            end if
+        end do
+    end function is_digit_string
+
+    ! Local name of an ONLY item: `new => old` binds `new` locally.
+    function local_name(item) result(name)
+        character(len=*), intent(in) :: item
+        character(len=:), allocatable :: name
+        integer :: arrow
+
+        arrow = index(item, '=>')
+        if (arrow > 0) then
+            name = trim(adjustl(item(1:arrow - 1)))
+        else
+            name = trim(adjustl(item))
+        end if
+    end function local_name
+
+    ! Name that an ONLY item requests from the module.
+    function remote_name(item) result(name)
+        character(len=*), intent(in) :: item
+        character(len=:), allocatable :: name
+        integer :: arrow
+
+        arrow = index(item, '=>')
+        if (arrow > 0) then
+            name = trim(adjustl(item(arrow + 2:)))
+        else
+            name = trim(adjustl(item))
+        end if
+    end function remote_name
+
+    function name_present(names, count, name) result(found)
+        type(string_t), intent(in) :: names(:)
+        integer, intent(in) :: count
+        character(len=*), intent(in) :: name
+        logical :: found
+        character(len=:), allocatable :: target_name
+        integer :: i
+
+        found = .false.
+        target_name = to_lower(trim(name))
+        do i = 1, count
+            if (.not. allocated(names(i)%s)) cycle
+            if (to_lower(trim(names(i)%s)) == target_name) then
+                found = .true.
+                return
+            end if
+        end do
+    end function name_present
+
+    ! Append with geometric growth. Entries past `count` are unused padding,
+    ! so every lookup must respect the count carried alongside the array.
+    subroutine append(names, count, name)
+        type(string_t), allocatable, intent(inout) :: names(:)
+        integer, intent(inout) :: count
+        character(len=*), intent(in) :: name
+        type(string_t), allocatable :: grown(:)
+        integer :: capacity
+
+        if (len_trim(name) == 0) return
+        capacity = size(names)
+        if (count >= capacity) then
+            allocate (grown(max(16, 2*capacity)))
+            if (count > 0) grown(1:count) = names(1:count)
+            call move_alloc(grown, names)
+        end if
+        count = count + 1
+        names(count)%s = trim(name)
+    end subroutine append
+
+    ! Public entities of the intrinsic module ISO_FORTRAN_ENV (F2018 16.10.2).
+    function is_iso_fortran_env_entity(name) result(is_entity)
+        character(len=*), intent(in) :: name
+        logical :: is_entity
+        character(len=:), allocatable :: lowered
+
+        lowered = to_lower(trim(name))
+        select case (lowered)
+        case ('atomic_int_kind', 'atomic_logical_kind', 'character_kinds', &
+              'character_storage_size', 'compiler_options', 'compiler_version', &
+              'current_team', 'error_unit', 'event_type', 'file_storage_size', &
+              'initial_team', 'input_unit', 'int8', 'int16', 'int32', 'int64', &
+              'integer_kinds', 'iostat_end', 'iostat_eor', &
+              'iostat_inquire_internal_unit', 'lock_type', 'logical_kinds', &
+              'notify_type', 'numeric_storage_size', 'output_unit', &
+              'parent_team', 'real16', 'real32', 'real64', 'real128', &
+              'real_kinds', 'stat_failed_image', 'stat_locked', &
+              'stat_locked_other_image', 'stat_stopped_image', 'stat_unlocked', &
+              'stat_unlocked_failed_image', 'team_type')
+            is_entity = .true.
+        case default
+            is_entity = .false.
+        end select
+    end function is_iso_fortran_env_entity
+
+end module semantic_literal_form_validation

--- a/test/api/test_reject_literal_01_diagnostics.f90
+++ b/test/api/test_reject_literal_01_diagnostics.f90
@@ -1,0 +1,169 @@
+program test_reject_literal_01_diagnostics
+    ! Issue #2894: malformed or disallowed literal forms must be rejected with a
+    ! source diagnostic, while the corrected neighboring form stays accepted.
+    !
+    ! Negative fixtures mirror the gfortran.dg sources kind_tests_4.f90,
+    ! pr95690.f90, unexpected_eof_2.f90, unexpected_eof_3.f90 and
+    ! unsigned_37.f90. Each is paired with a corrected neighbor.
+    use fortfront_compiler, only: compiler_frontend_result_t, &
+        compiler_frontend_options_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD, OPERATING_MODE_STRICT
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    call check_kind_tests_4(all_passed)
+    call check_pr95690(all_passed)
+    call check_unexpected_eof_2(all_passed)
+    call check_unexpected_eof_3(all_passed)
+    call check_unsigned_37(all_passed)
+
+    if (all_passed) then
+        print *, 'All literal form rejection tests passed'
+    else
+        print *, 'Literal form rejection tests FAILED'
+        stop 1
+    end if
+
+contains
+
+    function nl() result(c)
+        character(len=1) :: c
+
+        c = char(10)
+    end function nl
+
+    ! An undefined named kind parameter leaves the literal without a kind.
+    subroutine check_kind_tests_4(passed)
+        logical, intent(inout) :: passed
+
+        call expect_rejected('kind_tests_4', &
+            'rPos=0.0_dp'//nl()// &
+            'end'//nl(), passed)
+        call expect_accepted('kind_tests_4 corrected', &
+            'program p'//nl()// &
+            '    integer, parameter :: dp = kind(1.0d0)'//nl()// &
+            '    real(dp) :: rpos'//nl()// &
+            '    rpos = 0.0_dp'//nl()// &
+            'end program p'//nl(), passed)
+    end subroutine check_kind_tests_4
+
+    ! A procedure name is not a constant, so it is not a valid output item.
+    subroutine check_pr95690(passed)
+        logical, intent(inout) :: passed
+
+        call expect_rejected('pr95690', &
+            'module m'//nl()// &
+            'contains'//nl()// &
+            '   subroutine s'//nl()// &
+            '      print *, (erfc)'//nl()// &
+            '   end'//nl()// &
+            '   function erfc()'//nl()// &
+            '   end'//nl()// &
+            'end'//nl(), passed)
+        call expect_accepted('pr95690 corrected', &
+            'module m'//nl()// &
+            'contains'//nl()// &
+            '   subroutine s'//nl()// &
+            '      real :: value'//nl()// &
+            '      value = 1.0'//nl()// &
+            '      print *, value'//nl()// &
+            '   end subroutine s'//nl()// &
+            'end module m'//nl(), passed)
+    end subroutine check_pr95690
+
+    ! A character constant that is never closed runs off the end of the file.
+    subroutine check_unexpected_eof_2(passed)
+        logical, intent(inout) :: passed
+
+        call expect_rejected('unexpected_eof_2', &
+            'program p'//nl()// &
+            '   character(8) :: z'//nl()// &
+            '   z = ''abc&  ! unterminated'//nl(), passed)
+        call expect_accepted('unexpected_eof_2 corrected', &
+            'program p'//nl()// &
+            '   character(8) :: z'//nl()// &
+            '   z = ''abc'''//nl()// &
+            'end program p'//nl(), passed)
+    end subroutine check_unexpected_eof_2
+
+    ! Same rule in an initializer rather than an assignment.
+    subroutine check_unexpected_eof_3(passed)
+        logical, intent(inout) :: passed
+
+        call expect_rejected('unexpected_eof_3', &
+            'program p'//nl()// &
+            '   character(8) :: z = ''abc& ! unterminated'//nl(), passed)
+        call expect_accepted('unexpected_eof_3 corrected', &
+            'program p'//nl()// &
+            '   character(8) :: z = ''abc'''//nl()// &
+            'end program p'//nl(), passed)
+    end subroutine check_unexpected_eof_3
+
+    ! Unsigned kind names are not entities of ISO_FORTRAN_ENV.
+    subroutine check_unsigned_37(passed)
+        logical, intent(inout) :: passed
+
+        call expect_rejected('unsigned_37', &
+            'program main'//nl()// &
+            '  use iso_fortran_env, only : uint32'//nl()// &
+            'end program main'//nl(), passed)
+        call expect_accepted('unsigned_37 corrected', &
+            'program main'//nl()// &
+            '  use iso_fortran_env, only : int32'//nl()// &
+            '  integer(int32) :: value'//nl()// &
+            '  value = 1_int32'//nl()// &
+            'end program main'//nl(), passed)
+    end subroutine check_unsigned_37
+
+    ! A rejected fixture must fail the frontend and carry a source diagnostic.
+    subroutine expect_rejected(name, source, passed)
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_result_t) :: result
+        logical :: rejected, has_message
+
+        call run_frontend(source, result)
+        rejected = .not. (result%parse_ok .and. result%semantic_ok)
+        has_message = .false.
+        if (allocated(result%error_msg)) has_message = len_trim(result%error_msg) > 0
+
+        if (rejected .and. has_message) then
+            print *, 'PASS: rejected ', name
+        else
+            print *, 'FAIL: expected rejection with a diagnostic for ', name
+            passed = .false.
+        end if
+    end subroutine expect_rejected
+
+    ! The corrected neighbor of every rule must still compile.
+    subroutine expect_accepted(name, source, passed)
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_result_t) :: result
+
+        call run_frontend(source, result)
+        if (result%parse_ok .and. result%semantic_ok) then
+            print *, 'PASS: accepted ', name
+        else
+            print *, 'FAIL: expected acceptance for ', name
+            if (allocated(result%error_msg)) print *, '  ', trim(result%error_msg)
+            passed = .false.
+        end if
+    end subroutine expect_accepted
+
+    subroutine run_frontend(source, result)
+        character(len=*), intent(in) :: source
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: options
+
+        options%input_mode = INPUT_MODE_STANDARD
+        options%operating_mode = OPERATING_MODE_STRICT
+        call compile_frontend_from_string(source, result, options)
+    end subroutine run_frontend
+
+end program test_reject_literal_01_diagnostics


### PR DESCRIPTION
Closes #2894.

## Preserved compiler invariant

A literal constant must denote a value the standard allows at that point in the program. The rule family is enforced at the earliest layer that has enough information:

- **Lexer** (`src/lexer/lexer_scanners.f90`): a character constant not closed before the end of its line, and not resumed by a leading ampersand on the next line, runs off the end of the program unit (F2018 6.3.2.4). Surfaced through `lex_source`/`lex_file`.
- **Semantic** (`src/semantic/analyzers/semantic_literal_form_validation.f90`, new): a named kind parameter on a numeric literal must denote a named integer constant available in the compilation unit (checked in standard input mode; lazy Fortran supplies `dp` implicitly). An unrestricted `use` suppresses the check.
- **Semantic**: an `only:` name taken from the intrinsic module `ISO_FORTRAN_ENV` must be an entity that module defines; the unsigned kind names (`uint8` … `uint64`) are a vendor extension.
- **Semantic**: a bare procedure name is neither a constant nor a variable, so it is not a valid output list item.

Validation runs off typed arena nodes in a single traversal, never off file names or message text.

## Fixtures

Negative (each rejected with a source diagnostic and a nonzero result): `kind_tests_4.f90`, `pr95690.f90`, `unexpected_eof_2.f90`, `unexpected_eof_3.f90`, `unsigned_37.f90`.
Every rule is paired with a corrected neighbor that must still compile.

## Red / green evidence

Red on unmodified `main` (`git stash push -- src/`, then `fo exec test_reject_literal_01_diagnostics`):

```
FAIL: expected rejection with a diagnostic for kind_tests_4
FAIL: expected rejection with a diagnostic for pr95690
FAIL: expected rejection with a diagnostic for unexpected_eof_2
FAIL: expected rejection with a diagnostic for unexpected_eof_3
FAIL: expected rejection with a diagnostic for unsigned_37
Literal form rejection tests FAILED
```

(all five corrected neighbors already passed).

Green with the change:

```
test_reject_literal_01_diagnostics         PASS
```

Full local pipeline after rebase onto `origin/main`:

```
Static: OK (1383 modules)
Build: OK
Tests: OK
Lint: OK
All stages passed (85.0s)
```