### PR TITLE
End a contained procedure at a bare END statement

### DIFF
--- a/src/frontend/frontend_statement_contains_section_helpers.f90
+++ b/src/frontend/frontend_statement_contains_section_helpers.f90
@@ -177,6 +177,18 @@ contains
                         end if
                     end do
 
+                    ! A bare END statement is the END of this procedure
+                    ! (Fortran 2023 R1537/R1503: the subprogram name and even
+                    ! the SUBROUTINE/FUNCTION keyword are optional). Without
+                    ! this, the scan kept looking for "end subroutine" and
+                    ! swallowed every following sibling procedure into this
+                    ! one, so the host's CONTAINS section listed only the
+                    ! first of them.
+                    if (end_statement_is_bare(tokens, next_idx)) then
+                        end_pos = i
+                        exit
+                    end if
+
                     if (next_idx <= size(tokens)) then
                         if (tokens(next_idx)%kind == TK_KEYWORD .or. &
                             tokens(next_idx)%kind == TK_IDENTIFIER) then
@@ -206,6 +218,26 @@ contains
             end_pos = i
         end do
     end subroutine find_procedure_end
+
+    ! True when nothing but the statement terminator follows the END keyword,
+    ! i.e. the statement is "END" on its own rather than "END SUBROUTINE",
+    ! "END IF" or any other construct terminator.
+    logical function end_statement_is_bare(tokens, next_idx) result(is_bare)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: next_idx
+
+        is_bare = .true.
+        if (next_idx > size(tokens)) return
+
+        select case (tokens(next_idx)%kind)
+        case (TK_NEWLINE, TK_COMMENT, TK_EOF)
+            return
+        case (TK_OPERATOR)
+            is_bare = trim(tokens(next_idx)%text) == ";"
+        case default
+            is_bare = .false.
+        end select
+    end function end_statement_is_bare
 
 end module frontend_statement_token_walking_helpers
 

--- a/test/api/test_bare_end_contained_procedures.f90
+++ b/test/api/test_bare_end_contained_procedures.f90
@@ -1,0 +1,143 @@
+program test_bare_end_contained_procedures
+    ! A contained procedure may be terminated by a bare END statement
+    ! (Fortran 2023 R1537/R1503). The CONTAINS scan used to keep searching
+    ! for "end subroutine" past such an END, so every sibling procedure that
+    ! followed was swallowed into the first one and never reached the host's
+    ! body. IMPLICIT NONE (EXTERNAL) then reported the sibling as undeclared
+    ! (gfortran.dg/associated_assumed_rank.f90).
+    implicit none
+
+    logical :: all_tests_passed
+
+    all_tests_passed = .true.
+
+    print *, '=== bare END terminating contained procedures ==='
+
+    call test_siblings_after_bare_end_are_collected(all_tests_passed)
+    call test_mixed_terminators_collect_all_siblings(all_tests_passed)
+    call test_undeclared_external_still_rejected(all_tests_passed)
+
+    if (all_tests_passed) then
+        print *, 'All bare-END contained-procedure tests passed'
+        stop 0
+    else
+        print *, 'Some bare-END contained-procedure tests failed'
+        stop 1
+    end if
+
+contains
+
+    subroutine test_siblings_after_bare_end_are_collected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'two contained subroutines, both ended by bare END...'
+        source = 'implicit none (type, external)'//new_line('a')// &
+            'call foo(1)'//new_line('a')// &
+            'call bar(2)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine foo(n)'//new_line('a')// &
+            'integer, intent(in) :: n'//new_line('a')// &
+            'print *, n'//new_line('a')// &
+            'end'//new_line('a')// &
+            'subroutine bar(n)'//new_line('a')// &
+            'integer, intent(in) :: n'//new_line('a')// &
+            'print *, n'//new_line('a')// &
+            'end'//new_line('a')// &
+            'end'
+        call expect_frontend_success(source, passed)
+    end subroutine test_siblings_after_bare_end_are_collected
+
+    subroutine test_mixed_terminators_collect_all_siblings(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'bare END followed by an explicit END SUBROUTINE...'
+        source = 'implicit none (type, external)'//new_line('a')// &
+            'call first()'//new_line('a')// &
+            'call second()'//new_line('a')// &
+            'call third()'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine first()'//new_line('a')// &
+            'print *, 1'//new_line('a')// &
+            'end'//new_line('a')// &
+            'subroutine second()'//new_line('a')// &
+            'print *, 2'//new_line('a')// &
+            'end subroutine second'//new_line('a')// &
+            'subroutine third()'//new_line('a')// &
+            'print *, 3'//new_line('a')// &
+            'end'//new_line('a')// &
+            'end'
+        call expect_frontend_success(source, passed)
+    end subroutine test_mixed_terminators_collect_all_siblings
+
+    ! Negative control: collecting the siblings must not make the check
+    ! accept a procedure that really is undeclared.
+    subroutine test_undeclared_external_still_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'call to a procedure that is not contained (rejected)...'
+        source = 'implicit none (type, external)'//new_line('a')// &
+            'call foo(1)'//new_line('a')// &
+            'call absent(2)'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine foo(n)'//new_line('a')// &
+            'integer, intent(in) :: n'//new_line('a')// &
+            'print *, n'//new_line('a')// &
+            'end'//new_line('a')// &
+            'end'
+        call expect_frontend_error(source, 'absent', passed)
+    end subroutine test_undeclared_external_still_rejected
+
+    subroutine expect_frontend_success(source, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (.not. result%success()) then
+            print *, '  FAIL: valid source was rejected'
+            print *, trim(result%diagnostic_text)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_success
+
+    subroutine expect_frontend_error(source, fragment, passed)
+        use frontend_compiler_api, only: compiler_frontend_options_t, &
+            compiler_frontend_result_t, compile_frontend_from_string
+        use semantic_input_mode, only: INPUT_MODE_STANDARD
+        character(len=*), intent(in) :: source
+        character(len=*), intent(in) :: fragment
+        logical, intent(inout) :: passed
+        type(compiler_frontend_options_t) :: options
+        type(compiler_frontend_result_t) :: result
+
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        options%standardize = .false.
+        call compile_frontend_from_string(source, result, options)
+
+        if (result%success()) then
+            print *, '  FAIL: invalid source was accepted'
+            passed = .false.
+        else if (index(result%diagnostic_text, fragment) == 0) then
+            print *, '  FAIL: diagnostic does not mention '//fragment
+            print *, trim(result%diagnostic_text)
+            passed = .false.
+        else
+            print *, '  PASS'
+        end if
+    end subroutine expect_frontend_error
+
+end program test_bare_end_contained_procedures


### PR DESCRIPTION
## Problem

`gfortran.dg/associated_assumed_rank.f90` is valid and gfortran accepts it;
fortfront reported 13 copies of

```
Procedure 'foo' is not explicitly declared under IMPLICIT NONE (EXTERNAL)
```

Reduced:

```fortran
implicit none (type, external)
call foo(1)
call bar(2)
contains
subroutine foo(n)
    integer, intent(in) :: n
    print *, n
end                     ! <- bare END
subroutine bar(n)
    integer, intent(in) :: n
    print *, n
end
end
```

`bar` is reported as undeclared. `foo` is not.

## Cause

A subprogram may be ended by `END` alone — the name and even the
`SUBROUTINE`/`FUNCTION` keyword are optional (F2023 R1503/R1537).
`find_procedure_end` in `frontend_statement_contains_section_helpers.f90`
only stopped at `end subroutine` / `end function`, so on a bare `END` it
kept scanning and swallowed every following sibling procedure into the
first one's token span. Those siblings never became body entries of the
host, so `collect_declared_procedures` never saw them and the
`IMPLICIT NONE (EXTERNAL)` check treated a call to a sibling as a call to
an undeclared external procedure.

## Fix

Stop at `END` when nothing but the statement terminator (end of line,
comment, `;`, EOF) follows it. Every construct terminator — `END IF`,
`END DO`, `END SELECT`, `END TYPE`, … — carries a following keyword and is
untouched.

## Evidence

Corpus gate over `examples/` + `gfortran.dg` (8,641 files) against baseline
`4edcef6a`, false positives judged by `gfortran -fsyntax-only`:

| | over-rejections | false positives |
|---|---|---|
| main `8d7d5e6d` | 54 | 2 |
| this branch | 53 | 1 |

Diffed file by file against main: exactly one status change, and it is
`associated_assumed_rank.f90` REJECTED -> ACCEPTED. Zero newly rejected
files. The committed `examples/` baseline is unchanged.

`test_bare_end_contained_procedures` covers both sibling shapes (all bare
`END`, and bare `END` followed by an explicit `END SUBROUTINE`) and keeps a
negative control: a call to a procedure that is genuinely not contained is
still rejected.

Local `fo` pipeline green.