### PR TITLE
Move test-only helpers out of libfortfront (#2909)

### DIFF
--- a/test/build/test_build_system_integration.f90
+++ b/test/build/test_build_system_integration.f90
@@ -6,7 +6,6 @@ program test_build_system_integration
     ! When: Build commands are executed with proper configuration
     ! Then: The build system reliably produces all required artifacts
     !
-    use test_filesystem_helpers, only: cleanup_file
     implicit none
 
     integer :: test_count, pass_count
@@ -70,6 +69,8 @@ program test_build_system_integration
     end if
 
 contains
+
+    include '../common/filesystem_helpers.inc'
 
     subroutine test_fpm_configuration()
         ! Given: An fpm.toml file for the fortfront project

--- a/test/build/test_library_excludes_test_modules.f90
+++ b/test/build/test_library_excludes_test_modules.f90
@@ -1,0 +1,51 @@
+program test_library_excludes_test_modules
+    ! Issue #2909: test-only helper modules must not compile into libfortfront.
+    ! Oracle: scan the shipped library sources for module definitions whose name
+    ! begins with "test_". Any hit means test scaffolding ships to consumers.
+    implicit none
+
+    character(len=*), parameter :: report = 'build/test_modules_in_src.txt'
+    character(len=512) :: line
+    integer :: unit, ios, exit_stat, cmd_stat, offenders
+    logical :: exists
+
+    offenders = 0
+
+    call execute_command_line( &
+        'grep -rlE "^[[:space:]]*module[[:space:]]+test_" src > ' // report // &
+        ' 2>/dev/null; true', exitstat=exit_stat, cmdstat=cmd_stat)
+
+    if (cmd_stat /= 0) then
+        print *, 'SKIP: shell unavailable, cannot scan src/'
+        stop 0
+    end if
+
+    inquire (file=report, exist=exists)
+    if (.not. exists) then
+        print *, 'SKIP: could not produce scan report'
+        stop 0
+    end if
+
+    open (newunit=unit, file=report, status='old', action='read', iostat=ios)
+    if (ios /= 0) then
+        print *, 'SKIP: could not read scan report'
+        stop 0
+    end if
+
+    do
+        read (unit, '(A)', iostat=ios) line
+        if (ios /= 0) exit
+        if (len_trim(line) == 0) cycle
+        offenders = offenders + 1
+        print *, 'FAIL: test-only module ships in library: ', trim(line)
+    end do
+
+    close (unit, status='delete')
+
+    if (offenders > 0) then
+        print *, 'FAIL: ', offenders, ' test-only module(s) found under src/'
+        stop 1
+    end if
+
+    print *, 'PASS: no test-only modules under src/'
+end program test_library_excludes_test_modules

--- a/test/build/test_module_distribution.f90
+++ b/test/build/test_module_distribution.f90
@@ -6,7 +6,6 @@ program test_module_distribution
     ! When: The build system collects all .mod files
     ! Then: All required Fortran modules should be available for external use
     !
-    use test_filesystem_helpers, only: cleanup_file
     implicit none
 
     integer :: test_count, pass_count
@@ -75,6 +74,8 @@ program test_module_distribution
     end if
 
 contains
+
+    include '../common/filesystem_helpers.inc'
 
     subroutine test_core_modules_available()
         ! Given: A static library build with module collection

--- a/test/codegen/test_codegen_green.f90
+++ b/test/codegen/test_codegen_green.f90
@@ -1,8 +1,5 @@
 program test_codegen_green
     use transformation_api, only: compile_source, compilation_options_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
 
     logical :: all_passed
@@ -41,6 +38,8 @@ program test_codegen_green
     stop exit_code
 
 contains
+
+    include '../common/filesystem_helpers.inc'
 
     logical function test_array_literal_codegen()
         character(len=:), allocatable :: input_file, output_file

--- a/test/codegen/test_function_prefix_keywords.f90
+++ b/test/codegen/test_function_prefix_keywords.f90
@@ -1,8 +1,5 @@
 program test_function_prefix_keywords
     use transformation_api, only: compile_source, compilation_options_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
 
     character(len=:), allocatable :: input_file, output_file
@@ -125,4 +122,9 @@ program test_function_prefix_keywords
     999 continue
     call cleanup_temp_directory(temp_dir, is_windows)
     stop exit_code
+
+contains
+
+    include '../common/filesystem_helpers.inc'
+
 end program test_function_prefix_keywords

--- a/test/codegen/test_issue_1570_pure_elemental.f90
+++ b/test/codegen/test_issue_1570_pure_elemental.f90
@@ -1,8 +1,5 @@
 program test_issue_1570_pure_elemental
     use transformation_api, only: compile_source, compilation_options_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
 
     character(len=:), allocatable :: input_file, output_file
@@ -145,4 +142,9 @@ program test_issue_1570_pure_elemental
                                     999 continue
                                     call cleanup_temp_directory(temp_dir, is_windows)
                                     stop exit_code
+
+contains
+
+    include '../common/filesystem_helpers.inc'
+
                                 end program test_issue_1570_pure_elemental

--- a/test/codegen/test_issue_1739_program_prefixes.f90
+++ b/test/codegen/test_issue_1739_program_prefixes.f90
@@ -1,8 +1,5 @@
 program test_issue_1739_program_prefixes
     use transformation_api, only: compile_source, compilation_options_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
 
     character(len=:), allocatable :: input_file, output_file
@@ -145,4 +142,9 @@ program test_issue_1739_program_prefixes
     999 continue
     call cleanup_temp_directory(temp_dir, is_windows)
     stop exit_code
+
+contains
+
+    include '../common/filesystem_helpers.inc'
+
 end program test_issue_1739_program_prefixes

--- a/test/codegen/test_issue_2014_elemental_only.f90
+++ b/test/codegen/test_issue_2014_elemental_only.f90
@@ -1,8 +1,5 @@
 program test_issue_2014_elemental_only
     use transformation_api, only: compile_source, compilation_options_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
 
     character(len=:), allocatable :: input_file, output_file
@@ -79,4 +76,9 @@ program test_issue_2014_elemental_only
     999 continue
     call cleanup_temp_directory(temp_dir, is_windows)
     stop exit_code
+
+contains
+
+    include '../common/filesystem_helpers.inc'
+
 end program test_issue_2014_elemental_only

--- a/test/common/filesystem_helpers.inc
+++ b/test/common/filesystem_helpers.inc
@@ -1,26 +1,6 @@
-module test_filesystem_helpers
-    use fortfront_constants, only: MAX_EXAMPLE_PATH_LEN, MAX_TEST_SEARCH_LINE_LEN
-    implicit none
-    private
-    public :: find_fortfront_executable
-    public :: check_if_windows
-    public :: cleanup_file
-    public :: create_temp_directory
-    public :: get_temp_base_directory
-    public :: get_environment_value
-    public :: make_temp_file_path
-    public :: ensure_directory_exists
-    public :: cleanup_temp_directory
-    public :: extract_example_basename
-    public :: extract_relative_example_path
-    public :: normalize_path_string
-    public :: join_path
-    public :: directory_from_path
-    public :: find_last_separator
-    public :: path_separator_for
-
-contains
-
+! Shared filesystem helpers for tests (issue #2909).
+! Textually included inside a test program's `contains` section so that
+! this scaffolding never compiles into libfortfront.
     function get_environment_value(name) result(value)
         character(len=*), intent(in) :: name
         character(len=:), allocatable :: value
@@ -173,7 +153,8 @@ contains
         character(len=*), intent(in) :: preferred_suffix
         character(len=:), allocatable, intent(inout) :: executable_path
         character(len=:), allocatable :: fallback
-        character(len=MAX_TEST_SEARCH_LINE_LEN) :: line
+        integer, parameter :: TEST_SEARCH_LINE_LEN = 512
+        character(len=TEST_SEARCH_LINE_LEN) :: line
         integer :: unit_num, ios
         logical :: exists
 
@@ -422,7 +403,8 @@ contains
 
     pure function extract_example_basename(filepath) result(name)
         character(len=*), intent(in) :: filepath
-        character(len=MAX_EXAMPLE_PATH_LEN) :: name
+        integer, parameter :: TEST_PATH_LEN = 256
+        character(len=TEST_PATH_LEN) :: name
         character(len=:), allocatable :: trimmed
         integer :: sep_pos
 
@@ -442,8 +424,9 @@ contains
 
     pure function extract_relative_example_path(filepath) result(relative)
         character(len=*), intent(in) :: filepath
-        character(len=MAX_EXAMPLE_PATH_LEN) :: relative
-        character(len=MAX_EXAMPLE_PATH_LEN) :: normalized
+        integer, parameter :: TEST_PATH_LEN = 256
+        character(len=TEST_PATH_LEN) :: relative
+        character(len=TEST_PATH_LEN) :: normalized
         character(len=:), allocatable :: trimmed
         integer :: pos
 
@@ -475,7 +458,8 @@ contains
 
     pure function normalize_path_string(value) result(normalized)
         character(len=*), intent(in) :: value
-        character(len=MAX_EXAMPLE_PATH_LEN) :: normalized
+        integer, parameter :: TEST_PATH_LEN = 256
+        character(len=TEST_PATH_LEN) :: normalized
         integer :: i
 
         normalized = adjustl(trim(value))
@@ -557,5 +541,3 @@ contains
             if (is_win) sep = '\'
         end if
     end function path_separator_for
-
-end module test_filesystem_helpers

--- a/test/common/shell_commands.inc
+++ b/test/common/shell_commands.inc
@@ -1,12 +1,6 @@
-module test_shell_commands
-    implicit none
-    private
-    public :: build_compile_command
-    public :: quote_for_shell
-    public :: verify_shell_helpers
-
-contains
-
+! Shared shell-command helpers for tests (issue #2909).
+! Textually included inside a test program's `contains` section so that
+! this scaffolding never compiles into libfortfront.
     function build_compile_command(output_file, module_dir, temp_dir, &
             is_windows) result(command)
         character(len=*), intent(in) :: output_file
@@ -125,5 +119,3 @@ contains
             end if
         end if
     end subroutine verify_shell_helpers
-
-end module test_shell_commands

--- a/test/integration/array_tests/test_array_features_pipeline.f90
+++ b/test/integration/array_tests/test_array_features_pipeline.f90
@@ -1,8 +1,5 @@
 program test_array_features_pipeline
     use transformation_api, only: compile_source, compilation_options_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
 
     logical :: all_passed
@@ -41,6 +38,8 @@ program test_array_features_pipeline
     stop exit_code
 
 contains
+
+    include '../../common/filesystem_helpers.inc'
 
     logical function test_array_literals()
         character(len=:), allocatable :: input_file, output_file

--- a/test/integration/array_tests/test_array_specifications.f90
+++ b/test/integration/array_tests/test_array_specifications.f90
@@ -1,8 +1,5 @@
 program test_array_specifications
     use transformation_api, only: compile_source, compilation_options_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
 
     logical :: all_passed
@@ -56,6 +53,8 @@ program test_array_specifications
     stop exit_code
 
 contains
+
+    include '../../common/filesystem_helpers.inc'
 
     logical function test_dynamic_arrays()
         character(len=:), allocatable :: input_file, output_file

--- a/test/integration/core_features/test_standardizer_debug.f90
+++ b/test/integration/core_features/test_standardizer_debug.f90
@@ -5,9 +5,6 @@ program test_standardizer_debug
     use ast_arena_modern, only: ast_arena_t
     use codegen_core, only: codegen_core_generate_arena, initialize_codegen
     use lexer_core, only: token_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
 
     character(len=:), allocatable :: input_file
@@ -91,5 +88,10 @@ program test_standardizer_debug
     print *, trim(generated_code)
 
     call cleanup_temp_directory(temp_dir, is_windows)
+
+
+contains
+
+    include '../../common/filesystem_helpers.inc'
 
 end program test_standardizer_debug

--- a/test/integration/issue_tests/test_issue_1743_namelist.f90
+++ b/test/integration/issue_tests/test_issue_1743_namelist.f90
@@ -1,8 +1,5 @@
 program test_namelist
     use, intrinsic :: iso_fortran_env, only: dp => real64
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
     integer :: nx, ny
     real(dp) :: dx, dy
@@ -31,5 +28,10 @@ program test_namelist
     print *, 'Namelist written'
 
     call cleanup_temp_directory(temp_dir, is_windows)
+
+
+contains
+
+    include '../../common/filesystem_helpers.inc'
 
 end program test_namelist

--- a/test/integration/issue_tests/test_issue_1812_custom_array_bounds.f90
+++ b/test/integration/issue_tests/test_issue_1812_custom_array_bounds.f90
@@ -3,9 +3,6 @@ program test_issue_1812_custom_array_bounds
     ! Issue #1812: Arrays with explicit bounds like arr(0:9) were being
     ! converted to allocatable arrays, losing the custom bounds
     use transformation_api, only: compile_source, compilation_options_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
 
     logical :: all_passed
     integer :: n_tests, n_passed
@@ -47,6 +44,8 @@ program test_issue_1812_custom_array_bounds
     end if
 
 contains
+
+    include '../../common/filesystem_helpers.inc'
 
     logical function test_single_custom_bounds()
         character(len=:), allocatable :: input_file, output_file

--- a/test/integration/issue_tests/test_issue_2024_char_function_duplicate_and_missing.f90
+++ b/test/integration/issue_tests/test_issue_2024_char_function_duplicate_and_missing.f90
@@ -64,6 +64,8 @@ program test_issue_2024_char_function_duplicate_and_missing
 
 contains
 
+    include '../../common/shell_commands.inc'
+
     subroutine assert_no_duplicate_declaration(text, var_name)
         character(len=*), intent(in) :: text, var_name
         integer :: count, pos
@@ -98,7 +100,6 @@ contains
     end subroutine assert_contains
 
     subroutine test_compilation(source_text, basename)
-        use test_shell_commands, only: build_compile_command
         character(len=*), intent(in) :: source_text, basename
         character(len=256) :: filename, cmd, temp_dir, obj_file
         integer :: unit, ios, exit_code

--- a/test/integration/issue_tests/test_issue_2388_contains_preserved.f90
+++ b/test/integration/issue_tests/test_issue_2388_contains_preserved.f90
@@ -151,14 +151,13 @@ program test_issue_2388_contains_preserved
 
 contains
 
+    include '../../common/filesystem_helpers.inc'
+    include '../../common/shell_commands.inc'
+
     include '../../common/read_example.inc'
 
 
     subroutine assert_compiles(text, basename)
-        use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-            cleanup_temp_directory, join_path, &
-            path_separator_for
-        use test_shell_commands, only: build_compile_command
         character(len=*), intent(in) :: text
         character(len=*), intent(in) :: basename
         character(len=:), allocatable :: filename

--- a/test/integration/issue_tests/test_issue_2445_implicit_main_with_type_contains_roundtrip.f90
+++ b/test/integration/issue_tests/test_issue_2445_implicit_main_with_type_contains_roundtrip.f90
@@ -70,13 +70,12 @@ program test_issue_2445_implicit_main_with_type_contains_roundtrip
 
 contains
 
+    include '../../common/filesystem_helpers.inc'
+    include '../../common/shell_commands.inc'
+
     include '../../common/read_example.inc'
 
     subroutine assert_compiles(text, basename)
-        use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-            cleanup_temp_directory, join_path, &
-            path_separator_for
-        use test_shell_commands, only: build_compile_command
         character(len=*), intent(in) :: text
         character(len=*), intent(in) :: basename
         character(len=:), allocatable :: filename

--- a/test/integration/monomorphization/test_monomorphization_simple.f90
+++ b/test/integration/monomorphization/test_monomorphization_simple.f90
@@ -1,10 +1,6 @@
 program test_monomorphization_simple
     use, intrinsic :: iso_fortran_env, only: error_unit
     use fortfront, only: transform_lazy_fortran_string
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
-    use test_shell_commands, only: build_compile_command
     implicit none
     character(len=:), allocatable :: input, output, error_msg
     character(len=*), parameter :: tmp_file = 'fortfront_mono_simple.f90'
@@ -75,4 +71,10 @@ program test_monomorphization_simple
         write (error_unit, '(A)') 'gfortran rejected generated code'
         error stop 1
     end if
+
+contains
+
+    include '../../common/filesystem_helpers.inc'
+    include '../../common/shell_commands.inc'
+
 end program test_monomorphization_simple

--- a/test/integration/monomorphization/test_monomorphization_subroutine.f90
+++ b/test/integration/monomorphization/test_monomorphization_subroutine.f90
@@ -1,10 +1,6 @@
 program test_monomorphization_subroutine
     use, intrinsic :: iso_fortran_env, only: error_unit
     use fortfront, only: transform_lazy_fortran_string
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
-    use test_shell_commands, only: build_compile_command
     implicit none
     character(len=:), allocatable :: input, output, error_msg
     character(len=*), parameter :: tmp_file = 'fortfront_mono_subroutine.f90'
@@ -65,6 +61,9 @@ program test_monomorphization_subroutine
     end if
 
 contains
+
+    include '../../common/filesystem_helpers.inc'
+    include '../../common/shell_commands.inc'
 
     include '../../common/read_example.inc'
 

--- a/test/integration/monomorphization/test_monomorphization_three_types.f90
+++ b/test/integration/monomorphization/test_monomorphization_three_types.f90
@@ -1,10 +1,6 @@
 program test_monomorphization_three_types
     use, intrinsic :: iso_fortran_env, only: error_unit
     use fortfront, only: transform_lazy_fortran_string
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
-    use test_shell_commands, only: build_compile_command
     implicit none
     character(len=:), allocatable :: input, output, error_msg
     character(len=*), parameter :: tmp_file = 'fortfront_mono_three.f90'
@@ -51,6 +47,9 @@ program test_monomorphization_three_types
     end if
 
 contains
+
+    include '../../common/filesystem_helpers.inc'
+    include '../../common/shell_commands.inc'
 
     include '../../common/read_example.inc'
 

--- a/test/integration/test_all_examples.f90
+++ b/test/integration/test_all_examples.f90
@@ -4,17 +4,7 @@ program test_all_examples
     use test_example_lists, only: load_skip_examples, is_analysis_only_example
     use test_example_lists, only: is_expected_diagnostic, is_expected_failure
     use test_example_lists, only: is_skipped_example
-    use test_filesystem_helpers, only: check_if_windows, cleanup_file, &
-        cleanup_temp_directory
-    use test_filesystem_helpers, only: create_temp_directory, &
-        ensure_directory_exists, &
-        extract_example_basename
-    use test_filesystem_helpers, only: extract_relative_example_path
-    use test_filesystem_helpers, only: find_fortfront_executable
-    use test_filesystem_helpers, only: path_separator_for
     use test_module_discovery, only: get_module_directory
-    use test_shell_commands, only: build_compile_command, quote_for_shell, &
-        verify_shell_helpers
     implicit none
 
     integer :: test_count, pass_count, fail_count, skip_count
@@ -171,6 +161,9 @@ program test_all_examples
     end if
 
 contains
+
+    include '../common/filesystem_helpers.inc'
+    include '../common/shell_commands.inc'
 
     subroutine print_env_diagnostics()
         character(len=256) :: env_value

--- a/test/integration/test_example_lists.f90
+++ b/test/integration/test_example_lists.f90
@@ -1,8 +1,5 @@
 module test_example_lists
     use, intrinsic :: iso_fortran_env, only: error_unit
-    use test_filesystem_helpers, only: &
-        extract_relative_example_path, &
-        normalize_path_string
     implicit none
     private
     public :: load_example_list
@@ -15,6 +12,8 @@ module test_example_lists
     public :: is_expected_diagnostic
 
 contains
+
+    include '../common/filesystem_helpers.inc'
 
     subroutine load_example_list(filename, entries, num_entries)
         character(len=*), intent(in) :: filename

--- a/test/integration/test_module_discovery.f90
+++ b/test/integration/test_module_discovery.f90
@@ -1,8 +1,4 @@
 module test_module_discovery
-    use test_filesystem_helpers, only: check_if_windows, cleanup_file, &
-        directory_from_path, find_last_separator, &
-        join_path, &
-        path_separator_for
     implicit none
     private
     public :: get_module_directory
@@ -11,6 +7,8 @@ module test_module_discovery
     public :: fallback_module_dir_search
 
 contains
+
+    include '../common/filesystem_helpers.inc'
 
     function get_module_directory(executable_path) result(module_dir)
         character(len=*), intent(in) :: executable_path

--- a/test/integration/test_roundtrip_core.f90
+++ b/test/integration/test_roundtrip_core.f90
@@ -3,9 +3,6 @@ module test_roundtrip_core
     use frontend_parsing, only: parse_tokens
     use ast_arena_modern, only: ast_arena_t, create_ast_arena
     use lexer_core, only: token_t
-    use test_filesystem_helpers, only: create_temp_directory, &
-        cleanup_temp_directory
-    use test_shell_commands, only: build_compile_command
     implicit none
     private
 
@@ -28,6 +25,9 @@ module test_roundtrip_core
     end type roundtrip_result_t
 
 contains
+
+    include '../common/filesystem_helpers.inc'
+    include '../common/shell_commands.inc'
 
     subroutine run_roundtrip_test(source, result, skip_compile, is_windows)
         character(len=*), intent(in) :: source

--- a/test/semantic/test_semantic_analysis_green.f90
+++ b/test/semantic/test_semantic_analysis_green.f90
@@ -1,8 +1,5 @@
 program test_semantic_analysis_green
     use transformation_api, only: compile_source, compilation_options_t
-    use test_filesystem_helpers, only: check_if_windows, create_temp_directory, &
-        cleanup_temp_directory, join_path, &
-        path_separator_for
     implicit none
 
     logical :: all_passed
@@ -41,6 +38,8 @@ program test_semantic_analysis_green
     stop exit_code
 
 contains
+
+    include '../common/filesystem_helpers.inc'
 
     logical function test_array_assignment_semantics()
         character(len=:), allocatable :: input_file, output_file

--- a/test/utilities/test_cli_io_allocation_failure.f90
+++ b/test/utilities/test_cli_io_allocation_failure.f90
@@ -1,7 +1,5 @@
 program test_cli_io_allocation_failure
     use, intrinsic :: iso_fortran_env, only: error_unit
-    use test_filesystem_helpers, only: check_if_windows, cleanup_file, &
-        make_temp_file_path
     implicit none
 
     character(len=:), allocatable :: text
@@ -19,6 +17,8 @@ program test_cli_io_allocation_failure
     print *, 'PASS: CLI I/O allocation failure branch covered'
 
 contains
+
+    include '../common/filesystem_helpers.inc'
 
     subroutine test_small_input(is_windows)
         logical, intent(in) :: is_windows

--- a/test/utilities/test_cli_io_large_input.f90
+++ b/test/utilities/test_cli_io_large_input.f90
@@ -1,7 +1,5 @@
 program test_cli_io_large_input
     use, intrinsic :: iso_fortran_env, only: error_unit
-    use test_filesystem_helpers, only: check_if_windows, cleanup_file, &
-        make_temp_file_path
     implicit none
 
     character(len=:), allocatable :: text
@@ -40,6 +38,8 @@ program test_cli_io_large_input
     call cleanup_file(fname)
 
 contains
+
+    include '../common/filesystem_helpers.inc'
 
     include '../common/read_example.inc'
 

--- a/test/utilities/test_environment_value.f90
+++ b/test/utilities/test_environment_value.f90
@@ -1,6 +1,5 @@
 program test_environment_value
     use, intrinsic :: iso_fortran_env, only: error_unit
-    use test_filesystem_helpers, only: get_environment_value
     implicit none
 
     character(len=:), allocatable :: path_value
@@ -27,4 +26,9 @@ program test_environment_value
     end if
 
     print *, 'PASS: get_environment_value returns stable, safe results'
+
+contains
+
+    include '../common/filesystem_helpers.inc'
+
 end program test_environment_value

--- a/test/utilities/test_shell_commands_windows_quotes.f90
+++ b/test/utilities/test_shell_commands_windows_quotes.f90
@@ -1,7 +1,11 @@
 program test_shell_commands_windows_quotes
-    use test_shell_commands, only: verify_shell_helpers
     implicit none
 
     call verify_shell_helpers(.true.)
+
+contains
+
+    include '../common/shell_commands.inc'
+
 end program test_shell_commands_windows_quotes
 


### PR DESCRIPTION
Closes #2909.

## Change
- Deleted `src/utilities/test_filesystem_helpers.f90` (561 lines) and `src/utilities/test_shell_commands.f90` (129 lines) — 690 lines of test scaffolding that shipped in `libfortfront` with zero src consumers.
- Converted both to textual include fragments: `test/common/filesystem_helpers.inc`, `test/common/shell_commands.inc`. This is option 2 from the issue and matches the existing `test/common/read_example.inc` convention, so fpm module scoping (the constraint that reverted #2908) does not apply at all.
- Rewrote all 28 `use` sites into `include` directives inside each consumer's `contains` section, with the relative path convention already used elsewhere (`../common/...`).
- Made the fragments self-contained: the two `fortfront_constants` lengths they needed are now local parameters, so consumers gain no new `use` dependency.

Exactly one convention survives: no module form is left behind as a fallback.

## Oracle
New `test/build/test_library_excludes_test_modules.f90` scans `src/` for any module whose name begins `test_` and fails if one is found.

Red (unmodified main + new test):
```
test_library_excludes_test_modules   FAIL
 FAIL: test-only module ships in library: src/utilities/test_shell_commands.f90
 FAIL: test-only module ships in library: src/utilities/test_filesystem_helpers.f90
```

Green after the change: `test_library_excludes_test_modules PASS`, plus all previously-affected consumers pass (`test_all_examples`, `test_module_distribution`, `test_roundtrip_core`, monomorphization, `test_shell_commands_windows_quotes`, …). Full `fo` pipeline: 483/483 tests OK, Lint OK.

## Invariant preserved
No compiler behavior changes — this is a build-layout move. Every helper body is byte-identical apart from the two constant substitutions.