### PR TITLE
Treat mid-line digit strings as expressions, not statement labels (#2944)

### DIFF
--- a/src/parser/statements/parser_execution_statements_module.inc
+++ b/src/parser/statements/parser_execution_statements_module.inc
@@ -91,8 +91,12 @@
             ! Clear label for this statement
             if (allocated(stmt_label)) deallocate (stmt_label)
 
-            ! Check for numeric statement label like 10  i = i + 1
-            if (token%kind == TK_NUMBER) then
+            ! Check for numeric statement label like 10  i = i + 1.
+            ! A statement label is only a label when it opens the statement,
+            ! i.e. it is the first thing on its source line (or follows a ';').
+            ! A digit string later on the line is part of the statement, such
+            ! as the unit number in `flush 6`.
+            if (token%kind == TK_NUMBER .and. label_opens_statement(parser)) then
                 ! Save the label text
                 stmt_label = trim(token%text)
                 ! Consume the label and get next token
@@ -161,6 +165,35 @@
         end do
 
     contains
+        ! True when the token at the parser position is the first thing on its
+        ! source line, or directly follows a ';' statement separator. Only such
+        ! a digit string can be a statement label (F2003 R313).
+        logical function label_opens_statement(parser_ref) result(opens)
+            type(parser_state_t), intent(in) :: parser_ref
+            integer :: idx, label_line
+
+            opens = .true.
+            if (.not. associated(parser_ref%tokens)) return
+            idx = parser_ref%current_token
+            if (idx < 1 .or. idx > size(parser_ref%tokens)) return
+            label_line = parser_ref%tokens(idx)%line
+
+            do idx = parser_ref%current_token - 1, 1, -1
+                select case (parser_ref%tokens(idx)%kind)
+                case (TK_WHITESPACE, TK_COMMENT)
+                    cycle
+                case (TK_NEWLINE, TK_EOF)
+                    return
+                case (TK_OPERATOR)
+                    if (allocated(parser_ref%tokens(idx)%text)) then
+                        if (parser_ref%tokens(idx)%text == ";") return
+                    end if
+                end select
+                opens = parser_ref%tokens(idx)%line /= label_line
+                return
+            end do
+        end function label_opens_statement
+
         subroutine reset_pending_prefixes()
             if (allocated(pending_prefixes)) then
                 block

--- a/test/api/test_reject_label_01_diagnostics.f90
+++ b/test/api/test_reject_label_01_diagnostics.f90
@@ -51,6 +51,39 @@ program test_reject_label_01_diagnostics
         '   print *, a'//nl// &
         'end program pr24640', failures)
 
+    ! Issue #2944: a digit string that is not at the start of the statement is
+    ! part of the statement, not a label. Sources taken from the corpus files
+    ! named in the issue; all are accepted by gfortran -fsyntax-only.
+
+    ! lfortran/integration_tests/flush_04.f90
+    call expect_accepted('flush_04.f90 unit number', &
+        'program flush_04'//nl// &
+        '    use iso_fortran_env, only: output_unit, error_unit'//nl// &
+        '    implicit none'//nl// &
+        '    flush output_unit'//nl// &
+        '    flush error_unit'//nl// &
+        '    flush 6'//nl// &
+        'end program flush_04', failures)
+
+    ! lfortran/integration_tests/read_79.f90
+    call expect_accepted('read_79.f90 substring unit', &
+        'program read_79'//nl// &
+        '  logical :: x'//nl// &
+        '  integer :: stat'//nl// &
+        '  character(len=64) :: stored_data'//nl// &
+        '  stored_data = '' F'''//nl// &
+        '  stat = 0'//nl// &
+        '  read(stored_data(2:2), *, iostat=stat) x'//nl// &
+        '  if (stat /= 0) error stop'//nl// &
+        'end program read_79', failures)
+
+    ! gfortran.dg/comma_IO_extension_1.f90
+    call expect_accepted('comma_IO_extension_1.f90', &
+        'program extracomma'//nl// &
+        '  implicit none'//nl// &
+        '  write (*,*), 1, 2, 3'//nl// &
+        'end program extracomma', failures)
+
     ! Named construct labels keep working: they are identifiers, not labels.
     call expect_accepted('named construct label', &
         'program named'//nl// &


### PR DESCRIPTION
Closes #2944. Unblocks ffc PR #545.

## Preserved compiler invariant

A statement label opens a statement: it is the first thing on its source line (or directly follows a `;`), one to five digits, at least one nonzero, attached to a statement (F2003 R313/C304). The program-body parser previously treated *any* `TK_NUMBER` at the parser position as a label, so once a statement parser stopped early the remaining digits on the line were validated as a label by the #2930 rules and the file was rejected. Recognition is now gated on the label opening the statement; all #2930 rejections for real leading labels are untouched.

## Red evidence (main, b1f33bf)

```
flush_04.f90              6:11: error: Statement label without statement
read_79.f90               9:20: error: Invalid character ':' after statement label '2'
comma_IO_extension_1.f90  7:22: error: Statement label without statement
```
All three are accepted by `gfortran -fsyntax-only`.

## Green evidence

```
flush_04.f90              parse_ok=true semantic_ok=true
read_79.f90               parse_ok=true semantic_ok=true
comma_IO_extension_1.f90  parse_ok=true semantic_ok=true
```
Negative controls still rejected:
```
empty_label.f90  2:1: error: Statement label without statement
label_1.f90      5:1: error: Too many digits in statement label '0056780'
label_2.f90      7:1: error: Invalid character ':' after statement label '10'
```
Accepted-side fixtures for the three corpus files added to `test_reject_label_01_diagnostics` (source copied from the real corpus files); every existing negative case kept.

`make check-rejection-gate`: `784 files, accepted=729 rejected=55`, `OK: no newly rejected corpus files`.

Full local `fo` pipeline: Static OK, Build OK, Tests OK (483), Lint OK, All stages passed.