### PR TITLE
Stop inventing TARGET and INTENT(IN) on pointer entities (#2934)

### DIFF
--- a/examples/expected_failures.txt
+++ b/examples/expected_failures.txt
@@ -60,4 +60,3 @@ issue_2855_external_intrinsic_conflict.f90  # ERROR-TEST: entity both intrinsic 
 pr19936_3_ok.f90  # BUG: legacy (/ ... /) implied-do loses its (/ /) wrapper on emit
 pr96099_1_ok.f90  # BUG: IMPLICIT CLASS(t) (x) loses the letter-spec list on emit
 implicit_kind_selector_letter_specs.f90  # BUG: IMPLICIT with a kind/len selector loses the letter-spec list on emit
-impure_assignment_2_valid.f90  # BUG: TARGET copied into a type definition (#2934)

--- a/examples/f90/impure_assignment_2_valid.f90
+++ b/examples/f90/impure_assignment_2_valid.f90
@@ -1,6 +1,7 @@
 program impure_assignment_2_valid
-    ! VALID neighbour of impure_assignment_2.f90. The PURE function only reads
-    ! its dummy argument; the definition of the dummy moves into an impure
+    ! VALID neighbour of impure_assignment_2.f90. The pointer result is
+    ! produced by a PURE subroutine, where a POINTER dummy may be the target
+    ! of a pointer assignment; the definition of the dummy moves into an impure
     ! subroutine where a variable definition context is allowed.
     implicit none
 
@@ -10,11 +11,11 @@ program impure_assignment_2_valid
 
 contains
 
-    pure function give_next(node) result(res)
+    pure subroutine give_next(node, res)
         type(node_type), pointer :: node
         type(node_type), pointer :: res
         res => node%next
-    end function give_next
+    end subroutine give_next
 
     subroutine link(node, other)
         type(node_type), pointer :: node

--- a/src/codegen/decls/codegen_parameter_info.f90
+++ b/src/codegen/decls/codegen_parameter_info.f90
@@ -11,6 +11,7 @@ module codegen_parameter_info
         character(len=:), allocatable :: intent_str
         logical :: is_optional
         logical :: is_target
+        logical :: is_pointer
         logical :: is_mutated
     end type parameter_info_t
 

--- a/src/codegen/decls/codegen_parameter_mapping.f90
+++ b/src/codegen/decls/codegen_parameter_mapping.f90
@@ -35,6 +35,7 @@ contains
 
         if (present(owner)) then
             do i = 1, size(param_map)
+                if (param_map(i)%is_pointer) cycle
                 if (len_trim(param_map(i)%intent_str) == 0) then
                     owner_intent = get_owner_intent(owner, i)
                     if (len_trim(owner_intent) > 0) then
@@ -58,6 +59,7 @@ contains
             param_map(i)%intent_str = ""
             param_map(i)%is_optional = .false.
             param_map(i)%is_target = .false.
+            param_map(i)%is_pointer = .false.
             param_map(i)%is_mutated = .false.
 
             idx = param_indices(i)
@@ -115,7 +117,8 @@ contains
                             intent_str, &
                             body_node%has_intent, &
                             body_node%is_optional, &
-                            body_node%is_target)
+                            body_node%is_target, &
+                            body_node%is_pointer)
                     end do
                 else
                     if (body_node%has_intent) then
@@ -127,7 +130,8 @@ contains
                         intent_str, &
                         body_node%has_intent, &
                         body_node%is_optional, &
-                        body_node%is_target)
+                        body_node%is_target, &
+                        body_node%is_pointer)
                 end if
             end select
         end do
@@ -264,14 +268,19 @@ contains
     end subroutine set_parameter_mutated
 
     subroutine update_parameter_entry(param_map, name, intent_value, has_intent, &
-            is_optional, is_target)
+            is_optional, is_target, is_pointer)
         type(parameter_info_t), intent(inout) :: param_map(:)
         character(len=*), intent(in) :: name
         character(len=*), intent(in) :: intent_value
         logical, intent(in) :: has_intent
         logical, intent(in) :: is_optional
         logical, intent(in) :: is_target
+        logical, intent(in), optional :: is_pointer
         integer :: i
+        logical :: pointer_flag
+
+        pointer_flag = .false.
+        if (present(is_pointer)) pointer_flag = is_pointer
 
         do i = 1, size(param_map)
             if (.not. allocated(param_map(i)%name)) cycle
@@ -279,6 +288,13 @@ contains
 
             if (has_intent .and. len_trim(intent_value) > 0) then
                 param_map(i)%intent_str = trim(intent_value)
+            end if
+            ! F2018 C1583: a POINTER dummy is exempt from the INTENT(IN)
+            ! requirement; an invented INTENT(IN) would make pointer assignment
+            ! to its target illegal, so never synthesize one.
+            if (pointer_flag) then
+                param_map(i)%is_pointer = .true.
+                if (.not. has_intent) param_map(i)%intent_str = ""
             end if
             param_map(i)%is_optional = is_optional
             param_map(i)%is_target = is_target

--- a/src/codegen/decls/codegen_procedure_shared.f90
+++ b/src/codegen/decls/codegen_procedure_shared.f90
@@ -279,6 +279,11 @@ contains
             case ("pure", "elemental")
                 do i = 1, size(param_map)
                     if (.not. allocated(param_map(i)%name)) cycle
+                    ! F2018 C1583: POINTER dummies are exempt from the
+                    ! INTENT(IN) requirement of PURE/ELEMENTAL procedures, and
+                    ! an invented INTENT(IN) makes pointer assignment to their
+                    ! targets illegal.
+                    if (param_map(i)%is_pointer) cycle
                     if (len_trim(param_map(i)%intent_str) == 0) then
                         param_map(i)%intent_str = "in"
                     end if
@@ -299,6 +304,7 @@ contains
         do i = 1, size(param_map)
             if (.not. allocated(param_map(i)%name)) cycle
             if (param_map(i)%is_mutated) cycle
+            if (param_map(i)%is_pointer) cycle
             if (len_trim(param_map(i)%intent_str) == 0) then
                 ! Check if this parameter is a procedure type
                 ! ISO/IEC 1539-1:2018 Section 15.4.3.2: procedure dummy arguments

--- a/src/standardizers/standardizer_pointer_targets.f90
+++ b/src/standardizers/standardizer_pointer_targets.f90
@@ -73,9 +73,8 @@ contains
             type is (range_subscript_node)
             call collect_target_names(arena, expr%base_expr_index, names, count)
             type is (component_access_node)
-            if (allocated(expr%component_name)) then
-                call append_name(names, count, expr%component_name)
-            end if
+            ! Only the base object can acquire TARGET; a component name is not
+            ! an independent entity and TARGET is illegal in a type definition.
             if (expr%base_expr_index > 0) then
                 call collect_target_names(arena, expr%base_expr_index, names, count)
             end if
@@ -99,6 +98,8 @@ contains
 
             select type (decl => arena%entries(i)%node)
                 type is (declaration_node)
+                ! TARGET and POINTER are mutually exclusive attributes.
+                if (decl%is_pointer) cycle
                 if (allocated(decl%var_name)) then
                     candidate = to_lower(trim(decl%var_name))
                     if (candidate == lowered_name) then

--- a/test/standardizer/test_issue_2934_pointer_target_marking.f90
+++ b/test/standardizer/test_issue_2934_pointer_target_marking.f90
@@ -1,0 +1,78 @@
+program test_issue_2934_pointer_target_marking
+    ! Issue #2934: the pointer-target standardizer marked every name appearing
+    ! in a pointer-assignment target, including derived-type component names and
+    ! entities that are themselves POINTER. That emitted
+    !   type(node_type), pointer, target :: next => null()
+    ! inside a type definition and TARGET+POINTER on dummy arguments, both of
+    ! which gfortran rejects. The parameter standardizer additionally invented
+    ! INTENT(IN) for the POINTER dummy of a PURE procedure, which makes the
+    ! pointer assignment in its body illegal (F2018 C1583).
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use frontend_transformation, only: INPUT_MODE_STANDARD
+    use string_utils_mod, only: to_lower
+    use transformation_api, only: transform_with_context, transform_context_t
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    character(len=:), allocatable :: source, output, error_msg, lowered
+    type(transform_context_t) :: context
+
+    call read_example('examples/f90/impure_assignment_2_valid.f90', source)
+
+    context%input_mode = INPUT_MODE_STANDARD
+    context%has_filename = .true.
+    context%source_name = 'impure_assignment_2_valid'
+
+    call transform_with_context(source, output, error_msg, context)
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'FAIL: unexpected error: '//trim(error_msg)
+        error stop 1
+    end if
+    lowered = to_lower(output)
+
+    if (index(lowered, ', target') > 0 .or. index(lowered, 'target ::') > 0) then
+        write (error_unit, '(A)') 'FAIL: TARGET invented for pointer entities'
+        write (error_unit, '(A)') trim(output)
+        error stop 1
+    end if
+
+    if (index(lowered, 'intent(in)') > 0) then
+        write (error_unit, '(A)') &
+            'FAIL: INTENT(IN) invented for a POINTER dummy of a PURE procedure'
+        write (error_unit, '(A)') trim(output)
+        error stop 1
+    end if
+
+    call check_plain_target_still_marked()
+
+    print *, 'PASS: issue #2934 pointer target marking'
+
+contains
+
+    include '../common/read_example.inc'
+
+    subroutine check_plain_target_still_marked()
+        character(len=:), allocatable :: src, out, err
+
+        src = 'program pt'//new_line('a')// &
+            '    implicit none'//new_line('a')// &
+            '    integer, pointer :: p'//new_line('a')// &
+            '    integer :: a'//new_line('a')// &
+            '    a = 1'//new_line('a')// &
+            '    p => a'//new_line('a')// &
+            'end program pt'//new_line('a')
+
+        call transform_lazy_fortran_string(src, out, err)
+        if (len_trim(err) > 0) then
+            write (error_unit, '(A)') 'FAIL: unexpected error: '//trim(err)
+            error stop 1
+        end if
+        if (index(to_lower(out), ', target') == 0) then
+            write (error_unit, '(A)') &
+                'FAIL: plain pointer target lost its TARGET attribute'
+            write (error_unit, '(A)') trim(out)
+            error stop 1
+        end if
+    end subroutine check_plain_target_still_marked
+
+end program test_issue_2934_pointer_target_marking


### PR DESCRIPTION
Fixes #2934.

## Preserved invariant
Emitted code only carries attributes the source entity may legally have. TARGET is never attached to a POINTER entity or to a derived-type component, and INTENT(IN) is never synthesized for a POINTER dummy.

## What was wrong
1. `standardizer_pointer_targets` collected *every* name out of a pointer-assignment target, including the component name of `node%next` and the pointer variables themselves, then set `is_target` on any matching declaration anywhere in the arena. Result: `type(node_type), pointer, target :: next => null()` inside a type definition (illegal) and TARGET+POINTER on dummies (mutually exclusive).
2. Codegen's `apply_default_intents` / `apply_function_default_intents` forced INTENT(IN) on every dummy of a PURE/ELEMENTAL procedure. F2018 C1583 exempts POINTER dummies, and the invented INTENT(IN) makes a pointer assignment whose target is that dummy illegal.
3. `examples/f90/impure_assignment_2_valid.f90` was itself rejected by `gfortran -fsyntax-only`: a dummy argument of a PURE *function* may not be a pointer-assignment target. It now uses a PURE subroutine, which gfortran accepts, and is removed from `examples/expected_failures.txt`.

## Changes
- Only the base object of a component access is a TARGET candidate; POINTER declarations are skipped.
- `parameter_info_t` tracks POINTER dummies; both default-intent passes skip them.
- Example fixed to be valid Fortran; expected-failure entry dropped.

## Red evidence
New test `test/standardizer/test_issue_2934_pointer_target_marking.f90` on unmodified main emitted:
```
type(node_type), pointer, target :: next => null()
type(node_type), intent(in), target :: node
type(node_type), intent(inout), target, pointer :: other
```
=> `Summary: 0 passed, 1 failed`.

## Green evidence
- `fo test test_issue_2934_pointer_target_marking` => PASS (includes a positive control: a plain `p => a` still gains TARGET).
- `gfortran -fsyntax-only` accepts both the example source and the standardized output.
- Full `fo` pipeline: Static OK, Build OK, Tests OK (483), Lint OK.