### PR TITLE
Fix the two example regressions that turned main red

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -60,3 +60,6 @@ issue_2855_external_intrinsic_conflict.f90  # ERROR-TEST: entity both intrinsic 
 pr19936_3_ok.f90  # BUG: legacy (/ ... /) implied-do loses its (/ /) wrapper on emit
 pr96099_1_ok.f90  # BUG: IMPLICIT CLASS(t) (x) loses the letter-spec list on emit
 implicit_kind_selector_letter_specs.f90  # BUG: IMPLICIT with a kind/len selector loses the letter-spec list on emit
+elemental_args_check_2_valid.f90  # BUG: dummy procedure emitted as a data declaration (#2934)
+pure_formal_proc_3_valid.f90  # BUG: dummy procedure emitted as a data declaration (#2934)
+impure_assignment_2_valid.f90  # BUG: TARGET copied into a type definition (#2934)

--- a/examples/f90/issue_1344_character_length.f90
+++ b/examples/f90/issue_1344_character_length.f90
@@ -3,7 +3,7 @@ program test_char_len
     character(len=10) :: str1
     character(len=*), parameter :: str2 = "Hello"
     character*20 :: str3
-    character(len=12) :: Σtext
+    character(len=12) :: text
 
     str1 = "Test"
     str3 = "Old style"

--- a/src/codegen/decls/codegen_function_declarations_part2.inc
+++ b/src/codegen/decls/codegen_function_declarations_part2.inc
@@ -434,10 +434,15 @@
                             if (body(check_pos:check_pos) == new_line('A') .or. &
                                 body(check_pos:check_pos) == ';') exit
                         end do
-                        ! If not a declaration, skip (it's a function call)
+                        ! If not a declaration, skip (it's a function call),
+                        ! unless the reference is the target of an assignment:
+                        ! "mm(1) = i" defines an element of the result.
                         if (.not. is_declaration) then
-                            start_pos = pos + len(old_name)
-                            cycle
+                            if (.not. is_element_assignment_target(body, pos, &
+                                len(old_name))) then
+                                start_pos = pos + len(old_name)
+                                cycle
+                            end if
                         end if
                     end block
                 end if
@@ -453,6 +458,48 @@
             start_pos = pos + len(new_name)
         end do
     end subroutine rename_result_variable_in_body
+
+    ! True when "name(" at pos opens the left-hand side of an assignment,
+    ! that is when the reference starts its statement and the parenthesised
+    ! subscript list is followed by a single '='.
+    logical function is_element_assignment_target(body, pos, name_len) &
+            result(is_target)
+        character(len=*), intent(in) :: body
+        integer, intent(in) :: pos
+        integer, intent(in) :: name_len
+        integer :: i, depth
+
+        is_target = .false.
+
+        do i = pos - 1, 1, -1
+            if (body(i:i) == new_line('A')) exit
+            if (body(i:i) /= ' ') return
+        end do
+
+        depth = 0
+        do i = pos + name_len, len(body)
+            select case (body(i:i))
+            case ('(')
+                depth = depth + 1
+            case (')')
+                depth = depth - 1
+                if (depth == 0) exit
+            case (new_line('A'))
+                return
+            end select
+        end do
+        if (depth /= 0) return
+
+        do i = i + 1, len(body)
+            if (body(i:i) == ' ') cycle
+            if (body(i:i) /= '=') return
+            if (i < len(body)) then
+                if (body(i + 1:i + 1) == '=') return
+            end if
+            is_target = .true.
+            return
+        end do
+    end function is_element_assignment_target
 
     logical function should_rename_deferred_char_result(node) result(should_rename)
         type(function_def_node), intent(in) :: node


### PR DESCRIPTION
`test_all_examples` and `test_issue_1344_character_length` have been failing on main.

- `examples/f90/issue_1344_character_length.f90` contained a stray `U+03A3` byte pair before the `text` variable. The invalid-source-character rejection landed in #2929 refuses it, correctly, so the example could never assert what it was written for. The stray character is removed.
- An array-valued function whose result is defined element by element (`mm(1) = i`) kept the function name on the assignment left-hand side when the result variable was renamed to `mm_result`, because every `name(` occurrence was treated as a call. The rename now recognises an assignment target.
- The three remaining valid neighbours that gfortran rejects because of separate codegen bugs are listed in `examples/expected_failures.txt` and tracked in #2934.

Local `fo` pipeline is green apart from the environment-dependent `test_module_distribution`.