### PR TITLE
Treat procedure names as procedures, not implicit variables (#2950)

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -60,6 +60,4 @@ issue_2855_external_intrinsic_conflict.f90  # ERROR-TEST: entity both intrinsic 
 pr19936_3_ok.f90  # BUG: legacy (/ ... /) implied-do loses its (/ /) wrapper on emit
 pr96099_1_ok.f90  # BUG: IMPLICIT CLASS(t) (x) loses the letter-spec list on emit
 implicit_kind_selector_letter_specs.f90  # BUG: IMPLICIT with a kind/len selector loses the letter-spec list on emit
-elemental_args_check_2_valid.f90  # BUG: dummy procedure emitted as a data declaration (#2934)
-pure_formal_proc_3_valid.f90  # BUG: dummy procedure emitted as a data declaration (#2934)
 impure_assignment_2_valid.f90  # BUG: TARGET copied into a type definition (#2934)

--- a/examples/f90/issue_2950_procedure_actual_argument.f90
+++ b/examples/f90/issue_2950_procedure_actual_argument.f90
@@ -1,0 +1,25 @@
+program issue_2950_procedure_actual_argument
+    implicit none
+    intrinsic dcos
+    call apply(dcos)
+    call apply(expression)
+contains
+
+    subroutine apply(f)
+        interface
+            function f(x)
+                real(kind=8) :: f
+                real(kind=8), intent(in) :: x
+            end function f
+        end interface
+        real(kind=8) :: value
+        value = f(1.0d0)
+    end subroutine apply
+
+    function expression(x) result(y)
+        real(kind=8), intent(in) :: x
+        real(kind=8) :: y
+        y = x
+    end function expression
+
+end program issue_2950_procedure_actual_argument

--- a/src/codegen/decls/codegen_function_declarations.f90
+++ b/src/codegen/decls/codegen_function_declarations.f90
@@ -23,6 +23,7 @@ module codegen_function_declarations
         filter_implicit_statements, &
         append_parameter_declaration, &
         is_parameter_name, ensure_local_var_capacity, &
+        parameter_declared_by_interface, &
         is_local_var_collected
     use codegen_type_utils, only: get_type_standardization
     use codegen_grouped_body, only: generate_grouped_body

--- a/src/codegen/decls/codegen_function_declarations_part1.inc
+++ b/src/codegen/decls/codegen_function_declarations_part1.inc
@@ -461,6 +461,10 @@
         if (.not. allocated(func%body_indices)) return
         if (param_idx > size(param_map)) return
 
+        has_decl = parameter_declared_by_interface(arena, func%body_indices, &
+            param_map(param_idx)%name)
+        if (has_decl) return
+
         do body_idx = 1, size(func%body_indices)
             if (func%body_indices(body_idx) <= 0 .or. &
                 func%body_indices(body_idx) > arena%size) cycle

--- a/src/codegen/decls/codegen_procedure_shared.f90
+++ b/src/codegen/decls/codegen_procedure_shared.f90
@@ -3,7 +3,7 @@ module codegen_procedure_shared
     use ast_nodes_core, only: identifier_node, literal_node, program_node
     use ast_nodes_data, only: declaration_node, module_node, &
         parameter_declaration_node, intent_type_to_string
-    use ast_nodes_misc, only: implicit_statement_node
+    use ast_nodes_misc, only: implicit_statement_node, interface_block_node
     use codegen_declarations_core, only: build_parameter_dimensions, &
         fix_character_len_placeholder
     use codegen_parameter_info, only: parameter_info_t
@@ -27,12 +27,60 @@ module codegen_procedure_shared
     public :: get_param_type_from_param_decl
     public :: get_param_type_fallback
     public :: is_parameter_name
+    public :: parameter_declared_by_interface
     public :: is_local_var_collected
     public :: ensure_local_var_capacity
     public :: add_declared_vars
     public :: add_single_declared_var
 
 contains
+
+    ! True when an interface body in the specification part declares NAME.
+    ! Such a dummy argument has an explicit interface (Fortran 2018 15.4.3.2)
+    ! and is already declared, so no implicit type declaration may be
+    ! synthesized for it (Issue #2950).
+    logical function parameter_declared_by_interface(arena, body_indices, name) &
+        result(declared)
+        use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        character(len=*), intent(in) :: name
+        integer :: i, j, proc_index
+
+        declared = .false.
+        if (len_trim(name) == 0) return
+
+        do i = 1, size(body_indices)
+            if (body_indices(i) <= 0) cycle
+            if (body_indices(i) > arena%size) cycle
+            if (.not. allocated(arena%entries(body_indices(i))%node)) cycle
+            select type (block => arena%entries(body_indices(i))%node)
+            type is (interface_block_node)
+                if (.not. allocated(block%procedure_indices)) cycle
+                do j = 1, size(block%procedure_indices)
+                    proc_index = block%procedure_indices(j)
+                    if (proc_index <= 0) cycle
+                    if (proc_index > arena%size) cycle
+                    if (.not. allocated(arena%entries(proc_index)%node)) cycle
+                    select type (proc => arena%entries(proc_index)%node)
+                    type is (function_def_node)
+                        if (.not. allocated(proc%name)) cycle
+                        if (to_lower(trim(proc%name)) == to_lower(trim(name))) then
+                            declared = .true.
+                            return
+                        end if
+                    type is (subroutine_def_node)
+                        if (.not. allocated(proc%name)) cycle
+                        if (to_lower(trim(proc%name)) == to_lower(trim(name))) then
+                            declared = .true.
+                            return
+                        end if
+                    end select
+                end do
+            end select
+        end do
+    end function parameter_declared_by_interface
+
 
     function build_parameter_clause(arena, param_indices) result(clause)
         type(ast_arena_t), intent(in) :: arena

--- a/src/codegen/decls/codegen_subroutine_declarations.f90
+++ b/src/codegen/decls/codegen_subroutine_declarations.f90
@@ -13,6 +13,7 @@ module codegen_subroutine_declarations
         filter_implicit_statements, &
         append_parameter_declaration, &
         is_parameter_name, ensure_local_var_capacity, &
+        parameter_declared_by_interface, &
         is_local_var_collected, add_declared_vars, &
         add_single_declared_var
     use codegen_grouped_body_params, only: generate_grouped_body_with_params
@@ -160,6 +161,10 @@ contains
         has_decl = .false.
         if (.not. allocated(sub%body_indices)) return
         if (param_idx > size(param_map)) return
+
+        has_decl = parameter_declared_by_interface(arena, sub%body_indices, &
+            param_map(param_idx)%name)
+        if (has_decl) return
 
         do j = 1, size(sub%body_indices)
             body_idx = sub%body_indices(j)

--- a/src/codegen/programs/codegen_program_variables.f90
+++ b/src/codegen/programs/codegen_program_variables.f90
@@ -8,7 +8,7 @@ module codegen_program_variables
         allocate_statement_node, interface_block_node, &
         module_procedure_node, implicit_statement_node, &
         comment_node, directive_node, blank_line_node, &
-        namelist_statement_node
+        namelist_statement_node, intrinsic_statement_node
     use ast_nodes_data, only: declaration_node, module_node, derived_type_node
     use ast_nodes_legacy, only: enum_node
     use ast_nodes_procedure, only: function_def_node, subroutine_def_node

--- a/src/codegen/programs/codegen_program_variables_analysis.inc
+++ b/src/codegen/programs/codegen_program_variables_analysis.inc
@@ -381,6 +381,11 @@
         if (exists_in_list(state%var_names, state%var_count, name)) return
         if (exists_in_list(state%use_associated_names, &
                            state%use_associated_count, name)) return
+        ! A name known to be a procedure in this scope (contained procedure or
+        ! INTRINSIC declared) is a procedure reference, not an implicitly typed
+        ! variable (Issue #2950).
+        if (exists_in_list(state%internal_funcs, state%internal_count, &
+                           normalized_name)) return
 
         type_buf = mono_type_to_string(inferred_type, &
                                        include_shape=.true., &

--- a/src/codegen/programs/codegen_program_variables_collect.inc
+++ b/src/codegen/programs/codegen_program_variables_collect.inc
@@ -284,6 +284,23 @@
                     call try_add_internal_function(state, trim(decl%name))
                     call collect_entry_points_from_function(arena, decl, state)
                 end if
+            type is (subroutine_def_node)
+                ! A contained subroutine name is a procedure, not a variable
+                ! (Issue #2950): passing it as an actual argument must not
+                ! fabricate a declaration for it.
+                if (contains_seen .and. allocated(decl%name)) then
+                    call try_add_internal_function(state, trim(decl%name))
+                end if
+            type is (intrinsic_statement_node)
+                ! INTRINSIC declares the name as a procedure (Issue #2950).
+                if (contains_seen) cycle
+                if (allocated(decl%procedure_names)) then
+                    do j = 1, size(decl%procedure_names)
+                        if (.not. allocated(decl%procedure_names(j)%s)) cycle
+                        call try_add_internal_function(state, &
+                                                  trim(decl%procedure_names(j)%s))
+                    end do
+                end if
             type is (call_or_subscript_node)
                 if (contains_seen) cycle
                 if (allocated(decl%name)) then

--- a/test/test_issue_2950_procedure_actual_argument.f90
+++ b/test/test_issue_2950_procedure_actual_argument.f90
@@ -1,0 +1,81 @@
+program test_issue_2950_procedure_actual_argument
+    ! Issue #2950: a bare identifier that names a procedure - an INTRINSIC
+    ! declared name or a contained procedure - is a procedure reference when
+    ! it appears as an actual argument, never an implicitly typed variable.
+    ! Fabricating "real :: dcos" or "real :: expression" turns valid source
+    ! into source gfortran rejects and misleads downstream consumers, which
+    ! then resolve the name as an undeclared scalar.
+    use, intrinsic :: iso_fortran_env, only: error_unit, input_unit, iostat_end, &
+        & iostat_eor
+    use string_utils_mod, only: to_lower
+    use transformation_api, only: transform_context_t, transform_with_context, &
+        & INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=:), allocatable :: source_code
+    character(len=:), allocatable :: output_code
+    character(len=:), allocatable :: error_msg
+    character(len=:), allocatable :: lower_output
+    type(transform_context_t) :: ctx
+
+    call read_example('examples/f90/issue_2950_procedure_actual_argument.f90', &
+        & source_code)
+
+    ctx%input_mode = INPUT_MODE_STANDARD
+    ctx%has_filename = .true.
+    ctx%source_name = 'issue_2950_procedure_actual_argument'
+
+    call transform_with_context(source_code, output_code, error_msg, ctx)
+    if (allocated(error_msg) .and. len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context error: '// &
+            & trim(error_msg)
+        error stop 1
+    end if
+
+    if (.not. allocated(output_code)) then
+        write (error_unit, '(A)') 'FAIL: transform_with_context produced no output'
+        error stop 1
+    end if
+
+    lower_output = to_lower(output_code)
+
+    call assert_absent(lower_output, ':: dcos', &
+        & 'FAIL: intrinsic dcos declared as a variable')
+    call assert_absent(lower_output, ':: expression', &
+        & 'FAIL: contained function expression declared as a variable')
+    call assert_absent(lower_output, 'real :: f', &
+        & 'FAIL: dummy declared by an interface body typed as a variable')
+    call assert_contains(lower_output, 'intrinsic dcos', &
+        & 'FAIL: intrinsic statement for dcos lost')
+    call assert_contains(lower_output, 'call apply(expression)', &
+        & 'FAIL: procedure actual argument lost')
+
+    print *, 'PASS: Issue #2950 procedure actual arguments stay procedures'
+
+contains
+
+    include 'common/read_example.inc'
+
+    subroutine assert_absent(text, pattern, failure_message)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: pattern
+        character(len=*), intent(in) :: failure_message
+
+        if (index(text, pattern) > 0) then
+            write (error_unit, '(A)') trim(failure_message)
+            error stop 1
+        end if
+    end subroutine assert_absent
+
+    subroutine assert_contains(text, pattern, failure_message)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: pattern
+        character(len=*), intent(in) :: failure_message
+
+        if (index(text, pattern) == 0) then
+            write (error_unit, '(A)') trim(failure_message)
+            error stop 1
+        end if
+    end subroutine assert_contains
+
+end program test_issue_2950_procedure_actual_argument


### PR DESCRIPTION
Closes #2950 (also fixes the dummy-procedure half of #2934).

## Problem

A bare identifier naming a procedure - declared INTRINSIC, a contained
procedure, or a dummy argument given an explicit interface by an interface
body - was harvested by codegen as an implicitly typed variable. The emitted
program then carried `real :: dcos`, `real :: expression`, `real :: f`. That
is invalid Fortran (gfortran: "Symbol 'f' already has basic type of REAL",
"Interface mismatch in dummy procedure") and it makes downstream consumers
resolve the name as an undeclared scalar, which is what the corpus regression
in #2950 reported.

## Change

- program-level harvesting records contained subroutine names and every name
  in an INTRINSIC statement as procedures, and skips them when registering
  identifier references;
- procedure parameter declaration emission treats a dummy declared by an
  interface body in the same specification part as already declared
  (`parameter_declared_by_interface`, shared by the function and subroutine
  paths).

## Preserved invariant

Only names with no procedure evidence in the scope still receive an inferred
declaration, so lazy-fortran type inference is unchanged.

## Evidence

Red (on main): `test_issue_2950_procedure_actual_argument` fails with
`FAIL: intrinsic dcos declared as a variable`; running the CLI on
`examples/f90/issue_2950_procedure_actual_argument.f90` produced output that
`gfortran -fsyntax-only` rejects.

Green: the test passes, the transformed example is accepted by
`gfortran -fsyntax-only`, and two examples previously listed as expected
failures for #2934 (`elemental_args_check_2_valid.f90`,
`pure_formal_proc_3_valid.f90`) now pass and were removed from
`examples/expected_failures.txt`. Full local `fo` pipeline green
(483 tests, lint OK).