### PR TITLE
Enforce explicit-interface declaration rules (#2883)

### DIFF
--- a/src/parser/declarations/parser_interface_blocks.f90
+++ b/src/parser/declarations/parser_interface_blocks.f90
@@ -110,6 +110,14 @@ contains
 
         call reject_module_procedure_in_abstract(parser, lowered_text, is_abstract)
 
+        ! MODULE PROCEDURE is a module-procedure-stmt, not a MODULE prefix on a
+        ! procedure definition. Leaving it to the statement parser is what
+        ! records has_module_prefix, which distinguishes it from a plain
+        ! PROCEDURE statement (issue #2883).
+        if (trim(lowered_text) == "module") then
+            if (is_module_procedure_declaration(parser)) return
+        end if
+
         if (is_procedure_prefix(lowered_text)) then
             call append_interface_prefix(prefix_buffer, lowered_text)
             consumed_prefix = parser%consume()
@@ -236,7 +244,15 @@ contains
 
         if (token%kind == TK_IDENTIFIER) then
             lowered_text = to_lower(token%text)
-            if (is_procedure_prefix(lowered_text)) then
+            ! MODULE PROCEDURE is a module-procedure-stmt, not a MODULE prefix on a
+        ! procedure definition. Leaving it to the statement parser is what
+        ! records has_module_prefix, which distinguishes it from a plain
+        ! PROCEDURE statement (issue #2883).
+        if (trim(lowered_text) == "module") then
+            if (is_module_procedure_declaration(parser)) return
+        end if
+
+        if (is_procedure_prefix(lowered_text)) then
                 call append_interface_prefix(prefix_buffer, lowered_text)
                 consumed_token = parser%consume()
                 handled = .true.

--- a/src/parser/declarations/parser_module_structures.f90
+++ b/src/parser/declarations/parser_module_structures.f90
@@ -26,6 +26,10 @@ module parser_module_structures_module
     use parser_keyword_disambiguation_module, only: keyword_should_parse_as_identifier
     use parser_instantiate_statement_module, only: parse_instantiate_statement
     use parser_enum_statement_module, only: parse_enum_construct
+    use parser_external_statements_module, only: parse_external_statement
+    use parser_intrinsic_statements_module, only: parse_intrinsic_statement
+    use parser_dimension_statements_module, only: parse_dimension_statement
+    use parser_allocatable_statements_module, only: parse_allocatable_statement
     ! Temporarily removed to avoid circular dependency
     ! Will be added back after refactoring is complete
     implicit none
@@ -176,6 +180,16 @@ contains
             stmt_index = parse_enum_construct(parser, arena)
         case ("enumerator")
             stmt_index = handle_enum_construct(parser, arena, to_lower(token%text))
+        case ("external")
+            stmt_index = parse_external_statement(parser, arena)
+        case ("intrinsic")
+            stmt_index = parse_intrinsic_statement(parser, arena)
+        case ("dimension")
+            stmt_index = parse_dimension_statement(parser, arena)
+        case ("allocatable")
+            ! The ALLOCATABLE statement adds an attribute to a declaration
+            ! that is already in the arena, so it contributes no new index.
+            if (parse_allocatable_statement(parser, arena)) stmt_index = -1
         end select
     end function parse_module_declaration_statement
 
@@ -426,7 +440,8 @@ contains
         case ("public", "private", "use", "include", "namelist", "integer", &
                 "real", "logical", "character", "complex", "procedure", &
                 "type", "class", "module", "implicit", "interface", &
-                "abstract", "instantiate", "enum", "enumerator", "parameter")
+                "abstract", "instantiate", "enum", "enumerator", "parameter", &
+                "external", "intrinsic", "dimension", "allocatable")
             module_declaration_keyword = .true.
         case default
             module_declaration_keyword = .false.

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -25,6 +25,10 @@ use semantic_local_name_collision_validation, only: &
     validate_local_name_collisions
 use semantic_submodule_validation, only: validate_submodule_interfaces
 use semantic_bind_c_validation, only: validate_global_binding_labels
+use semantic_interface_declaration_validation, only: &
+    validate_interface_declarations
+use semantic_explicit_interface_checker, only: &
+    validate_whole_file_explicit_interface
 use semantic_strict_argument_type_checker_validation, only: &
     validate_value_dummy_attributes_in_arena
 use semantic_placement_validation, only: &
@@ -124,6 +128,16 @@ contains
         ! binding label namespace spans the whole compilation unit, so this
         ! runs once over the arena rather than per scoping unit.
         call validate_global_binding_labels(arena, ctx%errors)
+
+        ! Reject declarations that contradict an interface body of the same
+        ! scoping unit, and module-procedure-stmt names declared INTRINSIC
+        ! (F2018 15.4.3.2, C846, C1514). Issue #2883.
+        call validate_interface_declarations(arena, ctx%errors)
+
+        ! Reject references to an external subprogram of the same file whose
+        ! interface must be explicit (F2018 15.4.2.2). Issue #2883.
+        call validate_whole_file_explicit_interface(arena, ctx%errors, &
+            ctx%input_mode == INPUT_MODE_STANDARD)
 
         ! Reject VALUE dummy arguments that carry a conflicting attribute
         ! (F2018 C863). The sweep is arena-wide so every procedure definition

--- a/src/semantic/analyzers/semantic_explicit_interface_checker.f90
+++ b/src/semantic/analyzers/semantic_explicit_interface_checker.f90
@@ -1,7 +1,9 @@
 module semantic_explicit_interface_checker
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: call_or_subscript_node, program_node
-    use ast_nodes_data, only: declaration_node, module_node, submodule_node
+    use ast_nodes_bounds, only: range_expression_node
+    use ast_nodes_data, only: declaration_node, module_node, submodule_node, &
+        multi_unit_container_node, parameter_declaration_node
     use ast_nodes_misc, only: contains_node, interface_block_node, &
         module_procedure_node
     use ast_nodes_procedure, only: function_def_node, subroutine_call_node, &
@@ -19,12 +21,353 @@ module semantic_explicit_interface_checker
     implicit none
     private
 
+    ! Guard against malformed parent chains.
+    integer, parameter :: MAX_SCOPE_WALK = 64
+
     public :: validate_explicit_interface_for_function_reference
     public :: validate_explicit_interface_for_subroutine_call
+    public :: validate_whole_file_explicit_interface
     public :: build_explicit_interface_name_cache
     public :: is_part_reference
 
 contains
+
+    ! F2018 15.4.2.2: a procedure reference requires an explicit interface when
+    ! the procedure has a dummy argument with the ALLOCATABLE, ASYNCHRONOUS,
+    ! OPTIONAL, POINTER, TARGET, VALUE or VOLATILE attribute, or an
+    ! assumed-shape dummy. When such a procedure is an external subprogram of
+    ! the same file, the reference can be checked here.
+    ! gfortran.dg/whole_file_16.f90 and volatile14.f90 are the reference cases.
+    ! Issue #2883.
+    ! `standard_input` is false for lazy Fortran, whose standardizer moves an
+    ! external subprogram into the main program before the result is compiled,
+    ! so the requirement does not apply to the source as written.
+    subroutine validate_whole_file_explicit_interface(arena, errors, &
+            standard_input)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        logical, intent(in) :: standard_input
+
+        type(identifier_table_t) :: required
+        integer :: i
+
+        if (.not. standard_input) return
+        call identifier_table_init(required)
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (multi_unit_container_node)
+                call collect_interface_requiring_units(arena, node%body_indices, &
+                    required)
+            class default
+                cycle
+            end select
+        end do
+        if (required%count == 0) return
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (subroutine_call_node)
+                call check_call_needs_interface(arena, errors, required, node, i)
+            class default
+                cycle
+            end select
+        end do
+    end subroutine validate_whole_file_explicit_interface
+
+    ! External subprograms of this file whose interface must be explicit.
+    subroutine collect_interface_requiring_units(arena, body_indices, required)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: body_indices(:)
+        type(identifier_table_t), intent(inout) :: required
+
+        integer :: i
+
+        if (.not. allocated(body_indices)) return
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (unit => arena%entries(body_indices(i))%node)
+                type is (subroutine_def_node)
+                if (.not. procedure_requires_explicit_interface(arena, &
+                    unit%param_indices, unit%body_indices)) cycle
+                call cache_allocated_name(unit%name, required)
+                type is (function_def_node)
+                if (.not. procedure_requires_explicit_interface(arena, &
+                    unit%param_indices, unit%body_indices)) cycle
+                call cache_allocated_name(unit%name, required)
+            class default
+                cycle
+            end select
+        end do
+    end subroutine collect_interface_requiring_units
+
+    ! True when a dummy argument carries an attribute or shape that forces the
+    ! interface of the procedure to be explicit.
+    logical function procedure_requires_explicit_interface(arena, param_indices, &
+            body_indices) result(requires)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: param_indices(:)
+        integer, allocatable, intent(in) :: body_indices(:)
+
+        integer :: i
+
+        requires = .false.
+        if (.not. allocated(param_indices)) return
+        if (.not. allocated(body_indices)) return
+
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (decl => arena%entries(body_indices(i))%node)
+                type is (declaration_node)
+                if (.not. declaration_names_a_dummy(arena, param_indices, decl)) &
+                    cycle
+                if (declaration_forces_explicit_interface(arena, decl)) then
+                    requires = .true.
+                    return
+                end if
+            class default
+                cycle
+            end select
+        end do
+    end function procedure_requires_explicit_interface
+
+    logical function declaration_names_a_dummy(arena, param_indices, decl) &
+            result(is_dummy)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: param_indices(:)
+        type(declaration_node), intent(in) :: decl
+
+        integer :: i
+
+        is_dummy = .false.
+        if (.not. allocated(decl%var_name)) return
+        do i = 1, size(param_indices)
+            if (.not. arena%has_node_at(param_indices(i))) cycle
+            select type (param => arena%entries(param_indices(i))%node)
+                type is (parameter_declaration_node)
+                if (.not. allocated(param%name)) cycle
+                if (to_lower(trim(param%name)) /= to_lower(trim(decl%var_name))) &
+                    cycle
+                is_dummy = .true.
+                return
+            class default
+                cycle
+            end select
+        end do
+    end function declaration_names_a_dummy
+
+    logical function declaration_forces_explicit_interface(arena, decl) &
+            result(forces)
+        type(ast_arena_t), intent(in) :: arena
+        type(declaration_node), intent(in) :: decl
+
+        integer :: i
+
+        forces = decl%is_allocatable .or. decl%is_pointer
+        if (forces) return
+        forces = decl%is_optional .or. decl%is_target
+        if (forces) return
+        forces = decl%is_value .or. decl%is_volatile .or. decl%is_asynchronous
+        if (forces) return
+
+        if (.not. decl%is_array) return
+        if (.not. allocated(decl%dimension_indices)) return
+        do i = 1, size(decl%dimension_indices)
+            if (.not. arena%has_node_at(decl%dimension_indices(i))) cycle
+            select type (bound => arena%entries(decl%dimension_indices(i))%node)
+                type is (range_expression_node)
+                if (bound%start_index > 0) cycle
+                if (bound%end_index > 0) cycle
+                forces = .true.
+                return
+            class default
+                cycle
+            end select
+        end do
+    end function declaration_forces_explicit_interface
+
+    ! Report a call whose target needs an explicit interface that is not
+    ! visible in any enclosing scoping unit of the call.
+    subroutine check_call_needs_interface(arena, errors, required, expr, &
+            expr_index)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        type(identifier_table_t), intent(in) :: required
+        type(subroutine_call_node), intent(in) :: expr
+        integer, intent(in) :: expr_index
+
+        character(len=:), allocatable :: proc_name
+        integer :: scope_index
+        integer :: steps
+
+        if (.not. allocated(expr%name)) return
+        if (len_trim(expr%name) == 0) return
+        proc_name = to_lower(trim(expr%name))
+        if (is_part_reference(proc_name)) return
+        if (identifier_table_find(required, proc_name) <= 0) return
+
+        scope_index = expr_index
+        do steps = 1, MAX_SCOPE_WALK
+            scope_index = enclosing_scope_index(arena, scope_index)
+            if (scope_index <= 0) exit
+            if (scope_declares_name(arena, scope_index, proc_name)) return
+        end do
+
+        call errors%add_result(create_error_result( &
+            "Explicit interface required for '"//trim(expr%name)// &
+            "': the procedure has a dummy argument whose attributes or shape "// &
+            "make an explicit interface mandatory", ERROR_SEMANTIC, &
+            component="semantic_analyzer", &
+            context="explicit_interface_requirement", &
+            suggestion="Add an interface block for the procedure, or move it "// &
+            "into a module", &
+            line=expr%line, column=expr%column, end_line=expr%line, &
+            end_column=expr%column + 1))
+    end subroutine check_call_needs_interface
+
+    ! Whether one scoping unit provides an explicit interface for the name,
+    ! either through an interface block or by being the procedure itself.
+    ! Index of the nearest enclosing scoping unit, or 0 when there is none.
+    integer function enclosing_scope_index(arena, from_index) result(scope_index)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: from_index
+
+        integer :: current
+        integer :: steps
+
+        scope_index = 0
+        current = from_index
+        do steps = 1, MAX_SCOPE_WALK
+            if (current <= 0 .or. current > arena%size) return
+            current = arena%entries(current)%parent_index
+            if (current <= 0 .or. current > arena%size) return
+            if (.not. arena%has_node_at(current)) cycle
+            select type (node => arena%entries(current)%node)
+                type is (program_node)
+                scope_index = current
+                return
+                type is (module_node)
+                scope_index = current
+                return
+                type is (submodule_node)
+                scope_index = current
+                return
+                type is (function_def_node)
+                scope_index = current
+                return
+                type is (subroutine_def_node)
+                scope_index = current
+                return
+            class default
+                cycle
+            end select
+        end do
+    end function enclosing_scope_index
+
+    logical function names_match(node_name, lowered_name) result(matches)
+        character(len=:), allocatable, intent(in) :: node_name
+        character(len=*), intent(in) :: lowered_name
+
+        matches = .false.
+        if (.not. allocated(node_name)) return
+        if (len_trim(node_name) == 0) return
+        matches = to_lower(trim(node_name)) == lowered_name
+    end function names_match
+
+    ! Whether an interface block declares a procedure of this name.
+    logical function interface_declares_subroutine(arena, block, name) &
+            result(found)
+        type(ast_arena_t), intent(in) :: arena
+        type(interface_block_node), intent(in) :: block
+        character(len=*), intent(in) :: name
+
+        integer :: i
+        integer :: j
+
+        found = .false.
+        if (.not. allocated(block%procedure_indices)) return
+
+        do i = 1, size(block%procedure_indices)
+            if (.not. arena%has_node_at(block%procedure_indices(i))) cycle
+            select type (proc => arena%entries(block%procedure_indices(i))%node)
+                type is (subroutine_def_node)
+                if (names_match(proc%name, name)) then
+                    found = .true.
+                    return
+                end if
+                type is (function_def_node)
+                if (names_match(proc%name, name)) then
+                    found = .true.
+                    return
+                end if
+                type is (module_procedure_node)
+                if (.not. allocated(proc%procedure_names)) cycle
+                do j = 1, size(proc%procedure_names)
+                    if (to_lower(trim(proc%procedure_names(j)%s)) == name) then
+                        found = .true.
+                        return
+                    end if
+                end do
+            class default
+                cycle
+            end select
+        end do
+    end function interface_declares_subroutine
+
+    logical function scope_declares_name(arena, scope_index, name) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: scope_index
+        character(len=*), intent(in) :: name
+
+        found = .false.
+        if (.not. arena%has_node_at(scope_index)) return
+        select type (scope => arena%entries(scope_index)%node)
+            type is (module_node)
+            found = indices_declare_name(arena, scope%declaration_indices, name)
+            if (found) return
+            found = indices_declare_name(arena, scope%procedure_indices, name)
+            type is (program_node)
+            found = indices_declare_name(arena, scope%body_indices, name)
+            type is (function_def_node)
+            found = names_match(scope%name, name)
+            if (found) return
+            found = indices_declare_name(arena, scope%body_indices, name)
+            type is (subroutine_def_node)
+            found = names_match(scope%name, name)
+            if (found) return
+            found = indices_declare_name(arena, scope%body_indices, name)
+        class default
+            found = .false.
+        end select
+    end function scope_declares_name
+
+    logical function indices_declare_name(arena, indices, name) result(found)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: indices(:)
+        character(len=*), intent(in) :: name
+
+        integer :: i
+
+        found = .false.
+        if (.not. allocated(indices)) return
+        do i = 1, size(indices)
+            if (.not. arena%has_node_at(indices(i))) cycle
+            select type (node => arena%entries(indices(i))%node)
+                type is (interface_block_node)
+                found = interface_declares_subroutine(arena, node, name)
+                if (found) return
+                type is (function_def_node)
+                found = names_match(node%name, name)
+                if (found) return
+                type is (subroutine_def_node)
+                found = names_match(node%name, name)
+                if (found) return
+            class default
+                cycle
+            end select
+        end do
+    end function indices_declare_name
 
     ! True when the stored call designator is a part reference rather than a
     ! bare procedure name: a type-bound call (`b%show`), a coindexed call

--- a/src/semantic/analyzers/semantic_interface_declaration_validation.f90
+++ b/src/semantic/analyzers/semantic_interface_declaration_validation.f90
@@ -1,0 +1,502 @@
+module semantic_interface_declaration_validation
+    ! Issue #2883 (reject-interface-01). Explicit-interface declaration rules.
+    !
+    ! An interface body declares a name that is external and has an explicit
+    ! interface (F2018 15.4.3.2). Within the scoping unit that contains the
+    ! interface block, that name shall not be given the EXTERNAL or INTRINSIC
+    ! attribute again, shall not be given attributes outside the interface body,
+    ! and shall not also be defined as a contained procedure. A name declared
+    ! INTRINSIC likewise cannot be listed by a module-procedure-stmt.
+    !
+    ! Reference cases: gfortran.dg/interface_23.f90, interface_24.f90,
+    ! derived_function_interface_1.f90, module_procedure_2.f90.
+    !
+    ! Interface bodies carrying the MODULE prefix declare separate module
+    ! procedures, which are legitimately defined in the CONTAINS part of the
+    ! same module, so they are excluded from every rule below.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_nodes_core, only: program_node
+    use ast_nodes_data, only: declaration_node, module_node, &
+        multi_unit_container_node
+    use ast_nodes_misc, only: contains_node, interface_block_node, &
+        intrinsic_statement_node, module_procedure_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use string_utils_mod, only: to_lower
+    implicit none
+    private
+
+    public :: validate_interface_declarations
+
+    integer, parameter :: MAX_NAMES = 256
+
+    ! Names collected from one scoping unit.
+    type :: name_set_t
+        character(len=64) :: names(MAX_NAMES) = ""
+        integer :: count = 0
+    end type name_set_t
+
+contains
+
+    ! Check every scoping unit that can hold an interface block.
+    subroutine validate_interface_declarations(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+
+        integer :: i
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+            type is (module_node)
+                call check_scope(arena, errors, node%declaration_indices, &
+                    node%procedure_indices)
+                call check_assumed_length_results(arena, errors, &
+                    node%procedure_indices)
+            type is (multi_unit_container_node)
+                call check_container(arena, errors, node%body_indices)
+            type is (program_node)
+                call check_scope(arena, errors, node%body_indices)
+                call check_internal_assumed_length(arena, errors, &
+                    node%body_indices)
+            type is (function_def_node)
+                call check_scope(arena, errors, node%body_indices)
+                call check_internal_assumed_length(arena, errors, &
+                    node%body_indices)
+            type is (subroutine_def_node)
+                call check_scope(arena, errors, node%body_indices)
+                call check_internal_assumed_length(arena, errors, &
+                    node%body_indices)
+            class default
+                cycle
+            end select
+        end do
+    end subroutine validate_interface_declarations
+
+    ! F2018 C721: a function whose result has assumed character length shall be
+    ! an external function or a dummy procedure, so it may not be declared by
+    ! an interface body's host as a module or internal procedure.
+    ! gfortran.dg/assumed_charlen_function_6.f90 is the reference case.
+    subroutine check_assumed_length_results(arena, errors, procedure_indices)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer, allocatable, intent(in) :: procedure_indices(:)
+
+        integer :: i
+
+        if (.not. allocated(procedure_indices)) return
+        do i = 1, size(procedure_indices)
+            call check_one_assumed_length(arena, errors, procedure_indices(i))
+        end do
+    end subroutine check_assumed_length_results
+
+    ! Same rule for procedures after CONTAINS in a program or procedure body.
+    subroutine check_internal_assumed_length(arena, errors, body_indices)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer, allocatable, intent(in) :: body_indices(:)
+
+        integer :: i
+        logical :: after_contains
+
+        if (.not. allocated(body_indices)) return
+        after_contains = .false.
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (node => arena%entries(body_indices(i))%node)
+            type is (contains_node)
+                after_contains = .true.
+            class default
+                if (after_contains) call check_one_assumed_length(arena, errors, &
+                    body_indices(i))
+            end select
+        end do
+    end subroutine check_internal_assumed_length
+
+    subroutine check_one_assumed_length(arena, errors, node_index)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer, intent(in) :: node_index
+
+        integer :: i
+        character(len=:), allocatable :: result_name
+
+        if (.not. arena%has_node_at(node_index)) return
+        select type (func => arena%entries(node_index)%node)
+        type is (function_def_node)
+            if (.not. allocated(func%name)) return
+            result_name = to_lower(trim(func%name))
+            if (allocated(func%result_variable)) then
+                if (len_trim(func%result_variable) > 0) then
+                    result_name = to_lower(trim(func%result_variable))
+                end if
+            end if
+            if (.not. allocated(func%body_indices)) return
+            do i = 1, size(func%body_indices)
+                if (.not. arena%has_node_at(func%body_indices(i))) cycle
+                select type (decl => arena%entries(func%body_indices(i))%node)
+                type is (declaration_node)
+                    if (.not. decl%has_character_length) cycle
+                    if (.not. allocated(decl%character_length_expr)) cycle
+                    if (trim(decl%character_length_expr) /= "*") cycle
+                    if (.not. allocated(decl%var_name)) cycle
+                    if (to_lower(trim(decl%var_name)) /= result_name) cycle
+                    call errors%add_error("Character-valued result of '"// &
+                        trim(func%name)//"' has assumed length, which is "// &
+                        "allowed only for an external function or a dummy "// &
+                        "procedure", severity=ERROR_SEMANTIC, &
+                        component="semantic_interface_declaration", &
+                        line=decl%line, column=decl%column)
+                    return
+                class default
+                    cycle
+                end select
+            end do
+        class default
+            return
+        end select
+    end subroutine check_one_assumed_length
+
+    ! Apply every rule of the family to one scoping unit. `spec_indices` holds
+    ! the specification (and, for a program or procedure, execution) part;
+    ! `contained_indices` holds the procedures after CONTAINS when the node
+    ! keeps them separately, as module_node does.
+    subroutine check_scope(arena, errors, spec_indices, contained_indices)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer, allocatable, intent(in) :: spec_indices(:)
+        integer, allocatable, intent(in), optional :: contained_indices(:)
+
+        type(name_set_t) :: interface_names
+        type(name_set_t) :: intrinsic_names
+        integer :: i
+        logical :: after_contains
+
+        if (.not. allocated(spec_indices)) return
+
+        call collect_names(arena, spec_indices, interface_names, intrinsic_names)
+        if (interface_names%count == 0 .and. intrinsic_names%count == 0) return
+
+        after_contains = .false.
+        do i = 1, size(spec_indices)
+            if (.not. arena%has_node_at(spec_indices(i))) cycle
+            select type (node => arena%entries(spec_indices(i))%node)
+            type is (contains_node)
+                after_contains = .true.
+            type is (declaration_node)
+                call check_declaration(errors, node, interface_names)
+            type is (intrinsic_statement_node)
+                call check_intrinsic_statement(errors, node, interface_names)
+            type is (interface_block_node)
+                call check_module_procedures(arena, errors, node, intrinsic_names)
+            type is (function_def_node)
+                if (after_contains) call check_contained_name(errors, node%name, &
+                    node%line, node%column, interface_names)
+            type is (subroutine_def_node)
+                if (after_contains) call check_contained_name(errors, node%name, &
+                    node%line, node%column, interface_names)
+            class default
+                cycle
+            end select
+        end do
+
+        if (.not. present(contained_indices)) return
+        if (.not. allocated(contained_indices)) return
+        do i = 1, size(contained_indices)
+            if (.not. arena%has_node_at(contained_indices(i))) cycle
+            select type (node => arena%entries(contained_indices(i))%node)
+            type is (function_def_node)
+                call check_contained_name(errors, node%name, node%line, &
+                    node%column, interface_names)
+            type is (subroutine_def_node)
+                call check_contained_name(errors, node%name, node%line, &
+                    node%column, interface_names)
+            class default
+                cycle
+            end select
+        end do
+    end subroutine check_scope
+
+    ! An implicit main program (one with no PROGRAM statement) leaves its
+    ! leading interface blocks as direct children of the multi-unit container.
+    ! No valid source has an interface block outside a program unit, so such a
+    ! block belongs to the main program of the same file and its names are
+    ! checked against that program's contained procedures.
+    subroutine check_container(arena, errors, body_indices)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer, allocatable, intent(in) :: body_indices(:)
+
+        type(name_set_t) :: interface_names
+        type(name_set_t) :: intrinsic_names
+        integer :: i
+
+        if (.not. allocated(body_indices)) return
+        call collect_names(arena, body_indices, interface_names, intrinsic_names)
+        if (interface_names%count == 0) return
+
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (node => arena%entries(body_indices(i))%node)
+            type is (program_node)
+                call check_contained_procedures(arena, errors, &
+                    node%body_indices, interface_names)
+            class default
+                cycle
+            end select
+        end do
+    end subroutine check_container
+
+    ! Report contained procedures of one program unit whose names an interface
+    ! body already declared.
+    subroutine check_contained_procedures(arena, errors, body_indices, &
+            interface_names)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer, allocatable, intent(in) :: body_indices(:)
+        type(name_set_t), intent(in) :: interface_names
+
+        integer :: i
+        logical :: after_contains
+
+        if (.not. allocated(body_indices)) return
+        after_contains = .false.
+        do i = 1, size(body_indices)
+            if (.not. arena%has_node_at(body_indices(i))) cycle
+            select type (node => arena%entries(body_indices(i))%node)
+            type is (contains_node)
+                after_contains = .true.
+            type is (function_def_node)
+                if (after_contains) call check_contained_name(errors, node%name, &
+                    node%line, node%column, interface_names)
+            type is (subroutine_def_node)
+                if (after_contains) call check_contained_name(errors, node%name, &
+                    node%line, node%column, interface_names)
+            class default
+                cycle
+            end select
+        end do
+    end subroutine check_contained_procedures
+
+    ! Names declared by interface bodies, and names declared INTRINSIC, in one
+    ! scoping unit.
+    subroutine collect_names(arena, indices, interface_names, intrinsic_names)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: indices(:)
+        type(name_set_t), intent(inout) :: interface_names
+        type(name_set_t), intent(inout) :: intrinsic_names
+
+        integer :: i, j
+
+        do i = 1, size(indices)
+            if (.not. arena%has_node_at(indices(i))) cycle
+            select type (node => arena%entries(indices(i))%node)
+            type is (interface_block_node)
+                if (node%is_abstract) cycle
+                if (.not. allocated(node%procedure_indices)) cycle
+                do j = 1, size(node%procedure_indices)
+                    call collect_interface_body_name(arena, &
+                        node%procedure_indices(j), interface_names)
+                end do
+            type is (intrinsic_statement_node)
+                if (.not. allocated(node%procedure_names)) cycle
+                do j = 1, size(node%procedure_names)
+                    call add_name(intrinsic_names, node%procedure_names(j)%s)
+                end do
+            class default
+                cycle
+            end select
+        end do
+    end subroutine collect_names
+
+    ! Record the name an interface body declares, unless the body carries the
+    ! MODULE prefix (a separate module procedure interface).
+    subroutine collect_interface_body_name(arena, node_index, interface_names)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        type(name_set_t), intent(inout) :: interface_names
+
+        if (.not. arena%has_node_at(node_index)) return
+        select type (proc => arena%entries(node_index)%node)
+        type is (function_def_node)
+            if (has_module_prefix(proc%prefix_keywords)) return
+            if (.not. allocated(proc%name)) return
+            call add_name(interface_names, proc%name)
+        type is (subroutine_def_node)
+            if (has_module_prefix(proc%prefix_keywords)) return
+            if (.not. allocated(proc%name)) return
+            call add_name(interface_names, proc%name)
+        class default
+            return
+        end select
+    end subroutine collect_interface_body_name
+
+    logical function has_module_prefix(prefix_keywords) result(is_module)
+        character(len=16), allocatable, intent(in) :: prefix_keywords(:)
+
+        integer :: i
+
+        is_module = .false.
+        if (.not. allocated(prefix_keywords)) return
+        do i = 1, size(prefix_keywords)
+            if (to_lower(trim(prefix_keywords(i))) == "module") then
+                is_module = .true.
+                return
+            end if
+        end do
+    end function has_module_prefix
+
+    ! F2018 C1519 and 8.5.9: attributes of a name declared by an interface body
+    ! are specified inside that body. EXTERNAL is implied by the interface body
+    ! itself, so restating it duplicates the attribute.
+    subroutine check_declaration(errors, decl, interface_names)
+        type(error_collection_t), intent(inout) :: errors
+        type(declaration_node), intent(in) :: decl
+        type(name_set_t), intent(in) :: interface_names
+
+        integer :: i
+
+        if (decl%is_multi_declaration) then
+            if (.not. allocated(decl%var_names)) return
+            do i = 1, size(decl%var_names)
+                call report_declaration(errors, decl, decl%var_names(i), &
+                    interface_names)
+            end do
+        else
+            if (.not. allocated(decl%var_name)) return
+            call report_declaration(errors, decl, decl%var_name, interface_names)
+        end if
+    end subroutine check_declaration
+
+    subroutine report_declaration(errors, decl, name, interface_names)
+        type(error_collection_t), intent(inout) :: errors
+        type(declaration_node), intent(in) :: decl
+        character(len=*), intent(in) :: name
+        type(name_set_t), intent(in) :: interface_names
+
+        if (.not. contains_name(interface_names, name)) return
+
+        if (decl%is_external) then
+            call errors%add_error("Duplicate EXTERNAL attribute for '"// &
+                trim(name)//"': its INTERFACE body already makes it external", &
+                severity=ERROR_SEMANTIC, &
+                component="semantic_interface_declaration", &
+                line=decl%line, column=decl%column)
+        else
+            call errors%add_error("Attribute of '"//trim(name)// &
+                "' is declared outside its INTERFACE body", &
+                severity=ERROR_SEMANTIC, &
+                component="semantic_interface_declaration", &
+                line=decl%line, column=decl%column)
+        end if
+    end subroutine report_declaration
+
+    ! F2018 C846: INTRINSIC and an explicit interface for an external procedure
+    ! cannot both apply to one name.
+    subroutine check_intrinsic_statement(errors, stmt, interface_names)
+        type(error_collection_t), intent(inout) :: errors
+        type(intrinsic_statement_node), intent(in) :: stmt
+        type(name_set_t), intent(in) :: interface_names
+
+        integer :: i
+
+        if (.not. allocated(stmt%procedure_names)) return
+        do i = 1, size(stmt%procedure_names)
+            if (.not. contains_name(interface_names, stmt%procedure_names(i)%s)) &
+                cycle
+            call errors%add_error("INTRINSIC attribute of '"// &
+                trim(stmt%procedure_names(i)%s)// &
+                "' conflicts with the EXTERNAL attribute implied by its "// &
+                "INTERFACE body", &
+                severity=ERROR_SEMANTIC, &
+                component="semantic_interface_declaration", &
+                line=stmt%line, column=stmt%column)
+        end do
+    end subroutine check_intrinsic_statement
+
+    ! F2018 C1514: a name in a module-procedure-stmt shall be accessible as a
+    ! module procedure. A name declared INTRINSIC is not one.
+    subroutine check_module_procedures(arena, errors, block, intrinsic_names)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        type(interface_block_node), intent(in) :: block
+        type(name_set_t), intent(in) :: intrinsic_names
+
+        integer :: i, j
+
+        if (intrinsic_names%count == 0) return
+        if (.not. allocated(block%procedure_indices)) return
+        do i = 1, size(block%procedure_indices)
+            if (.not. arena%has_node_at(block%procedure_indices(i))) cycle
+            select type (proc => arena%entries(block%procedure_indices(i))%node)
+            type is (module_procedure_node)
+                ! Only MODULE PROCEDURE is restricted to module procedures; a
+                ! plain PROCEDURE statement may name an intrinsic (F2018
+                ! C1512), as gfortran.dg/pr95500.f90 does.
+                if (.not. proc%has_module_prefix) cycle
+                if (.not. allocated(proc%procedure_names)) cycle
+                do j = 1, size(proc%procedure_names)
+                    if (.not. contains_name(intrinsic_names, &
+                        proc%procedure_names(j)%s)) cycle
+                    call errors%add_error("'"// &
+                        trim(proc%procedure_names(j)%s)// &
+                        "' is declared INTRINSIC and cannot be a MODULE "// &
+                        "PROCEDURE", severity=ERROR_SEMANTIC, &
+                        component="semantic_interface_declaration", &
+                        line=proc%line, column=proc%column)
+                end do
+            class default
+                cycle
+            end select
+        end do
+    end subroutine check_module_procedures
+
+    ! A contained procedure already has an explicit interface, so an interface
+    ! body for the same name in the host is invalid.
+    subroutine check_contained_name(errors, name, line, column, interface_names)
+        type(error_collection_t), intent(inout) :: errors
+        character(len=:), allocatable, intent(in) :: name
+        integer, intent(in) :: line
+        integer, intent(in) :: column
+        type(name_set_t), intent(in) :: interface_names
+
+        if (.not. allocated(name)) return
+        if (.not. contains_name(interface_names, name)) return
+
+        call errors%add_error("'"//trim(name)// &
+            "' already has an explicit interface: an INTERFACE body in the "// &
+            "host cannot declare a contained procedure", &
+            severity=ERROR_SEMANTIC, &
+            component="semantic_interface_declaration", &
+            line=line, column=column)
+    end subroutine check_contained_name
+
+    subroutine add_name(set, name)
+        type(name_set_t), intent(inout) :: set
+        character(len=*), intent(in) :: name
+
+        if (len_trim(name) == 0) return
+        if (set%count >= MAX_NAMES) return
+        set%count = set%count + 1
+        set%names(set%count) = to_lower(trim(name))
+    end subroutine add_name
+
+    logical function contains_name(set, name) result(found)
+        type(name_set_t), intent(in) :: set
+        character(len=*), intent(in) :: name
+
+        integer :: i
+        character(len=:), allocatable :: lowered
+
+        found = .false.
+        if (len_trim(name) == 0) return
+        lowered = to_lower(trim(name))
+        do i = 1, set%count
+            if (trim(set%names(i)) == lowered) then
+                found = .true.
+                return
+            end if
+        end do
+    end function contains_name
+
+end module semantic_interface_declaration_validation

--- a/test/api/test_reject_interface_01_diagnostics.f90
+++ b/test/api/test_reject_interface_01_diagnostics.f90
@@ -18,6 +18,18 @@ program test_reject_interface_01_diagnostics
     call test_module_procedure_in_generic_interface_accepted(all_tests_passed)
     call test_abstract_interface_with_subroutine_body_accepted(all_tests_passed)
     call test_abstract_interface_with_function_body_accepted(all_tests_passed)
+    call test_external_statement_for_interface_name_rejected(all_tests_passed)
+    call test_intrinsic_statement_for_interface_name_rejected(all_tests_passed)
+    call test_attribute_outside_interface_body_rejected(all_tests_passed)
+    call test_contained_procedure_with_interface_rejected(all_tests_passed)
+    call test_intrinsic_as_module_procedure_rejected(all_tests_passed)
+    call test_assumed_length_module_function_rejected(all_tests_passed)
+    call test_call_without_required_interface_rejected(all_tests_passed)
+    call test_external_statement_without_interface_accepted(all_tests_passed)
+    call test_attribute_inside_interface_body_accepted(all_tests_passed)
+    call test_separate_module_procedure_accepted(all_tests_passed)
+    call test_assumed_length_external_function_accepted(all_tests_passed)
+    call test_call_with_interface_block_accepted(all_tests_passed)
 
     if (all_tests_passed) then
         print *, 'All interface declaration rejection tests passed'
@@ -104,6 +116,214 @@ contains
             'end module m'
         call expect_frontend_accepts(source, passed)
     end subroutine test_abstract_interface_with_function_body_accepted
+
+    ! interface_23: an interface body already makes the name external.
+    subroutine test_external_statement_for_interface_name_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing EXTERNAL for an interface-declared name (rejected)...'
+        source = 'module a'//new_line('a')// &
+            'interface'//new_line('a')// &
+            'subroutine foo'//new_line('a')// &
+            'end subroutine'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'external foo'//new_line('a')// &
+            'end module a'
+        call expect_frontend_error(source, 'Duplicate EXTERNAL attribute', passed)
+    end subroutine test_external_statement_for_interface_name_rejected
+
+    ! interface_23: INTRINSIC conflicts with the implied EXTERNAL attribute.
+    subroutine test_intrinsic_statement_for_interface_name_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing INTRINSIC for an interface-declared name (rejected)...'
+        source = 'module b'//new_line('a')// &
+            'interface'//new_line('a')// &
+            'function sin(x)'//new_line('a')// &
+            'real :: sin, x'//new_line('a')// &
+            'end function'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'intrinsic sin'//new_line('a')// &
+            'end module b'
+        call expect_frontend_error(source, 'INTRINSIC attribute', passed)
+    end subroutine test_intrinsic_statement_for_interface_name_rejected
+
+    ! interface_24: attributes belong inside the interface body.
+    subroutine test_attribute_outside_interface_body_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing attribute outside an INTERFACE body (rejected)...'
+        source = 'module m1'//new_line('a')// &
+            'interface'//new_line('a')// &
+            'real function f1()'//new_line('a')// &
+            'end function'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'dimension :: f1(4)'//new_line('a')// &
+            'end module m1'
+        call expect_frontend_error(source, 'outside its INTERFACE body', passed)
+    end subroutine test_attribute_outside_interface_body_rejected
+
+    ! derived_function_interface_1: a contained procedure already has an
+    ! explicit interface.
+    subroutine test_contained_procedure_with_interface_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing INTERFACE body for a contained procedure (rejected)...'
+        source = 'program main'//new_line('a')// &
+            'interface'//new_line('a')// &
+            'real function fun()'//new_line('a')// &
+            'end function fun'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'print *, 1'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'real function fun()'//new_line('a')// &
+            'fun = 1.0'//new_line('a')// &
+            'end function fun'//new_line('a')// &
+            'end program main'
+        call expect_frontend_error(source, 'already has an explicit interface', &
+            passed)
+    end subroutine test_contained_procedure_with_interface_rejected
+
+    ! module_procedure_2: an INTRINSIC name is not a module procedure.
+    subroutine test_intrinsic_as_module_procedure_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing MODULE PROCEDURE naming an INTRINSIC (rejected)...'
+        source = 'program test'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'intrinsic sin'//new_line('a')// &
+            'interface gen2'//new_line('a')// &
+            'module procedure sin'//new_line('a')// &
+            'end interface gen2'//new_line('a')// &
+            'end program test'
+        call expect_frontend_error(source, 'cannot be a MODULE PROCEDURE', passed)
+    end subroutine test_intrinsic_as_module_procedure_rejected
+
+    ! assumed_charlen_function_6: assumed-length result of a module procedure.
+    subroutine test_assumed_length_module_function_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing assumed-length result of a module function ' // &
+            '(rejected)...'
+        source = 'module funcs'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'function assumed_len(x)'//new_line('a')// &
+            'character(*) assumed_len'//new_line('a')// &
+            'integer, intent(in) :: x'//new_line('a')// &
+            'end function assumed_len'//new_line('a')// &
+            'end module funcs'
+        call expect_frontend_error(source, 'has assumed length', passed)
+    end subroutine test_assumed_length_module_function_rejected
+
+    ! whole_file_16 and volatile14: the callee needs an explicit interface.
+    subroutine test_call_without_required_interface_rejected(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing call to an assumed-shape procedure without an ' // &
+            'interface (rejected)...'
+        source = 'program main'//new_line('a')// &
+            'real, dimension(2) :: a'//new_line('a')// &
+            'call foo(a)'//new_line('a')// &
+            'end program main'//new_line('a')// &
+            'subroutine foo(a)'//new_line('a')// &
+            'real, dimension(:) :: a'//new_line('a')// &
+            'end subroutine foo'
+        call expect_frontend_error(source, 'Explicit interface required', passed)
+    end subroutine test_call_without_required_interface_rejected
+
+    ! Corrected neighbour: EXTERNAL alone, with no interface body.
+    subroutine test_external_statement_without_interface_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing EXTERNAL without an interface body (accepted)...'
+        source = 'module a'//new_line('a')// &
+            'external foo'//new_line('a')// &
+            'intrinsic sin'//new_line('a')// &
+            'end module a'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_external_statement_without_interface_accepted
+
+    ! Corrected neighbour of interface_24: module m3 of the same fixture.
+    subroutine test_attribute_inside_interface_body_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing attribute inside the INTERFACE body (accepted)...'
+        source = 'module m3'//new_line('a')// &
+            'interface'//new_line('a')// &
+            'real function f3()'//new_line('a')// &
+            'dimension :: f3(4)'//new_line('a')// &
+            'end function'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'end module m3'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_attribute_inside_interface_body_accepted
+
+    ! A separate module procedure interface is defined in the same module.
+    subroutine test_separate_module_procedure_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing separate module procedure definition (accepted)...'
+        source = 'module m'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'interface'//new_line('a')// &
+            'module subroutine work(x)'//new_line('a')// &
+            'integer, intent(in) :: x'//new_line('a')// &
+            'end subroutine work'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'module subroutine work(x)'//new_line('a')// &
+            'integer, intent(in) :: x'//new_line('a')// &
+            'end subroutine work'//new_line('a')// &
+            'end module m'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_separate_module_procedure_accepted
+
+    ! Corrected neighbour: an external function may have assumed-length result.
+    subroutine test_assumed_length_external_function_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing assumed-length result of an external function ' // &
+            '(accepted)...'
+        source = 'function assumed_len(x)'//new_line('a')// &
+            'character(*) assumed_len'//new_line('a')// &
+            'integer, intent(in) :: x'//new_line('a')// &
+            'assumed_len = ""'//new_line('a')// &
+            'end function assumed_len'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_assumed_length_external_function_accepted
+
+    ! Corrected neighbour of whole_file_16: the interface is provided.
+    subroutine test_call_with_interface_block_accepted(passed)
+        logical, intent(inout) :: passed
+        character(len=:), allocatable :: source
+
+        print *, 'Testing call with an explicit interface block (accepted)...'
+        source = 'program main'//new_line('a')// &
+            'real, dimension(2) :: a'//new_line('a')// &
+            'interface'//new_line('a')// &
+            'subroutine foo(a)'//new_line('a')// &
+            'real, dimension(:) :: a'//new_line('a')// &
+            'end subroutine foo'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'call foo(a)'//new_line('a')// &
+            'end program main'//new_line('a')// &
+            'subroutine foo(a)'//new_line('a')// &
+            'real, dimension(:) :: a'//new_line('a')// &
+            'end subroutine foo'
+        call expect_frontend_accepts(source, passed)
+    end subroutine test_call_with_interface_block_accepted
 
     subroutine expect_frontend_error(source, expected, passed)
         use frontend_compiler_api, only: compiler_frontend_options_t, &


### PR DESCRIPTION
Enforces the explicit-interface declaration family of issue #2883.

## Preserved compiler invariant

A name declared by an interface body is external and has an explicit
interface (F2018 15.4.3.2). In the scoping unit holding the interface block
that name may not be given EXTERNAL or INTRINSIC again, may not be given
attributes outside the interface body, and may not also be a contained
procedure. MODULE PROCEDURE may not name a procedure declared INTRINSIC. A
module or internal function may not have an assumed-length character result
(C721). A reference to an external subprogram of the same file whose dummy
arguments carry ALLOCATABLE/ASYNCHRONOUS/OPTIONAL/POINTER/TARGET/VALUE/
VOLATILE or an assumed shape requires a visible explicit interface
(15.4.2.2). Every corrected neighbour still compiles.

## Fixtures now rejected (gfortran.dg basenames)

interface_abstract_3 (already), interface_23, interface_24,
derived_function_interface_1, module_procedure_2,
assumed_charlen_function_6, whole_file_16, volatile14.

The last two are diagnosed in standard-Fortran input mode; the lazy-Fortran
standardizer hoists an external subprogram into the main program, so the
requirement does not apply to lazy input as written and the rule is gated on
standard mode.

Not covered by this PR and left on #2883: `dummy_optional_arg.f90` and
`interface_39.f90`. Both need AST representation that does not exist yet -
the OPTIONAL statement is dropped by the procedure-body statement parser,
and a kind-selector expression such as `character(kind=gkind())` is dropped
entirely - so they cannot be validated on typed nodes today.

## Supporting frontend work

- Module specification parts now represent EXTERNAL, INTRINSIC, DIMENSION
  and ALLOCATABLE statements instead of dropping them.
- `MODULE PROCEDURE` inside an interface block is parsed as a
  module-procedure-stmt instead of a MODULE prefix plus a plain PROCEDURE
  statement, so `has_module_prefix` is finally meaningful. That distinction
  is what keeps the valid `procedure :: alog, dlog` of gfortran.dg/pr95500
  accepted while `module procedure sin` is rejected.

## Red evidence

`test/api/test_reject_interface_01_diagnostics.f90` built at origin/main
(throwaway worktree):

```
Testing EXTERNAL for an interface-declared name (rejected)... FAIL: invalid source was accepted
Testing INTRINSIC for an interface-declared name (rejected)... FAIL: invalid source was accepted
Testing attribute outside an INTERFACE body (rejected)... FAIL: invalid source was accepted
Testing INTERFACE body for a contained procedure (rejected)... FAIL: invalid source was accepted
Testing MODULE PROCEDURE naming an INTRINSIC (rejected)... FAIL: invalid source was accepted
Testing assumed-length result of a module function (rejected)... FAIL: invalid source was accepted
Testing call to an assumed-shape procedure without an interface (rejected)... FAIL: invalid source was accepted
Summary: 0 passed, 1 failed
```

All five accepted-side (corrected-neighbour) cases already passed on main,
so the test is not trivially red.

## Green evidence

- `fo test test_reject_interface_01_diagnostics`: PASS (7 rejection cases,
  5 corrected neighbours).
- Full `fo` pipeline: Static OK, Build OK, Tests OK (483), Lint OK.
- `make check-rejection-gate`: OK, no newly rejected corpus file.
- Whole gfortran.dg gate (7857 files) against a baseline built at the same
  origin/main commit: 8 newly rejected files, all invalid under
  `gfortran -fsyntax-only` - the 5 intended fixtures plus pr39695_2/3/4,
  which gfortran also rejects. Zero valid files newly rejected, and no file
  moved from REJECTED to ACCEPTED.

Part of #2883.
