### PR TITLE
Keep statements after a derived-type component in lazy mode (#2941)

### DIFF
--- a/src/frontend/frontend_statement_boundary.f90
+++ b/src/frontend/frontend_statement_boundary.f90
@@ -341,7 +341,11 @@ contains
             end if
         case ("type")
             if (tokens(stmt_start)%text == "type" .and. idx > stmt_start) then
-                nesting_level = nesting_level + 1
+                ! Component declarations such as "type(a_t) :: y" reuse the
+                ! keyword but do not open a nested definition.
+                if (is_type_start(tokens, idx)) then
+                    nesting_level = nesting_level + 1
+                end if
             end if
         case ("forall")
             if (idx > stmt_start) then

--- a/src/parser/core/mixed_construct_detector.f90
+++ b/src/parser/core/mixed_construct_detector.f90
@@ -295,7 +295,12 @@ contains
                     do i = start_pos + 1, size(tokens)
                         if (tokens(i)%kind == TK_KEYWORD) then
                             if (trim(tokens(i)%text) == "type") then
-                                depth = depth + 1
+                                ! Only a type *definition* nests. A component
+                                ! declaration "type(a_t) :: y" and the closing
+                                ! "end type" keyword must not raise the depth.
+                                if (opens_type_definition(tokens, i)) then
+                                    depth = depth + 1
+                                end if
                             else if (trim(tokens(i)%text) == "end") then
                                 ! Check next token for "type"
                                 if (i + 1 <= size(tokens) .and. tokens(i + 1)%kind == &
@@ -337,6 +342,28 @@ contains
                 ! Default to end of tokens
                 end_pos = size(tokens)
             end subroutine find_declaration_range
+
+            ! True when the "type" keyword at pos opens a derived type
+            ! definition rather than a component/entity declaration or the
+            ! "type" of a closing "end type".
+            function opens_type_definition(tokens, pos) result(opens)
+                type(token_t), intent(in) :: tokens(:)
+                integer, intent(in) :: pos
+                logical :: opens
+
+                opens = .true.
+
+                if (pos > 1) then
+                    if (tokens(pos - 1)%kind == TK_KEYWORD) then
+                        if (trim(tokens(pos - 1)%text) == "end") opens = .false.
+                    end if
+                end if
+                if (.not. opens) return
+
+                if (pos < size(tokens)) then
+                    if (trim(tokens(pos + 1)%text) == "(") opens = .false.
+                end if
+            end function opens_type_definition
 
             logical function line_continues(tokens, newline_pos) result(continues)
                 type(token_t), intent(in) :: tokens(:)

--- a/src/standardizers/standardizer_declarations_collection.f90
+++ b/src/standardizers/standardizer_declarations_collection.f90
@@ -581,7 +581,13 @@ subroutine handle_identifier_assignment_target(arena, assign, target, &
 
     existing_idx = find_existing_variable_index(target%name, var_names, &
         var_count)
-    var_type = infer_assignment_type(arena, assign%value_index)
+    ! Copying an already inferred derived binding propagates its type
+    ! (Issue #2941): "q = p" where p is type(p_t) makes q type(p_t).
+    var_type = copied_derived_var_type(arena, assign%value_index, var_names, &
+        var_types, var_count)
+    if (len_trim(var_type) == 0) then
+        var_type = infer_assignment_type(arena, assign%value_index)
+    end if
 
     if (existing_idx > 0) then
         call update_existing_variable_type(existing_idx, var_type, &
@@ -593,6 +599,35 @@ subroutine handle_identifier_assignment_target(arena, assign, target, &
             func_count)
     end if
 end subroutine handle_identifier_assignment_target
+
+! Type of a bare identifier RHS when that identifier was already inferred to
+! be of derived type; empty otherwise.
+function copied_derived_var_type(arena, value_index, var_names, var_types, &
+        var_count) result(var_type)
+    type(ast_arena_t), intent(in) :: arena
+    integer, intent(in) :: value_index
+    character(len=64), intent(in) :: var_names(:)
+    character(len=64), intent(in) :: var_types(:)
+    integer, intent(in) :: var_count
+    character(len=64) :: var_type
+    integer :: source_idx
+
+    var_type = ""
+    if (value_index <= 0 .or. value_index > arena%size) return
+    if (.not. allocated(arena%entries(value_index)%node)) return
+
+    select type (v => arena%entries(value_index)%node)
+        type is (identifier_node)
+        if (.not. allocated(v%name)) return
+        source_idx = find_existing_variable_index(v%name, var_names, var_count)
+    class default
+        return
+    end select
+
+    if (source_idx <= 0) return
+    if (index(to_lower(var_types(source_idx)), "type(") /= 1) return
+    var_type = var_types(source_idx)
+end function copied_derived_var_type
 
 function find_existing_variable_index(var_name, var_names, var_count) &
         result(idx)
@@ -728,6 +763,11 @@ subroutine update_existing_variable_type(existing_idx, var_type, var_types)
 
     ! Do not overwrite allocatable declarations (fixes #2069)
     if (index(to_lower(var_types(existing_idx)), 'allocatable') > 0) then
+        ! Keep existing allocatable type
+        ! A derived binding keeps its type; a later intrinsic-valued
+        ! assignment must not silently retype it (Issue #2941).
+    else if (index(to_lower(var_types(existing_idx)), 'type(') == 1 &
+            .and. index(to_lower(var_type), 'type(') /= 1) then
         ! Keep existing allocatable type
     else if (is_character_type_string(var_types(existing_idx)) &
             .and. is_character_type_string(var_type)) then

--- a/test/lazy_fortran/test_issue_2941_nested_derived_component.f90
+++ b/test/lazy_fortran/test_issue_2941_nested_derived_component.f90
@@ -1,0 +1,123 @@
+program test_issue_2941_nested_derived_component
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    if (.not. test_statement_after_nested_type()) all_passed = .false.
+    if (.not. test_allocatable_component()) all_passed = .false.
+    if (.not. test_declaration_after_nested_type()) all_passed = .false.
+    if (.not. test_copied_derived_binding()) all_passed = .false.
+
+    if (all_passed) then
+        print *, 'PASS: Issue #2941 nested derived component keeps later statements'
+    else
+        error stop 'FAIL: Issue #2941 nested derived component'
+    end if
+
+contains
+
+    logical function standardize(source, output) result(ok)
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable, intent(out) :: output
+        character(len=:), allocatable :: error_msg
+
+        ok = .true.
+        call transform_lazy_fortran_string(source, output, error_msg)
+        if (.not. allocated(output)) then
+            write (error_unit, '(A)') 'ERROR: no output'
+            ok = .false.
+            return
+        end if
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                write (error_unit, '(A)') 'ERROR: '//trim(error_msg)
+                ok = .false.
+            end if
+        end if
+    end function standardize
+
+    logical function expect(output, needle, context) result(ok)
+        character(len=*), intent(in) :: output, needle, context
+
+        ok = index(output, needle) > 0
+        if (.not. ok) then
+            write (error_unit, '(A)') 'ERROR: '//context// &
+                ' missing "'//needle//'"'
+            write (error_unit, '(A)') trim(output)
+        end if
+    end function expect
+
+    logical function test_statement_after_nested_type() result(ok)
+        character(len=:), allocatable :: output
+
+        ok = standardize( &
+             'type :: a_t'//new_line('a')// &
+             '    integer :: x'//new_line('a')// &
+             'end type'//new_line('a')// &
+             'type :: b_t'//new_line('a')// &
+             '    type(a_t) :: y'//new_line('a')// &
+             'end type'//new_line('a')// &
+             'print *, 42'//new_line('a'), output)
+        if (.not. ok) return
+        if (.not. expect(output, 'type(a_t) :: y', 'nested component')) ok = .false.
+        if (.not. expect(output, 'print *, 42', 'nested component')) ok = .false.
+    end function test_statement_after_nested_type
+
+    logical function test_allocatable_component() result(ok)
+        character(len=:), allocatable :: output
+
+        ok = standardize( &
+             'type :: a_t'//new_line('a')// &
+             '    integer :: x'//new_line('a')// &
+             'end type'//new_line('a')// &
+             'type :: b_t'//new_line('a')// &
+             '    integer :: n'//new_line('a')// &
+             '    type(a_t), allocatable :: y'//new_line('a')// &
+             'end type'//new_line('a')// &
+             'print *, 7'//new_line('a'), output)
+        if (.not. ok) return
+        if (.not. expect(output, 'print *, 7', 'allocatable component')) ok = .false.
+    end function test_allocatable_component
+
+    logical function test_declaration_after_nested_type() result(ok)
+        character(len=:), allocatable :: output
+
+        ok = standardize( &
+             'type :: a_t'//new_line('a')// &
+             '    integer :: x'//new_line('a')// &
+             'end type'//new_line('a')// &
+             'type :: b_t'//new_line('a')// &
+             '    type(a_t) :: y'//new_line('a')// &
+             'end type'//new_line('a')// &
+             'integer :: k'//new_line('a')// &
+             'k = 3'//new_line('a')// &
+             'print *, k'//new_line('a'), output)
+        if (.not. ok) return
+        if (.not. expect(output, 'integer :: k', 'decl after')) ok = .false.
+        if (.not. expect(output, 'k = 3', 'decl after')) ok = .false.
+        if (.not. expect(output, 'print *, k', 'decl after')) ok = .false.
+    end function test_declaration_after_nested_type
+
+    logical function test_copied_derived_binding() result(ok)
+        character(len=:), allocatable :: output
+
+        ok = standardize( &
+             'type :: p_t'//new_line('a')// &
+             '    integer :: x'//new_line('a')// &
+             'end type'//new_line('a')// &
+             'p = p_t(3)'//new_line('a')// &
+             'q = p'//new_line('a')// &
+             'print *, q%x'//new_line('a'), output)
+        if (.not. ok) return
+        if (.not. expect(output, 'type(p_t) :: p, q', 'copied binding')) ok = .false.
+        if (index(output, 'integer :: q') > 0) then
+            write (error_unit, '(A)') 'ERROR: q inferred as integer'
+            ok = .false.
+        end if
+    end function test_copied_derived_binding
+
+end program test_issue_2941_nested_derived_component


### PR DESCRIPTION
Fixes #2941.

## Problem
In lazy (implicit-program) input, a derived type definition containing a component of derived type swallowed every following statement. `find_statement_boundary` counted the `type` keyword of a component declaration (`type(a_t) :: y`) as opening a *nested* type definition, so the closing `end type` only dropped the nesting back to 1 and the construct ran to EOF.

Same miscount existed in `mixed_construct_detector%find_declaration_range`.

## Fix
- `frontend_statement_boundary`: only raise the nesting level when `is_type_start` says the `type` keyword actually opens a definition (already the predicate used when the construct is *detected*; now also used when it is *closed*).
- `mixed_construct_detector`: same guard via a local `opens_type_definition` helper (an `end type` keyword or a `type(` component no longer nests).
- `standardizer_declarations_collection`: copying an inferred derived binding propagates the type (`q = p` with `p` of `type(p_t)` now declares `q` as `type(p_t)` instead of `integer`), and a later intrinsic-valued assignment no longer silently retypes a derived binding.

## Invariant preserved
Standard `program`/`end program` input and `select type` / `end type <name>` handling are untouched; `is_type_start` already rejects `end type`, `select type`, and `type(`.

## Evidence
Red on unmodified main (`fo test test_issue_2941_nested_derived_component`): output was
```
program main
    implicit none
    type :: a_t
        integer :: x
    end type a_t
    type :: b_t
        type(a_t) :: y
    end type b_t
end program main
```
with `print *, 42`, `integer :: k`, `k = 3` all missing; `q = p` inferred `integer :: q`.

Green after the fix: `test_issue_2941_nested_derived_component PASS`.

Full local `fo` pipeline: Build OK, Static OK, tests green except `test_all_examples`, which fails identically on an unmodified `origin/main` worktree (per-example 2 s internal timeout under machine load) — verified as pre-existing, not a regression.