### PR TITLE
Restore the test-duplication gate as a blocking CI check (#2910)

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -34,8 +34,8 @@ This directory contains GitHub Actions CI/CD workflow definitions for automated 
 **3. Duplication Check**
 - Validates zero-duplication policy
 - Detects end-to-end tests with inline full programs
-- Status: WARNING mode (provides visibility, does not block)
-- Commands: `make check-duplication`
+- Status: BLOCKING (violations fail CI; issue #2910)
+- Commands: `make check-duplication`, `make check-duplication-gate`
 - Script: `scripts/check_test_duplication.py`
 
 **4. Round-Trip Validation**

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,10 +90,11 @@ jobs:
 
     - name: Check Test Duplication (CLAUDE.md compliance)
       if: runner.os == 'Linux'
-      continue-on-error: true
       run: |
         echo "Checking for end-to-end test duplication violations..."
-        make check-duplication || echo "⚠️ Found test duplication violations - see issue #1975"
+        make check-duplication
+        echo "Negative control: the gate must still be able to fail (issue #2910)"
+        make check-duplication-gate
 
     - name: Clean Project Root Before Tests (issue #2148)
       if: runner.os == 'Linux'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,11 +310,12 @@ end program
 
 **Issue #1975 - Test Deduplication Migration**
 
-**Status: complete.** The end-to-end test deduplication is done: `make check-duplication` reports 0 violations and 0 warnings. End-to-end tests reference `examples/`; unit tests keep small inline inputs as described above.
+**Status: enforced.** `make check-duplication` reports 0 violations; some tests remain in the advisory warning band (6-15 inline `new_line('a')` occurrences), which the gate reports but does not fail on. End-to-end tests reference `examples/`; unit tests keep small inline inputs as described above.
 
-**CI Enforcement** (ACTIVE):
+**CI Enforcement** (ACTIVE — blocking since issue #2910):
 - Check script: `scripts/check_test_duplication.py`
-- Make target: `make check-duplication`
+- Make target: `make check-duplication` (fails the build on violations)
+- Negative control: `make check-duplication-gate` proves the gate can still fail
 - CI workflow: `.github/workflows/ci.yml`
 
 Keep it at zero: new end-to-end tests must use `read_example()` rather than inline full programs.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build test test-small-stack check-duplication check-doc-links check-rejection-gate check-root-cleanliness clean help libfortfront.a
+.PHONY: all build test test-small-stack check-duplication check-duplication-gate check-doc-links check-rejection-gate check-root-cleanliness clean help libfortfront.a
 
 # Default target
 all: build
@@ -56,6 +56,10 @@ test-small-stack:
 check-duplication:
 	@python3 scripts/check_test_duplication.py
 
+# Negative control (issue #2910): prove the duplication gate can still fail.
+check-duplication-gate:
+	@bash scripts/test_check_test_duplication.sh
+
 # Corpus rejection gate (issue #2924): no example may become newly rejected.
 # Run the same script with --corpus <gfortran.dg> for the full conformance diff.
 check-rejection-gate:
@@ -105,6 +109,7 @@ help:
 	@echo "  make test     - Run tests"
 	@echo "  make test-small-stack [TEST_STACK_KB=1024] - Run tests with small stack"
 	@echo "  make check-duplication - Check for test duplication violations"
+	@echo "  make check-duplication-gate - Negative control for the duplication gate"
 	@echo "  make check-rejection-gate - Fail on newly rejected corpus files"
 	@echo "  make check-doc-links - Check repository Markdown for broken relative links"
 	@echo "  make check-root-cleanliness - Check project root for polluting files (issue #2148)"

--- a/examples/f90/issue_2910_program_unit_query_forms.f90
+++ b/examples/f90/issue_2910_program_unit_query_forms.f90
@@ -1,0 +1,17 @@
+module m
+    use dep, only: local => remote
+    private
+    integer, parameter :: n = 2
+    type :: pair
+        integer :: x
+    contains
+        procedure :: show
+    end type pair
+contains
+    subroutine show(self)
+        type(pair) :: self
+    end subroutine show
+end module m
+program p
+    use m
+end program p

--- a/examples/f90/issue_2910_statement_query_forms.f90
+++ b/examples/f90/issue_2910_statement_query_forms.f90
@@ -1,0 +1,58 @@
+program statements
+    class(*), allocatable :: object
+    integer :: values(3), choice, ios
+    logical :: mask(3), opened
+    open(unit=10,file='data.txt',status='old',access='sequential',form='formatted',recl=80,blank='null',position='rewind',action='read',delim='quote',pad='yes',iostat=ios,err=900)
+    close(unit=10,status='keep',iostat=ios,err=900)
+    close(unit=11)
+    rewind(unit=10,iostat=ios,err=900)
+    backspace(unit=10,iostat=ios,err=900)
+    endfile(unit=10,iostat=ios,err=900)
+    inquire(unit=10,opened=opened,iostat=ios,err=900)
+    print '(I0)', choice
+    write(unit=10,fmt='(I0)',iostat=ios,err=900) choice
+    read(unit=10,fmt='(I0)',iostat=ios,end=800,err=900) choice
+    700 format(I0)
+    associate(alias => choice)
+        values(1) = alias
+    end associate
+    block
+        integer :: local
+        local = choice
+    end block
+    allocate(object, source=choice)
+    select type (object)
+        type is (integer)
+        values(1) = object
+    class default
+        values(1) = 0
+    end select
+    select rank(values)
+        rank(1)
+        values = 1
+        rank default
+        values = 0
+    end select
+    where(mask)
+        values = 1
+    elsewhere(.not. mask)
+        values = 2
+    elsewhere
+        values = 3
+    end where
+    where(mask) values = 3
+    goto 100
+    goto (100,200), choice
+    pause 1
+    pause 'hold'
+    pause
+    100 continue
+    200 continue
+    800 continue
+    900 continue
+contains
+    subroutine inner
+        goto 100
+        100 continue
+    end subroutine inner
+end program statements

--- a/examples/f90/issue_2924_coindexed_type_bound_call.f90
+++ b/examples/f90/issue_2924_coindexed_type_bound_call.f90
@@ -1,0 +1,23 @@
+module m_coarray_call
+    implicit none
+    type :: t0
+    contains
+        procedure, nopass :: sub => t0_sub
+    end type t0
+    type :: t1
+        type(t0) :: nopoly
+    end type t1
+    type :: t2
+        type(t1) :: c
+    end type t2
+contains
+    subroutine t0_sub()
+        print *, 1
+    end subroutine t0_sub
+end module m_coarray_call
+program p_coarray_call
+    use m_coarray_call, only: t2
+    implicit none
+    type(t2) :: x[*]
+    call x[1]%c%nopoly%sub()
+end program p_coarray_call

--- a/examples/f90/issue_2924_implicit_none_external_type_bound.f90
+++ b/examples/f90/issue_2924_implicit_none_external_type_bound.f90
@@ -1,0 +1,19 @@
+module m_tbp_external
+    implicit none (type, external)
+    type :: box_t
+        integer :: v = 1
+    contains
+        procedure :: show => box_show
+    end type box_t
+contains
+    subroutine box_show(self)
+        class(box_t), intent(in) :: self
+        print *, self%v
+    end subroutine box_show
+end module m_tbp_external
+program p_tbp_external
+    use m_tbp_external, only: box_t
+    implicit none (type, external)
+    type(box_t) :: b
+    call b%show()
+end program p_tbp_external

--- a/examples/skip_all_examples.txt
+++ b/examples/skip_all_examples.txt
@@ -57,3 +57,7 @@ lf/issue_652_multi_var_allocatable.lf
 f90/debug_error_missing_then.f90
 f90/issue_256_fix_suggestion.f90
 f90/issue_256_invalid_syntax_missing_then.f90
+f90/issue_2910_statement_query_forms.f90
+f90/issue_2910_program_unit_query_forms.f90
+f90/issue_2924_coindexed_type_bound_call.f90
+f90/issue_2924_implicit_none_external_type_bound.f90

--- a/scripts/test_check_test_duplication.sh
+++ b/scripts/test_check_test_duplication.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+# Negative control for the zero-duplication gate (issue #2910).
+#
+# The gate was suppressed in CI for weeks and nobody noticed, because a gate
+# that cannot fail is indistinguishable from no gate. This self-test proves
+# both directions of the gate on every run:
+#   1. the current tree passes,
+#   2. a deliberately added inline end-to-end fixture makes it fail.
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROBE="${ROOT}/test/api/zz_duplication_gate_probe.f90"
+
+cleanup() {
+    rm -f "${PROBE}"
+}
+trap cleanup EXIT
+
+cleanup
+
+python3 "${ROOT}/scripts/check_test_duplication.py" >/dev/null
+clean_status=$?
+if [ "${clean_status}" -ne 0 ]; then
+    echo "FAIL: duplication gate reports violations on the current tree" >&2
+    python3 "${ROOT}/scripts/check_test_duplication.py" >&2
+    exit 1
+fi
+echo "PASS: clean tree accepted by the duplication gate"
+
+{
+    echo "program zz_duplication_gate_probe"
+    echo "    implicit none"
+    echo "    character(len=:), allocatable :: source"
+    echo ""
+    echo "    source = 'program probe'//new_line('a')// &"
+    for i in $(seq 1 20); do
+        echo "        '    integer :: v${i}'//new_line('a')// &"
+    done
+    echo "        'end program probe'"
+    echo "    print *, len(source)"
+    echo "end program zz_duplication_gate_probe"
+} > "${PROBE}"
+
+python3 "${ROOT}/scripts/check_test_duplication.py" >/dev/null
+probe_status=$?
+cleanup
+
+if [ "${probe_status}" -eq 0 ]; then
+    echo "FAIL: duplication gate accepted an inline end-to-end fixture" >&2
+    exit 1
+fi
+echo "PASS: inline end-to-end fixture rejected by the duplication gate"

--- a/test/api/test_compiler_program_unit_queries.f90
+++ b/test/api/test_compiler_program_unit_queries.f90
@@ -34,23 +34,8 @@ contains
         character(len=:), allocatable :: source
         integer :: i
 
-        source = 'module m'//new_line('a')// &
-            '  use dep, only: local => remote'//new_line('a')// &
-            '  private'//new_line('a')// &
-            '  integer, parameter :: n = 2'//new_line('a')// &
-            '  type :: pair'//new_line('a')// &
-            '    integer :: x'//new_line('a')// &
-            '  contains'//new_line('a')// &
-            '    procedure :: show'//new_line('a')// &
-            '  end type pair'//new_line('a')// &
-            'contains'//new_line('a')// &
-            '  subroutine show(self)'//new_line('a')// &
-            '    type(pair) :: self'//new_line('a')// &
-            '  end subroutine show'//new_line('a')// &
-            'end module m'//new_line('a')// &
-            'program p'//new_line('a')// &
-            '  use m'//new_line('a')// &
-            'end program p'
+        call read_example( &
+            'examples/f90/issue_2910_program_unit_query_forms.f90', source)
         call compile_parse_only(source, result, 'module and program')
 
         units = query_program_units(result%arena, result%root_index)
@@ -352,5 +337,7 @@ contains
         write (error_unit, '(2a)') 'FAIL: ', trim(message)
         error stop 1
     end subroutine require
+
+    include '../common/read_example.inc'
 
 end program test_compiler_program_unit_queries

--- a/test/api/test_compiler_statement_queries.f90
+++ b/test/api/test_compiler_statement_queries.f90
@@ -35,50 +35,8 @@ contains
     function statement_source() result(source)
         character(len=:), allocatable :: source
 
-        source = 'program statements'//new_line('a')// &
-            'class(*), allocatable :: object'//new_line('a')// &
-            'integer :: values(3), choice, ios'//new_line('a')// &
-            'logical :: mask(3), opened'//new_line('a')// &
-            "open(unit=10,file='data.txt',status='old',access='sequential',"// &
-            "form='formatted',recl=80,blank='null',position='rewind',"// &
-            "action='read',delim='quote',pad='yes',iostat=ios,err=900)"// &
-            new_line('a')// &
-            "close(unit=10,status='keep',iostat=ios,err=900)"//new_line('a')// &
-            'close(unit=11)'//new_line('a')// &
-            'rewind(unit=10,iostat=ios,err=900)'//new_line('a')// &
-            'backspace(unit=10,iostat=ios,err=900)'//new_line('a')// &
-            'endfile(unit=10,iostat=ios,err=900)'//new_line('a')// &
-            'inquire(unit=10,opened=opened,iostat=ios,err=900)'//new_line('a')// &
-            "print '(I0)', choice"//new_line('a')// &
-            "write(unit=10,fmt='(I0)',iostat=ios,err=900) choice"// &
-            new_line('a')// &
-            "read(unit=10,fmt='(I0)',iostat=ios,end=800,err=900) choice"// &
-            new_line('a')// &
-            '700 format(I0)'//new_line('a')// &
-            'associate(alias => choice)'//new_line('a')// &
-            'values(1) = alias'//new_line('a')//'end associate'//new_line('a')// &
-            'block'//new_line('a')//'integer :: local'//new_line('a')// &
-            'local = choice'//new_line('a')//'end block'//new_line('a')// &
-            'allocate(object, source=choice)'//new_line('a')// &
-            'select type (object)'//new_line('a')//'type is (integer)'// &
-            new_line('a')//'values(1) = object'//new_line('a')// &
-            'class default'//new_line('a')//'values(1) = 0'//new_line('a')// &
-            'end select'//new_line('a')//'select rank(values)'//new_line('a')// &
-            'rank(1)'//new_line('a')//'values = 1'//new_line('a')// &
-            'rank default'//new_line('a')//'values = 0'//new_line('a')// &
-            'end select'//new_line('a')//'where(mask)'//new_line('a')// &
-            'values = 1'//new_line('a')//'elsewhere(.not. mask)'//new_line('a')// &
-            'values = 2'//new_line('a')//'elsewhere'//new_line('a')// &
-            'values = 3'//new_line('a')//'end where'//new_line('a')// &
-            'where(mask) values = 3'//new_line('a')//'goto 100'//new_line('a')// &
-            'goto (100,200), choice'//new_line('a')//'pause 1'//new_line('a')// &
-            "pause 'hold'"//new_line('a')//'pause'//new_line('a')// &
-            '100 continue'//new_line('a')//'200 continue'//new_line('a')// &
-            '800 continue'//new_line('a')//'900 continue'//new_line('a')// &
-            'contains'//new_line('a')//'subroutine inner'//new_line('a')// &
-            'goto 100'//new_line('a')//'100 continue'//new_line('a')// &
-            'end subroutine inner'//new_line('a')// &
-            'end program statements'
+        call read_example('examples/f90/issue_2910_statement_query_forms.f90', &
+            source)
     end function statement_source
 
     subroutine test_io_queries(arena)
@@ -504,5 +462,7 @@ contains
         write (error_unit, '(A)') 'FAIL: '//message
         error stop 1
     end subroutine fail
+
+    include '../common/read_example.inc'
 
 end program test_compiler_statement_queries

--- a/test/api/test_issue_2924_corpus_accepted_forms.f90
+++ b/test/api/test_issue_2924_corpus_accepted_forms.f90
@@ -77,29 +77,8 @@ contains
         character(len=:), allocatable :: source
 
         print *, 'Coindexed type-bound call (accepted)...'
-        source = 'module m_coarray_call'//new_line('a')// &
-            'implicit none'//new_line('a')// &
-            'type :: t0'//new_line('a')// &
-            'contains'//new_line('a')// &
-            'procedure, nopass :: sub => t0_sub'//new_line('a')// &
-            'end type t0'//new_line('a')// &
-            'type :: t1'//new_line('a')// &
-            'type(t0) :: nopoly'//new_line('a')// &
-            'end type t1'//new_line('a')// &
-            'type :: t2'//new_line('a')// &
-            'type(t1) :: c'//new_line('a')// &
-            'end type t2'//new_line('a')// &
-            'contains'//new_line('a')// &
-            'subroutine t0_sub()'//new_line('a')// &
-            'print *, 1'//new_line('a')// &
-            'end subroutine t0_sub'//new_line('a')// &
-            'end module m_coarray_call'//new_line('a')// &
-            'program p_coarray_call'//new_line('a')// &
-            'use m_coarray_call, only: t2'//new_line('a')// &
-            'implicit none'//new_line('a')// &
-            'type(t2) :: x[*]'//new_line('a')// &
-            'call x[1]%c%nopoly%sub()'//new_line('a')// &
-            'end program p_coarray_call'
+        call read_example( &
+            'examples/f90/issue_2924_coindexed_type_bound_call.f90', source)
         call expect_frontend_success(source, passed)
     end subroutine test_coindexed_type_bound_call_accepted
 
@@ -110,25 +89,9 @@ contains
         character(len=:), allocatable :: source
 
         print *, 'Type-bound call under IMPLICIT NONE (EXTERNAL) (accepted)...'
-        source = 'module m_tbp_external'//new_line('a')// &
-            'implicit none (type, external)'//new_line('a')// &
-            'type :: box_t'//new_line('a')// &
-            'integer :: v = 1'//new_line('a')// &
-            'contains'//new_line('a')// &
-            'procedure :: show => box_show'//new_line('a')// &
-            'end type box_t'//new_line('a')// &
-            'contains'//new_line('a')// &
-            'subroutine box_show(self)'//new_line('a')// &
-            'class(box_t), intent(in) :: self'//new_line('a')// &
-            'print *, self%v'//new_line('a')// &
-            'end subroutine box_show'//new_line('a')// &
-            'end module m_tbp_external'//new_line('a')// &
-            'program p_tbp_external'//new_line('a')// &
-            'use m_tbp_external, only: box_t'//new_line('a')// &
-            'implicit none (type, external)'//new_line('a')// &
-            'type(box_t) :: b'//new_line('a')// &
-            'call b%show()'//new_line('a')// &
-            'end program p_tbp_external'
+        call read_example( &
+            'examples/f90/issue_2924_implicit_none_external_type_bound.f90', &
+            source)
         call expect_frontend_success(source, passed)
     end subroutine test_external_implicit_none_type_bound_accepted
 
@@ -311,5 +274,7 @@ contains
             print *, '  PASS'
         end if
     end subroutine expect_frontend_success
+
+    include '../common/read_example.inc'
 
 end program test_issue_2924_corpus_accepted_forms


### PR DESCRIPTION
Fixes #2910.

## Problem
`make check-duplication` had been failing since 2026-07-10 while CI reported green, because the step carried both `continue-on-error: true` and `|| echo ...`. A gate that cannot fail is not a gate.

## Change
1. Extracted the four oversized inline end-to-end fixtures into `examples/f90/` and read them via `read_example()`:
   - `issue_2910_statement_query_forms.f90` (was 57 inline `new_line('a')`)
   - `issue_2910_program_unit_query_forms.f90`
   - `issue_2924_coindexed_type_bound_call.f90`
   - `issue_2924_implicit_none_external_type_bound.f90`
   Registered in `examples/skip_all_examples.txt` (covered by targeted regression tests), the existing convention for fixtures owned by a focused test.
2. Removed `continue-on-error` and the `|| echo` swallow from the CI step.
3. Added `scripts/test_check_test_duplication.sh` / `make check-duplication-gate`: a permanent negative control that asserts the clean tree passes AND that a deliberately added inline end-to-end fixture makes the gate fail. CI runs it right after the gate, so a future re-suppression is itself detectable.
4. Corrected the two false claims in `CLAUDE.md` (status and enforcement) and the workflow README's "WARNING mode" line.

## Preserved invariant
No compiler behavior changes. The extracted fixture text is byte-equivalent in meaning to the previous inline strings; all four tests still assert the same query results, so the frontend contract they pin is unchanged.

## Red evidence (unmodified main, 23677658)
```
VIOLATIONS (must fix): 3 tests
  test/api/test_compiler_statement_queries.f90:38 (57 new_line('a'))
  test/api/test_issue_2924_corpus_accepted_forms.f90:80 (22 new_line('a'))
  test/api/test_compiler_program_unit_queries.f90:37 (16 new_line('a'))
FAIL: Found 3 end-to-end test violations   (exit 2)
```

## Green evidence
```
make check-duplication      -> PASS: No end-to-end test violations found
make check-duplication-gate -> PASS: clean tree accepted by the duplication gate
                               PASS: inline end-to-end fixture rejected by the duplication gate
fo                          -> Tests: OK (483 passed) / Lint: OK / All stages passed
```
