### PR TITLE
Stop rejecting three valid corpus sources (#2951)

### DIFF
--- a/src/semantic/analyzers/semantic_literal_form_validation.f90
+++ b/src/semantic/analyzers/semantic_literal_form_validation.f90
@@ -39,6 +39,7 @@ contains
         type(string_t), allocatable :: procedures(:)
         integer, allocatable :: kind_literals(:)
         integer, allocatable :: output_items(:)
+        integer, allocatable :: output_owners(:)
         integer, allocatable :: imports(:)
         integer :: available_count, procedure_count
         integer :: kind_count, output_count, import_count
@@ -46,8 +47,8 @@ contains
 
         call scan_arena(arena, available, available_count, procedures, &
                         procedure_count, kind_literals, kind_count, &
-                        output_items, output_count, imports, import_count, &
-                        unrestricted_use)
+                        output_items, output_owners, output_count, imports, &
+                        import_count, unrestricted_use)
 
         ! Lazy Fortran supplies kind names such as `dp` implicitly, so a named
         ! kind parameter is only required to be declared in standard input.
@@ -56,16 +57,16 @@ contains
                                        available, available_count, errors)
         end if
         call check_intrinsic_module_imports(arena, imports, import_count, errors)
-        call check_output_list_items(arena, output_items, output_count, &
-                                     available, available_count, procedures, &
-                                     procedure_count, errors)
+        call check_output_list_items(arena, output_items, output_owners, &
+                                     output_count, available, available_count, &
+                                     procedures, procedure_count, errors)
     end subroutine validate_literal_forms
 
     ! Single arena traversal feeding every rule below.
     subroutine scan_arena(arena, available, available_count, procedures, &
                           procedure_count, kind_literals, kind_count, &
-                          output_items, output_count, imports, import_count, &
-                          unrestricted_use)
+                          output_items, output_owners, output_count, imports, &
+                          import_count, unrestricted_use)
         type(ast_arena_t), intent(in) :: arena
         type(string_t), allocatable, intent(out) :: available(:)
         integer, intent(out) :: available_count
@@ -74,17 +75,19 @@ contains
         integer, allocatable, intent(out) :: kind_literals(:)
         integer, intent(out) :: kind_count
         integer, allocatable, intent(out) :: output_items(:)
+        integer, allocatable, intent(out) :: output_owners(:)
         integer, intent(out) :: output_count
         integer, allocatable, intent(out) :: imports(:)
         integer, intent(out) :: import_count
         logical, intent(out) :: unrestricted_use
         character(len=:), allocatable :: suffix
-        integer :: i, j
+        integer :: i, j, owner_count
 
         allocate (available(0))
         allocate (procedures(0))
         allocate (kind_literals(0))
         allocate (output_items(0))
+        allocate (output_owners(0))
         allocate (imports(0))
         available_count = 0
         procedure_count = 0
@@ -106,6 +109,8 @@ contains
                 type is (print_statement_node)
                 if (.not. allocated(node%expression_indices)) cycle
                 do j = 1, size(node%expression_indices)
+                    owner_count = output_count
+                    call append_index(output_owners, owner_count, i)
                     call append_index(output_items, output_count, &
                                       node%expression_indices(j))
                 end do
@@ -205,11 +210,13 @@ contains
 
     ! A bare procedure name is neither a constant nor a variable, so it cannot
     ! appear as an output list item.
-    subroutine check_output_list_items(arena, output_items, output_count, &
-                                       available, available_count, procedures, &
+    subroutine check_output_list_items(arena, output_items, output_owners, &
+                                       output_count, available, &
+                                       available_count, procedures, &
                                        procedure_count, errors)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: output_items(:)
+        integer, intent(in) :: output_owners(:)
         integer, intent(in) :: output_count
         type(string_t), intent(in) :: available(:)
         integer, intent(in) :: available_count
@@ -230,6 +237,10 @@ contains
                 if (name_present(available, available_count, item%name)) cycle
                 if (.not. name_present(procedures, procedure_count, &
                                        item%name)) cycle
+                ! Inside its own body the function name is the result
+                ! variable, so it is a valid output item there.
+                if (in_own_function_body(arena, output_owners(i), &
+                                         item%name)) cycle
                 call report(errors, 'Invalid constant in output list: '// &
                             item%name//' is a procedure name, not a floating '// &
                             'constant or variable', item%line, item%column, &
@@ -238,6 +249,41 @@ contains
             end select
         end do
     end subroutine check_output_list_items
+
+    ! True when one of the enclosing function definitions of node_index names
+    ! its result with this name, either implicitly or through RESULT.
+    function in_own_function_body(arena, node_index, name) result(is_result)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
+        logical :: is_result
+        character(len=:), allocatable :: lowered
+        integer :: current
+
+        is_result = .false.
+        lowered = to_lower(trim(name))
+        current = node_index
+        do while (current > 0)
+            if (current > arena%size) exit
+            if (.not. arena%has_node_at(current)) exit
+            select type (scope => arena%entries(current)%node)
+                type is (function_def_node)
+                if (allocated(scope%result_variable)) then
+                    if (to_lower(trim(scope%result_variable)) == lowered) then
+                        is_result = .true.
+                        return
+                    end if
+                end if
+                if (allocated(scope%name)) then
+                    if (to_lower(trim(scope%name)) == lowered) then
+                        is_result = .true.
+                        return
+                    end if
+                end if
+            end select
+            current = arena%entries(current)%parent_index
+        end do
+    end function in_own_function_body
 
     ! Append an arena index with geometric growth.
     subroutine append_index(indices, count, value)
@@ -379,7 +425,8 @@ contains
         names(count)%s = trim(name)
     end subroutine append
 
-    ! Public entities of the intrinsic module ISO_FORTRAN_ENV (F2018 16.10.2).
+    ! Public entities of the intrinsic module ISO_FORTRAN_ENV (F2023 16.10.2,
+    ! which added the LOGICAL8 ... LOGICAL64 kind constants).
     function is_iso_fortran_env_entity(name) result(is_entity)
         character(len=*), intent(in) :: name
         logical :: is_entity
@@ -392,7 +439,8 @@ contains
               'current_team', 'error_unit', 'event_type', 'file_storage_size', &
               'initial_team', 'input_unit', 'int8', 'int16', 'int32', 'int64', &
               'integer_kinds', 'iostat_end', 'iostat_eor', &
-              'iostat_inquire_internal_unit', 'lock_type', 'logical_kinds', &
+              'iostat_inquire_internal_unit', 'lock_type', 'logical8', &
+              'logical16', 'logical32', 'logical64', 'logical_kinds', &
               'notify_type', 'numeric_storage_size', 'output_unit', &
               'parent_team', 'real16', 'real32', 'real64', 'real128', &
               'real_kinds', 'stat_failed_image', 'stat_locked', &

--- a/src/semantic/analyzers/semantic_submodule_validation.f90
+++ b/src/semantic/analyzers/semantic_submodule_validation.f90
@@ -216,6 +216,9 @@ contains
             interface_is_module, interface_label)
         if (.not. allocated(interface_label)) return
         if (.not. allocated(label)) return
+        ! A MODULE PROCEDURE body carries no binding label of its own; it
+        ! inherits the one from its interface body (F2023 C1554).
+        if (len_trim(label) == 0) return
         if (label == interface_label) return
 
         call report(errors, 'mismatch in BIND(C) names ("'//label//'"/"'// &

--- a/test/api/test_accept_semantic_2951_valid_sources.f90
+++ b/test/api/test_accept_semantic_2951_valid_sources.f90
@@ -1,0 +1,174 @@
+program test_accept_semantic_2951_valid_sources
+    ! Issue #2951: three valid corpus sources were rejected by the semantic
+    ! tightening rules of #2894 and the submodule interface check.
+    !
+    !   * lfortran intent_01.f90: inside a function, the function name denotes
+    !     the result variable, so it is a valid output list item.
+    !   * lfortran intrinsics_404.f90: logical8 is an F2023 entity of the
+    !     intrinsic module ISO_FORTRAN_ENV.
+    !   * lfortran submodule_52.f90: a separate module subprogram need not
+    !     repeat the binding label of its interface body.
+    !
+    ! Each accepted fixture is paired with the rejection it must not weaken.
+    use fortfront_compiler, only: compiler_frontend_result_t, &
+        compiler_frontend_options_t, compile_frontend_from_string, &
+        INPUT_MODE_STANDARD, OPERATING_MODE_STRICT
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    call check_result_variable_output(all_passed)
+    call check_logical_kind_import(all_passed)
+    call check_module_procedure_binding(all_passed)
+
+    if (all_passed) then
+        print *, 'All issue 2951 acceptance tests passed'
+    else
+        print *, 'Issue 2951 acceptance tests FAILED'
+        stop 1
+    end if
+
+contains
+
+    function nl() result(c)
+        character(len=1) :: c
+
+        c = char(10)
+    end function nl
+
+    ! The function name inside its own body is the result variable.
+    subroutine check_result_variable_output(passed)
+        logical, intent(inout) :: passed
+
+        call expect_accepted('intent_01', &
+            'module dflt_intent'//nl()// &
+            'contains'//nl()// &
+            'subroutine foo(c, d)'//nl()// &
+            'real :: c, d, e, g'//nl()// &
+            'e = f(c)'//nl()// &
+            'g = f(d)'//nl()// &
+            'contains'//nl()// &
+            'real function f(x)'//nl()// &
+            'real, intent(in) :: x'//nl()// &
+            'f = 2*x'//nl()// &
+            'print *, f'//nl()// &
+            'end function f'//nl()// &
+            'end subroutine foo'//nl()// &
+            'end module'//nl(), passed)
+        ! A procedure name used outside its own body stays a rejection.
+        call expect_rejected('pr95690', &
+            'module m'//nl()// &
+            'contains'//nl()// &
+            '   subroutine s'//nl()// &
+            '      print *, (erfc)'//nl()// &
+            '   end'//nl()// &
+            '   function erfc()'//nl()// &
+            '   end'//nl()// &
+            'end'//nl(), passed)
+    end subroutine check_result_variable_output
+
+    ! logical8 is a standard ISO_FORTRAN_ENV entity since F2023.
+    subroutine check_logical_kind_import(passed)
+        logical, intent(inout) :: passed
+
+        call expect_accepted('intrinsics_404', &
+            'program intrinsics_401'//nl()// &
+            '    use iso_fortran_env, only: logical8'//nl()// &
+            '    implicit none'//nl()// &
+            '    logical(kind=logical8) :: x'//nl()// &
+            '    x = .true.'//nl()// &
+            '    if (.not. x) error stop'//nl()// &
+            'end program intrinsics_401'//nl(), passed)
+        ! Unsigned kind names remain a vendor extension, not an entity.
+        call expect_rejected('unsigned_37', &
+            'program main'//nl()// &
+            '  use iso_fortran_env, only : uint32'//nl()// &
+            'end program main'//nl(), passed)
+    end subroutine check_logical_kind_import
+
+    ! A MODULE PROCEDURE body carries no binding label of its own.
+    subroutine check_module_procedure_binding(passed)
+        logical, intent(inout) :: passed
+
+        call expect_accepted('submodule_52', &
+            'module submodule_52_m'//nl()// &
+            '  implicit none'//nl()// &
+            '  interface'//nl()// &
+            '    module integer function bar(x) bind(C, name="bar_c")'//nl()// &
+            '      integer, intent(in) :: x'//nl()// &
+            '    end function'//nl()// &
+            '  end interface'//nl()// &
+            'end module'//nl()// &
+            'submodule(submodule_52_m) submodule_52_m_sub'//nl()// &
+            '  implicit none'//nl()// &
+            'contains'//nl()// &
+            '  module procedure bar'//nl()// &
+            '    bar = x + 1'//nl()// &
+            '  end procedure'//nl()// &
+            'end submodule'//nl(), passed)
+        ! A restated but different binding label is still a mismatch.
+        call expect_rejected('submodule binding mismatch', &
+            'module m'//nl()// &
+            '  implicit none'//nl()// &
+            '  interface'//nl()// &
+            '    module subroutine foo() bind(C, name="foo_c")'//nl()// &
+            '    end subroutine'//nl()// &
+            '  end interface'//nl()// &
+            'end module'//nl()// &
+            'submodule(m) m_sub'//nl()// &
+            '  implicit none'//nl()// &
+            'contains'//nl()// &
+            '  module subroutine foo() bind(C, name="other_c")'//nl()// &
+            '  end subroutine'//nl()// &
+            'end submodule'//nl(), passed)
+    end subroutine check_module_procedure_binding
+
+    subroutine expect_accepted(name, source, passed)
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_result_t) :: result
+
+        call run_frontend(source, result)
+        if (result%parse_ok .and. result%semantic_ok) then
+            print *, 'PASS: accepted ', name
+        else
+            print *, 'FAIL: expected acceptance for ', name
+            if (allocated(result%error_msg)) print *, '  ', trim(result%error_msg)
+            passed = .false.
+        end if
+    end subroutine expect_accepted
+
+    subroutine expect_rejected(name, source, passed)
+        character(len=*), intent(in) :: name
+        character(len=*), intent(in) :: source
+        logical, intent(inout) :: passed
+        type(compiler_frontend_result_t) :: result
+        logical :: rejected, has_message
+
+        call run_frontend(source, result)
+        rejected = .not. (result%parse_ok .and. result%semantic_ok)
+        has_message = .false.
+        if (allocated(result%error_msg)) has_message = len_trim(result%error_msg) > 0
+
+        if (rejected .and. has_message) then
+            print *, 'PASS: rejected ', name
+        else
+            print *, 'FAIL: expected rejection with a diagnostic for ', name
+            passed = .false.
+        end if
+    end subroutine expect_rejected
+
+    subroutine run_frontend(source, result)
+        character(len=*), intent(in) :: source
+        type(compiler_frontend_result_t), intent(out) :: result
+        type(compiler_frontend_options_t) :: options
+
+        options%input_mode = INPUT_MODE_STANDARD
+        options%operating_mode = OPERATING_MODE_STRICT
+        call compile_frontend_from_string(source, result, options)
+    end subroutine run_frontend
+
+end program test_accept_semantic_2951_valid_sources


### PR DESCRIPTION
Fixes three of the six false-positive rejections in issue #2951. The other three (`gfortran.dg/generic_6.f90`, `use_14.f90`, `use_26.f90`) do not originate in FortFront: no source in this repository emits those diagnostics, so they are ffc-side.

## Changes

- `semantic_literal_form_validation`: a function name used inside its own body denotes the result variable, so it is a valid output list item (`lfortran/integration_tests/intent_01.f90`). Resolved by walking the enclosing scopes of the owning print statement.
- `semantic_literal_form_validation`: `LOGICAL8 ... LOGICAL64` are entities of ISO_FORTRAN_ENV since F2023 (`lfortran/integration_tests/intrinsics_404.f90`, same family as the `iso_fortran_env_9.f90" false positive from the #2924 audit).
- `semantic_submodule_validation`: a MODULE PROCEDURE body carries no binding label of its own and inherits the interface body's, so an empty label is not a mismatch (`lfortran/integration_tests/submodule_52.f90`).

## Preserved invariant

Every relaxation is paired with the rejection it must not weaken, in the same new test: `print *, (erfc)` outside `erfc` stays rejected, `use iso_fortran_env, only: uint32` stays rejected, and a restated but *different* BIND(C) label on a separate module subprogram stays rejected.

## Evidence

Red on unmodified main (`fo test test_accept_semantic_2951_valid_sources`):

```
FAIL: expected acceptance for intent_01
  - Invalid constant in output list: f is a procedure name, not a floating constant or variable
FAIL: expected acceptance for intrinsics_404
  - Invalid literal kind import: logical8 is not an entity of the intrinsic module ISO_FORTRAN_ENV ...
FAIL: expected acceptance for submodule_52
  - mismatch in BIND(C) names (""/"bar_c") for module procedure "bar"
PASS: rejected pr95690 / unsigned_37 / submodule binding mismatch
```

Green: full `fo` pipeline, Build OK, Tests OK 483/483, Lint OK.