### PR TITLE
Rename monomorphized call sites to their specialization (#2971)

### DIFF
--- a/examples/lf/issue_2971_callsite_rename.lf
+++ b/examples/lf/issue_2971_callsite_rename.lf
@@ -1,0 +1,6 @@
+function twice(x)
+    twice = 2 * x
+end function
+
+print *, twice(3)
+print *, twice(2.5)

--- a/src/standardizers/ast_monomorphization_part1.inc
+++ b/src/standardizers/ast_monomorphization_part1.inc
@@ -269,8 +269,9 @@
         integer, intent(inout) :: module_count
         character(len=*), allocatable, intent(inout) :: module_names(:)
         type(type_signature_t), allocatable :: proc_sigs(:)
+        type(type_signature_t), allocatable :: all_sigs(:)
         integer, allocatable :: variant_indices(:)
-        integer :: mod_idx
+        integer :: mod_idx, sig_i
 
         if (procedure_has_explicit_types(arena, proc_idx)) then
             handled = .false.
@@ -287,9 +288,17 @@
             return
         end if
 
+        ! Issue #2971: keep every call site's signature, not just the unique
+        ! ones, so each call can be routed to the specialization made for it.
+        all_sigs = proc_sigs
+        do sig_i = 1, size(all_sigs)
+            call normalize_signature_param_types(all_sigs(sig_i))
+        end do
+
         call normalize_and_deduplicate_signatures(proc_sigs, handled)
         if (.not. handled) then
             if (allocated(proc_sigs)) deallocate (proc_sigs)
+            if (allocated(all_sigs)) deallocate (all_sigs)
             return
         end if
 
@@ -299,10 +308,68 @@
                                                variant_indices)
         call register_generated_module(mod_idx, proc_name, module_indices, &
                                        module_count, module_names)
+        call rename_call_sites_to_specializations(arena, proc_name, all_sigs, &
+                                                  proc_sigs)
 
+        if (allocated(all_sigs)) deallocate (all_sigs)
         if (allocated(proc_sigs)) deallocate (proc_sigs)
         if (allocated(variant_indices)) deallocate (variant_indices)
     end subroutine process_specializable_procedure
+
+    ! Issue #2971: every call site must name the specialization created for it,
+    ! leaving the untyped original unreferenced.
+    subroutine rename_call_sites_to_specializations(arena, proc_name, all_sigs, &
+                                                    unique_sigs)
+        type(ast_arena_t), intent(inout) :: arena
+        character(len=*), intent(in) :: proc_name
+        type(type_signature_t), intent(in) :: all_sigs(:)
+        type(type_signature_t), intent(in) :: unique_sigs(:)
+        integer :: j, k
+        character(len=:), allocatable :: mangled_name
+
+        do j = 1, size(all_sigs)
+            if (all_sigs(j)%call_site_node <= 0) cycle
+            do k = 1, size(unique_sigs)
+                if (.not. signatures_are_identical(all_sigs(j), &
+                                                   unique_sigs(k))) cycle
+                mangled_name = signature_mangled_name(proc_name, unique_sigs(k))
+                call set_call_site_name(arena, all_sigs(j)%call_site_node, &
+                                        proc_name, mangled_name)
+                exit
+            end do
+        end do
+    end subroutine rename_call_sites_to_specializations
+
+    function signature_mangled_name(proc_name, signature) result(mangled_name)
+        character(len=*), intent(in) :: proc_name
+        type(type_signature_t), intent(in) :: signature
+        character(len=:), allocatable :: mangled_name
+
+        if (allocated(signature%param_type_strings)) then
+            mangled_name = mangle_procedure_name(proc_name, &
+                                                 signature%param_kinds, &
+                                                 signature%param_type_strings)
+        else
+            mangled_name = mangle_procedure_name(proc_name, &
+                                                 signature%param_kinds)
+        end if
+    end function signature_mangled_name
+
+    subroutine set_call_site_name(arena, call_index, expected_name, new_name)
+        type(ast_arena_t), intent(inout) :: arena
+        integer, intent(in) :: call_index
+        character(len=*), intent(in) :: expected_name
+        character(len=*), intent(in) :: new_name
+
+        if (len_trim(new_name) == 0) return
+        if (.not. arena%has_node_at(call_index)) return
+        select type (node => arena%entries(call_index)%node)
+        type is (call_or_subscript_node)
+            if (.not. allocated(node%name)) return
+            if (node%name /= expected_name) return
+            node%name = trim(new_name)
+        end select
+    end subroutine set_call_site_name
 
     subroutine debug_log_signatures(signatures, proc_name)
         type(signatures_map_t), intent(in) :: signatures

--- a/test/test_issue_2971_callsite_rename.f90
+++ b/test/test_issue_2971_callsite_rename.f90
@@ -1,0 +1,45 @@
+program test_issue_2971_callsite_rename
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use fortfront, only: transform_lazy_fortran_string
+    implicit none
+    character(len=:), allocatable :: source, output, error_msg
+
+    call read_example('examples/lf/issue_2971_callsite_rename.lf', source)
+    call transform_lazy_fortran_string(source, output, error_msg)
+
+    if (len_trim(error_msg) > 0) then
+        write (error_unit, '(A)') 'test_issue_2971: transformation error: '// &
+            trim(error_msg)
+        error stop 1
+    end if
+
+    if (index(output, 'twice__i32') <= 0) then
+        write (error_unit, '(A)') 'FAIL: missing twice__i32 specialization'
+        write (error_unit, '(A)') output
+        error stop 1
+    end if
+    if (index(output, 'twice__r') <= 0) then
+        write (error_unit, '(A)') 'FAIL: missing real specialization of twice'
+        write (error_unit, '(A)') output
+        error stop 1
+    end if
+
+    ! Each call site must name the specialization created for it, so both
+    ! mangled names appear inside print statements.
+    if (index(output, 'print *, twice__i32(') <= 0) then
+        write (error_unit, '(A)') 'FAIL: integer call site not renamed'
+        write (error_unit, '(A)') output
+        error stop 1
+    end if
+    if (index(output, 'print *, twice__r') <= 0) then
+        write (error_unit, '(A)') 'FAIL: real call site not renamed'
+        write (error_unit, '(A)') output
+        error stop 1
+    end if
+
+    write (*, '(A)') 'PASS: monomorphized call sites name their specialization'
+
+contains
+
+    include 'common/read_example.inc'
+end program test_issue_2971_callsite_rename


### PR DESCRIPTION
Fixes #2971.

## Problem
`transform_monomorphization` created `twice__i32`/`twice__r64` specializations but left both `call_or_subscript` nodes named `twice`. Every backend had to re-derive the call-site-to-specialization mapping the pass already computed, by re-inferring argument kinds and re-parsing FortFront's mangling scheme.

## Change
`process_specializable_procedure` now keeps the pre-deduplication signature list (each entry carries its own `call_site_node`), and after the variants and generic-interface module are created it renames each call site to the mangled name of the unique signature it matches. Renaming is guarded: it only fires on a `call_or_subscript_node` whose name still equals the original procedure name.

## Preserved invariant
The generated module and its generic interface are unchanged, so the emitted Fortran remains valid standard Fortran; the only difference is that each call now names the specialization directly and the untyped original is unreferenced.

## Red evidence
On unmodified main, `fo test test_issue_2971_callsite_rename`:
```
FAIL: integer call site not renamed
...
    print *, twice(3)
    print *, twice(2.5_8)
```

## Green evidence
Full `fo` pipeline in the worktree: Build OK, Tests OK (483/483), Lint OK, All stages passed (92.7s).