### PR TITLE
Allow a statement label before a construct terminator (#2949)

### DIFF
--- a/src/parser/core/parser_construct_terminators.f90
+++ b/src/parser/core/parser_construct_terminators.f90
@@ -313,8 +313,9 @@ contains
         is_construct = .false.
         if (tokens(j)%kind /= TK_KEYWORD) return
         k = next_significant(tokens, j + 1)
-        ! A labelled DO is terminated by its label, not by END DO.
-        if (k > 0) then
+        ! A labelled DO is terminated by its label, not by END DO. The label
+        ! belongs to the DO statement itself, so it must be on the same line.
+        if (continues_statement(tokens, j, k)) then
             if (tokens(k)%kind == TK_NUMBER) return
         end if
         is_construct = .true.
@@ -382,6 +383,15 @@ contains
         integer :: colon, after
 
         j = i
+        ! A numeric statement label may precede any statement, including a
+        ! construct terminator used as a branch target.
+        if (tokens(i)%kind == TK_NUMBER) then
+            after = next_significant(tokens, i + 1)
+            if (after == 0) return
+            if (.not. continues_statement(tokens, i, after)) return
+            j = after
+            return
+        end if
         if (tokens(i)%kind /= TK_IDENTIFIER) return
         colon = next_significant(tokens, i + 1)
         if (colon == 0) return

--- a/test/api/test_reject_end_01_diagnostics.f90
+++ b/test/api/test_reject_end_01_diagnostics.f90
@@ -141,6 +141,35 @@ program test_reject_end_01_diagnostics
         "   end do"//nl// &
         "end program p"//nl)
 
+    ! Issue #2949: end_block_label_1.f90 terminates BLOCK with a labelled
+    ! END BLOCK used as a GOTO target.
+    call assert_accepted("end_block_label_1.f90", &
+        "program p"//nl// &
+        "   integer :: i"//nl// &
+        "   i = 0"//nl// &
+        "   block"//nl// &
+        "     if (i == 0) goto 1"//nl// &
+        "     i = 2"//nl// &
+        "1  end block"//nl// &
+        "   print *, i"//nl// &
+        "end"//nl)
+    call assert_accepted("labelled-end-do", &
+        "program p"//nl// &
+        "   integer :: i"//nl// &
+        "   do"//nl// &
+        "      exit"//nl// &
+        "2  end do"//nl// &
+        "end"//nl)
+
+    ! A labelled terminator must still be validated against its construct.
+    call assert_rejected("labelled-mismatched-terminator", &
+        "program p"//nl// &
+        "   block"//nl// &
+        "   do"//nl// &
+        "3  end block"//nl// &
+        "end"//nl, &
+        "Expecting END DO statement")
+
     write (output_unit, '(A)') "PASS: reject-end-01 construct terminator diagnostics"
 
 contains


### PR DESCRIPTION
Fixes #2949.

`gfortran.dg/end_block_label_1.f90` regressed to FAIL: a BLOCK closed by a labelled `1  end block` was reported as `END BLOCK statement expected`.

Cause: the construct-terminator validator (from #2931) classified statements from their first token. A leading numeric statement label made the terminator line unrecognisable, the rest of the line was skipped, and the construct stayed open until the next bare END. Additionally `starts_do_construct` looked at the next significant token across line breaks, so a number opening the *following* line was mistaken for a labelled DO's terminator label.

Fix: `skip_statement_label` now also skips a leading numeric label on the same line, and the labelled-DO heuristic requires the label to be on the DO statement's own line.

Preserved invariant: terminators are still matched against their construct — a labelled `3 end block` closing an open DO is still rejected with `Expecting END DO statement` (covered by a new negative case).

Red: `fo test test_reject_end_01_diagnostics` before the fix — `FAIL: end_block_label_1.f90 was rejected / END BLOCK statement expected at line 9, column 1`, and `FAIL: labelled-mismatched-terminator was accepted` after the first partial fix.
Green: `fo test test_reject_end_01_diagnostics` PASS; full `fo` pipeline: Tests OK, Lint OK, all stages passed (162.4s).