### PR TITLE
fix: keep program unit after module when procedure body has an interface block (#2928)

### DIFF
--- a/src/frontend/frontend_program_unit_scanner_part2.inc
+++ b/src/frontend/frontend_program_unit_scanner_part2.inc
@@ -399,7 +399,8 @@
         integer, intent(in) :: unit_start
         character(len=*), intent(in) :: unit_type
         integer, intent(out) :: unit_end
-        integer :: i, interface_nesting
+        integer :: i, interface_nesting, prev_idx
+        logical :: opens_interface
         character(len=:), allocatable :: lowered
 
         unit_end = unit_start
@@ -412,7 +413,18 @@
             else if (tokens(i)%kind == TK_KEYWORD .or. &
                      tokens(i)%kind == TK_IDENTIFIER) then
                 lowered = to_lower(trim(tokens(i)%text))
+                opens_interface = .false.
                 if (lowered == "interface" .and. interface_nesting == 0) then
+                    ! "end interface" closes a block, it never opens one
+                    opens_interface = .true.
+                    prev_idx = find_prev_nontrivial_index(tokens, i)
+                    if (prev_idx > 0) then
+                        if (token_is_word_at(tokens, prev_idx, "end")) then
+                            opens_interface = .false.
+                        end if
+                    end if
+                end if
+                if (opens_interface) then
                     interface_nesting = interface_nesting + 1
                 else if (lowered == "end") then
                     if (i + 1 <= size(tokens)) then

--- a/test/parser/test_issue_2928_interface_in_module_proc.f90
+++ b/test/parser/test_issue_2928_interface_in_module_proc.f90
@@ -1,0 +1,50 @@
+program test_issue_2928_interface_in_module_proc
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    character(len=:), allocatable :: source, output, error_msg
+    logical :: all_passed
+
+    all_passed = .true.
+
+    source = 'module m2'//new_line('a')// &
+             'contains'//new_line('a')// &
+             '   subroutine run()'//new_line('a')// &
+             '      interface'//new_line('a')// &
+             '         integer function g()'//new_line('a')// &
+             '         end function g'//new_line('a')// &
+             '      end interface'//new_line('a')// &
+             '      print *, 5'//new_line('a')// &
+             '   end subroutine run'//new_line('a')// &
+             'end module m2'//new_line('a')// &
+             'program p2'//new_line('a')// &
+             '   use m2'//new_line('a')// &
+             '   call run()'//new_line('a')// &
+             'end program p2'//new_line('a')
+
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (len_trim(error_msg) > 0) then
+        print *, "FAIL: transform error: ", trim(error_msg)
+        all_passed = .false.
+    end if
+
+    if (index(output, 'module m2') == 0) then
+        print *, "FAIL: module m2 missing from output"
+        all_passed = .false.
+    end if
+
+    if (index(output, 'program p2') == 0) then
+        print *, "FAIL: program p2 unit dropped from output"
+        print *, "Output was:"
+        print *, output
+        all_passed = .false.
+    end if
+
+    if (all_passed) then
+        print *, "PASS: issue 2928 interface in module procedure body"
+    else
+        stop 1
+    end if
+
+end program test_issue_2928_interface_in_module_proc


### PR DESCRIPTION
Fixes #2928.

## Problem
`handle_procedure_unit` in the program-unit scanner treated the `interface` token of an `END INTERFACE` statement as opening a new interface block: the `end` branch decremented `interface_nesting` to 0, then the next iteration saw `interface` with nesting 0 and incremented it again. The nesting never returned to 0, so the scanner never found `end subroutine` and swallowed the rest of the file — the `program` unit following the module was dropped from the AST entirely.

## Fix
Skip the increment when the previous non-trivial token is `end` (same guard already used by `handle_module_unit`).

## Invariant preserved
Every top-level program unit in the source is scanned and reaches the AST, regardless of interface blocks nested in module-contained procedure bodies.

## Evidence
New behavioral test `test/parser/test_issue_2928_interface_in_module_proc.f90` transforms the reduced reproducer and asserts both `module m2` and `program p2` appear in the output.

- RED on unmodified main: `FAIL: program p2 unit dropped from output` (output ended at `end module m2`).
- GREEN with fix: `test_issue_2928_interface_in_module_proc PASS`.
- Full local `fo` pipeline: build/lint/format clean, 482/483 tests pass; the only failure is `test_all_examples` (example `benchmark_5000_lines.f90`), which fails identically on unmodified origin/main and contains no interface blocks.