### PR TITLE
Reject local and host-associated name collisions (#2888)

### DIFF
--- a/examples/expected_diagnostics.txt
+++ b/examples/expected_diagnostics.txt
@@ -52,3 +52,10 @@ f90/typebound_override_1.f90
 f90/typebound_override_2.f90
 f90/typebound_override_4.f90
 f90/typebound_override_5.f90
+f90/common_29.f90
+f90/host_assoc_types_1.f90
+f90/pr104351.f90
+f90/pr123375.f90
+f90/pr77414.f90
+f90/pr96102.f90
+f90/used_types_25.f90

--- a/examples/f90/common_29.f90
+++ b/examples/f90/common_29.f90
@@ -1,0 +1,16 @@
+! Negative fixture for issue #2888 (reject-scope-02), after gfortran.dg.
+! The COMMON statement declares an object T in a scope that already uses the
+! host associated derived type T, so one name would denote both.
+module common_29_mod
+    implicit none
+    type t
+        integer :: k
+    end type t
+contains
+    subroutine s()
+        type(t) :: x
+        common t
+
+        x%k = 1
+    end subroutine s
+end module common_29_mod

--- a/examples/f90/common_29_corrected.f90
+++ b/examples/f90/common_29_corrected.f90
@@ -1,0 +1,18 @@
+! Corrected neighbour of common_29.f90 (issue #2888).
+! The COMMON object has its own name, so the host associated type T keeps
+! denoting the type alone.
+module common_29_corrected_mod
+    implicit none
+    type t
+        integer :: k
+    end type t
+contains
+    subroutine s()
+        type(t) :: x
+        integer :: shared
+        common /com/ shared
+
+        x%k = 1
+        shared = x%k
+    end subroutine s
+end module common_29_corrected_mod

--- a/examples/f90/host_assoc_types_1.f90
+++ b/examples/f90/host_assoc_types_1.f90
@@ -1,0 +1,18 @@
+! Negative fixture for issue #2888 (reject-scope-02), after gfortran.dg.
+! The DO construct name repeats the host associated derived type VERTEX that
+! the same scoping unit uses in a declaration.
+module host_assoc_types_1_mod
+    implicit none
+    type vertex
+        integer :: k
+    end type vertex
+contains
+    subroutine s1()
+        type(vertex) :: a
+        integer :: i
+
+        vertex: do i = 1, 2
+        end do vertex
+        a%k = i
+    end subroutine s1
+end module host_assoc_types_1_mod

--- a/examples/f90/host_assoc_types_1_corrected.f90
+++ b/examples/f90/host_assoc_types_1_corrected.f90
@@ -1,0 +1,17 @@
+! Corrected neighbour of host_assoc_types_1.f90 (issue #2888).
+! A construct name that differs from the host associated type name is legal.
+module host_assoc_types_1_corrected_mod
+    implicit none
+    type vertex
+        integer :: k
+    end type vertex
+contains
+    subroutine s1()
+        type(vertex) :: a
+        integer :: i
+
+        scan_vertices: do i = 1, 2
+        end do scan_vertices
+        a%k = i
+    end subroutine s1
+end module host_assoc_types_1_corrected_mod

--- a/examples/f90/pr104351.f90
+++ b/examples/f90/pr104351.f90
@@ -1,0 +1,20 @@
+! Negative fixture for issue #2888 (reject-scope-02), after gfortran.dg.
+! The name F is declared as a variable of type T and is also the name of a
+! procedure contained in the same scoping unit.
+program pr104351
+    implicit none
+    type t
+        integer :: k
+    end type t
+    type(t) :: f
+
+    f%k = 1
+contains
+    real function g() result(z)
+        z = 0.0
+    end function g
+
+    real function f() result(z)
+        z = 0.0
+    end function f
+end program pr104351

--- a/examples/f90/pr104351_corrected.f90
+++ b/examples/f90/pr104351_corrected.f90
@@ -1,0 +1,16 @@
+! Corrected neighbour of pr104351.f90 (issue #2888).
+! The variable and the contained function have distinct names.
+program pr104351_corrected
+    implicit none
+    type t
+        integer :: k
+    end type t
+    type(t) :: value
+
+    value%k = 1
+    print *, value%k, f()
+contains
+    real function f() result(z)
+        z = 0.0
+    end function f
+end program pr104351_corrected

--- a/examples/f90/pr123375.f90
+++ b/examples/f90/pr123375.f90
@@ -1,0 +1,17 @@
+! Negative fixture for issue #2888 (reject-scope-02), after gfortran.dg.
+! F2023 C8105: an interface body that accesses AA by use association may not
+! also IMPORT it from the host scoping unit.
+module pr123375_mod
+    implicit none
+    integer :: aa
+end module pr123375_mod
+
+module pr123375_bad
+    implicit none
+    interface
+        subroutine bah()
+            use pr123375_mod
+            import aa
+        end subroutine bah
+    end interface
+end module pr123375_bad

--- a/examples/f90/pr123375_corrected.f90
+++ b/examples/f90/pr123375_corrected.f90
@@ -1,0 +1,17 @@
+! Corrected neighbour of pr123375.f90 (issue #2888).
+! AA is use associated in the host scoping unit and imported into the
+! interface body, which is the legal shape.
+module pr123375_corrected_mod
+    implicit none
+    integer :: aa
+end module pr123375_corrected_mod
+
+module pr123375_corrected
+    use pr123375_corrected_mod
+    implicit none
+    interface
+        subroutine bah()
+            import aa
+        end subroutine bah
+    end interface
+end module pr123375_corrected

--- a/examples/f90/pr77414.f90
+++ b/examples/f90/pr77414.f90
@@ -1,0 +1,16 @@
+! Negative fixture for issue #2888 (reject-scope-02), after gfortran.dg.
+! A contained procedure may not repeat the name of the procedure that
+! contains it.
+subroutine pr77414_outer(x)
+    implicit none
+    character(len=*), intent(in) :: x
+
+    print *, len(x)
+contains
+    subroutine pr77414_outer(y)
+        implicit none
+        character(len=*), intent(in) :: y
+
+        print *, len(y)
+    end subroutine pr77414_outer
+end subroutine pr77414_outer

--- a/examples/f90/pr77414_corrected.f90
+++ b/examples/f90/pr77414_corrected.f90
@@ -1,0 +1,15 @@
+! Corrected neighbour of pr77414.f90 (issue #2888).
+! The contained procedure carries its own name.
+subroutine pr77414_corrected_outer(x)
+    implicit none
+    character(len=*), intent(in) :: x
+
+    call report(x)
+contains
+    subroutine report(y)
+        implicit none
+        character(len=*), intent(in) :: y
+
+        print *, len(y)
+    end subroutine report
+end subroutine pr77414_corrected_outer

--- a/examples/f90/pr96102.f90
+++ b/examples/f90/pr96102.f90
@@ -1,0 +1,15 @@
+! Negative fixture for issue #2888 (reject-scope-02), after gfortran.dg.
+! N is host associated into S and referenced there, so an internal procedure
+! of S may not carry the same name.
+module pr96102_mod
+    implicit none
+    integer :: n = 2
+contains
+    subroutine s()
+        if (n /= 0) print *, 'nonzero'
+    contains
+        integer function n()
+            n = 0
+        end function n
+    end subroutine s
+end module pr96102_mod

--- a/examples/f90/pr96102_corrected.f90
+++ b/examples/f90/pr96102_corrected.f90
@@ -1,0 +1,15 @@
+! Corrected neighbour of pr96102.f90 (issue #2888).
+! The internal procedure has a name of its own, so the host associated
+! variable keeps its meaning inside S.
+module pr96102_corrected_mod
+    implicit none
+    integer :: n = 2
+contains
+    subroutine s()
+        if (n /= 0) print *, 'nonzero', zero()
+    contains
+        integer function zero()
+            zero = 0
+        end function zero
+    end subroutine s
+end module pr96102_corrected_mod

--- a/examples/f90/used_types_25.f90
+++ b/examples/f90/used_types_25.f90
@@ -1,0 +1,17 @@
+! Negative fixture for issue #2888 (reject-scope-02), after gfortran.dg.
+! The main program defines a derived type whose name is already accessible by
+! use association.
+module used_types_25_mod
+    implicit none
+    type t
+        integer :: k
+    end type t
+end module used_types_25_mod
+
+program used_types_25
+    use used_types_25_mod
+    implicit none
+    type t
+        integer :: j
+    end type t
+end program used_types_25

--- a/examples/f90/used_types_25_corrected.f90
+++ b/examples/f90/used_types_25_corrected.f90
@@ -1,0 +1,23 @@
+! Corrected neighbour of used_types_25.f90 (issue #2888).
+! A locally defined type with its own name coexists with the use associated
+! one.
+module used_types_25_corrected_mod
+    implicit none
+    type t
+        integer :: k
+    end type t
+end module used_types_25_corrected_mod
+
+program used_types_25_corrected
+    use used_types_25_corrected_mod
+    implicit none
+    type local_t
+        integer :: j
+    end type local_t
+    type(t) :: a
+    type(local_t) :: b
+
+    a%k = 1
+    b%j = 2
+    print *, a%k, b%j
+end program used_types_25_corrected

--- a/src/frontend/frontend_compiler_resolution.f90
+++ b/src/frontend/frontend_compiler_resolution.f90
@@ -5,7 +5,8 @@ module frontend_compiler_resolution
     use ast_nodes_core, only: call_or_subscript_node, identifier_node, &
                               program_node
     use ast_nodes_data, only: declaration_node, derived_type_node, &
-                              module_node, parameter_declaration_node, submodule_node
+                              mixed_construct_container_node, module_node, &
+                              parameter_declaration_node, submodule_node
     use ast_nodes_misc, only: interface_block_node, statement_function_node, &
                               use_statement_node, visibility_statement_node
     use ast_nodes_procedure, only: function_def_node, subroutine_call_node, &
@@ -52,6 +53,10 @@ module frontend_compiler_resolution
     public :: resolve_name_at_node
     public :: resolve_identifier_binding
     public :: find_module_index
+    ! Association-aware lookups used by the scope collision validator (#2888).
+    public :: find_enclosing_scope
+    public :: find_host_scope
+    public :: resolve_use_binding
 
 contains
 
@@ -316,6 +321,9 @@ contains
         type is (block_construct_node)
             call collect_from_indices(arena, node%body_indices, scope_node_index, &
                                       association, bindings, count)
+        type is (mixed_construct_container_node)
+            call collect_from_indices(arena, node%implicit_declaration_indices, &
+                                      scope_node_index, association, bindings, count)
         end select
     end subroutine collect_scope_bindings
 
@@ -554,6 +562,8 @@ contains
             call copy_indices(node%body_indices, indices)
         type is (block_construct_node)
             call copy_indices(node%body_indices, indices)
+        type is (mixed_construct_container_node)
+            call copy_indices(node%implicit_declaration_indices, indices)
         end select
     end subroutine get_scope_statement_indices
 
@@ -774,6 +784,10 @@ contains
         type is (associate_node)
             is_scope = .true.
         type is (block_construct_node)
+            is_scope = .true.
+        type is (mixed_construct_container_node)
+            ! A main program without a PROGRAM statement is still a scoping
+            ! unit; its statements hang off the container (issue #2888).
             is_scope = .true.
         end select
     end function is_scope_node

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -560,6 +560,7 @@ contains
         type(ast_arena_t), intent(inout) :: arena
         type(parser_state_t), intent(inout) :: parent_parser
         integer :: first_token
+        integer :: keyword_token
         character(len=:), allocatable :: token_lower, stmt_label
         type(parser_state_t) :: block_parser
         type(token_t) :: token
@@ -586,9 +587,15 @@ contains
             end if
         end if
 
-        if (first_token <= stmt_size) then
-            if (stmt_tokens(first_token)%kind == TK_KEYWORD) then
-                token_lower = to_lower(stmt_tokens(first_token)%text)
+        ! A construct name (name: DO ...) precedes the construct keyword; the
+        ! DO parser consumes the name itself, so only the dispatch position
+        ! moves past it here (issue #2888).
+        keyword_token = construct_keyword_position(stmt_tokens, stmt_size, &
+                                                   first_token)
+
+        if (keyword_token <= stmt_size) then
+            if (stmt_tokens(keyword_token)%kind == TK_KEYWORD) then
+                token_lower = to_lower(stmt_tokens(keyword_token)%text)
                 if (trim(token_lower) == "if") then
                     if (associated(parent_parser%diagnostic_sink)) then
                         stmt_index = parse_if_statement_tokens(stmt_tokens, arena, &
@@ -643,6 +650,50 @@ contains
             end if
         end if
     end function parse_body_statement_tokens
+
+    ! Index of the construct keyword of a statement, skipping a leading
+    ! construct name. Only the DO construct is named here: its parser accepts
+    ! the name, the other construct parsers do not yet.
+    integer function construct_keyword_position(stmt_tokens, stmt_size, &
+            first_token) result(keyword_token)
+        type(token_t), intent(in) :: stmt_tokens(:)
+        integer, intent(in) :: stmt_size
+        integer, intent(in) :: first_token
+        integer :: colon_token
+        integer :: candidate
+
+        keyword_token = first_token
+        if (first_token > stmt_size) return
+        if (stmt_tokens(first_token)%kind /= TK_IDENTIFIER) return
+        colon_token = next_significant_token(stmt_tokens, stmt_size, &
+                                             first_token + 1)
+        if (colon_token > stmt_size) return
+        if (stmt_tokens(colon_token)%kind /= TK_OPERATOR) return
+        if (trim(stmt_tokens(colon_token)%text) /= ":") return
+        candidate = next_significant_token(stmt_tokens, stmt_size, colon_token + 1)
+        if (candidate > stmt_size) return
+        if (stmt_tokens(candidate)%kind /= TK_KEYWORD) return
+        if (to_lower(trim(stmt_tokens(candidate)%text)) /= "do") return
+        keyword_token = candidate
+    end function construct_keyword_position
+
+    ! Index of the next token that is not whitespace, a newline or a comment.
+    integer function next_significant_token(stmt_tokens, stmt_size, start_token) &
+            result(token_index)
+        type(token_t), intent(in) :: stmt_tokens(:)
+        integer, intent(in) :: stmt_size
+        integer, intent(in) :: start_token
+
+        token_index = start_token
+        do while (token_index <= stmt_size)
+            select case (stmt_tokens(token_index)%kind)
+            case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
+                token_index = token_index + 1
+            case default
+                return
+            end select
+        end do
+    end function next_significant_token
 
     integer function parse_do_statement_tokens(stmt_tokens, arena, parent_parser) &
             result(do_index)

--- a/src/semantic/analyzers/semantic_local_name_collision_validation.f90
+++ b/src/semantic/analyzers/semantic_local_name_collision_validation.f90
@@ -1,28 +1,53 @@
 module semantic_local_name_collision_validation
-    ! Issue #2888 (reject-scope-02). F2023 19.3.1 puts derived-type names and
-    ! variable names in the same class of local identifier, so within one
-    ! scoping unit a name shall not be both. gfortran.dg/type_decl_4.f90 is the
-    ! reference case ("Symbol 'xx' at (1) also declared as a type at (2)").
+    ! Issue #2888 (reject-scope-02): name collisions inside one scoping unit,
+    ! and between a scoping unit and the entities it inherits by host or use
+    ! association. F2023 19.3.1 puts derived-type names, variable names,
+    ! procedure names and construct names into the same class of local
+    ! identifier, so within one scoping unit a name shall not denote two of
+    ! them, and a locally declared name shall not clash with an inherited name
+    ! that the same scoping unit also uses.
     !
-    ! Only that pairing is diagnosed here: a derived-type definition whose name
-    ! is also the name of a variable or named constant declared in the same
-    ! scoping unit. Declaring an entity OF the type is untouched, and so is any
-    ! collision that involves host or use association rather than two local
-    ! declarations.
+    ! Diagnosed families, with their gfortran.dg reference cases:
+    !   * type/entity and procedure/entity collisions in one scoping unit
+    !     (type_decl_4.f90, pr104351.f90)
+    !   * a contained procedure whose name repeats its host's own name
+    !     (pr77414.f90)
+    !   * an internal procedure whose name repeats a host entity that the host
+    !     scope also references (pr96102.f90)
+    !   * a local derived-type definition of a use-associated name
+    !     (used_types_25.f90)
+    !   * a COMMON member or a construct name that repeats a host-associated
+    !     derived type used in the same scope (common_29.f90,
+    !     host_assoc_types_1.f90)
+    !   * IMPORT of a name that is already use-associated in the local scope
+    !     (pr123375.f90)
     use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: identifier_node
+    use ast_nodes_data, only: declaration_node
+    use ast_nodes_legacy, only: common_block_node
+    use ast_nodes_loops, only: do_loop_node
+    use ast_nodes_misc, only: import_statement_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
     use error_handling, only: error_collection_t, ERROR_SEMANTIC
     use frontend_compiler_resolution, only: declaration_binding_t, &
-        get_scope_bindings, is_scope_node, BINDING_DECLARATION, &
-        BINDING_NAMED_CONSTANT, BINDING_DERIVED_TYPE
+        get_scope_bindings, get_scope_statement_indices, is_scope_node, &
+        find_enclosing_scope, find_host_scope, resolve_name_in_scope, &
+        resolve_use_binding, BINDING_DECLARATION, BINDING_NAMED_CONSTANT, &
+        BINDING_DERIVED_TYPE, BINDING_FUNCTION, BINDING_SUBROUTINE, &
+        ASSOCIATION_HOST, ASSOCIATION_USE
     implicit none
     private
+
+    integer, parameter :: CLASS_NONE = 0
+    integer, parameter :: CLASS_ENTITY = 1
+    integer, parameter :: CLASS_TYPE = 2
+    integer, parameter :: CLASS_PROCEDURE = 3
 
     public :: validate_local_name_collisions
 
 contains
 
-    ! Report every scoping unit that declares one name both as a derived type
-    ! and as a variable or named constant.
+    ! Run every collision rule over every scoping unit in the arena.
     subroutine validate_local_name_collisions(arena, errors)
         type(ast_arena_t), intent(in) :: arena
         type(error_collection_t), intent(inout) :: errors
@@ -32,53 +57,327 @@ contains
             if (.not. arena%has_node_at(i)) cycle
             if (.not. is_scope_node(arena, i)) cycle
             call check_scope(arena, i, errors)
+            call check_inherited_collisions(arena, i, errors)
+            call check_common_and_construct_names(arena, i, errors)
+            call check_imports(arena, i, errors)
         end do
     end subroutine validate_local_name_collisions
 
-    ! Compare the direct bindings of one scoping unit pairwise. At most one
-    ! diagnostic is emitted per entity binding.
+    ! Compare the direct bindings of one scoping unit pairwise, and against the
+    ! name of the scoping unit itself. At most one diagnostic per binding.
     subroutine check_scope(arena, scope_index, errors)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: scope_index
         type(error_collection_t), intent(inout) :: errors
         type(declaration_binding_t), allocatable :: bindings(:)
         character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: scope_name
         integer :: i, j
 
         call get_scope_bindings(arena, scope_index, bindings, error_msg)
         if (len_trim(error_msg) > 0) return
+        scope_name = scope_unit_name(arena, scope_index)
         do j = 1, size(bindings)
-            if (.not. is_entity_binding(bindings(j))) cycle
+            if (binding_class(bindings(j)) == CLASS_NONE) cycle
+            if (binding_class(bindings(j)) == CLASS_PROCEDURE) then
+                if (len_trim(scope_name) > 0) then
+                    if (same_name(scope_name, bindings(j)%name)) then
+                        call report(arena, bindings(j), errors, &
+                            "' is already defined as the name of its host "// &
+                            "scoping unit")
+                        cycle
+                    end if
+                end if
+            end if
+            if (binding_class(bindings(j)) == CLASS_TYPE) cycle
             do i = 1, size(bindings)
-                if (bindings(i)%binding_kind /= BINDING_DERIVED_TYPE) cycle
+                if (i == j) cycle
+                if (binding_class(bindings(i)) == CLASS_NONE) cycle
+                if (binding_class(bindings(i)) == binding_class(bindings(j))) cycle
                 if (.not. same_name(bindings(i)%name, bindings(j)%name)) cycle
-                call report_collision(arena, bindings(j), errors)
+                if (binding_class(bindings(i)) == CLASS_TYPE) then
+                    call report(arena, bindings(j), errors, &
+                        "' is also declared as a type in the same scoping unit")
+                else
+                    call report(arena, bindings(j), errors, &
+                        "' is already defined in the same scoping unit")
+                end if
                 exit
             end do
         end do
     end subroutine check_scope
 
-    ! Whether a binding names a data entity rather than a type or procedure.
-    logical function is_entity_binding(binding) result(is_entity)
+    ! Collisions between a local declaration and an inherited name: an internal
+    ! procedure that repeats a host entity the host also references, and a
+    ! derived-type definition of a use-associated name.
+    subroutine check_inherited_collisions(arena, scope_index, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        type(error_collection_t), intent(inout) :: errors
+        type(declaration_binding_t), allocatable :: bindings(:)
+        type(declaration_binding_t) :: inherited
+        character(len=:), allocatable :: error_msg
+        integer :: i, host_index
+        logical :: internal_scope
+
+        call get_scope_bindings(arena, scope_index, bindings, error_msg)
+        if (len_trim(error_msg) > 0) return
+        host_index = find_host_scope(arena, scope_index)
+        internal_scope = is_procedure_scope(arena, scope_index)
+        do i = 1, size(bindings)
+            if (bindings(i)%binding_kind == BINDING_DERIVED_TYPE) then
+                call resolve_use_binding(arena, scope_index, bindings(i)%name, &
+                                         inherited)
+                if (inherited%found) then
+                    call report(arena, bindings(i), errors, &
+                        "' has already been defined by use association")
+                end if
+                cycle
+            end if
+            if (binding_class(bindings(i)) /= CLASS_PROCEDURE) cycle
+            if (host_index <= 0) cycle
+            if (.not. internal_scope) cycle
+            call resolve_name_in_scope(arena, host_index, bindings(i)%name, &
+                                       inherited, error_msg)
+            if (len_trim(error_msg) > 0) cycle
+            if (.not. inherited%found) cycle
+            if (binding_class(inherited) /= CLASS_ENTITY) cycle
+            if (.not. name_referenced_as_data_object(arena, scope_index, &
+                                                     bindings(i)%name)) cycle
+            call report(arena, bindings(i), errors, &
+                "' is host associated and cannot also name an internal "// &
+                "procedure of the same name")
+        end do
+    end subroutine check_inherited_collisions
+
+    ! A COMMON member or a construct name may not repeat a derived type that the
+    ! same scoping unit uses by host or use association.
+    subroutine check_common_and_construct_names(arena, scope_index, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        type(error_collection_t), intent(inout) :: errors
+        integer, allocatable :: indices(:)
+        integer :: i, j
+
+        call get_scope_statement_indices(arena, scope_index, indices)
+        do i = 1, size(indices)
+            if (.not. arena%has_node_at(indices(i))) cycle
+            select type (node => arena%entries(indices(i))%node)
+            type is (common_block_node)
+                if (.not. allocated(node%member_names)) cycle
+                do j = 1, size(node%member_names)
+                    if (.not. inherited_type_used_here(arena, scope_index, &
+                                                       node%member_names(j)%s)) cycle
+                    call report_at(errors, node%member_names(j)%s, node%line, &
+                                   node%column, incompatible_object_message())
+                end do
+            type is (do_loop_node)
+                if (.not. allocated(node%label)) cycle
+                if (.not. inherited_type_used_here(arena, scope_index, &
+                                                   node%label)) cycle
+                call report_at(errors, node%label, node%line, node%column, &
+                               incompatible_object_message())
+            end select
+        end do
+    end subroutine check_common_and_construct_names
+
+    function incompatible_object_message() result(text)
+        character(len=:), allocatable :: text
+
+        text = "' names an incompatible object of the same name as a host "// &
+            "associated derived type"
+    end function incompatible_object_message
+
+    ! IMPORT may only bring in names of the host scoping unit, so importing a
+    ! name that the local scope already accesses by use association is invalid.
+    subroutine check_imports(arena, scope_index, errors)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        type(error_collection_t), intent(inout) :: errors
+        type(declaration_binding_t) :: binding
+        integer, allocatable :: indices(:)
+        integer :: i, j
+
+        call get_scope_statement_indices(arena, scope_index, indices)
+        do i = 1, size(indices)
+            if (.not. arena%has_node_at(indices(i))) cycle
+            select type (node => arena%entries(indices(i))%node)
+            type is (import_statement_node)
+                if (.not. node%has_list) cycle
+                if (.not. allocated(node%import_list)) cycle
+                do j = 1, size(node%import_list)
+                    call resolve_use_binding(arena, scope_index, &
+                                             node%import_list(j)%s, binding)
+                    if (.not. binding%found) cycle
+                    call report_at(errors, node%import_list(j)%s, node%line, &
+                                   node%column, &
+                                   "' cannot be imported because it is "// &
+                                   "already accessible in the local scope")
+                end do
+            end select
+        end do
+    end subroutine check_imports
+
+    ! Whether NAME is used as a derived type in this scope and resolves to a
+    ! type inherited by host or use association.
+    logical function inherited_type_used_here(arena, scope_index, name) &
+            result(is_inherited)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        character(len=*), intent(in) :: name
+        type(declaration_binding_t) :: binding
+        character(len=:), allocatable :: error_msg
+        character(len=:), allocatable :: spec_name
+        integer, allocatable :: indices(:)
+        logical :: used
+        integer :: i
+
+        is_inherited = .false.
+        if (len_trim(name) == 0) return
+        used = .false.
+        call get_scope_statement_indices(arena, scope_index, indices)
+        do i = 1, size(indices)
+            if (.not. arena%has_node_at(indices(i))) cycle
+            select type (node => arena%entries(indices(i))%node)
+            type is (declaration_node)
+                if (.not. allocated(node%type_name)) cycle
+                spec_name = derived_type_spec_name(node%type_name)
+                if (len_trim(spec_name) == 0) cycle
+                if (same_name(spec_name, name)) used = .true.
+            end select
+        end do
+        if (.not. used) return
+        call resolve_name_in_scope(arena, scope_index, name, binding, error_msg)
+        if (len_trim(error_msg) > 0) return
+        if (.not. binding%found) return
+        if (binding%binding_kind /= BINDING_DERIVED_TYPE) return
+        if (binding%association == ASSOCIATION_HOST) is_inherited = .true.
+        if (binding%association == ASSOCIATION_USE) is_inherited = .true.
+    end function inherited_type_used_here
+
+    ! Derived-type name inside a type(...) or class(...) spec, empty otherwise.
+    function derived_type_spec_name(type_name) result(name)
+        character(len=*), intent(in) :: type_name
+        character(len=:), allocatable :: name
+        character(len=:), allocatable :: text
+        integer :: open_pos, close_pos
+
+        name = ''
+        text = trim(adjustl(type_name))
+        open_pos = index(text, '(')
+        close_pos = index(text, ')', back=.true.)
+        if (open_pos <= 1) return
+        if (close_pos <= open_pos + 1) return
+        if (.not. same_name(text(1:open_pos - 1), 'type')) then
+            if (.not. same_name(text(1:open_pos - 1), 'class')) return
+        end if
+        name = trim(adjustl(text(open_pos + 1:close_pos - 1)))
+    end function derived_type_spec_name
+
+    ! Whether NAME appears directly in SCOPE_INDEX as a data object, that is a
+    ! bare name rather than a procedure reference or an array section. A bare
+    ! name can never denote an internal procedure, so it still means the
+    ! inherited entity and the two spellings of the name conflict.
+    logical function name_referenced_as_data_object(arena, scope_index, name) &
+            result(referenced)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        character(len=*), intent(in) :: name
+        integer :: i
+
+        referenced = .false.
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            if (.not. is_bare_name_reference(arena, i, name)) cycle
+            if (find_enclosing_scope(arena, i) /= scope_index) cycle
+            referenced = .true.
+            return
+        end do
+    end function name_referenced_as_data_object
+
+    ! Whether the node is a bare identifier reference spelling NAME.
+    logical function is_bare_name_reference(arena, node_index, name) result(is_bare)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=*), intent(in) :: name
+
+        is_bare = .false.
+        select type (node => arena%entries(node_index)%node)
+        type is (identifier_node)
+            if (.not. allocated(node%name)) return
+            is_bare = same_name(node%name, name)
+        end select
+    end function is_bare_name_reference
+
+    ! Whether the scoping unit is a procedure, so procedures contained in it are
+    ! internal procedures rather than module procedures.
+    logical function is_procedure_scope(arena, scope_index) result(is_procedure)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+
+        is_procedure = .false.
+        select type (node => arena%entries(scope_index)%node)
+        type is (function_def_node)
+            is_procedure = .true.
+        type is (subroutine_def_node)
+            is_procedure = .true.
+        end select
+    end function is_procedure_scope
+
+    ! Declared name of a scoping unit, empty when it has none.
+    function scope_unit_name(arena, scope_index) result(name)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        character(len=:), allocatable :: name
+
+        name = ''
+        select type (node => arena%entries(scope_index)%node)
+        type is (function_def_node)
+            if (allocated(node%name)) name = node%name
+        type is (subroutine_def_node)
+            if (allocated(node%name)) name = node%name
+        end select
+    end function scope_unit_name
+
+    ! Class of local identifier a binding belongs to.
+    integer function binding_class(binding) result(class_id)
         type(declaration_binding_t), intent(in) :: binding
 
-        is_entity = binding%binding_kind == BINDING_DECLARATION .or. &
-            binding%binding_kind == BINDING_NAMED_CONSTANT
-    end function is_entity_binding
+        select case (binding%binding_kind)
+        case (BINDING_DECLARATION, BINDING_NAMED_CONSTANT)
+            class_id = CLASS_ENTITY
+        case (BINDING_DERIVED_TYPE)
+            class_id = CLASS_TYPE
+        case (BINDING_FUNCTION, BINDING_SUBROUTINE)
+            class_id = CLASS_PROCEDURE
+        case default
+            class_id = CLASS_NONE
+        end select
+    end function binding_class
 
-    subroutine report_collision(arena, binding, errors)
+    subroutine report(arena, binding, errors, suffix)
         type(ast_arena_t), intent(in) :: arena
         type(declaration_binding_t), intent(in) :: binding
         type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: suffix
         integer :: line, column
 
         call binding_position(arena, binding, line, column)
+        call report_at(errors, binding%name, line, column, suffix)
+    end subroutine report
+
+    subroutine report_at(errors, name, line, column, suffix)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: name
+        integer, intent(in) :: line
+        integer, intent(in) :: column
+        character(len=*), intent(in) :: suffix
+
         call errors%add_error( &
-            "Symbol '"//trim(binding%name)//"' is also declared as a type "// &
-            "in the same scoping unit", &
+            "Symbol '"//trim(name)//suffix, &
             severity=ERROR_SEMANTIC, component="semantic_scope_collision", &
             line=line, column=column)
-    end subroutine report_collision
+    end subroutine report_at
 
     ! Source position of the declaration that carries the colliding name.
     subroutine binding_position(arena, binding, line, column)

--- a/test/api/test_reject_scope_02_diagnostics.f90
+++ b/test/api/test_reject_scope_02_diagnostics.f90
@@ -19,6 +19,34 @@ program test_reject_scope_02_diagnostics
     all_passed = .true.
     if (.not. test_type_and_variable_collision_rejected()) all_passed = .false.
     if (.not. test_corrected_neighbour_accepted()) all_passed = .false.
+    if (.not. test_rejected('examples/f90/common_29.f90', &
+        'incompatible object', "'t'")) all_passed = .false.
+    if (.not. test_rejected('examples/f90/host_assoc_types_1.f90', &
+        'incompatible object', "'vertex'")) all_passed = .false.
+    if (.not. test_rejected('examples/f90/pr104351.f90', &
+        'already defined', "'f'")) all_passed = .false.
+    if (.not. test_rejected('examples/f90/pr77414.f90', &
+        'already defined', "'pr77414_outer'")) all_passed = .false.
+    if (.not. test_rejected('examples/f90/pr96102.f90', &
+        'internal procedure of the same name', "'n'")) all_passed = .false.
+    if (.not. test_rejected('examples/f90/used_types_25.f90', &
+        'use association', "'t'")) all_passed = .false.
+    if (.not. test_rejected('examples/f90/pr123375.f90', &
+        'already accessible in the local scope', "'aa'")) all_passed = .false.
+    if (.not. test_accepted('examples/f90/common_29_corrected.f90')) &
+        all_passed = .false.
+    if (.not. test_accepted('examples/f90/host_assoc_types_1_corrected.f90')) &
+        all_passed = .false.
+    if (.not. test_accepted('examples/f90/pr104351_corrected.f90')) &
+        all_passed = .false.
+    if (.not. test_accepted('examples/f90/pr77414_corrected.f90')) &
+        all_passed = .false.
+    if (.not. test_accepted('examples/f90/pr96102_corrected.f90')) &
+        all_passed = .false.
+    if (.not. test_accepted('examples/f90/used_types_25_corrected.f90')) &
+        all_passed = .false.
+    if (.not. test_accepted('examples/f90/pr123375_corrected.f90')) &
+        all_passed = .false.
 
     if (all_passed) then
         print *, 'All reject-scope-02 diagnostics tests passed.'
@@ -77,6 +105,58 @@ contains
         end if
         print *, '  PASS: corrected neighbour still accepted'
     end function test_corrected_neighbour_accepted
+
+    ! An invalid fixture must be rejected with a diagnostic of this rule family
+    ! that names the offending symbol.
+    logical function test_rejected(path, rule_text, symbol_text) result(ok)
+        character(len=*), intent(in) :: path
+        character(len=*), intent(in) :: rule_text
+        character(len=*), intent(in) :: symbol_text
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: source
+        character(len=:), allocatable :: text
+
+        ok = .true.
+        call read_example(path, source)
+        call compile_standard(source, result)
+        if (result%success()) then
+            print *, '  FAIL: accepted invalid fixture ', path
+            ok = .false.
+            return
+        end if
+        text = lowered(diagnostic_of(result))
+        if (index(text, rule_text) == 0) then
+            print *, '  FAIL: wrong rule for ', path, ' -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        if (index(text, symbol_text) == 0) then
+            print *, '  FAIL: symbol not named for ', path, ' -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        print *, '  PASS: rejected ', path
+    end function test_rejected
+
+    ! A corrected neighbour must keep compiling.
+    logical function test_accepted(path) result(ok)
+        character(len=*), intent(in) :: path
+        type(compiler_frontend_result_t) :: result
+        character(len=:), allocatable :: source
+
+        ok = .true.
+        call read_example(path, source)
+        call compile_standard(source, result)
+        if (.not. result%success()) then
+            print *, '  FAIL: rejected valid fixture ', path, ' -> ', &
+                trim(diagnostic_of(result))
+            ok = .false.
+            return
+        end if
+        print *, '  PASS: accepted ', path
+    end function test_accepted
 
     subroutine compile_standard(source, result)
         character(len=*), intent(in) :: source


### PR DESCRIPTION
Closes #2888.

## Preserved compiler invariant

A name is a local identifier of exactly one class within a scoping unit, and a
locally declared name may not clash with a name the scoping unit inherits by
host or use association and also uses in a way only the inherited entity can
satisfy (F2023 19.3.1, C8105). Programs that violate this were accepted and
resolved by whichever binding a lookup reached first.

## What is now rejected

Each shape has a negative fixture under `examples/f90/` with the gfortran.dg
basename and a corrected neighbour that gfortran accepts:

| fixture | rule |
|---|---|
| `pr104351.f90` | contained procedure repeats another local identifier of its host |
| `pr77414.f90` | contained procedure repeats the host procedure's own name |
| `pr96102.f90` | internal procedure repeats a host entity referenced as a bare name |
| `used_types_25.f90` | derived-type definition of a use-associated name |
| `common_29.f90` | COMMON member repeats a host associated derived type used here |
| `host_assoc_types_1.f90` | DO construct name repeats a host associated derived type used here |
| `pr123375.f90` | IMPORT of a name already use associated in the local scope |

The rules are reference-sensitive where the standard is: an internal procedure
may legally shadow a host variable when every reference is a procedure
reference (gfortran.dg `host_assoc_function_1.f90`, `array_constructor_57.f90`),
so only a bare-name reference triggers the internal-procedure diagnostic.

## Representation fixes (not workarounds)

* A main program without a PROGRAM statement is a scoping unit; its statements
  hang off the mixed-construct container, which was not a scope node. The
  resolution layer now treats that container as the implicit main program's
  scoping unit, so every scope rule sees it. One canonical mechanism, no
  second path in the validator.
* A named DO construct inside a contained procedure was dropped from the AST
  entirely: the procedure-body dispatcher looked for the construct keyword at
  the first token, and a construct name precedes it. The dispatch position now
  skips the name; the DO parser already consumes it. Named IF/SELECT/BLOCK in
  contained procedures remain unhandled — adjacent, reported, not fixed here.

## Red evidence

Unmodified main (`origin/main` worktree, `frontend_probe`) on the seven new
negative fixtures: `semantic_ok=True` for all seven, i.e. every invalid program
was accepted.

## Green evidence

* `fo test test_reject_scope_02_diagnostics` — PASS (7 rejections with
  rule-specific diagnostics naming the symbol, 8 accepted neighbours).
* Full `fo` pipeline: build 369/369, tests 483/483, lint OK.

## Rejection gate

`scripts/corpus_rejection_gate.sh` over `examples/` plus the full gfortran.dg
suite (8656 files) against an unmodified-main baseline: exactly 8 files flip
ACCEPTED → REJECTED, and `gfortran -fsyntax-only` rejects all 8 (the 7 fixture
originals plus `internal_references_1.f90` and `pr96102b.f90`). **Zero valid
files are newly rejected.** `make check-rejection-gate` is clean.

Known remaining gap, to be filed separately: the original uppercase
`gfortran.dg/host_assoc_types_1.f90` still parses wrong because an uppercase
derived-type component together with an uppercase `END TYPE` makes the type
body swallow the rest of the module. Reduced case in the follow-up issue.