### PR TITLE
Represent derived-type parameters in the AST and public queries (#2952)

### DIFF
--- a/src/ast/nodes/ast_nodes_data.f90
+++ b/src/ast/nodes/ast_nodes_data.f90
@@ -6,6 +6,12 @@ module ast_nodes_data
     implicit none
     private
 
+    ! Derived-type parameter classification (issue #2952)
+    public :: PARAM_UNKNOWN, PARAM_KIND, PARAM_LEN
+    integer, parameter :: PARAM_UNKNOWN = 0
+    integer, parameter :: PARAM_KIND = 1
+    integer, parameter :: PARAM_LEN = 2
+
     ! Public constants for parameter intent
     public :: INTENT_NONE, INTENT_IN, INTENT_OUT, INTENT_INOUT
     integer, parameter :: INTENT_NONE = 0
@@ -85,6 +91,8 @@ module ast_nodes_data
         logical :: disable_grouping = .false. ! Skip declaration grouping
         character(len=:), allocatable :: accessibility ! 'public'/'private'
         character(len=:), allocatable :: bind_name ! bind(c, name="...") value
+        ! Derived-type parameter actuals, e.g. type(box_t(3, 8)) (issue #2952)
+        integer, allocatable :: type_param_indices(:) ! Arena indices of actuals
     contains
         procedure :: accept => declaration_accept
         procedure :: assign => declaration_assign
@@ -188,6 +196,10 @@ module ast_nodes_data
         integer, allocatable :: component_indices(:) ! Component indices (stack-based)
         logical :: has_parameters = .false. ! Whether it has parameters
         integer, allocatable :: param_indices(:) ! Parameter indices (stack-based)
+        ! Derived-type parameter formals (issue #2952)
+        type(string_t), allocatable :: param_names(:) ! Formal names, in order
+        integer, allocatable :: param_classes(:) ! PARAM_* classification
+        integer, allocatable :: param_defaults(:) ! Arena index of default, or 0
         logical :: has_contains = .false. ! Whether type has CONTAINS section
         integer, allocatable :: binding_indices(:) ! Type-bound procedure indices
     contains
@@ -306,6 +318,11 @@ contains
             lhs%bind_name = rhs%bind_name
         else if (allocated(lhs%bind_name)) then
             deallocate (lhs%bind_name)
+        end if
+        if (allocated(rhs%type_param_indices)) then
+            lhs%type_param_indices = rhs%type_param_indices
+        else if (allocated(lhs%type_param_indices)) then
+            deallocate (lhs%type_param_indices)
         end if
         if (allocated(rhs%dimension_indices)) then
             lhs%dimension_indices = rhs%dimension_indices
@@ -569,6 +586,23 @@ contains
         ! Handle param_indices array
         if (allocated(rhs%param_indices)) then
             lhs%param_indices = rhs%param_indices
+        end if
+
+        ! Handle derived-type parameter formals
+        if (allocated(rhs%param_names)) then
+            lhs%param_names = rhs%param_names
+        else if (allocated(lhs%param_names)) then
+            deallocate (lhs%param_names)
+        end if
+        if (allocated(rhs%param_classes)) then
+            lhs%param_classes = rhs%param_classes
+        else if (allocated(lhs%param_classes)) then
+            deallocate (lhs%param_classes)
+        end if
+        if (allocated(rhs%param_defaults)) then
+            lhs%param_defaults = rhs%param_defaults
+        else if (allocated(lhs%param_defaults)) then
+            deallocate (lhs%param_defaults)
         end if
 
         lhs%has_contains = rhs%has_contains

--- a/src/fortfront_compiler.f90
+++ b/src/fortfront_compiler.f90
@@ -11,6 +11,9 @@ module fortfront_compiler
         is_identifier, get_identifier_name, &
         get_declaration_initializer, &
         get_derived_type_components, &
+        get_derived_type_parameters, &
+        get_declaration_type_parameters, &
+        type_parameter_t, PARAM_UNKNOWN, PARAM_KIND, PARAM_LEN, &
         get_array_literal_elements, &
         get_import_list, get_interface_block_body, &
         has_bind_c_attribute, get_bind_c_name, &

--- a/src/frontend/frontend_compiler_queries.f90
+++ b/src/frontend/frontend_compiler_queries.f90
@@ -12,7 +12,8 @@ module frontend_compiler_queries
         alt_return_spec_node
     use ast_nodes_data, only: declaration_node, derived_type_node, &
         parameter_declaration_node, module_node, block_data_node, &
-        submodule_node, multi_unit_container_node, type_binding_node
+        submodule_node, multi_unit_container_node, type_binding_node, &
+        PARAM_UNKNOWN, PARAM_KIND, PARAM_LEN
     use ast_nodes_misc, only: interface_block_node, import_statement_node, &
         use_statement_node, visibility_statement_node, &
         namelist_statement_node, data_statement_node, &
@@ -35,6 +36,10 @@ module frontend_compiler_queries
     public :: get_identifier_name
     public :: get_declaration_initializer
     public :: get_derived_type_components
+    public :: get_derived_type_parameters
+    public :: get_declaration_type_parameters
+    public :: type_parameter_t
+    public :: PARAM_UNKNOWN, PARAM_KIND, PARAM_LEN
     public :: get_array_literal_elements
     public :: get_import_list
     public :: get_interface_block_body
@@ -77,6 +82,13 @@ module frontend_compiler_queries
     public :: query_array_slice, query_array_bounds, query_range_expression, &
         query_component_access, query_array_literal, query_pointer_assignment, &
         query_nullify
+
+    ! Derived-type parameter formal (issue #2952)
+    type :: type_parameter_t
+        character(len=:), allocatable :: name
+        integer :: classification = PARAM_UNKNOWN ! PARAM_KIND / PARAM_LEN
+        integer :: default_index = 0 ! Arena index of default value, or 0
+    end type type_parameter_t
 
     type :: array_slice_query_t
         logical :: found = .false.
@@ -638,6 +650,68 @@ contains
             end if
         end select
     end function get_declaration_initializer
+
+    ! Compiler-facing query: return the derived-type parameter formals of a
+    ! type definition, in declaration order, with their KIND/LEN
+    ! classification and the arena index of their default value.
+    subroutine get_derived_type_parameters(arena, type_index, params)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: type_index
+        type(type_parameter_t), allocatable, intent(out) :: params(:)
+        integer :: i, n
+
+        if (.not. arena%has_node_at(type_index)) then
+            allocate (params(0))
+            return
+        end if
+        select type (node => arena%entries(type_index)%node)
+            type is (derived_type_node)
+            if (.not. allocated(node%param_names)) then
+                allocate (params(0))
+                return
+            end if
+            n = size(node%param_names)
+            allocate (params(n))
+            do i = 1, n
+                params(i)%name = node%param_names(i)%s
+                if (allocated(node%param_classes)) then
+                    if (size(node%param_classes) >= i) then
+                        params(i)%classification = node%param_classes(i)
+                    end if
+                end if
+                if (allocated(node%param_defaults)) then
+                    if (size(node%param_defaults) >= i) then
+                        params(i)%default_index = node%param_defaults(i)
+                    end if
+                end if
+            end do
+        class default
+            allocate (params(0))
+        end select
+    end subroutine get_derived_type_parameters
+
+    ! Compiler-facing query: return the arena indices of the derived-type
+    ! parameter actuals on an entity declaration, e.g. type(box_t(3, 8)).
+    subroutine get_declaration_type_parameters(arena, decl_index, params)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: decl_index
+        integer, allocatable, intent(out) :: params(:)
+
+        if (.not. arena%has_node_at(decl_index)) then
+            allocate (params(0))
+            return
+        end if
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            if (allocated(node%type_param_indices)) then
+                params = node%type_param_indices
+            else
+                allocate (params(0))
+            end if
+        class default
+            allocate (params(0))
+        end select
+    end subroutine get_declaration_type_parameters
 
     ! Compiler-facing query: copy the component_indices of a derived
     ! type definition into an allocatable result.

--- a/src/parser/declarations/parser_declarations_core_module.f90
+++ b/src/parser/declarations/parser_declarations_core_module.f90
@@ -16,6 +16,7 @@ module parser_declarations_core_module
     use declaration_attribute_utils, only: declaration_attribute_info_t
     use parser_utilities, only: peek_next_nontrivial_token
     use parser_keyword_disambiguation_module, only: looks_like_implicit_statement
+    use ast_nodes_data, only: declaration_node
     implicit none
     private
 
@@ -68,6 +69,7 @@ contains
                     end if
                 end if
             end if
+            call attach_declaration_type_parameters(arena, decl_index, type_spec)
             return
         end if
 
@@ -96,7 +98,26 @@ contains
                 end if
             end if
         end if
+        call attach_declaration_type_parameters(arena, decl_index, type_spec)
     end function parse_declaration
+
+    ! Issue #2952: keep the derived-type parameter actuals of an entity
+    ! declaration, e.g. `type(box_t(3, 8)) :: a`, on the declaration node.
+    subroutine attach_declaration_type_parameters(arena, decl_index, type_spec)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: decl_index
+        type(type_specifier_t), intent(in) :: type_spec
+
+        if (decl_index <= 0) return
+        if (.not. allocated(type_spec%derived_parameter_nodes)) return
+        if (size(type_spec%derived_parameter_nodes) == 0) return
+        if (.not. arena%has_node_at(decl_index)) return
+
+        select type (node => arena%entries(decl_index)%node)
+            type is (declaration_node)
+            node%type_param_indices = type_spec%derived_parameter_nodes
+        end select
+    end subroutine attach_declaration_type_parameters
 
     ! Attribute rules that the attr-spec list alone cannot decide because they
     ! also depend on the entity's array spec or its initializer.

--- a/src/parser/declarations/parser_declarations_derived_module.f90
+++ b/src/parser/declarations/parser_declarations_derived_module.f90
@@ -10,6 +10,10 @@ module parser_declarations_derived_module
     use parser_declarations_core_module, only: parse_declaration
     use parser_submodule_placement_module, only: reject_misplaced_submodule
     use string_utils_mod, only: to_lower
+    use string_types, only: string_t
+    use ast_nodes_data, only: derived_type_node, PARAM_KIND, PARAM_LEN, &
+        PARAM_UNKNOWN
+    use parser_expressions_module, only: parse_comparison
     implicit none
     private
 
@@ -33,11 +37,15 @@ contains
         integer :: component_count
         integer, allocatable :: binding_indices(:)
         integer :: binding_count
+        type(string_t), allocatable :: param_names(:)
+        type(string_t), allocatable :: tp_names(:)
+        integer, allocatable :: tp_classes(:)
+        integer, allocatable :: tp_defaults(:)
 
         type_index = 0
 
         call parse_type_definition_header(parser, type_name, header_attributes, &
-            has_header_attrs, invalid_type_spec)
+            has_header_attrs, invalid_type_spec, param_names)
         if (invalid_type_spec) then
             return
         end if
@@ -61,22 +69,78 @@ contains
 
         call collect_derived_type_components(parser, arena, component_indices, &
             component_count, binding_indices, &
-            binding_count)
+            binding_count, tp_names, tp_classes, tp_defaults)
         type_index = finalize_derived_type(arena, type_name, header_attributes, &
             has_header_attrs, component_indices, &
             component_count, binding_indices, &
             binding_count, extends_parent)
+        call attach_type_parameters(arena, type_index, param_names, tp_names, &
+            tp_classes, tp_defaults)
     end function parse_derived_type_def
+
+    ! Record the derived-type parameter formals on the pushed node: the header
+    ! fixes the order, the body supplies the KIND/LEN class and the default.
+    subroutine attach_type_parameters(arena, type_index, param_names, tp_names, &
+            tp_classes, tp_defaults)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: type_index
+        type(string_t), allocatable, intent(in) :: param_names(:)
+        type(string_t), allocatable, intent(in) :: tp_names(:)
+        integer, allocatable, intent(in) :: tp_classes(:)
+        integer, allocatable, intent(in) :: tp_defaults(:)
+        type(string_t), allocatable :: ordered_names(:)
+        integer, allocatable :: classes(:)
+        integer, allocatable :: defaults(:)
+        integer :: i, j
+
+        if (type_index <= 0) return
+        if (.not. arena%has_node_at(type_index)) return
+        if (.not. allocated(param_names)) return
+        if (.not. allocated(tp_names)) return
+
+        if (size(param_names) > 0) then
+            ordered_names = param_names
+        else if (size(tp_names) > 0) then
+            ordered_names = tp_names
+        else
+            return
+        end if
+
+        allocate (classes(size(ordered_names)))
+        allocate (defaults(size(ordered_names)))
+        classes = PARAM_UNKNOWN
+        defaults = 0
+
+        do i = 1, size(ordered_names)
+            do j = 1, size(tp_names)
+                if (to_lower(ordered_names(i)%s) /= to_lower(tp_names(j)%s)) cycle
+                classes(i) = tp_classes(j)
+                defaults(i) = tp_defaults(j)
+                exit
+            end do
+        end do
+
+        select type (node => arena%entries(type_index)%node)
+            type is (derived_type_node)
+            node%has_parameters = .true.
+            node%param_names = ordered_names
+            node%param_classes = classes
+            node%param_defaults = defaults
+        end select
+    end subroutine attach_type_parameters
 
     subroutine parse_type_definition_header(parser, type_name, &
             header_attributes, &
-            has_header_attrs, invalid_type_spec)
+            has_header_attrs, invalid_type_spec, param_names)
         type(parser_state_t), intent(inout) :: parser
         character(len=*), intent(out) :: type_name
         character(len=:), allocatable, intent(out) :: header_attributes
         logical, intent(out) :: has_header_attrs
         logical, intent(out) :: invalid_type_spec
+        type(string_t), allocatable, intent(out) :: param_names(:)
         type(token_t) :: token
+
+        allocate (param_names(0))
 
         type_name = ""
         has_header_attrs = .false.
@@ -109,8 +173,90 @@ contains
         token = parser%consume()
         type_name = trim(token%text)
 
+        call parse_type_parameter_names(parser, param_names)
         call skip_type_header_trivia(parser)
     end subroutine parse_type_definition_header
+
+    ! F2018 R728: parse the type-param-name-list of a parameterized derived
+    ! type header, e.g. `type :: box_t(n, k)`.
+    subroutine parse_type_parameter_names(parser, param_names)
+        type(parser_state_t), intent(inout) :: parser
+        type(string_t), allocatable, intent(inout) :: param_names(:)
+        type(token_t) :: token
+
+        call skip_inline_trivia(parser)
+        token = parser%peek()
+        if (token%kind /= TK_OPERATOR) return
+        if (token%text /= "(") return
+        token = parser%consume()
+
+        do while (.not. parser%is_at_end())
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+            if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
+                token = parser%consume()
+                call append_name(param_names, trim(token%text))
+            else if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                token = parser%consume()
+                exit
+            else
+                exit
+            end if
+
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                token = parser%consume()
+            else if (token%kind == TK_OPERATOR .and. token%text == ")") then
+                token = parser%consume()
+                exit
+            else
+                exit
+            end if
+        end do
+    end subroutine parse_type_parameter_names
+
+    subroutine skip_inline_trivia(parser)
+        type(parser_state_t), intent(inout) :: parser
+        type(token_t) :: token
+
+        do while (.not. parser%is_at_end())
+            token = parser%peek()
+            if (token%kind == TK_WHITESPACE .or. token%kind == TK_COMMENT) then
+                token = parser%consume()
+            else
+                exit
+            end if
+        end do
+    end subroutine skip_inline_trivia
+
+    subroutine append_name(names, name)
+        type(string_t), allocatable, intent(inout) :: names(:)
+        character(len=*), intent(in) :: name
+        type(string_t), allocatable :: grown(:)
+        integer :: n
+
+        if (.not. allocated(names)) allocate (names(0))
+        n = size(names)
+        allocate (grown(n + 1))
+        if (n > 0) grown(1:n) = names
+        grown(n + 1)%s = name
+        call move_alloc(grown, names)
+    end subroutine append_name
+
+    subroutine append_int_value(values, value)
+        integer, allocatable, intent(inout) :: values(:)
+        integer, intent(in) :: value
+        integer, allocatable :: grown(:)
+        integer :: n
+
+        if (.not. allocated(values)) allocate (values(0))
+        n = size(values)
+        allocate (grown(n + 1))
+        if (n > 0) grown(1:n) = values
+        grown(n + 1) = value
+        call move_alloc(grown, values)
+    end subroutine append_int_value
 
     subroutine skip_type_header_trivia(parser)
         type(parser_state_t), intent(inout) :: parser
@@ -131,13 +277,16 @@ contains
 
     subroutine collect_derived_type_components(parser, arena, component_indices, &
             component_count, binding_indices, &
-            binding_count)
+            binding_count, tp_names, tp_classes, tp_defaults)
         type(parser_state_t), intent(inout) :: parser
         type(ast_arena_t), intent(inout) :: arena
         integer, allocatable, intent(out) :: component_indices(:)
         integer, intent(out) :: component_count
         integer, allocatable, intent(out) :: binding_indices(:)
         integer, intent(out) :: binding_count
+        type(string_t), allocatable, intent(out) :: tp_names(:)
+        integer, allocatable, intent(out) :: tp_classes(:)
+        integer, allocatable, intent(out) :: tp_defaults(:)
         integer, allocatable :: indices(:)
         integer, allocatable :: bind_indices(:)
         integer :: capacity
@@ -153,6 +302,9 @@ contains
         allocate (bind_indices(bind_capacity))
         binding_count = 0
         in_contains = .false.
+        allocate (tp_names(0))
+        allocate (tp_classes(0))
+        allocate (tp_defaults(0))
 
         do while (.not. parser%is_at_end())
             if (end_type_ahead(parser)) then
@@ -172,6 +324,15 @@ contains
                 in_contains = .true.
                 call skip_component_trivia(parser)
                 cycle
+            end if
+
+            if (.not. in_contains) then
+                if (type_parameter_decl_ahead(parser)) then
+                    call parse_type_parameter_declaration(parser, arena, &
+                        tp_names, tp_classes, tp_defaults)
+                    call skip_component_trivia(parser)
+                    cycle
+                end if
             end if
 
             if (in_contains) then
@@ -206,6 +367,129 @@ contains
         call finalize_binding_storage(bind_indices, binding_count, &
             binding_indices)
     end subroutine collect_derived_type_components
+
+    ! F2018 R731: a type-param-def-stmt is an INTEGER declaration carrying the
+    ! KIND or LEN attribute. Detect it before the generic component parser,
+    ! which has no representation for those attributes.
+    logical function type_parameter_decl_ahead(parser) result(is_param_decl)
+        type(parser_state_t), intent(inout) :: parser
+        integer :: i
+        integer :: depth
+        character(len=:), allocatable :: lowered
+
+        is_param_decl = .false.
+        depth = 0
+
+        i = parser%current_token
+        do while (i <= size(parser%tokens))
+            if (parser%tokens(i)%kind == TK_WHITESPACE) then
+                i = i + 1
+                cycle
+            end if
+            exit
+        end do
+        if (i > size(parser%tokens)) return
+        lowered = to_lower(trim(parser%tokens(i)%text))
+        if (lowered /= "integer") return
+
+        i = i + 1
+        do while (i <= size(parser%tokens))
+            if (parser%tokens(i)%kind == TK_NEWLINE) exit
+            lowered = to_lower(trim(parser%tokens(i)%text))
+            if (lowered == "(") then
+                depth = depth + 1
+            else if (lowered == ")") then
+                depth = depth - 1
+            else if (lowered == "::") then
+                exit
+            else if (depth == 0) then
+                if (lowered == "kind" .or. lowered == "len") then
+                    is_param_decl = .true.
+                    exit
+                end if
+            end if
+            i = i + 1
+        end do
+    end function type_parameter_decl_ahead
+
+    ! Parse `integer, kind :: k = 4` / `integer, len :: n` inside a derived
+    ! type body, recording the KIND/LEN classification and default value.
+    subroutine parse_type_parameter_declaration(parser, arena, tp_names, &
+            tp_classes, tp_defaults)
+        type(parser_state_t), intent(inout) :: parser
+        type(ast_arena_t), intent(inout) :: arena
+        type(string_t), allocatable, intent(inout) :: tp_names(:)
+        integer, allocatable, intent(inout) :: tp_classes(:)
+        integer, allocatable, intent(inout) :: tp_defaults(:)
+        type(token_t) :: token
+        character(len=:), allocatable :: lowered
+        integer :: classification
+        integer :: default_index
+
+        classification = PARAM_UNKNOWN
+
+        call skip_inline_trivia(parser)
+        token = parser%consume() ! consume 'integer'
+
+        do while (.not. parser%is_at_end())
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+            if (.not. (token%kind == TK_OPERATOR .and. token%text == ",")) exit
+            token = parser%consume()
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+            lowered = to_lower(trim(token%text))
+            if (lowered == "kind") then
+                classification = PARAM_KIND
+                token = parser%consume()
+            else if (lowered == "len") then
+                classification = PARAM_LEN
+                token = parser%consume()
+            else
+                token = parser%consume()
+            end if
+        end do
+
+        call skip_inline_trivia(parser)
+        token = parser%peek()
+        if (token%kind == TK_OPERATOR .and. token%text == "::") then
+            token = parser%consume()
+        end if
+
+        do while (.not. parser%is_at_end())
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+            if (token%kind /= TK_IDENTIFIER .and. token%kind /= TK_KEYWORD) exit
+            token = parser%consume()
+            default_index = 0
+
+            call skip_inline_trivia(parser)
+            if (.not. parser%is_at_end()) then
+                block
+                    type(token_t) :: next_token
+                    next_token = parser%peek()
+                    if (next_token%kind == TK_OPERATOR) then
+                        if (next_token%text == "=") then
+                            next_token = parser%consume()
+                            default_index = parse_comparison(parser, arena)
+                        end if
+                    end if
+                end block
+            end if
+
+            call append_name(tp_names, trim(token%text))
+            call append_int_value(tp_classes, classification)
+            call append_int_value(tp_defaults, max(default_index, 0))
+
+            call skip_inline_trivia(parser)
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. token%text == ",") then
+                token = parser%consume()
+            else
+                exit
+            end if
+        end do
+    end subroutine parse_type_parameter_declaration
 
     logical function end_type_ahead(parser) result(is_end)
         type(parser_state_t), intent(inout) :: parser

--- a/test/test_pdt_type_parameters.f90
+++ b/test/test_pdt_type_parameters.f90
@@ -1,0 +1,99 @@
+program test_pdt_type_parameters
+    ! Issue #2952: derived-type parameters (PDT) must be represented in the AST
+    ! and reachable through public compiler-facing queries:
+    !   get_derived_type_parameters (formals: name, KIND/LEN, default)
+    !   get_declaration_type_parameters (actuals on an entity declaration)
+    use fortfront, only: compile_frontend_from_string, &
+        compiler_frontend_options_t, &
+        compiler_frontend_result_t, INPUT_MODE_STANDARD, &
+        get_node_type_at
+    use fortfront_compiler, only: get_derived_type_parameters, &
+        get_declaration_type_parameters, &
+        type_parameter_t, &
+        PARAM_KIND, PARAM_LEN
+    implicit none
+
+    call test_type_parameter_formals()
+    call test_type_parameter_actuals()
+
+    print *, 'PASS: derived-type parameters are represented and queryable'
+
+contains
+
+    function pdt_source() result(src)
+        character(:), allocatable :: src
+
+        src = 'program t'//new_line('a')// &
+            '  type :: box_t(n, k)'//new_line('a')// &
+            '    integer, len :: n'//new_line('a')// &
+            '    integer, kind :: k = 4'//new_line('a')// &
+            '    integer :: tag'//new_line('a')// &
+            '  end type box_t'//new_line('a')// &
+            '  type(box_t(3, 8)) :: a'//new_line('a')// &
+            'end program t'
+    end function pdt_source
+
+    subroutine compile_pdt(result)
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: options
+
+        options = compiler_frontend_options_t()
+        options%run_semantics = .true.
+        options%input_mode = INPUT_MODE_STANDARD
+        call compile_frontend_from_string(pdt_source(), result, options)
+        if (.not. result%success()) then
+            print *, 'FAIL: frontend rejected PDT source: ', &
+                trim(result%diagnostic_text)
+            error stop 1
+        end if
+    end subroutine compile_pdt
+
+    subroutine test_type_parameter_formals()
+        type(compiler_frontend_result_t) :: result
+        type(type_parameter_t), allocatable :: params(:)
+        integer :: i
+        logical :: ok
+
+        call compile_pdt(result)
+
+        ok = .false.
+        do i = 1, result%arena%size
+            if (trim(get_node_type_at(result%arena, i)) /= 'derived_type') cycle
+            call get_derived_type_parameters(result%arena, i, params)
+            if (size(params) /= 2) cycle
+            if (params(1)%name /= 'n') cycle
+            if (params(1)%classification /= PARAM_LEN) cycle
+            if (params(2)%name /= 'k') cycle
+            if (params(2)%classification /= PARAM_KIND) cycle
+            if (params(2)%default_index <= 0) cycle
+            ok = .true.
+        end do
+
+        if (.not. ok) then
+            print *, 'FAIL: type-parameter formals not represented on derived type'
+            error stop 1
+        end if
+    end subroutine test_type_parameter_formals
+
+    subroutine test_type_parameter_actuals()
+        type(compiler_frontend_result_t) :: result
+        integer, allocatable :: actuals(:)
+        integer :: i
+        logical :: ok
+
+        call compile_pdt(result)
+
+        ok = .false.
+        do i = 1, result%arena%size
+            if (trim(get_node_type_at(result%arena, i)) /= 'declaration') cycle
+            call get_declaration_type_parameters(result%arena, i, actuals)
+            if (size(actuals) == 2) ok = .true.
+        end do
+
+        if (.not. ok) then
+            print *, 'FAIL: type-parameter actuals not captured on declaration'
+            error stop 1
+        end if
+    end subroutine test_type_parameter_actuals
+
+end program test_pdt_type_parameters


### PR DESCRIPTION
Fixes #2952. Unblocks lazy-fortran/ffc#411.

## What changed
- `derived_type_node` stores the type-parameter formals: names in header order, KIND/LEN classification, and the arena index of a default value.
- The derived-type body parser recognizes `integer, kind|len :: p [= expr]` (F2018 R731) before the generic component parser, which has no representation for those attributes.
- `declaration_node` keeps the derived-type parameter actuals that the type-specifier parser already produced but dropped, e.g. `type(box_t(3, 8)) :: a`.
- New compiler-facing queries `get_derived_type_parameters` / `get_declaration_type_parameters`, with `type_parameter_t` and `PARAM_KIND`/`PARAM_LEN`/`PARAM_UNKNOWN`.

## Preserved invariant
Non-parameterized derived types are untouched: the header parameter list is only read when a `(` follows the type name, and the body hook only fires for an INTEGER declaration carrying a KIND or LEN attribute at attribute level, so ordinary components (including `integer :: len`) still go through the generic component parser. Existing `get_derived_type_components` behaviour is unchanged.

## Evidence
Red (new test `test/test_pdt_type_parameters.f90` on unmodified origin/main): fails to build — `Error: Procedure 'get_declaration_type_parameters' called with an implicit interface`, `Symbol 'params' has no IMPLICIT type`.

Green: `fo test test_pdt_type_parameters` passes, and the full `fo` pipeline is green: Build OK, Tests OK (483), Lint OK.