### PR TITLE
Give monomorphic procedure copies their own body nodes (#2958)

### DIFF
--- a/src/ast/ast_subtree_clone.f90
+++ b/src/ast/ast_subtree_clone.f90
@@ -1,0 +1,1289 @@
+module ast_subtree_clone
+    ! Deep-copies an AST subtree into fresh arena nodes so a transformation
+    ! can give a generated procedure its own body instead of sharing the
+    ! original procedure's statements (issue #2958). Each clone is linked to
+    ! its cloned parent, so a name reference inside the clone resolves inside
+    ! the cloning procedure rather than in the original one.
+    use ast_arena_modern, only: ast_arena_t, link_children_to_parent
+    use ast_base, only: ast_node
+    use ast_nodes_array, only: where_node, where_stmt_node
+    use ast_nodes_associate, only: associate_node, block_construct_node
+    use ast_nodes_bounds, only: array_bounds_node, array_operation_node, &
+        array_slice_node, range_expression_node
+    use ast_nodes_conditional, only: case_block_node, case_default_node, &
+        if_node, rank_block_node, &
+        select_case_node, select_rank_node, &
+        select_type_node, type_guard_block_node
+    use ast_nodes_core, only: array_literal_node, assignment_node, &
+        binary_op_node, call_or_subscript_node, &
+        component_access_node, pointer_assignment_node, &
+        program_node, range_subscript_node
+    use ast_nodes_data, only: block_data_node, declaration_node, &
+        derived_type_node, mixed_construct_container_node, &
+        module_node, multi_unit_container_node, &
+        parameter_declaration_node, submodule_node
+    use ast_nodes_generics, only: implements_block_node, requirement_block_node, &
+        template_block_node, trait_block_node
+    use ast_nodes_io, only: backspace_statement_node, close_statement_node, &
+        endfile_statement_node, inquire_statement_node, &
+        io_implied_do_node, open_statement_node, &
+        print_statement_node, read_statement_node, &
+        rewind_statement_node, write_statement_node
+    use ast_nodes_loops, only: do_loop_node, do_while_node, &
+        forall_node
+    use ast_nodes_misc, only: allocate_statement_node, complex_literal_node, &
+        data_statement_node, deallocate_statement_node, &
+        interface_block_node, statement_function_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_call_node, &
+        subroutine_def_node
+    use ast_nodes_transfer, only: entry_node, error_stop_node, &
+        goto_node, nullify_node, &
+        pause_node, return_node, &
+        stop_node
+    use uid_generator, only: generate_uid
+    implicit none
+    private
+
+    public :: clone_ast_subtree
+
+contains
+
+    ! Clone the node at node_index and, recursively, everything it owns.
+    ! Returns the index of the cloned root; an invalid index is returned as-is.
+    recursive function clone_ast_subtree(arena, node_index) result(new_index)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: node_index
+        integer :: new_index
+        class(ast_node), allocatable :: work
+        character(len=:), allocatable :: node_type
+
+        new_index = node_index
+        if (node_index < 1) return
+        if (node_index > arena%size) return
+        if (.not. arena%has_node_at(node_index)) return
+
+        allocate (work, source=arena%entries(node_index)%node)
+        node_type = trim(arena%entries(node_index)%node_type)
+        new_index = clone_work_node(arena, work, node_type)
+        if (new_index <= 0) new_index = node_index
+    end function clone_ast_subtree
+
+    recursive function clone_child_list(arena, indices) result(new_indices)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: indices(:)
+        integer :: new_indices(size(indices))
+        integer :: i
+
+        do i = 1, size(indices)
+            new_indices(i) = clone_ast_subtree(arena, indices(i))
+        end do
+    end function clone_child_list
+
+    subroutine link_child(arena, parent_index, child_index)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: parent_index
+        integer, intent(in) :: child_index
+        integer :: one_child(1)
+
+        if (child_index < 1) return
+        one_child(1) = child_index
+        call link_children_to_parent(arena, parent_index, one_child)
+    end subroutine link_child
+
+    recursive function clone_work_node(arena, work, node_type) result(new_index)
+        type(ast_arena_t), intent(inout) :: arena
+        class(ast_node), intent(in) :: work
+        character(len=*), intent(in) :: node_type
+        integer :: new_index
+
+        new_index = 0
+        select type (src => work)
+        type is (allocate_statement_node)
+            block
+                type(allocate_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%var_indices)) then
+                    copy%var_indices = clone_child_list(arena, copy%var_indices)
+                end if
+                if (allocated(copy%shape_indices)) then
+                    copy%shape_indices = clone_child_list(arena, copy%shape_indices)
+                end if
+                copy%stat_var_index = clone_ast_subtree(arena, copy%stat_var_index)
+                copy%errmsg_var_index = clone_ast_subtree(arena, copy%errmsg_var_index)
+                copy%source_expr_index = clone_ast_subtree( &
+                    arena, copy%source_expr_index)
+                copy%mold_expr_index = clone_ast_subtree(arena, copy%mold_expr_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%var_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%var_indices)
+                end if
+                if (allocated(copy%shape_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%shape_indices)
+                end if
+                call link_child(arena, new_index, copy%stat_var_index)
+                call link_child(arena, new_index, copy%errmsg_var_index)
+                call link_child(arena, new_index, copy%source_expr_index)
+                call link_child(arena, new_index, copy%mold_expr_index)
+            end block
+        type is (array_bounds_node)
+            block
+                type(array_bounds_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%lower_bound_index = clone_ast_subtree( &
+                    arena, copy%lower_bound_index)
+                copy%upper_bound_index = clone_ast_subtree( &
+                    arena, copy%upper_bound_index)
+                copy%stride_index = clone_ast_subtree(arena, copy%stride_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%lower_bound_index)
+                call link_child(arena, new_index, copy%upper_bound_index)
+                call link_child(arena, new_index, copy%stride_index)
+            end block
+        type is (array_literal_node)
+            block
+                type(array_literal_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%element_indices)) then
+                    copy%element_indices = clone_child_list(arena, copy%element_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%element_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%element_indices)
+                end if
+            end block
+        type is (array_operation_node)
+            block
+                type(array_operation_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%left_operand_index = clone_ast_subtree( &
+                    arena, copy%left_operand_index)
+                copy%right_operand_index = clone_ast_subtree( &
+                    arena, copy%right_operand_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%left_operand_index)
+                call link_child(arena, new_index, copy%right_operand_index)
+            end block
+        type is (array_slice_node)
+            block
+                type(array_slice_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%array_index = clone_ast_subtree(arena, copy%array_index)
+                copy%bounds_indices = clone_child_list(arena, copy%bounds_indices)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%array_index)
+                call link_children_to_parent(arena, new_index, copy%bounds_indices)
+            end block
+        type is (assignment_node)
+            block
+                type(assignment_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%target_index = clone_ast_subtree(arena, copy%target_index)
+                copy%value_index = clone_ast_subtree(arena, copy%value_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%target_index)
+                call link_child(arena, new_index, copy%value_index)
+            end block
+        type is (associate_node)
+            block
+                type(associate_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (backspace_statement_node)
+            block
+                type(backspace_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%iostat_var_index = clone_ast_subtree(arena, copy%iostat_var_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%iostat_var_index)
+            end block
+        type is (binary_op_node)
+            block
+                type(binary_op_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%left_index = clone_ast_subtree(arena, copy%left_index)
+                copy%right_index = clone_ast_subtree(arena, copy%right_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%left_index)
+                call link_child(arena, new_index, copy%right_index)
+            end block
+        type is (block_construct_node)
+            block
+                type(block_construct_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (block_data_node)
+            block
+                type(block_data_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%statement_indices)) then
+                    copy%statement_indices = clone_child_list( &
+                        arena, copy%statement_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%statement_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%statement_indices)
+                end if
+            end block
+        type is (call_or_subscript_node)
+            block
+                type(call_or_subscript_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%base_expr_index = clone_ast_subtree(arena, copy%base_expr_index)
+                if (allocated(copy%arg_indices)) then
+                    copy%arg_indices = clone_child_list(arena, copy%arg_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%base_expr_index)
+                if (allocated(copy%arg_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%arg_indices)
+                end if
+            end block
+        type is (case_block_node)
+            block
+                type(case_block_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%value_indices)) then
+                    copy%value_indices = clone_child_list(arena, copy%value_indices)
+                end if
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%value_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%value_indices)
+                end if
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (case_default_node)
+            block
+                type(case_default_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (close_statement_node)
+            block
+                type(close_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%iostat_var_index = clone_ast_subtree(arena, copy%iostat_var_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%iostat_var_index)
+            end block
+        type is (complex_literal_node)
+            block
+                type(complex_literal_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%real_index = clone_ast_subtree(arena, copy%real_index)
+                copy%imag_index = clone_ast_subtree(arena, copy%imag_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%real_index)
+                call link_child(arena, new_index, copy%imag_index)
+            end block
+        type is (component_access_node)
+            block
+                type(component_access_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%base_expr_index = clone_ast_subtree(arena, copy%base_expr_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%base_expr_index)
+            end block
+        type is (data_statement_node)
+            block
+                type(data_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%object_indices)) then
+                    copy%object_indices = clone_child_list(arena, copy%object_indices)
+                end if
+                if (allocated(copy%value_indices)) then
+                    copy%value_indices = clone_child_list(arena, copy%value_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%object_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%object_indices)
+                end if
+                if (allocated(copy%value_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%value_indices)
+                end if
+            end block
+        type is (deallocate_statement_node)
+            block
+                type(deallocate_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%var_indices)) then
+                    copy%var_indices = clone_child_list(arena, copy%var_indices)
+                end if
+                copy%stat_var_index = clone_ast_subtree(arena, copy%stat_var_index)
+                copy%errmsg_var_index = clone_ast_subtree(arena, copy%errmsg_var_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%var_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%var_indices)
+                end if
+                call link_child(arena, new_index, copy%stat_var_index)
+                call link_child(arena, new_index, copy%errmsg_var_index)
+            end block
+        type is (declaration_node)
+            block
+                type(declaration_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%initializer_index = clone_ast_subtree( &
+                    arena, copy%initializer_index)
+                if (allocated(copy%dimension_indices)) then
+                    copy%dimension_indices = clone_child_list( &
+                        arena, copy%dimension_indices)
+                end if
+                if (allocated(copy%type_param_indices)) then
+                    copy%type_param_indices = clone_child_list( &
+                        arena, copy%type_param_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%initializer_index)
+                if (allocated(copy%dimension_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%dimension_indices)
+                end if
+                if (allocated(copy%type_param_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%type_param_indices)
+                end if
+            end block
+        type is (derived_type_node)
+            block
+                type(derived_type_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%component_indices)) then
+                    copy%component_indices = clone_child_list( &
+                        arena, copy%component_indices)
+                end if
+                if (allocated(copy%param_indices)) then
+                    copy%param_indices = clone_child_list(arena, copy%param_indices)
+                end if
+                if (allocated(copy%binding_indices)) then
+                    copy%binding_indices = clone_child_list(arena, copy%binding_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%component_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%component_indices)
+                end if
+                if (allocated(copy%param_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%param_indices)
+                end if
+                if (allocated(copy%binding_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%binding_indices)
+                end if
+            end block
+        type is (do_loop_node)
+            block
+                type(do_loop_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%start_expr_index = clone_ast_subtree(arena, copy%start_expr_index)
+                copy%end_expr_index = clone_ast_subtree(arena, copy%end_expr_index)
+                copy%step_expr_index = clone_ast_subtree(arena, copy%step_expr_index)
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%start_expr_index)
+                call link_child(arena, new_index, copy%end_expr_index)
+                call link_child(arena, new_index, copy%step_expr_index)
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (do_while_node)
+            block
+                type(do_while_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%condition_index = clone_ast_subtree(arena, copy%condition_index)
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%condition_index)
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (endfile_statement_node)
+            block
+                type(endfile_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%iostat_var_index = clone_ast_subtree(arena, copy%iostat_var_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%iostat_var_index)
+            end block
+        type is (entry_node)
+            block
+                type(entry_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%param_indices)) then
+                    copy%param_indices = clone_child_list(arena, copy%param_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%param_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%param_indices)
+                end if
+            end block
+        type is (error_stop_node)
+            block
+                type(error_stop_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%error_code_index = clone_ast_subtree(arena, copy%error_code_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%error_code_index)
+            end block
+        type is (forall_node)
+            block
+                type(forall_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%lower_bound_indices)) then
+                    copy%lower_bound_indices = clone_child_list( &
+                        arena, copy%lower_bound_indices)
+                end if
+                if (allocated(copy%upper_bound_indices)) then
+                    copy%upper_bound_indices = clone_child_list( &
+                        arena, copy%upper_bound_indices)
+                end if
+                if (allocated(copy%stride_indices)) then
+                    copy%stride_indices = clone_child_list(arena, copy%stride_indices)
+                end if
+                copy%mask_expr_index = clone_ast_subtree(arena, copy%mask_expr_index)
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%lower_bound_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%lower_bound_indices)
+                end if
+                if (allocated(copy%upper_bound_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%upper_bound_indices)
+                end if
+                if (allocated(copy%stride_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%stride_indices)
+                end if
+                call link_child(arena, new_index, copy%mask_expr_index)
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (function_def_node)
+            block
+                type(function_def_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%param_indices)) then
+                    copy%param_indices = clone_child_list(arena, copy%param_indices)
+                end if
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%param_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%param_indices)
+                end if
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (goto_node)
+            block
+                type(goto_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%selector_index = clone_ast_subtree(arena, copy%selector_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%selector_index)
+            end block
+        type is (if_node)
+            block
+                type(if_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%condition_index = clone_ast_subtree(arena, copy%condition_index)
+                if (allocated(copy%then_body_indices)) then
+                    copy%then_body_indices = clone_child_list( &
+                        arena, copy%then_body_indices)
+                end if
+                if (allocated(copy%else_body_indices)) then
+                    copy%else_body_indices = clone_child_list( &
+                        arena, copy%else_body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%condition_index)
+                if (allocated(copy%then_body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%then_body_indices)
+                end if
+                if (allocated(copy%else_body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%else_body_indices)
+                end if
+            end block
+        type is (implements_block_node)
+            block
+                type(implements_block_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%declaration_indices)) then
+                    copy%declaration_indices = clone_child_list( &
+                        arena, copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    copy%procedure_indices = clone_child_list( &
+                        arena, copy%procedure_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%declaration_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%procedure_indices)
+                end if
+            end block
+        type is (inquire_statement_node)
+            block
+                type(inquire_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%iostat_var_index = clone_ast_subtree(arena, copy%iostat_var_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%iostat_var_index)
+            end block
+        type is (interface_block_node)
+            block
+                type(interface_block_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%procedure_indices)) then
+                    copy%procedure_indices = clone_child_list( &
+                        arena, copy%procedure_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%procedure_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%procedure_indices)
+                end if
+            end block
+        type is (io_implied_do_node)
+            block
+                type(io_implied_do_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%expr_index = clone_ast_subtree(arena, copy%expr_index)
+                if (allocated(copy%object_indices)) then
+                    copy%object_indices = clone_child_list(arena, copy%object_indices)
+                end if
+                copy%start_expr_index = clone_ast_subtree(arena, copy%start_expr_index)
+                copy%end_expr_index = clone_ast_subtree(arena, copy%end_expr_index)
+                copy%step_expr_index = clone_ast_subtree(arena, copy%step_expr_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%expr_index)
+                if (allocated(copy%object_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%object_indices)
+                end if
+                call link_child(arena, new_index, copy%start_expr_index)
+                call link_child(arena, new_index, copy%end_expr_index)
+                call link_child(arena, new_index, copy%step_expr_index)
+            end block
+        type is (mixed_construct_container_node)
+            block
+                type(mixed_construct_container_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%implicit_declaration_indices)) then
+                    copy%implicit_declaration_indices = clone_child_list( &
+                        arena, copy%implicit_declaration_indices)
+                end if
+                if (allocated(copy%explicit_program_indices)) then
+                    copy%explicit_program_indices = clone_child_list( &
+                        arena, copy%explicit_program_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%implicit_declaration_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%implicit_declaration_indices)
+                end if
+                if (allocated(copy%explicit_program_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%explicit_program_indices)
+                end if
+            end block
+        type is (module_node)
+            block
+                type(module_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%declaration_indices)) then
+                    copy%declaration_indices = clone_child_list( &
+                        arena, copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    copy%procedure_indices = clone_child_list( &
+                        arena, copy%procedure_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%declaration_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%procedure_indices)
+                end if
+            end block
+        type is (multi_unit_container_node)
+            block
+                type(multi_unit_container_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (nullify_node)
+            block
+                type(nullify_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%pointer_indices)) then
+                    copy%pointer_indices = clone_child_list(arena, copy%pointer_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%pointer_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%pointer_indices)
+                end if
+            end block
+        type is (open_statement_node)
+            block
+                type(open_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%iostat_var_index = clone_ast_subtree(arena, copy%iostat_var_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%iostat_var_index)
+            end block
+        type is (parameter_declaration_node)
+            block
+                type(parameter_declaration_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%dimension_indices)) then
+                    copy%dimension_indices = clone_child_list( &
+                        arena, copy%dimension_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%dimension_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%dimension_indices)
+                end if
+            end block
+        type is (pause_node)
+            block
+                type(pause_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%pause_code_index = clone_ast_subtree(arena, copy%pause_code_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%pause_code_index)
+            end block
+        type is (pointer_assignment_node)
+            block
+                type(pointer_assignment_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%pointer_index = clone_ast_subtree(arena, copy%pointer_index)
+                copy%target_index = clone_ast_subtree(arena, copy%target_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%pointer_index)
+                call link_child(arena, new_index, copy%target_index)
+            end block
+        type is (print_statement_node)
+            block
+                type(print_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%expression_indices)) then
+                    copy%expression_indices = clone_child_list( &
+                        arena, copy%expression_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%expression_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%expression_indices)
+                end if
+            end block
+        type is (program_node)
+            block
+                type(program_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (range_expression_node)
+            block
+                type(range_expression_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%start_index = clone_ast_subtree(arena, copy%start_index)
+                copy%end_index = clone_ast_subtree(arena, copy%end_index)
+                copy%stride_index = clone_ast_subtree(arena, copy%stride_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%start_index)
+                call link_child(arena, new_index, copy%end_index)
+                call link_child(arena, new_index, copy%stride_index)
+            end block
+        type is (range_subscript_node)
+            block
+                type(range_subscript_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%base_expr_index = clone_ast_subtree(arena, copy%base_expr_index)
+                copy%start_index = clone_ast_subtree(arena, copy%start_index)
+                copy%end_index = clone_ast_subtree(arena, copy%end_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%base_expr_index)
+                call link_child(arena, new_index, copy%start_index)
+                call link_child(arena, new_index, copy%end_index)
+            end block
+        type is (rank_block_node)
+            block
+                type(rank_block_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (read_statement_node)
+            block
+                type(read_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%var_indices)) then
+                    copy%var_indices = clone_child_list(arena, copy%var_indices)
+                end if
+                copy%iostat_var_index = clone_ast_subtree(arena, copy%iostat_var_index)
+                copy%format_expr_index = clone_ast_subtree( &
+                    arena, copy%format_expr_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%var_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%var_indices)
+                end if
+                call link_child(arena, new_index, copy%iostat_var_index)
+                call link_child(arena, new_index, copy%format_expr_index)
+            end block
+        type is (requirement_block_node)
+            block
+                type(requirement_block_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%declaration_indices)) then
+                    copy%declaration_indices = clone_child_list( &
+                        arena, copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    copy%procedure_indices = clone_child_list( &
+                        arena, copy%procedure_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%declaration_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%procedure_indices)
+                end if
+            end block
+        type is (return_node)
+            block
+                type(return_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%selector_index = clone_ast_subtree(arena, copy%selector_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%selector_index)
+            end block
+        type is (rewind_statement_node)
+            block
+                type(rewind_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%iostat_var_index = clone_ast_subtree(arena, copy%iostat_var_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%iostat_var_index)
+            end block
+        type is (select_case_node)
+            block
+                type(select_case_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%selector_index = clone_ast_subtree(arena, copy%selector_index)
+                if (allocated(copy%case_indices)) then
+                    copy%case_indices = clone_child_list(arena, copy%case_indices)
+                end if
+                copy%default_index = clone_ast_subtree(arena, copy%default_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%selector_index)
+                if (allocated(copy%case_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%case_indices)
+                end if
+                call link_child(arena, new_index, copy%default_index)
+            end block
+        type is (select_rank_node)
+            block
+                type(select_rank_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%selector_index = clone_ast_subtree(arena, copy%selector_index)
+                if (allocated(copy%rank_indices)) then
+                    copy%rank_indices = clone_child_list(arena, copy%rank_indices)
+                end if
+                copy%default_index = clone_ast_subtree(arena, copy%default_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%selector_index)
+                if (allocated(copy%rank_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%rank_indices)
+                end if
+                call link_child(arena, new_index, copy%default_index)
+            end block
+        type is (select_type_node)
+            block
+                type(select_type_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%selector_index = clone_ast_subtree(arena, copy%selector_index)
+                if (allocated(copy%guard_indices)) then
+                    copy%guard_indices = clone_child_list(arena, copy%guard_indices)
+                end if
+                copy%default_index = clone_ast_subtree(arena, copy%default_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%selector_index)
+                if (allocated(copy%guard_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%guard_indices)
+                end if
+                call link_child(arena, new_index, copy%default_index)
+            end block
+        type is (statement_function_node)
+            block
+                type(statement_function_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%body_expr_index = clone_ast_subtree(arena, copy%body_expr_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%body_expr_index)
+            end block
+        type is (stop_node)
+            block
+                type(stop_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%stop_code_index = clone_ast_subtree(arena, copy%stop_code_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%stop_code_index)
+            end block
+        type is (submodule_node)
+            block
+                type(submodule_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%declaration_indices)) then
+                    copy%declaration_indices = clone_child_list( &
+                        arena, copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    copy%procedure_indices = clone_child_list( &
+                        arena, copy%procedure_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%declaration_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%procedure_indices)
+                end if
+            end block
+        type is (subroutine_call_node)
+            block
+                type(subroutine_call_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%arg_indices)) then
+                    copy%arg_indices = clone_child_list(arena, copy%arg_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%arg_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%arg_indices)
+                end if
+            end block
+        type is (subroutine_def_node)
+            block
+                type(subroutine_def_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%param_indices)) then
+                    copy%param_indices = clone_child_list(arena, copy%param_indices)
+                end if
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%param_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%param_indices)
+                end if
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (template_block_node)
+            block
+                type(template_block_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%declaration_indices)) then
+                    copy%declaration_indices = clone_child_list( &
+                        arena, copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    copy%procedure_indices = clone_child_list( &
+                        arena, copy%procedure_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%declaration_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%procedure_indices)
+                end if
+            end block
+        type is (trait_block_node)
+            block
+                type(trait_block_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%declaration_indices)) then
+                    copy%declaration_indices = clone_child_list( &
+                        arena, copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    copy%procedure_indices = clone_child_list( &
+                        arena, copy%procedure_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%declaration_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%declaration_indices)
+                end if
+                if (allocated(copy%procedure_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%procedure_indices)
+                end if
+            end block
+        type is (type_guard_block_node)
+            block
+                type(type_guard_block_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%body_indices)) then
+                    copy%body_indices = clone_child_list(arena, copy%body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%body_indices)
+                end if
+            end block
+        type is (where_node)
+            block
+                type(where_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%mask_expr_index = clone_ast_subtree(arena, copy%mask_expr_index)
+                if (allocated(copy%where_body_indices)) then
+                    copy%where_body_indices = clone_child_list( &
+                        arena, copy%where_body_indices)
+                end if
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%mask_expr_index)
+                if (allocated(copy%where_body_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%where_body_indices)
+                end if
+            end block
+        type is (where_stmt_node)
+            block
+                type(where_stmt_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                copy%mask_expr_index = clone_ast_subtree(arena, copy%mask_expr_index)
+                copy%assignment_index = clone_ast_subtree(arena, copy%assignment_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                call link_child(arena, new_index, copy%mask_expr_index)
+                call link_child(arena, new_index, copy%assignment_index)
+            end block
+        type is (write_statement_node)
+            block
+                type(write_statement_node) :: copy
+
+                copy = src
+                copy%uid = generate_uid()
+                if (allocated(copy%arg_indices)) then
+                    copy%arg_indices = clone_child_list(arena, copy%arg_indices)
+                end if
+                copy%iostat_var_index = clone_ast_subtree(arena, copy%iostat_var_index)
+                copy%format_expr_index = clone_ast_subtree( &
+                    arena, copy%format_expr_index)
+                call arena%push(copy, node_type)
+                new_index = arena%size
+                if (allocated(copy%arg_indices)) then
+                    call link_children_to_parent(arena, new_index, &
+                                                 copy%arg_indices)
+                end if
+                call link_child(arena, new_index, copy%iostat_var_index)
+                call link_child(arena, new_index, copy%format_expr_index)
+            end block
+        class default
+            block
+                class(ast_node), allocatable :: copy
+
+                allocate (copy, source=src)
+                copy%uid = generate_uid()
+                call arena%push(copy, node_type)
+                new_index = arena%size
+            end block
+        end select
+    end function clone_work_node
+
+end module ast_subtree_clone

--- a/src/standardizers/ast_monomorphization.f90
+++ b/src/standardizers/ast_monomorphization.f90
@@ -1,6 +1,7 @@
 module ast_monomorphization
     use, intrinsic :: iso_fortran_env, only: error_unit
-    use ast_arena_modern, only: ast_arena_t
+    use ast_arena_modern, only: ast_arena_t, link_children_to_parent
+    use ast_subtree_clone, only: clone_ast_subtree
     use ast_nodes_core, only: program_node, call_or_subscript_node, &
         assignment_node, identifier_node, literal_node, &
         create_program

--- a/src/standardizers/ast_monomorphization_part2.inc
+++ b/src/standardizers/ast_monomorphization_part2.inc
@@ -826,6 +826,14 @@
 
         call arena%push(new_func, "function_def")
         new_idx = arena%size
+        ! Issue #2958: the specialization must own its parameters and body so
+        ! that every name inside it resolves to a declaration of this copy.
+        if (allocated(new_param_indices)) then
+            call link_children_to_parent(arena, new_idx, new_param_indices)
+        end if
+        if (allocated(body_indices_copy)) then
+            call link_children_to_parent(arena, new_idx, body_indices_copy)
+        end if
     end function clone_function_with_signature
 
     function clone_function_parameters(arena, orig_func, signature) &
@@ -890,6 +898,7 @@
         integer :: new_idx
         type(subroutine_def_node), pointer :: orig_subr
         type(subroutine_def_node) :: new_subr
+        integer :: body_i
         integer, allocatable :: new_param_indices(:)
         integer, allocatable :: body_indices_copy(:)
         character(len=:), allocatable :: mangled_name
@@ -917,6 +926,15 @@
         if (allocated(orig_subr%body_indices)) then
             allocate (body_indices_copy(size(orig_subr%body_indices)))
             body_indices_copy = orig_subr%body_indices
+            do body_i = 1, size(body_indices_copy)
+                body_indices_copy(body_i) = clone_ast_subtree(arena, &
+                                                              body_indices_copy(body_i))
+            end do
+            call get_subroutine_node(arena, sub_idx, orig_subr)
+            if (.not. associated(orig_subr)) then
+                new_idx = 0
+                return
+            end if
         else
             allocate (body_indices_copy(0))
         end if
@@ -957,6 +975,12 @@
 
         call arena%push(new_subr, "subroutine_def")
         new_idx = arena%size
+        if (allocated(new_param_indices)) then
+            call link_children_to_parent(arena, new_idx, new_param_indices)
+        end if
+        if (allocated(body_indices_copy)) then
+            call link_children_to_parent(arena, new_idx, body_indices_copy)
+        end if
 
         call infer_intent_for_cloned_subroutine(arena, new_idx, new_subr)
     end function clone_subroutine_with_signature

--- a/src/standardizers/ast_monomorphization_part3.inc
+++ b/src/standardizers/ast_monomorphization_part3.inc
@@ -31,7 +31,6 @@
         integer, allocatable :: body_indices_copy(:)
         character(len=:), allocatable :: lowered_return
         integer :: i
-        type(declaration_node) :: decl_copy
         logical :: has_result_decl
         integer :: new_decl_idx
         integer, allocatable :: dim_indices(:)
@@ -51,7 +50,11 @@
             original_body_indices = orig_func%body_indices
             allocate (body_indices_copy(size(original_body_indices)))
             do i = 1, size(original_body_indices)
-                body_indices_copy(i) = original_body_indices(i)
+                ! Issue #2958: the specialization owns its body. Sharing the
+                ! original statements left every name in the copy bound to the
+                ! original procedure's declarations.
+                body_indices_copy(i) = clone_ast_subtree(arena, &
+                                                         original_body_indices(i))
                 if (body_indices_copy(i) < 1) cycle
                 if (body_indices_copy(i) > arena%size) cycle
                 if (.not. allocated(arena%entries(body_indices_copy(i))%node)) cycle
@@ -61,33 +64,29 @@
                     if (.not. allocated(decl%var_name)) cycle
                     if (trim(decl%var_name) /= trim(result_name)) cycle
                     has_result_decl = .true.
-                    decl_copy = decl
-                    decl_copy%uid = generate_uid()
                     if (len_trim(return_type) > 0) then
-                        decl_copy%type_name = trim(return_type)
+                        decl%type_name = trim(return_type)
                     end if
-                    decl_copy%has_kind = .false.
+                    decl%has_kind = .false.
                     if (len_trim(lowered_return) > 0) then
-                        decl_copy%is_allocatable = &
+                        decl%is_allocatable = &
                             index(lowered_return, "allocatable") > 0
-                        decl_copy%is_array = &
+                        decl%is_array = &
                             index(lowered_return, "dimension(") > 0
                     else
-                        decl_copy%is_allocatable = .false.
-                        decl_copy%is_array = .false.
+                        decl%is_allocatable = .false.
+                        decl%is_array = .false.
                     end if
-                    if (decl_copy%is_array) then
+                    if (decl%is_array) then
                         call extract_dimension_from_type_string( &
-                             decl_copy%type_name, decl_copy%dimension_indices)
-                        decl_copy%type_name = strip_dimension_from_type( &
-                             decl_copy%type_name)
+                             decl%type_name, decl%dimension_indices)
+                        decl%type_name = strip_dimension_from_type( &
+                             decl%type_name)
                     else
-                        if (allocated(decl_copy%dimension_indices)) then
-                            deallocate (decl_copy%dimension_indices)
+                        if (allocated(decl%dimension_indices)) then
+                            deallocate (decl%dimension_indices)
                         end if
                     end if
-                    call arena%push(decl_copy, "declaration")
-                    body_indices_copy(i) = arena%size
                 end select
             end do
         else

--- a/test/api/test_issue_2958_monomorph_body_binding.f90
+++ b/test/api/test_issue_2958_monomorph_body_binding.f90
@@ -1,0 +1,107 @@
+program test_issue_2958_monomorph_body_binding
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use ast_nodes_core, only: identifier_node
+    use ast_nodes_procedure, only: function_def_node
+    use fortfront_compiler, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string, &
+        INPUT_MODE_LAZY, declaration_binding_t, resolve_name_at_node
+    implicit none
+
+    call test_monomorphic_copies_own_their_body()
+    print *, 'PASS: monomorphic copies own their body bindings'
+
+contains
+
+    subroutine test_monomorphic_copies_own_their_body()
+        type(compiler_frontend_result_t) :: result
+        type(compiler_frontend_options_t) :: options
+        integer :: i, j, func_index, checked
+        integer, allocatable :: body(:)
+        character(len=:), allocatable :: fname
+
+        options = compiler_frontend_options_t()
+        options%input_mode = INPUT_MODE_LAZY
+        options%run_semantics = .true.
+        options%standardize = .true.
+        call compile_frontend_from_string( &
+            'function twice(x)'//new_line('a')// &
+            '  twice = 2 * x'//new_line('a')// &
+            'end function'//new_line('a')// &
+            'print *, twice(3)'//new_line('a')// &
+            'print *, twice(2.5)'//new_line('a'), result, options)
+        if (.not. result%success()) then
+            write (error_unit, '(A)') 'FAIL: frontend rejected reproducer'
+            if (allocated(result%error_msg)) then
+                write (error_unit, '(A)') result%error_msg
+            end if
+            error stop 1
+        end if
+
+        checked = 0
+        do i = 1, result%arena%size
+            if (.not. result%arena%has_node_at(i)) cycle
+            select type (node => result%arena%entries(i)%node)
+            type is (function_def_node)
+                if (.not. allocated(node%name)) cycle
+                fname = trim(node%name)
+                if (index(fname, 'twice__') /= 1) cycle
+                if (.not. allocated(node%body_indices)) cycle
+                body = node%body_indices
+                func_index = i
+            class default
+                cycle
+            end select
+            do j = 1, size(body)
+                call check_subtree(result, body(j), func_index, fname, checked)
+            end do
+        end do
+
+        if (checked == 0) then
+            write (error_unit, '(A)') &
+                'FAIL: no monomorphic copy body reference to x was found'
+            error stop 1
+        end if
+    end subroutine test_monomorphic_copies_own_their_body
+
+    recursive subroutine check_subtree(result, node_index, func_index, fname, &
+                                       checked)
+        type(compiler_frontend_result_t), intent(in) :: result
+        integer, intent(in) :: node_index
+        integer, intent(in) :: func_index
+        character(len=*), intent(in) :: fname
+        integer, intent(inout) :: checked
+        type(declaration_binding_t) :: binding
+        character(len=:), allocatable :: error_msg
+        integer :: k
+
+        if (node_index < 1 .or. node_index > result%arena%size) return
+        if (.not. result%arena%has_node_at(node_index)) return
+        select type (node => result%arena%entries(node_index)%node)
+        type is (identifier_node)
+            if (.not. allocated(node%name)) return
+            if (trim(node%name) /= 'x') return
+            call resolve_name_at_node(result%arena, node_index, 'x', binding, &
+                                      error_msg)
+            checked = checked + 1
+            if (len_trim(error_msg) > 0) then
+                write (error_unit, '(A)') 'FAIL: '//trim(error_msg)
+                error stop 1
+            end if
+            if (.not. binding%found) then
+                write (error_unit, '(A)') 'FAIL: x unresolved in '//fname
+                error stop 1
+            end if
+            if (binding%scope_node_index /= func_index) then
+                write (error_unit, '(A)') &
+                    'FAIL: x in '//fname//' binds outside its own procedure'
+                error stop 1
+            end if
+        end select
+        do k = 1, result%arena%size
+            if (.not. result%arena%has_node_at(k)) cycle
+            if (result%arena%entries(k)%parent_index /= node_index) cycle
+            call check_subtree(result, k, func_index, fname, checked)
+        end do
+    end subroutine check_subtree
+
+end program test_issue_2958_monomorph_body_binding


### PR DESCRIPTION
Fixes #2958.

## Problem

`transform_monomorphization` gave each concrete signature a fresh
`function_def_node` with fresh parameter nodes, but reused the ORIGINAL
procedure's body statement nodes. A body node has exactly one parent in the
arena, so every name reference in a specialization resolved into the original
(untyped) procedure's scope. A backend consuming FortFront name resolution
cannot lower such a copy (ffc: `integer identifier was not declared: x`).

The copies' parameter and body nodes were also never linked to the copy at all
(`parent_index == 0`), so the specialization was not even a scope.

## Change

- New `src/ast/ast_subtree_clone.f90`: `clone_ast_subtree(arena, node_index)`
  deep-copies an AST subtree into fresh arena nodes, rewriting every owned child
  index and linking each clone to its cloned parent. Node types without child
  indices fall through to a shallow clone of the node itself.
- `ast_monomorphization` now clones the body of each function and subroutine
  specialization instead of sharing it, and links the copy's parameters and body
  to the copy so it is a real scope.

Preserved invariant: within a procedure node, every name reference resolves to a
declaration in that same procedure.

## Evidence

Red (origin/main worktree, new test `test/api/test_issue_2958_monomorph_body_binding.f90`):

```
FAIL: x in twice__i32 binds outside its own procedure
Summary: 0 passed, 1 failed
```

Green (this branch): that test passes, and the full `fo` pipeline is green
locally: `Static: OK / Build: OK / Tests: OK (483) / Lint: OK`.