### PR TITLE
Represent alternate returns in the AST and semantic model (#2933)

### DIFF
--- a/src/ast/factory/ast_factory.f90
+++ b/src/ast/factory/ast_factory.f90
@@ -65,7 +65,7 @@ module ast_factory
         push_stop, push_return, push_entry, push_continue, push_goto, &
         push_error_stop, push_cycle, push_exit, push_allocate, push_deallocate, &
         push_io_implied_do, push_pause, push_nullify, &
-        push_common_block, push_enum
+        push_common_block, push_enum, push_alt_return_spec
 
     ! Error nodes
     use ast_factory_errors, only: push_error_node
@@ -133,6 +133,7 @@ module ast_factory
         push_goto, push_error_stop, push_pause, push_nullify
     public :: push_cycle, push_exit, push_allocate, push_deallocate, push_io_implied_do
     public :: push_common_block, push_enum
+    public :: push_alt_return_spec
 
     ! Error nodes
     public :: push_error_node

--- a/src/ast/factory/ast_factory_declarations.f90
+++ b/src/ast/factory/ast_factory_declarations.f90
@@ -312,7 +312,7 @@ contains
     function push_parameter_declaration(arena, name, type_name, kind_value, &
             intent_value, is_optional, is_target, &
             is_unsigned, dimension_indices, line, column, &
-            parent_index, character_length_expr) &
+            parent_index, character_length_expr, is_alternate_return) &
             result(param_index)
         type(ast_arena_t), intent(inout) :: arena
         character(len=*), intent(in) :: name, type_name
@@ -321,6 +321,7 @@ contains
         integer, intent(in), optional :: dimension_indices(:)
         integer, intent(in), optional :: line, column, parent_index
         character(len=*), intent(in), optional :: character_length_expr
+        logical, intent(in), optional :: is_alternate_return
         integer :: param_index
         type(parameter_declaration_node) :: param
 
@@ -353,6 +354,8 @@ contains
         param%is_optional = resolve_optional_flag(is_optional, .false.)
         param%is_target = resolve_optional_flag(is_target, .false.)
         param%is_unsigned = resolve_optional_flag(is_unsigned, .false.)
+        param%is_alternate_return = resolve_optional_flag(is_alternate_return, &
+            .false.)
 
         call assign_dimension_metadata(param%is_array, param%dimension_indices, &
             dimension_indices)

--- a/src/ast/factory/ast_factory_statements.f90
+++ b/src/ast/factory/ast_factory_statements.f90
@@ -11,6 +11,7 @@ module ast_factory_statements
     use ast_nodes_control, only: stop_node, return_node, entry_node, goto_node, &
         error_stop_node, cycle_node, exit_node, &
         continue_node, pause_node, nullify_node
+    use ast_nodes_transfer, only: alt_return_spec_node
     use ast_nodes_io, only: io_implied_do_node
     use ast_nodes_legacy, only: common_block_node, enum_node
     implicit none
@@ -25,6 +26,7 @@ module ast_factory_statements
     public :: push_stop, push_return, push_entry, push_continue, push_goto, &
         push_error_stop
     public :: push_cycle, push_exit, push_pause, push_nullify
+    public :: push_alt_return_spec
     public :: push_allocate, push_deallocate
     public :: push_io_implied_do
     public :: push_common_block, push_enum
@@ -379,18 +381,44 @@ contains
     end function push_stop
 
     ! Create RETURN statement node and add to stack
-    function push_return(arena, line, column, parent_index) result(return_index)
+    function push_return(arena, line, column, parent_index, selector_index) &
+            result(return_index)
         type(ast_arena_t), intent(inout) :: arena
         integer, intent(in), optional :: line, column, parent_index
+        integer, intent(in), optional :: selector_index
         integer :: return_index
         type(return_node) :: return_stmt
         return_stmt%uid = generate_uid()
         if (present(line)) return_stmt%line = line
         if (present(column)) return_stmt%column = column
+        if (present(selector_index)) then
+            if (selector_index > 0) then
+                return_stmt%selector_index = selector_index
+                return_stmt%has_selector = .true.
+            end if
+        end if
 
         call arena%push(return_stmt, "return_node", parent_index)
         return_index = arena%size
     end function push_return
+
+    ! Create alternate return spec node (*<label>) and add to stack
+    function push_alt_return_spec(arena, label_value, line, column, &
+            parent_index) result(spec_index)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: label_value
+        integer, intent(in), optional :: line, column, parent_index
+        integer :: spec_index
+        type(alt_return_spec_node) :: spec
+
+        spec%uid = generate_uid()
+        spec%label_value = label_value
+        if (present(line)) spec%line = line
+        if (present(column)) spec%column = column
+
+        call arena%push(spec, "alt_return_spec", parent_index)
+        spec_index = arena%size
+    end function push_alt_return_spec
 
     ! Create ENTRY statement node and add to stack
     function push_entry(arena, name, params_text, param_indices, line, column, &

--- a/src/ast/nodes/ast_nodes_control.f90
+++ b/src/ast/nodes/ast_nodes_control.f90
@@ -17,7 +17,7 @@ module ast_nodes_control
     use ast_nodes_transfer, only: cycle_node, exit_node, stop_node, &
         return_node, entry_node, goto_node, &
         error_stop_node, continue_node, pause_node, &
-        nullify_node, create_continue
+        nullify_node, create_continue, alt_return_spec_node
     use ast_nodes_associate, only: association_t, associate_node, &
         create_associate, block_construct_node, &
         create_block_construct
@@ -38,7 +38,7 @@ module ast_nodes_control
     public :: where_node, where_stmt_node
     public :: cycle_node, exit_node, stop_node, return_node, entry_node, goto_node
     public :: error_stop_node, continue_node, associate_node, pause_node
-    public :: nullify_node, block_construct_node
+    public :: nullify_node, block_construct_node, alt_return_spec_node
 
     ! Re-export factory functions
     public :: create_do_loop, create_do_while, create_if, create_select_case

--- a/src/ast/nodes/ast_nodes_data.f90
+++ b/src/ast/nodes/ast_nodes_data.f90
@@ -106,6 +106,7 @@ module ast_nodes_data
         logical :: is_optional = .false. ! Whether parameter is optional
         logical :: is_target = .false. ! Whether target attribute is present
         logical :: is_unsigned = .false. ! Whether unsigned attribute is present
+        logical :: is_alternate_return = .false. ! Whether this is a `*` dummy
         ! Array dimension support
         logical :: is_array = .false. ! Whether this is
         ! an array parameter
@@ -358,6 +359,7 @@ contains
             deallocate (lhs%character_length_expr)
         end if
         lhs%has_character_length = rhs%has_character_length
+        lhs%is_alternate_return = rhs%is_alternate_return
         lhs%intent_type = rhs%intent_type
         lhs%is_optional = rhs%is_optional
         lhs%is_target = rhs%is_target

--- a/src/ast/nodes/ast_nodes_transfer.f90
+++ b/src/ast/nodes/ast_nodes_transfer.f90
@@ -8,6 +8,7 @@ module ast_nodes_transfer
     ! Public types
     public :: cycle_node, exit_node, stop_node, return_node, entry_node
     public :: goto_node, error_stop_node, continue_node, pause_node, nullify_node
+    public :: alt_return_spec_node, create_alt_return_spec
     ! Constructors migrated from ast_core
     public :: create_cycle, create_exit, create_stop, create_return, create_entry
     public :: create_goto, create_error_stop, create_continue, create_pause
@@ -44,12 +45,23 @@ module ast_nodes_transfer
 
     ! Return statement node
     type, extends(ast_node) :: return_node
-        ! RETURN statement has no additional data
+        ! Alternate-return selector: RETURN <scalar-int-expr>
+        logical :: has_selector = .false. ! Distinguishes RETURN from RETURN 0
+        integer :: selector_index = 0 ! Selector expression index
     contains
         procedure :: accept => return_accept
         procedure :: assign => return_assign
         generic :: assignment(=) => assign
     end type return_node
+
+    ! Alternate return spec used as actual argument: *<label>
+    type, extends(ast_node) :: alt_return_spec_node
+        integer :: label_value = 0 ! Branch target statement label
+    contains
+        procedure :: accept => alt_return_spec_accept
+        procedure :: assign => alt_return_spec_assign
+        generic :: assignment(=) => assign
+    end type alt_return_spec_node
 
     ! Entry statement node
     type, extends(ast_node) :: entry_node
@@ -230,16 +242,57 @@ contains
         lhs%constant_integer = rhs%constant_integer
         lhs%constant_real = rhs%constant_real
         lhs%constant_type = rhs%constant_type
+        lhs%has_selector = rhs%has_selector
+        lhs%selector_index = rhs%selector_index
     end subroutine return_assign
 
-    function create_return(line, column) result(node)
+    function create_return(line, column, selector_index) result(node)
         integer, intent(in), optional :: line, column
+        integer, intent(in), optional :: selector_index
         type(return_node) :: node
 
         node%uid = generate_uid()
         if (present(line)) node%line = line
         if (present(column)) node%column = column
+        if (present(selector_index)) then
+            if (selector_index > 0) then
+                node%selector_index = selector_index
+                node%has_selector = .true.
+            end if
+        end if
     end function create_return
+
+    ! Alternate return spec implementations
+    subroutine alt_return_spec_accept(this, visitor)
+        class(alt_return_spec_node), intent(in) :: this
+        class(ast_visitor_base_t), intent(inout) :: visitor
+    end subroutine alt_return_spec_accept
+
+    subroutine alt_return_spec_assign(lhs, rhs)
+        class(alt_return_spec_node), intent(inout) :: lhs
+        class(alt_return_spec_node), intent(in) :: rhs
+        lhs%line = rhs%line
+        lhs%column = rhs%column
+        lhs%uid = rhs%uid
+        lhs%inferred_type = rhs%inferred_type
+        lhs%is_constant = rhs%is_constant
+        lhs%constant_logical = rhs%constant_logical
+        lhs%constant_integer = rhs%constant_integer
+        lhs%constant_real = rhs%constant_real
+        lhs%constant_type = rhs%constant_type
+        lhs%label_value = rhs%label_value
+    end subroutine alt_return_spec_assign
+
+    function create_alt_return_spec(label_value, line, column) result(node)
+        integer, intent(in) :: label_value
+        integer, intent(in), optional :: line, column
+        type(alt_return_spec_node) :: node
+
+        node%uid = generate_uid()
+        node%label_value = label_value
+        if (present(line)) node%line = line
+        if (present(column)) node%column = column
+    end function create_alt_return_spec
 
     ! Entry statement implementations
     subroutine entry_accept(this, visitor)

--- a/src/codegen/api/codegen_core.f90
+++ b/src/codegen/api/codegen_core.f90
@@ -165,6 +165,8 @@ contains
             code = generate_code_termination(arena, node, node_index)
             type is (return_node)
             code = generate_code_return(arena, node, node_index)
+            type is (alt_return_spec_node)
+            code = generate_code_alt_return_spec(arena, node, node_index)
             type is (entry_node)
             code = generate_code_entry(arena, node, node_index)
             type is (continue_node)

--- a/src/codegen/statements/codegen_statements.f90
+++ b/src/codegen/statements/codegen_statements.f90
@@ -25,6 +25,7 @@ module codegen_statements
     public :: generate_code_format_statement
     public :: generate_code_termination
     public :: generate_code_return
+    public :: generate_code_alt_return_spec
     public :: generate_code_entry
     public :: generate_code_continue
     public :: generate_code_goto

--- a/src/codegen/statements/codegen_statements_part1.inc
+++ b/src/codegen/statements/codegen_statements_part1.inc
@@ -344,9 +344,24 @@
         character(len=:), allocatable :: code
 
         code = "return"
+        if (node%has_selector) then
+            if (node%selector_index > 0) then
+                code = code//" "//generate_code_from_arena(arena, &
+                    node%selector_index)
+            end if
+        end if
 
         call prepend_stmt_label(code, node%stmt_label)
     end function generate_code_return
+
+    function generate_code_alt_return_spec(arena, node, node_index) result(code)
+        type(ast_arena_t), intent(in) :: arena
+        type(alt_return_spec_node), intent(in) :: node
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: code
+
+        code = "*"//int_to_string(node%label_value)
+    end function generate_code_alt_return_spec
 
     function generate_code_entry(arena, node, node_index) result(code)
         type(ast_arena_t), intent(in) :: arena

--- a/src/fortfront.f90
+++ b/src/fortfront.f90
@@ -50,6 +50,9 @@ module fortfront
         get_case_default_body, get_case_range_info, &
         get_select_type_info, get_type_guard_info, &
         get_dummy_allocatable_attribute, &
+        get_alternate_return_label, &
+        get_return_selector, &
+        is_alternate_return_dummy, &
         get_program_body_info, &
         get_module_body_info, &
         get_function_body_info, &

--- a/src/fortfront_compiler.f90
+++ b/src/fortfront_compiler.f90
@@ -18,6 +18,9 @@ module fortfront_compiler
         get_case_default_body, get_case_range_info, &
         get_select_type_info, get_type_guard_info, &
         get_dummy_allocatable_attribute, &
+        get_alternate_return_label, &
+        get_return_selector, &
+        is_alternate_return_dummy, &
         get_program_body_info, &
         get_module_body_info, &
         get_function_body_info, &

--- a/src/frontend/frontend_compiler_queries.f90
+++ b/src/frontend/frontend_compiler_queries.f90
@@ -8,7 +8,8 @@ module frontend_compiler_queries
         pointer_assignment_node
     use ast_nodes_bounds, only: array_slice_node, array_bounds_node, &
         range_expression_node
-    use ast_nodes_transfer, only: nullify_node
+    use ast_nodes_transfer, only: nullify_node, return_node, &
+        alt_return_spec_node
     use ast_nodes_data, only: declaration_node, derived_type_node, &
         parameter_declaration_node, module_node, block_data_node, &
         submodule_node, multi_unit_container_node, type_binding_node
@@ -46,6 +47,9 @@ module frontend_compiler_queries
     public :: get_select_type_info
     public :: get_type_guard_info
     public :: get_dummy_allocatable_attribute
+    public :: get_alternate_return_label
+    public :: get_return_selector
+    public :: is_alternate_return_dummy
     public :: get_program_body_info
     public :: get_module_body_info
     public :: get_function_body_info
@@ -956,6 +960,56 @@ contains
             is_alloc = .false.
         end select
     end function get_dummy_allocatable_attribute
+
+    ! Compiler-facing query: statement label of an alternate return spec
+    ! (`*<label>` actual argument).  Returns 0 for any other node kind.
+    function get_alternate_return_label(arena, node_index) result(label)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        integer :: label
+
+        label = 0
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (alt_return_spec_node)
+            label = node%label_value
+        end select
+    end function get_alternate_return_label
+
+    ! Compiler-facing query: alternate-return selector of a RETURN statement.
+    ! A plain RETURN reports has_selector = .false., which stays distinct from
+    ! RETURN 0.
+    subroutine get_return_selector(arena, node_index, has_selector, &
+            selector_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        logical, intent(out) :: has_selector
+        integer, intent(out) :: selector_index
+
+        has_selector = .false.
+        selector_index = 0
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (return_node)
+            has_selector = node%has_selector
+            selector_index = node%selector_index
+        end select
+    end subroutine get_return_selector
+
+    ! Compiler-facing query: whether a dummy argument is an alternate-return
+    ! slot (`*` in the dummy argument list).
+    function is_alternate_return_dummy(arena, node_index) result(is_alt)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        logical :: is_alt
+
+        is_alt = .false.
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (parameter_declaration_node)
+            is_alt = node%is_alternate_return
+        end select
+    end function is_alternate_return_dummy
 
     ! Compiler-facing query: return the name and body statement indices of a
     ! program_node.  Wrong node kind returns zero-length body_indices, an empty

--- a/src/parser/control_flow/parser_control_statements.f90
+++ b/src/parser/control_flow/parser_control_statements.f90
@@ -68,7 +68,7 @@ contains
         integer :: return_index
 
         type(token_t) :: token
-        integer :: line, column
+        integer :: line, column, selector_index
 
         ! Consume 'return' keyword
         token = parser%peek()
@@ -76,9 +76,22 @@ contains
         column = token%column
         token = parser%consume()
 
+        ! Optional alternate-return selector: RETURN <scalar-int-expr>
+        selector_index = 0
+        token = parser%peek()
+        ! A bare identifier after RETURN is not treated as a selector: lazy
+        ! Fortran uses `return <name>` for a result value.
+        if (token%line == line) then
+            if (token%kind == TK_NUMBER) then
+                selector_index = parse_comparison(parser, arena)
+            else if (token%kind == TK_OPERATOR .and. token%text == "(") then
+                selector_index = parse_comparison(parser, arena)
+            end if
+        end if
+
         ! Create RETURN node
         return_index = push_return(arena, line=line, column=column, &
-            parent_index=parent_index)
+            parent_index=parent_index, selector_index=selector_index)
     end function parse_return_statement
 
     function parse_entry_statement(parser, arena, parent_index) result(entry_index)

--- a/src/parser/declarations/parser_parameter_handling.f90
+++ b/src/parser/declarations/parser_parameter_handling.f90
@@ -587,7 +587,8 @@ contains
             is_optional=.false., &
             is_target=.false., &
             line=token%line, &
-            column=token%column)
+            column=token%column, &
+            is_alternate_return=(trim(token%text) == "*"))
         param_indices = [param_indices, param_index]
     end subroutine append_untyped_parameter
 

--- a/src/parser/procedures/parser_call.f90
+++ b/src/parser/procedures/parser_call.f90
@@ -1,12 +1,14 @@
 module parser_call_module
     ! Shared call-statement parser used across control-flow helpers
     use lexer_core, only: token_t
-    use lexer_token_types, only: TK_IDENTIFIER, TK_OPERATOR, TK_KEYWORD
+    use lexer_token_types, only: TK_IDENTIFIER, TK_OPERATOR, TK_KEYWORD, &
+        TK_NUMBER
     use parser_inline_instantiation_module, only: consume_inline_instantiation
     use parser_state_module, only: parser_state_t
     use parser_expressions_module, only: parse_range
     use ast_arena_modern, only: ast_arena_t
-    use ast_factory, only: push_subroutine_call, push_literal
+    use ast_factory, only: push_subroutine_call, push_literal, &
+        push_alt_return_spec
     use ast_types, only: LITERAL_STRING
     implicit none
     private
@@ -14,6 +16,38 @@ module parser_call_module
     public :: parse_call_statement
 
 contains
+
+    ! An alternate return spec is a `*` immediately followed by a statement
+    ! label, appearing where an actual argument is expected.
+    function is_alt_return_spec(parser) result(is_spec)
+        type(parser_state_t), intent(in) :: parser
+        logical :: is_spec
+        type(token_t) :: star_token, label_token
+
+        is_spec = .false.
+        star_token = parser%get_token_at_index(parser%current_token)
+        if (star_token%kind /= TK_OPERATOR) return
+        if (star_token%text /= "*") return
+        label_token = parser%get_token_at_index(parser%current_token + 1)
+        if (label_token%kind /= TK_NUMBER) return
+        is_spec = verify(trim(label_token%text), "0123456789") == 0
+    end function is_alt_return_spec
+
+    function parse_alt_return_spec(parser, arena) result(spec_index)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        integer :: spec_index
+        type(token_t) :: token
+        integer :: label_value, ios
+
+        token = parser%consume() ! consume '*'
+        spec_index = 0
+        token = parser%consume() ! consume label
+        read (token%text, *, iostat=ios) label_value
+        if (ios /= 0) return
+        spec_index = push_alt_return_spec(arena, label_value, &
+            token%line, token%column)
+    end function parse_alt_return_spec
 
     subroutine parse_call_arguments(parser, arena, arg_indices)
         use ast_nodes_core, only: assignment_node
@@ -33,7 +67,11 @@ contains
                 exit
             end if
 
-            arg_index = parse_range(parser, arena)
+            if (is_alt_return_spec(parser)) then
+                arg_index = parse_alt_return_spec(parser, arena)
+            else
+                arg_index = parse_range(parser, arena)
+            end if
             if (arg_index > 0) then
                 ! Mark assignment nodes as keyword arguments
                 if (arg_index <= arena%size) then

--- a/test/test_alternate_return_frontend.f90
+++ b/test/test_alternate_return_frontend.f90
@@ -1,0 +1,176 @@
+program test_alternate_return_frontend
+    ! Issue #2933: the frontend must represent alternate returns:
+    !   * `*<label>` actual arguments
+    !   * the `RETURN <scalar-int-expr>` selector
+    !   * `*` dummy arguments marked by an explicit attribute
+    use fortfront, only: compile_frontend_from_string, &
+        compiler_frontend_options_t, &
+        compiler_frontend_result_t, INPUT_MODE_STANDARD, &
+        get_node_type_at, emit_fortran
+    use fortfront_compiler, only: get_alternate_return_label, &
+        get_return_selector, &
+        is_alternate_return_dummy
+    implicit none
+
+    call test_alt_return_actual_argument()
+    call test_return_selector()
+    call test_plain_return_has_no_selector()
+    call test_alternate_return_dummy()
+
+    print *, 'PASS: alternate return representation available'
+
+contains
+
+    subroutine compile_ok(src, result)
+        character(len=*), intent(in) :: src
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: options
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(src, result, options)
+        if (.not. result%success()) then
+            print *, 'FAIL: frontend rejected source: ', &
+                trim(result%diagnostic_text)
+            error stop 1
+        end if
+    end subroutine compile_ok
+
+    subroutine test_alt_return_actual_argument()
+        type(compiler_frontend_result_t) :: result
+        character(:), allocatable :: src, code
+        integer :: i, found, label
+
+        src = 'program p'//new_line('a')// &
+            '  call s(1, *10)'//new_line('a')// &
+            '10 continue'//new_line('a')// &
+            'end program p'
+
+        call compile_ok(src, result)
+
+        found = 0
+        do i = 1, result%arena%size
+            label = get_alternate_return_label(result%arena, i)
+            if (label == 0) cycle
+            found = found + 1
+            if (label /= 10) then
+                print *, 'FAIL: wrong alternate return label ', label
+                error stop 1
+            end if
+        end do
+        if (found /= 1) then
+            print *, 'FAIL: expected one alternate return spec, got ', found
+            error stop 1
+        end if
+
+        call emit_fortran(result%arena, result%root_index, code)
+        if (index(code, '*10') == 0) then
+            print *, 'FAIL: emitted code lost alternate return spec:'
+            print *, code
+            error stop 1
+        end if
+    end subroutine test_alt_return_actual_argument
+
+    subroutine test_return_selector()
+        type(compiler_frontend_result_t) :: result
+        character(:), allocatable :: src, code
+        logical :: has_selector
+        integer :: i, selector_index, found
+
+        src = 'subroutine s(a, *)'//new_line('a')// &
+            '  integer, intent(in) :: a'//new_line('a')// &
+            '  if (a > 0) return 1'//new_line('a')// &
+            '  return'//new_line('a')// &
+            'end subroutine s'
+
+        call compile_ok(src, result)
+
+        found = 0
+        do i = 1, result%arena%size
+            if (trim(get_node_type_at(result%arena, i)) /= 'return_node') cycle
+            call get_return_selector(result%arena, i, has_selector, &
+                selector_index)
+            if (.not. has_selector) cycle
+            found = found + 1
+            if (selector_index <= 0) then
+                print *, 'FAIL: selector index not set'
+                error stop 1
+            end if
+        end do
+        if (found /= 1) then
+            print *, 'FAIL: expected one return with selector, got ', found
+            error stop 1
+        end if
+
+        call emit_fortran(result%arena, result%root_index, code)
+        if (index(code, 'return 1') == 0) then
+            print *, 'FAIL: emitted code lost return selector:'
+            print *, code
+            error stop 1
+        end if
+    end subroutine test_return_selector
+
+    subroutine test_plain_return_has_no_selector()
+        type(compiler_frontend_result_t) :: result
+        character(:), allocatable :: src
+        logical :: has_selector
+        integer :: i, selector_index, found
+
+        src = 'subroutine s2()'//new_line('a')// &
+            '  return'//new_line('a')// &
+            'end subroutine s2'
+
+        call compile_ok(src, result)
+
+        found = 0
+        do i = 1, result%arena%size
+            if (trim(get_node_type_at(result%arena, i)) /= 'return_node') cycle
+            call get_return_selector(result%arena, i, has_selector, &
+                selector_index)
+            found = found + 1
+            if (has_selector) then
+                print *, 'FAIL: plain RETURN reported a selector'
+                error stop 1
+            end if
+        end do
+        if (found /= 1) then
+            print *, 'FAIL: expected one plain return, got ', found
+            error stop 1
+        end if
+    end subroutine test_plain_return_has_no_selector
+
+    subroutine test_alternate_return_dummy()
+        type(compiler_frontend_result_t) :: result
+        character(:), allocatable :: src
+        integer :: i, alt_count, plain_count
+
+        src = 'subroutine s3(a, *)'//new_line('a')// &
+            '  integer, intent(in) :: a'//new_line('a')// &
+            'end subroutine s3'
+
+        call compile_ok(src, result)
+
+        alt_count = 0
+        plain_count = 0
+        do i = 1, result%arena%size
+            if (trim(get_node_type_at(result%arena, i)) /= &
+                'parameter_declaration') cycle
+            if (is_alternate_return_dummy(result%arena, i)) then
+                alt_count = alt_count + 1
+            else
+                plain_count = plain_count + 1
+            end if
+        end do
+        if (alt_count /= 1) then
+            print *, 'FAIL: expected one alternate return dummy, got ', &
+                alt_count
+            error stop 1
+        end if
+        if (plain_count /= 1) then
+            print *, 'FAIL: expected one ordinary dummy, got ', plain_count
+            error stop 1
+        end if
+    end subroutine test_alternate_return_dummy
+
+end program test_alternate_return_frontend


### PR DESCRIPTION
Closes #2933.

## What changed
- New `alt_return_spec_node`: `call s(1, *10)` now parses the `*<label>` actual argument instead of producing an unsupported expression node.
- `return_node` gained `has_selector`/`selector_index`, so `RETURN 1` keeps its selector. A plain `RETURN` stays distinguishable from `RETURN 0`. A bare identifier after `RETURN` is deliberately not a selector: lazy Fortran uses `return <name>` for a result value.
- `parameter_declaration_node%is_alternate_return` marks `*` dummies with an attribute rather than the old name convention.
- Public typed queries: `get_alternate_return_label`, `get_return_selector`, `is_alternate_return_dummy`; codegen re-emits `*10` and `return 1`.

## Preserved compiler invariant
No selector is silently discarded: an alternate-return branch is either represented in the AST and re-emitted, or it is not accepted. Previously `RETURN 1` compiled as a plain `RETURN` (wrong-code path).

## Evidence
- Red: `test/test_alternate_return_frontend.f90` on unmodified src fails to build — `get_alternate_return_label`, `get_return_selector`, `is_alternate_return_dummy` have no explicit interface (`Summary: 0 passed, 1 failed`).
- Green: `fo test test_alternate_return_frontend` PASS; full `fo` pipeline: Static OK, Build OK, Tests OK, Lint OK.