### PR TITLE
Reject conflicting Lazy module generic references (#2978)

### DIFF
--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -34,6 +34,8 @@ use semantic_strict_argument_type_checker_validation, only: &
 use semantic_placement_validation, only: &
     validate_declaration_placement_in_arena
 use semantic_call_signature_checker, only: validate_call_signatures_in_arena
+use semantic_lazy_module_generic_validation, only: &
+    validate_lazy_module_generics
 use call_graph_signatures_mod, only: create_signatures_map
 use semantic_validation_utils, only: int_to_str
 use ast_nodes_data, only: declaration_node
@@ -143,6 +145,13 @@ contains
         ! (F2018 C863). The sweep is arena-wide so every procedure definition
         ! is covered, not only those the inference dispatch visits.
         call validate_value_dummy_attributes_in_arena(arena, ctx%errors)
+
+        ! Reject a module-contained untyped Lazy procedure that is referenced
+        ! at conflicting argument types: monomorphization does not specialize
+        ! module procedures, so one body would serve both. Issue #2978.
+        if (ctx%input_mode == INPUT_MODE_LAZY) then
+            call validate_lazy_module_generics(arena, ctx%errors)
+        end if
 
         ! Reject procedure-call signature mismatches (F2018 15.5.1 and
         ! 15.5.2.9). The sweep resolves scopes structurally, so it reaches

--- a/src/semantic/analyzers/semantic_lazy_module_generic_validation.f90
+++ b/src/semantic/analyzers/semantic_lazy_module_generic_validation.f90
@@ -1,0 +1,201 @@
+module semantic_lazy_module_generic_validation
+    ! Issue #2978. Monomorphization (ast_monomorphization) specializes an
+    ! untyped Lazy procedure only when it is a child of the compilation-unit
+    ! root. A procedure contained in a module keeps a single body, so a
+    ! reference at two incompatible argument types would compile to one call
+    ! target and silently return garbage.
+    !
+    ! Until module procedures are monomorphized as well, that shape is
+    ! rejected here. The rule is deliberately narrow, so that missing
+    ! knowledge means silence and never a rejection:
+    !
+    !   * Lazy input only. Standard Fortran gives an undeclared dummy its
+    !     implicit type, which is a definite type checked elsewhere.
+    !   * The procedure must be contained in a module and must have at least
+    !     one dummy argument without an explicit type.
+    !   * Its name must be defined exactly once in the whole arena, so every
+    !     reference to that name is a reference to this procedure.
+    !   * Only references whose actual arguments are all literals are
+    !     classified. A reference carrying anything else is ignored.
+    use ast_arena_modern, only: ast_arena_t
+    use ast_base, only: LITERAL_INTEGER, LITERAL_LOGICAL, LITERAL_REAL, &
+        LITERAL_STRING, LITERAL_COMPLEX
+    use ast_nodes_core, only: call_or_subscript_node, literal_node
+    use ast_nodes_data, only: module_node
+    use ast_nodes_procedure, only: function_def_node, subroutine_def_node
+    use error_handling, only: error_collection_t, ERROR_SEMANTIC
+    use procedure_classification, only: procedure_has_explicit_types
+    use string_utils_mod, only: to_lower
+    implicit none
+    private
+
+    public :: validate_lazy_module_generics
+
+contains
+
+    ! Reject every module-contained untyped Lazy procedure that is referenced
+    ! with conflicting literal argument types.
+    subroutine validate_lazy_module_generics(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+        integer :: j
+
+        if (arena%size <= 0) return
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (module_node)
+                if (.not. allocated(node%procedure_indices)) cycle
+                do j = 1, size(node%procedure_indices)
+                    call check_module_procedure(arena, errors, node%name, &
+                        node%procedure_indices(j))
+                end do
+            end select
+        end do
+    end subroutine validate_lazy_module_generics
+
+    subroutine check_module_procedure(arena, errors, module_name, proc_index)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        character(len=*), intent(in) :: module_name
+        integer, intent(in) :: proc_index
+        character(len=:), allocatable :: proc_name
+        character(len=:), allocatable :: first_signature
+        character(len=:), allocatable :: other_signature
+        character(len=:), allocatable :: signature
+        integer :: conflict_line
+        integer :: conflict_column
+        integer :: i
+
+        if (.not. arena%has_node_at(proc_index)) return
+
+        select type (proc => arena%entries(proc_index)%node)
+            type is (function_def_node)
+            if (.not. allocated(proc%name)) return
+            proc_name = proc%name
+            type is (subroutine_def_node)
+            if (.not. allocated(proc%name)) return
+            proc_name = proc%name
+        class default
+            return
+        end select
+
+        if (procedure_has_explicit_types(arena, proc_index)) return
+        if (.not. name_defined_once(arena, proc_name)) return
+
+        conflict_line = 0
+        conflict_column = 0
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (call_node => arena%entries(i)%node)
+                type is (call_or_subscript_node)
+                if (.not. allocated(call_node%name)) cycle
+                if (to_lower(call_node%name) /= to_lower(proc_name)) cycle
+                call classify_arguments(arena, call_node%arg_indices, signature)
+                if (.not. allocated(signature)) cycle
+                if (.not. allocated(first_signature)) then
+                    first_signature = signature
+                else if (signature /= first_signature) then
+                    if (.not. allocated(other_signature)) then
+                        other_signature = signature
+                        conflict_line = call_node%line
+                        conflict_column = call_node%column
+                    end if
+                end if
+            end select
+        end do
+
+        if (.not. allocated(other_signature)) return
+
+        call errors%add_error( &
+            "Lazy generic procedure '"//trim(proc_name)//"' contained in "// &
+            "module '"//trim(module_name)//"' is referenced with conflicting "// &
+            "argument types ("//first_signature//" and "//other_signature// &
+            "); module procedures are not specialized, so one body would be "// &
+            "called at both types", &
+            severity=ERROR_SEMANTIC, component="semantic_lazy_module_generic", &
+            line=conflict_line, column=conflict_column)
+    end subroutine check_module_procedure
+
+    ! .true. when exactly one procedure definition in the arena carries this
+    ! name, so that a reference to the name is unambiguous.
+    logical function name_defined_once(arena, proc_name) result(unique)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: proc_name
+        integer :: count
+        integer :: i
+
+        count = 0
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (function_def_node)
+                if (allocated(node%name)) then
+                    if (to_lower(node%name) == to_lower(proc_name)) then
+                        count = count + 1
+                    end if
+                end if
+                type is (subroutine_def_node)
+                if (allocated(node%name)) then
+                    if (to_lower(node%name) == to_lower(proc_name)) then
+                        count = count + 1
+                    end if
+                end if
+            end select
+        end do
+
+        unique = count == 1
+    end function name_defined_once
+
+    ! Build a comma separated type list for an argument list made only of
+    ! literals. Leaves the result unallocated when any argument is anything
+    ! else, or when there are no arguments.
+    subroutine classify_arguments(arena, arg_indices, signature)
+        type(ast_arena_t), intent(in) :: arena
+        integer, allocatable, intent(in) :: arg_indices(:)
+        character(len=:), allocatable, intent(out) :: signature
+        character(len=:), allocatable :: text
+        character(len=:), allocatable :: arg_type
+        integer :: i
+
+        if (.not. allocated(arg_indices)) return
+        if (size(arg_indices) == 0) return
+
+        text = ''
+        do i = 1, size(arg_indices)
+            call classify_literal(arena, arg_indices(i), arg_type)
+            if (.not. allocated(arg_type)) return
+            if (i > 1) text = text//', '
+            text = text//arg_type
+        end do
+
+        signature = text
+    end subroutine classify_arguments
+
+    subroutine classify_literal(arena, node_index, arg_type)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable, intent(out) :: arg_type
+
+        if (.not. arena%has_node_at(node_index)) return
+
+        select type (node => arena%entries(node_index)%node)
+            type is (literal_node)
+            select case (node%literal_kind)
+            case (LITERAL_INTEGER)
+                arg_type = 'integer'
+            case (LITERAL_REAL)
+                arg_type = 'real'
+            case (LITERAL_LOGICAL)
+                arg_type = 'logical'
+            case (LITERAL_STRING)
+                arg_type = 'character'
+            case (LITERAL_COMPLEX)
+                arg_type = 'complex'
+            end select
+        end select
+    end subroutine classify_literal
+
+end module semantic_lazy_module_generic_validation

--- a/test/test_issue_2978_module_generic_conflict.f90
+++ b/test/test_issue_2978_module_generic_conflict.f90
@@ -1,0 +1,173 @@
+program test_issue_2978_module_generic_conflict
+    ! Issue #2978: a Lazy module procedure with untyped dummy arguments that is
+    ! referenced at two incompatible argument types is not monomorphized, so a
+    ! single body would be called at both types. That must be diagnosed, never
+    ! silently miscompiled.
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    logical :: all_passed
+
+    all_passed = .true.
+
+    if (.not. test_conflicting_module_call_is_rejected()) all_passed = .false.
+    if (.not. test_single_type_module_call_is_accepted()) all_passed = .false.
+    if (.not. test_explicitly_typed_module_procedure_is_accepted()) &
+        all_passed = .false.
+    if (.not. test_program_level_generic_still_monomorphizes()) &
+        all_passed = .false.
+    if (.not. test_corpus_generic_interface_module_is_accepted()) &
+        all_passed = .false.
+
+    if (all_passed) then
+        print *, 'PASS: Issue #2978 module generic conflict diagnostics'
+    else
+        error stop 'FAIL: Issue #2978 module generic conflict diagnostics'
+    end if
+
+contains
+
+    include 'common/read_example.inc'
+
+    subroutine standardize(source, output, error_msg)
+        character(len=*), intent(in) :: source
+        character(len=:), allocatable, intent(out) :: output
+        character(len=:), allocatable, intent(out) :: error_msg
+
+        call transform_lazy_fortran_string(source, output, error_msg)
+        if (.not. allocated(error_msg)) error_msg = ''
+        if (.not. allocated(output)) output = ''
+    end subroutine standardize
+
+    logical function test_conflicting_module_call_is_rejected() result(ok)
+        character(len=:), allocatable :: source, output, error_msg
+
+        source = 'module lm'//new_line('A')// &
+            'contains'//new_line('A')// &
+            '  function twice(x)'//new_line('A')// &
+            '    twice = 2 * x'//new_line('A')// &
+            '  end function'//new_line('A')// &
+            '  subroutine useboth()'//new_line('A')// &
+            '    print *, twice(3)'//new_line('A')// &
+            '    print *, twice(2.5)'//new_line('A')// &
+            '  end subroutine'//new_line('A')// &
+            'end module lm'//new_line('A')// &
+            'program main'//new_line('A')// &
+            '  use lm'//new_line('A')// &
+            '  call useboth()'//new_line('A')// &
+            'end program'
+
+        call standardize(source, output, error_msg)
+        ok = len_trim(error_msg) > 0
+        if (.not. ok) then
+            write (error_unit, '(A)') &
+                'ERROR: conflicting module generic accepted silently'
+            write (error_unit, '(A)') trim(output)
+            return
+        end if
+        if (index(error_msg, 'twice') == 0) then
+            write (error_unit, '(A)') &
+                'ERROR: diagnostic does not name the procedure: '// &
+                trim(error_msg)
+            ok = .false.
+        end if
+    end function test_conflicting_module_call_is_rejected
+
+    logical function test_single_type_module_call_is_accepted() result(ok)
+        character(len=:), allocatable :: source, output, error_msg
+
+        source = 'module lm'//new_line('A')// &
+            'contains'//new_line('A')// &
+            '  function twice(x)'//new_line('A')// &
+            '    twice = 2 * x'//new_line('A')// &
+            '  end function'//new_line('A')// &
+            '  subroutine useone()'//new_line('A')// &
+            '    print *, twice(2.5)'//new_line('A')// &
+            '    print *, twice(3.5)'//new_line('A')// &
+            '  end subroutine'//new_line('A')// &
+            'end module lm'//new_line('A')// &
+            'program main'//new_line('A')// &
+            '  use lm'//new_line('A')// &
+            '  call useone()'//new_line('A')// &
+            'end program'
+
+        call standardize(source, output, error_msg)
+        ok = len_trim(error_msg) == 0
+        if (.not. ok) then
+            write (error_unit, '(A)') &
+                'ERROR: single-type module generic rejected: '//trim(error_msg)
+        end if
+    end function test_single_type_module_call_is_accepted
+
+    logical function test_explicitly_typed_module_procedure_is_accepted() &
+            result(ok)
+        character(len=:), allocatable :: source, output, error_msg
+
+        source = 'module lm'//new_line('A')// &
+            '  implicit none'//new_line('A')// &
+            'contains'//new_line('A')// &
+            '  real function twice(x)'//new_line('A')// &
+            '    real, intent(in) :: x'//new_line('A')// &
+            '    twice = 2 * x'//new_line('A')// &
+            '  end function'//new_line('A')// &
+            '  subroutine useboth()'//new_line('A')// &
+            '    print *, twice(3.0)'//new_line('A')// &
+            '    print *, twice(2.5)'//new_line('A')// &
+            '  end subroutine'//new_line('A')// &
+            'end module lm'//new_line('A')// &
+            'program main'//new_line('A')// &
+            '  use lm'//new_line('A')// &
+            '  call useboth()'//new_line('A')// &
+            'end program'
+
+        call standardize(source, output, error_msg)
+        ok = len_trim(error_msg) == 0
+        if (.not. ok) then
+            write (error_unit, '(A)') &
+                'ERROR: explicitly typed module procedure rejected: '// &
+                trim(error_msg)
+        end if
+    end function test_explicitly_typed_module_procedure_is_accepted
+
+    logical function test_program_level_generic_still_monomorphizes() result(ok)
+        character(len=:), allocatable :: source, output, error_msg
+
+        source = 'function twice(x)'//new_line('A')// &
+            '  twice = 2 * x'//new_line('A')// &
+            'end function'//new_line('A')// &
+            'print *, twice(3)'//new_line('A')// &
+            'print *, twice(2.5)'
+
+        call standardize(source, output, error_msg)
+        ok = len_trim(error_msg) == 0
+        if (.not. ok) then
+            write (error_unit, '(A)') &
+                'ERROR: program-level generic rejected: '//trim(error_msg)
+            return
+        end if
+        if (index(output, 'twice__') == 0) then
+            write (error_unit, '(A)') &
+                'ERROR: program-level generic no longer monomorphized'
+            write (error_unit, '(A)') trim(output)
+            ok = .false.
+        end if
+    end function test_program_level_generic_still_monomorphizes
+    ! Accepted-side control taken from the corpus: a module whose generic
+    ! interface resolves two explicitly typed specifics at two argument types
+    ! must keep compiling.
+    logical function test_corpus_generic_interface_module_is_accepted() &
+            result(ok)
+        character(len=:), allocatable :: source, output, error_msg
+
+        call read_example('examples/lf/issue_1411_generic_module.lf', source)
+        call standardize(source, output, error_msg)
+        ok = len_trim(error_msg) == 0
+        if (.not. ok) then
+            write (error_unit, '(A)') &
+                'ERROR: corpus generic-interface module rejected: '// &
+                trim(error_msg)
+        end if
+    end function test_corpus_generic_interface_module_is_accepted
+
+end program test_issue_2978_module_generic_conflict


### PR DESCRIPTION
Fixes #2978.

## Invariant preserved

Emitting one procedure body and calling it at two incompatible argument types must never happen silently. Monomorphization (`ast_monomorphization`) specializes untyped Lazy procedures only at the compilation-unit root, so a module-contained procedure kept a single body and a reference at two types miscompiled with no diagnostic. Since module procedures are not specialized, that shape is now rejected — the second branch the issue explicitly allows.

## Change

New `src/semantic/analyzers/semantic_lazy_module_generic_validation.f90`, an arena sweep called from `analyze_program` in Lazy input mode only. It rejects a module-contained procedure with an untyped dummy that is referenced with conflicting literal argument types. The rule is deliberately narrow so that missing knowledge means silence, never a rejection:

- Lazy input only (standard Fortran gives an undeclared dummy its implicit type, checked elsewhere).
- The procedure must be contained in a module and have at least one dummy without an explicit type.
- Its name must be defined exactly once in the whole arena, so every reference is unambiguous.
- Only references whose actual arguments are all literals are classified; anything else is ignored.

## Red evidence

On unmodified main, `test_issue_2978_module_generic_conflict` fails on its first case only:

```
test_issue_2978_module_generic_conflict    FAIL
  ERROR: conflicting module generic accepted silently
```

The three negative controls (single-type module call, explicitly typed module procedure, program-level generic still monomorphized to `twice__*`) already passed on main, so the test is red exactly on the defect.

## Green evidence

- `fo test test_issue_2978_module_generic_conflict` PASS, including an accepted-side control drawn from the real corpus (`examples/lf/issue_1411_generic_module.lf`, a module whose generic interface resolves two typed specifics at two argument types).
- CLI on the issue reproducer now reports: `Lazy generic procedure 'twice' contained in module 'lm' is referenced with conflicting argument types (integer and real); module procedures are not specialized, so one body would be called at both types`.
- Rejection gate: `make check-rejection-gate` — 821 files, accepted=749 rejected=72, `OK: no newly rejected corpus files`. Zero valid files newly rejected.
- Full local `fo` pipeline: Static OK, Build OK, Tests OK, Lint OK.