### PR TITLE
Reject USE ONLY imports of generic specs a module does not export (#2887)

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -20,6 +20,10 @@ f90/protected_9.f90
 f90/contiguous_12.f90
 f90/external_initializer.f90
 f90/iso_fortran_env_4.f90
+f90/use_9.f90
+f90/use_19.f90
+f90/operator_6.f90
+f90/interface_operator_3.f90
 f90/type_decl_4.f90
 f90/class_is_1.f90
 f90/type_is_1.f90

--- a/examples/f90/interface_operator_3.f90
+++ b/examples/f90/interface_operator_3.f90
@@ -1,0 +1,27 @@
+! Negative fixture for issue #2887 (reject-use-01).
+! A module that extends only operator(==) exports the generic spec under both
+! spellings == and .eq., but neither /= nor .ne. is exported by it.
+! Derived from gfortran.dg/interface_operator_3.f90 (module m8).
+module m_eq
+    implicit none
+    private :: t3
+    type t3
+    integer :: i
+end type t3
+interface operator(==)
+    module procedure my_cmp
+end interface
+contains
+    elemental function my_cmp(a, b) result(c)
+        type(t3), intent(in) :: a, b
+        logical :: c
+        c = a%i == b%i
+    end function my_cmp
+end module m_eq
+
+module m8
+    use m_eq, only: operator(==), operator(.eq.)
+    use m_eq, only: operator(/=)
+    use m_eq, only: operator(.ne.)
+    implicit none
+end module m8

--- a/examples/f90/interface_operator_3_corrected.f90
+++ b/examples/f90/interface_operator_3_corrected.f90
@@ -1,0 +1,33 @@
+! Corrected neighbour of interface_operator_3.f90 (issue #2887).
+! Old and new spellings of the same relational operator denote one generic
+! spec, so both may be imported from a module that extends either spelling.
+module m_eq
+    implicit none
+    type t3
+    integer :: i
+end type t3
+interface operator(==)
+    module procedure my_cmp
+end interface
+interface operator(.ne.)
+    module procedure my_ncmp
+end interface
+contains
+    elemental function my_cmp(a, b) result(c)
+        type(t3), intent(in) :: a, b
+        logical :: c
+        c = a%i == b%i
+    end function my_cmp
+
+    elemental function my_ncmp(a, b) result(c)
+        type(t3), intent(in) :: a, b
+        logical :: c
+        c = a%i /= b%i
+    end function my_ncmp
+end module m_eq
+
+module m8
+    use m_eq, only: operator(==), operator(.eq.)
+    use m_eq, only: operator(/=), operator(.ne.)
+    implicit none
+end module m8

--- a/examples/f90/operator_6.f90
+++ b/examples/f90/operator_6.f90
@@ -1,0 +1,11 @@
+! Negative fixture for issue #2887 (reject-use-01).
+! An ONLY clause naming a defined operator of an empty module.
+! Derived from gfortran.dg/operator_6.f90.
+module foo
+    implicit none
+end module foo
+
+program test
+    use foo, only: operator(.none.)
+    implicit none
+end program test

--- a/examples/f90/operator_6_corrected.f90
+++ b/examples/f90/operator_6_corrected.f90
@@ -1,0 +1,18 @@
+! Corrected neighbour of operator_6.f90 (issue #2887).
+module foo
+    implicit none
+    interface operator(.none.)
+        module procedure none_of
+    end interface
+contains
+    logical function none_of(a) result(c)
+        logical, intent(in) :: a
+        c = .not. a
+    end function none_of
+end module foo
+
+program test
+    use foo, only: operator(.none.)
+    implicit none
+    print *, .none. .true.
+end program test

--- a/examples/f90/use_19.f90
+++ b/examples/f90/use_19.f90
@@ -1,0 +1,11 @@
+! Negative fixture for issue #2887 (reject-use-01).
+! The ONLY clause imports an intrinsic operator the module does not extend.
+! Derived from gfortran.dg/use_19.f90.
+module m
+    implicit none
+end module m
+
+program main
+    use m, only: operator(/)
+    implicit none
+end program main

--- a/examples/f90/use_19_corrected.f90
+++ b/examples/f90/use_19_corrected.f90
@@ -1,0 +1,19 @@
+! Corrected neighbour of use_19.f90 (issue #2887).
+! The module extends the intrinsic operator, so importing it is legal.
+module m
+    implicit none
+    interface operator(/)
+        module procedure divide_flags
+    end interface
+contains
+    logical function divide_flags(a, b) result(c)
+        logical, intent(in) :: a, b
+        c = a .and. .not. b
+    end function divide_flags
+end module m
+
+program main
+    use m, only: operator(/)
+    implicit none
+    print *, .true./.false.
+end program main

--- a/examples/f90/use_9.f90
+++ b/examples/f90/use_9.f90
@@ -1,0 +1,20 @@
+! Negative fixture for issue #2887 (reject-use-01).
+! The ONLY clause imports a defined operator the module does not export.
+! F2023 14.2.2: every name in an only-list shall be a public entity of the
+! module. Derived from gfortran.dg/use_9.f90.
+module test
+    implicit none
+    interface operator(.bar.)
+        module procedure func
+    end interface
+contains
+    integer function func(a)
+        integer, intent(in) :: a
+        func = a + 1
+    end function func
+end module test
+
+program main
+    use test, only: operator(.func.)
+    implicit none
+end program main

--- a/examples/f90/use_9_corrected.f90
+++ b/examples/f90/use_9_corrected.f90
@@ -1,0 +1,19 @@
+! Corrected neighbour of use_9.f90 (issue #2887).
+! The ONLY clause names the operator the module really exports.
+module test
+    implicit none
+    interface operator(.bar.)
+        module procedure func
+    end interface
+contains
+    integer function func(a)
+        integer, intent(in) :: a
+        func = a + 1
+    end function func
+end module test
+
+program main
+    use test, only: operator(.bar.)
+    implicit none
+    print *, .bar. 1
+end program main

--- a/src/frontend/frontend_compiler_resolution.f90
+++ b/src/frontend/frontend_compiler_resolution.f90
@@ -51,6 +51,7 @@ module frontend_compiler_resolution
     public :: resolve_name_in_scope
     public :: resolve_name_at_node
     public :: resolve_identifier_binding
+    public :: find_module_index
 
 contains
 

--- a/src/parser/core/parser_import_resolution.f90
+++ b/src/parser/core/parser_import_resolution.f90
@@ -3,7 +3,7 @@ module parser_import_resolution_module
     ! Import resolution module for use, include statements
     use lexer_core, only: token_t, TK_IDENTIFIER, TK_STRING, &
         TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, TK_COMMENT, &
-        TK_WHITESPACE
+        TK_WHITESPACE, TK_EOF
     use parser_state_module, only: parser_state_t
     use ast_arena_modern, only: ast_arena_t
     use ast_factory, only: push_use_statement, push_include_statement, push_literal
@@ -11,6 +11,7 @@ module parser_import_resolution_module
     use ast_types, only: LITERAL_STRING
     use string_types, only: string_t
     use url_utilities, only: extract_module_from_url
+    use generic_spec_names, only: make_generic_spec
     implicit none
     private
 
@@ -141,6 +142,7 @@ contains
             character(len=:), allocatable :: local_name, remote_name
 
             token = parser%peek()
+            if (parse_generic_spec_entry(parser)) return
             if (token%kind == TK_IDENTIFIER) then
                 token = parser%consume()
                 local_name = trimmed_or_empty(token%text)
@@ -162,6 +164,83 @@ contains
                 end if
             end if
         end subroutine parse_single_identifier_with_rename
+
+        ! A USE ONLY list entry may be a generic spec: OPERATOR(op) or
+        ! ASSIGNMENT(=). Store it in the canonical spec form so that the two
+        ! spellings of a relational operator compare equal.
+        logical function parse_generic_spec_entry(parser) result(handled)
+            type(parser_state_t), intent(inout) :: parser
+            type(token_t) :: token
+            type(token_t) :: next_token
+            character(len=:), allocatable :: spec_kind
+            character(len=:), allocatable :: symbol
+            character(len=:), allocatable :: spec
+            character(len=:), allocatable :: target_spec
+
+            handled = .false.
+            token = parser%peek()
+            if (token%kind /= TK_IDENTIFIER .and. token%kind /= TK_KEYWORD) return
+            spec_kind = to_lower(trim(token%text))
+            if (spec_kind /= "operator" .and. spec_kind /= "assignment") return
+            next_token = parser%get_token_at_index(parser%current_token + 1)
+            if (next_token%kind /= TK_OPERATOR) return
+            if (trim(next_token%text) /= "(") return
+
+            handled = .true.
+            token = parser%consume() ! spec keyword
+            token = parser%consume() ! '('
+            token = parser%peek()
+            symbol = trim(token%text)
+            if (token%kind /= TK_EOF) token = parser%consume()
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. trim(token%text) == ")") then
+                token = parser%consume()
+            end if
+            spec = make_generic_spec(spec_kind, symbol)
+
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. trim(token%text) == "=>") then
+                token = parser%consume()
+                if (parse_generic_spec_target(parser, target_spec)) then
+                    call append_rename_pair(spec, target_spec)
+                    return
+                end if
+            end if
+            call append_only(spec)
+        end function parse_generic_spec_entry
+
+        ! The target of a rename may itself be a generic spec, as in
+        ! OPERATOR(.local.) => OPERATOR(.remote.).
+        logical function parse_generic_spec_target(parser, spec) result(parsed)
+            type(parser_state_t), intent(inout) :: parser
+            character(len=:), allocatable, intent(out) :: spec
+            type(token_t) :: token
+            type(token_t) :: next_token
+            character(len=:), allocatable :: spec_kind
+            character(len=:), allocatable :: symbol
+
+            parsed = .false.
+            spec = ""
+            token = parser%peek()
+            if (token%kind /= TK_IDENTIFIER .and. token%kind /= TK_KEYWORD) return
+            spec_kind = to_lower(trim(token%text))
+            if (spec_kind /= "operator" .and. spec_kind /= "assignment") return
+            next_token = parser%get_token_at_index(parser%current_token + 1)
+            if (next_token%kind /= TK_OPERATOR) return
+            if (trim(next_token%text) /= "(") return
+
+            parsed = .true.
+            token = parser%consume() ! spec keyword
+            token = parser%consume() ! '('
+            token = parser%peek()
+            symbol = trim(token%text)
+            if (token%kind /= TK_EOF) token = parser%consume()
+            token = parser%peek()
+            if (token%kind == TK_OPERATOR .and. trim(token%text) == ")") then
+                token = parser%consume()
+            end if
+            spec = make_generic_spec(spec_kind, symbol)
+        end function parse_generic_spec_target
 
         function trimmed_or_empty(text) result(clean)
             character(len=*), intent(in) :: text

--- a/src/parser/declarations/parser_interface_block_headers_module.f90
+++ b/src/parser/declarations/parser_interface_block_headers_module.f90
@@ -1,5 +1,6 @@
 module parser_interface_block_headers_module
     use string_utils_mod, only: to_lower
+    use generic_spec_names, only: normalize_generic_operator
     use lexer_core, only: token_t, TK_KEYWORD, TK_IDENTIFIER, TK_OPERATOR
     use parser_state_module, only: parser_state_t
     implicit none
@@ -205,8 +206,8 @@ contains
             if (trim(interface_kind) == "interface") then
                 matches = to_lower(trim(end_name)) == to_lower(trim(interface_name))
             else
-                matches = normalized_operator(end_symbol) == &
-                    normalized_operator(operator_symbol)
+                matches = normalize_generic_operator(end_symbol) == &
+                    normalize_generic_operator(operator_symbol)
             end if
         end if
 
@@ -231,29 +232,6 @@ contains
                 " ("//trim(operator_symbol)//")"
         end if
     end function expected_end_text
-
-    ! Relational operators have two spellings that denote the same generic
-    ! spec, so compare them in one normalised form.
-    function normalized_operator(symbol) result(normalized)
-        character(len=*), intent(in) :: symbol
-        character(len=:), allocatable :: normalized
-
-        normalized = to_lower(trim(symbol))
-        select case (normalized)
-        case (".gt.")
-            normalized = ">"
-        case (".lt.")
-            normalized = "<"
-        case (".ge.")
-            normalized = ">="
-        case (".le.")
-            normalized = "<="
-        case (".eq.")
-            normalized = "=="
-        case (".ne.")
-            normalized = "/="
-        end select
-    end function normalized_operator
 
     function upper_case(text) result(upper)
         character(len=*), intent(in) :: text

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -20,6 +20,7 @@ use semantic_type_hierarchy_validation, only: populate_type_hierarchy
 use semantic_enum_validation, only: validate_enum_definitions
 use semantic_literal_form_validation, only: validate_literal_forms
 use semantic_use_nature_validation, only: validate_use_module_nature
+use semantic_use_export_validation, only: validate_use_only_exports
 use semantic_local_name_collision_validation, only: &
     validate_local_name_collisions
 use semantic_submodule_validation, only: validate_submodule_interfaces
@@ -111,6 +112,7 @@ contains
         ! Whole-arena scoping-unit checks. They run for every root kind,
         ! including a bare module root, which the dispatch below skips.
         call validate_use_module_nature(arena, ctx%errors)
+        call validate_use_only_exports(arena, ctx%errors)
         call validate_local_name_collisions(arena, ctx%errors)
 
         ! Separate module subprograms are checked against the interface bodies

--- a/src/semantic/analyzers/semantic_use_export_validation.f90
+++ b/src/semantic/analyzers/semantic_use_export_validation.f90
@@ -1,0 +1,286 @@
+module semantic_use_export_validation
+    ! Issue #2887 (reject-use-01). F2023 14.2.2: every name and generic spec in
+    ! the ONLY list of a USE statement shall be a public entity of the module
+    ! being accessed. gfortran.dg/use_9.f90, use_19.f90, operator_6.f90 and
+    ! interface_operator_3.f90 are the reference cases.
+    !
+    ! The rule is applied only when the module is defined in the same source
+    ! and its export list is fully understood by this analyzer: a module that
+    ! itself accesses another module, or that contains a construct this
+    ! analyzer does not model, is skipped. Missing knowledge therefore means
+    ! silence, never a rejection.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_misc, only: use_statement_node, interface_block_node, &
+        comment_node, implicit_statement_node, module_procedure_node, &
+        contains_node, visibility_statement_node
+    use ast_nodes_data, only: declaration_node, derived_type_node, &
+        parameter_declaration_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use frontend_compiler_resolution, only: is_scope_node, &
+        get_scope_statement_indices, find_module_index
+    use generic_spec_names, only: normalize_generic_operator, is_generic_spec
+    use string_types, only: string_t
+    use string_utils_mod, only: to_lower
+    implicit none
+    private
+
+    public :: validate_use_only_exports
+
+contains
+
+    ! Check every USE ... ONLY list in the arena against the exports of the
+    ! module it names, when that module is available and fully understood.
+    subroutine validate_use_only_exports(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (use_statement_node)
+                call check_use_statement(arena, node, errors)
+            end select
+        end do
+    end subroutine validate_use_only_exports
+
+    subroutine check_use_statement(arena, node, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(use_statement_node), intent(in) :: node
+        type(error_collection_t), intent(inout) :: errors
+        type(string_t), allocatable :: exports(:)
+        character(len=:), allocatable :: module_name
+        integer :: module_index
+        integer :: i
+
+        if (.not. node%has_only) return
+        if (node%is_intrinsic) return
+        if (.not. allocated(node%module_name)) return
+        module_name = trim(node%module_name)
+        if (len_trim(module_name) == 0) return
+        module_index = find_module_index(arena, module_name)
+        if (module_index <= 0) return
+        if (.not. collect_exports(arena, module_index, exports)) return
+
+        if (allocated(node%only_list)) then
+            do i = 1, size(node%only_list)
+                call report_missing(node, exports, node%only_list(i)%s, &
+                    module_name, errors)
+            end do
+        end if
+        if (allocated(node%rename_list)) then
+            i = 2
+            do while (i <= size(node%rename_list))
+                call report_missing(node, exports, node%rename_list(i)%s, &
+                    module_name, errors)
+                i = i + 2
+            end do
+        end if
+    end subroutine check_use_statement
+
+    ! Emit the diagnostic when an accessed generic spec is absent from the
+    ! module. Plain names are left alone: their export set depends on module
+    ! constructs (common blocks, enumerators, ...) this analyzer does not
+    ! model, and silence is the only safe answer there.
+    subroutine report_missing(node, exports, entity, module_name, errors)
+        type(use_statement_node), intent(in) :: node
+        type(string_t), intent(in) :: exports(:)
+        character(len=*), intent(in) :: entity
+        character(len=*), intent(in) :: module_name
+        type(error_collection_t), intent(inout) :: errors
+        character(len=:), allocatable :: wanted
+
+        if (len_trim(entity) == 0) return
+        if (.not. is_generic_spec(entity)) return
+        wanted = canonical(entity)
+        if (list_contains(exports, wanted)) return
+
+        call errors%add_error( &
+            "Generic spec '"//wanted//"' referenced in USE ONLY is not "// &
+            "found in module '"//trim(module_name)//"'", &
+            severity=ERROR_SEMANTIC, component="semantic_use_export", &
+            line=node%line, column=node%column)
+    end subroutine report_missing
+
+    ! Gather the names a module makes available. Returns .false. when the
+    ! module's export list cannot be determined exactly, in which case no
+    ! diagnostic may be derived from it.
+    logical function collect_exports(arena, module_index, exports) result(known)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: module_index
+        type(string_t), allocatable, intent(out) :: exports(:)
+        integer, allocatable :: indices(:)
+        integer :: count
+        integer :: i
+
+        known = .true.
+        count = 0
+        allocate (exports(0))
+        call get_scope_statement_indices(arena, module_index, indices)
+        do i = 1, size(indices)
+            if (.not. known) exit
+            call add_statement_exports(arena, indices(i), exports, count, known)
+        end do
+        if (.not. known) return
+        exports = exports(1:count)
+    end function collect_exports
+
+    subroutine add_statement_exports(arena, node_index, exports, count, known)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(string_t), allocatable, intent(inout) :: exports(:)
+        integer, intent(inout) :: count
+        logical, intent(inout) :: known
+        integer :: i
+
+        if (.not. arena%has_node_at(node_index)) then
+            known = .false.
+            return
+        end if
+        select type (node => arena%entries(node_index)%node)
+            type is (use_statement_node)
+            ! The module re-exports entities this analyzer cannot see.
+            known = .false.
+            type is (declaration_node)
+            if (node%is_multi_declaration) then
+                if (allocated(node%var_names)) then
+                    do i = 1, size(node%var_names)
+                        call append(exports, count, node%var_names(i))
+                    end do
+                end if
+            else if (allocated(node%var_name)) then
+                call append(exports, count, node%var_name)
+            end if
+            type is (parameter_declaration_node)
+            if (allocated(node%name)) call append(exports, count, node%name)
+            type is (derived_type_node)
+            if (allocated(node%name)) call append(exports, count, node%name)
+            type is (function_def_node)
+            if (allocated(node%name)) call append(exports, count, node%name)
+            type is (subroutine_def_node)
+            if (allocated(node%name)) call append(exports, count, node%name)
+            type is (module_procedure_node)
+            if (allocated(node%procedure_names)) then
+                do i = 1, size(node%procedure_names)
+                    call append(exports, count, node%procedure_names(i)%s)
+                end do
+            end if
+            type is (interface_block_node)
+            call add_interface_exports(arena, node, exports, count, known)
+            type is (visibility_statement_node)
+            ! Visibility narrows exports; a private entity is still present,
+            ! so nothing is added and nothing is unknown here.
+            type is (implicit_statement_node)
+            type is (comment_node)
+            type is (contains_node)
+        class default
+            known = .false.
+        end select
+    end subroutine add_statement_exports
+
+    ! An interface block exports its generic name or generic spec, and the
+    ! names of the specific procedures declared inside a plain interface.
+    subroutine add_interface_exports(arena, node, exports, count, known)
+        type(ast_arena_t), intent(in) :: arena
+        type(interface_block_node), intent(in) :: node
+        type(string_t), allocatable, intent(inout) :: exports(:)
+        integer, intent(inout) :: count
+        logical, intent(inout) :: known
+        character(len=:), allocatable :: kind_text
+        integer :: i
+
+        kind_text = ''
+        if (allocated(node%kind)) kind_text = to_lower(trim(node%kind))
+        if (kind_text == "operator" .or. kind_text == "assignment") then
+            if (allocated(node%operator)) then
+                call append(exports, count, kind_text//"("// &
+                    normalize_generic_operator(node%operator)//")")
+            end if
+        else if (kind_text == "read" .or. kind_text == "write") then
+            ! Defined input/output generic specs are not named in ONLY lists
+            ! that this rule inspects; treat them as opaque.
+            known = .false.
+            return
+        else if (allocated(node%name)) then
+            if (len_trim(node%name) > 0) call append(exports, count, node%name)
+        end if
+
+        if (.not. allocated(node%procedure_indices)) return
+        do i = 1, size(node%procedure_indices)
+            call add_interface_procedure(arena, node%procedure_indices(i), &
+                exports, count)
+        end do
+    end subroutine add_interface_exports
+
+    subroutine add_interface_procedure(arena, node_index, exports, count)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(string_t), allocatable, intent(inout) :: exports(:)
+        integer, intent(inout) :: count
+        integer :: i
+
+        if (.not. arena%has_node_at(node_index)) return
+        select type (node => arena%entries(node_index)%node)
+            type is (function_def_node)
+            if (allocated(node%name)) call append(exports, count, node%name)
+            type is (subroutine_def_node)
+            if (allocated(node%name)) call append(exports, count, node%name)
+            type is (module_procedure_node)
+            if (allocated(node%procedure_names)) then
+                do i = 1, size(node%procedure_names)
+                    call append(exports, count, node%procedure_names(i)%s)
+                end do
+            end if
+        end select
+    end subroutine add_interface_procedure
+
+    subroutine append(exports, count, name)
+        type(string_t), allocatable, intent(inout) :: exports(:)
+        integer, intent(inout) :: count
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: canonical_name
+        type(string_t), allocatable :: bigger(:)
+
+        if (len_trim(name) == 0) return
+        if (count >= size(exports)) then
+            allocate (bigger(max(8, 2*size(exports))))
+            if (count > 0) bigger(1:count) = exports(1:count)
+            call move_alloc(bigger, exports)
+        end if
+        count = count + 1
+        canonical_name = canonical(name)
+        exports(count) = string_t(canonical_name)
+    end subroutine append
+
+    logical function list_contains(exports, wanted) result(found)
+        type(string_t), intent(in) :: exports(:)
+        character(len=*), intent(in) :: wanted
+        integer :: i
+
+        found = .false.
+        do i = 1, size(exports)
+            if (.not. allocated(exports(i)%s)) cycle
+            if (exports(i)%s == wanted) then
+                found = .true.
+                return
+            end if
+        end do
+    end function list_contains
+
+    ! Case-insensitive form of a name, with the two spellings of a relational
+    ! operator folded onto one generic spec.
+    function canonical(name) result(text)
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: text
+        integer :: open_paren
+
+        text = to_lower(trim(name))
+        if (.not. is_generic_spec(text)) return
+        open_paren = index(text, "(")
+        if (open_paren <= 1) return
+        text = text(1:open_paren)// &
+            normalize_generic_operator(text(open_paren + 1:len(text) - 1))//")"
+    end function canonical
+
+end module semantic_use_export_validation

--- a/src/utilities/generic_spec_names.f90
+++ b/src/utilities/generic_spec_names.f90
@@ -1,0 +1,68 @@
+module generic_spec_names
+    ! Canonical spelling of the generic specs that may appear in an INTERFACE
+    ! statement and in a USE ONLY list. Fortran gives the relational operators
+    ! two spellings (== and .eq., /= and .ne., ...) that denote the SAME
+    ! generic spec (F2023 10.1.5.5.1), so every comparison of operator names
+    ! goes through normalize_generic_operator, and every stored USE ONLY entry
+    ! for a generic spec is built with make_generic_spec.
+    use string_utils_mod, only: to_lower
+    implicit none
+    private
+
+    public :: normalize_generic_operator
+    public :: make_generic_spec
+    public :: is_generic_spec
+
+contains
+
+    ! Fold the two spellings of the relational operators onto one form.
+    function normalize_generic_operator(symbol) result(normalized)
+        character(len=*), intent(in) :: symbol
+        character(len=:), allocatable :: normalized
+
+        normalized = to_lower(trim(symbol))
+        select case (normalized)
+        case (".gt.")
+            normalized = ">"
+        case (".lt.")
+            normalized = "<"
+        case (".ge.")
+            normalized = ">="
+        case (".le.")
+            normalized = "<="
+        case (".eq.")
+            normalized = "=="
+        case (".ne.")
+            normalized = "/="
+        end select
+    end function normalize_generic_operator
+
+    ! Canonical text for a generic spec, e.g. "operator(==)" or
+    ! "assignment(=)". kind is "operator" or "assignment".
+    function make_generic_spec(kind, symbol) result(spec)
+        character(len=*), intent(in) :: kind
+        character(len=*), intent(in) :: symbol
+        character(len=:), allocatable :: spec
+
+        spec = to_lower(trim(kind))//"("// &
+            normalize_generic_operator(symbol)//")"
+    end function make_generic_spec
+
+    ! Whether a USE ONLY entry names a generic spec rather than a plain name.
+    logical function is_generic_spec(text) result(is_spec)
+        character(len=*), intent(in) :: text
+        character(len=:), allocatable :: lowered
+
+        lowered = to_lower(trim(text))
+        is_spec = .false.
+        if (len(lowered) < 3) return
+        if (lowered(len(lowered):len(lowered)) /= ")") return
+        if (len(lowered) > 9) then
+            if (lowered(1:9) == "operator(") is_spec = .true.
+        end if
+        if (len(lowered) > 11) then
+            if (lowered(1:11) == "assignment(") is_spec = .true.
+        end if
+    end function is_generic_spec
+
+end module generic_spec_names

--- a/test/api/test_reject_use_01_diagnostics.f90
+++ b/test/api/test_reject_use_01_diagnostics.f90
@@ -19,6 +19,19 @@ program test_reject_use_01_diagnostics
     all_passed = .true.
     if (.not. test_conflicting_natures_rejected()) all_passed = .false.
     if (.not. test_corrected_neighbour_accepted()) all_passed = .false.
+    if (.not. test_missing_export_rejected('use_9', 'operator(.func.)')) &
+        all_passed = .false.
+    if (.not. test_missing_export_rejected('use_19', 'operator(/)')) &
+        all_passed = .false.
+    if (.not. test_missing_export_rejected('operator_6', 'operator(.none.)')) &
+        all_passed = .false.
+    if (.not. test_missing_export_rejected('interface_operator_3', &
+        'operator(/=)')) all_passed = .false.
+    if (.not. test_accepted('use_9_corrected')) all_passed = .false.
+    if (.not. test_accepted('use_19_corrected')) all_passed = .false.
+    if (.not. test_accepted('operator_6_corrected')) all_passed = .false.
+    if (.not. test_accepted('interface_operator_3_corrected')) &
+        all_passed = .false.
 
     if (all_passed) then
         print *, 'All reject-use-01 diagnostics tests passed.'
@@ -77,6 +90,58 @@ contains
         end if
         print *, '  PASS: corrected neighbour still accepted'
     end function test_corrected_neighbour_accepted
+
+    ! A USE ONLY list may only access entities the module really exports
+    ! (F2023 14.2.2). The expected entity text is the canonical generic spec.
+    logical function test_missing_export_rejected(basename, entity) result(ok)
+        character(len=*), intent(in) :: basename
+        character(len=*), intent(in) :: entity
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: text
+
+        ok = .true.
+        call read_example('examples/f90/'//basename//'.f90', source)
+        call compile_standard(source, result)
+
+        if (result%success()) then
+            print *, '  FAIL: accepted missing export in ', basename
+            ok = .false.
+            return
+        end if
+
+        text = lowered(diagnostic_of(result))
+        if (index(text, 'not found in module') == 0) then
+            print *, '  FAIL: wrong rule for ', basename, ' -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        if (index(text, lowered(entity)) == 0) then
+            print *, '  FAIL: diagnostic does not name ', entity, ' -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        print *, '  PASS: missing export rejected in ', basename
+    end function test_missing_export_rejected
+
+    logical function test_accepted(basename) result(ok)
+        character(len=*), intent(in) :: basename
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: source
+
+        ok = .true.
+        call read_example('examples/f90/'//basename//'.f90', source)
+        call compile_standard(source, result)
+        if (.not. result%success()) then
+            print *, '  FAIL: rejected valid ', basename, ' -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        print *, '  PASS: accepted ', basename
+    end function test_accepted
 
     subroutine compile_standard(source, result)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
Closes #2887.

## Preserved compiler invariant
A USE statement may only access entities the named module makes available (F2023 14.2.2). Operator and assignment generic specs were not even represented before this change: the only-list parser stopped at `operator(` and silently dropped the entry.

## Change
- `parser_import_resolution`: parse `OPERATOR(op)` / `ASSIGNMENT(=)` in USE ONLY lists **and** in renames (`operator(.a.) => operator(.b.)`), stored in one canonical spec form.
- New `generic_spec_names`: the single canonical spelling for generic specs, folding the two spellings of the relational operators (`.eq.`/`==`, ...) onto one form. The private copy of that folding inside `parser_interface_block_headers_module` is **retired** in favour of it - exactly one convention survives.
- New `semantic_use_export_validation`: rejects an accessed generic spec that the module - when defined in the same source and when its export list is fully understood - does not export. A module that itself USEs another module, or that holds a construct the analyzer does not model, is skipped: missing knowledge means silence, never a rejection. Plain names are deliberately not checked (their export set depends on common blocks, enumerators and other constructs not modelled here); that restriction was derived from the rejection gate, which showed 12 valid corpus files falsely rejected by a name-based check.

## Red evidence (unmodified main, `frontend_probe`)
All four negative fixtures compiled clean: `use_9`, `use_19`, `operator_6`, `interface_operator_3` -> `parse_ok:true, semantic_ok:true, diagnostic_text:""`.

## Green evidence
- `use_9` -> `Generic spec 'operator(.func.)' referenced in USE ONLY is not found in module 'test'`; `use_19` -> `operator(/)`; `operator_6` -> `operator(.none.)`; `interface_operator_3` -> `operator(/=)` (accepted under both spellings `==`/`.eq.`).
- All four corrected neighbours still accepted; each fixture pair verified against `gfortran -fsyntax-only` as the oracle.
- `fo test test_reject_use_01_diagnostics` PASS; full `fo` pipeline green (483 tests, lint OK, fmt clean for touched-by-me files).

## Rejection-work gate
- `make check-rejection-gate`: OK, no newly rejected corpus file.
- Full gfortran.dg sweep (7857 files) against a baseline built from unmodified `origin/main`: exactly 4 newly rejected files - `interface_operator_3.f90`, `operator_6.f90`, `use_19.f90`, `use_9.f90` - all of which gfortran itself rejects. **Zero valid files newly rejected.**

## Scope note
Issue #2887 lists further USE-family fixtures (`use_15`, `use_16`, `use_rename_5`, `use_rename_11`, `use_iso_c_binding`, `function_kinds_2`) whose rules are different constraint families (program-unit name conflicts, host/rename collisions, intrinsic-module symbol tables). They need separate mechanisms and are left to follow-up work.