### PR TITLE
Stop silently dropping source in five scanner paths (#2966, #2967, #2972, #2974, #2977)

### DIFF
--- a/src/frontend/frontend_statement_boundary.f90
+++ b/src/frontend/frontend_statement_boundary.f90
@@ -44,7 +44,7 @@ contains
         idx = start_index
         do while (idx <= size(tokens) .and. depth > 0)
             if (tokens(idx)%kind == TK_OPERATOR) then
-                select case (tokens(idx)%text)
+                select case (trim(to_lower(tokens(idx)%text)))
                 case ("(")
                     depth = depth + 1
                 case (")")
@@ -143,7 +143,7 @@ contains
         idx = idx + 1
         do while (idx <= size(tokens) .and. depth > 0)
             if (tokens(idx)%kind == TK_OPERATOR) then
-                select case (tokens(idx)%text)
+                select case (trim(to_lower(tokens(idx)%text)))
                 case ("(")
                     depth = depth + 1
                 case (")")
@@ -223,12 +223,12 @@ contains
         if (stmt_start < 1 .or. stmt_start > size(tokens)) return
         if (tokens(stmt_start)%kind /= TK_KEYWORD) return
 
-        select case (tokens(stmt_start)%text)
+        select case (trim(to_lower(tokens(stmt_start)%text)))
         case ("if")
             max_idx = min(stmt_start + 20, size(tokens))
             do i = stmt_start + 1, max_idx
                 if (tokens(i)%kind == TK_KEYWORD) then
-                    if (tokens(i)%text == "then") then
+                    if (trim(to_lower(tokens(i)%text)) == "then") then
                         is_multiline = .true.
                         nesting_level = 1
                         return
@@ -254,8 +254,8 @@ contains
                         nesting_level = 1
                         return
                     else if (tokens(i)%kind == TK_KEYWORD) then
-                        if (tokens(i)%text == "end" .or. &
-                            tokens(i)%text == "elsewhere") then
+                        if (trim(to_lower(tokens(i)%text)) == "end" .or. &
+                            trim(to_lower(tokens(i)%text)) == "elsewhere") then
                             is_multiline = .true.
                             nesting_level = 1
                             return
@@ -322,7 +322,7 @@ contains
         logical, intent(out) :: found_end
 
         found_end = .false.
-        select case (tokens(idx)%text)
+        select case (trim(to_lower(tokens(idx)%text)))
         case ("if")
             call maybe_increment_if_nesting(tokens, stmt_start, idx, &
                 nesting_level)
@@ -335,12 +335,13 @@ contains
                 end if
             end if
         case ("submodule")
-            if (tokens(stmt_start)%text == "submodule" .and. idx > stmt_start) &
-                then
+            if (trim(to_lower(tokens(stmt_start)%text)) == "submodule" .and. &
+                idx > stmt_start) then
                 nesting_level = nesting_level + 1
             end if
         case ("type")
-            if (tokens(stmt_start)%text == "type" .and. idx > stmt_start) then
+            if (trim(to_lower(tokens(stmt_start)%text)) == "type" .and. &
+                idx > stmt_start) then
                 ! Component declarations such as "type(a_t) :: y" reuse the
                 ! keyword but do not open a nested definition.
                 if (is_type_start(tokens, idx)) then
@@ -389,7 +390,7 @@ contains
         prev_kw = idx - 1
         do while (prev_kw >= stmt_start)
             if (tokens(prev_kw)%kind == TK_KEYWORD) then
-                if (tokens(prev_kw)%text == "else") then
+                if (trim(to_lower(tokens(prev_kw)%text)) == "else") then
                     is_elseif = .true.
                 end if
                 exit
@@ -408,7 +409,7 @@ contains
         limit = min(idx + 20, size(tokens))
         do j = idx + 1, limit
             if (tokens(j)%kind == TK_KEYWORD) then
-                if (tokens(j)%text == "then") then
+                if (trim(to_lower(tokens(j)%text)) == "then") then
                     nesting_level = nesting_level + 1
                     return
                 end if
@@ -429,7 +430,7 @@ contains
         found_end = .false.
         if (idx + 1 <= size(tokens)) then
             if (tokens(idx + 1)%kind == TK_KEYWORD) then
-                if (tokens(idx + 1)%text == "if") then
+                if (trim(to_lower(tokens(idx + 1)%text)) == "if") then
                     call try_close_construct(tokens, stmt_start, "if", idx + 1, &
                         nesting_level, stmt_end, found_end, &
                         .false.)
@@ -462,7 +463,7 @@ contains
         end do
         if (kw_pos <= size(tokens)) then
             if (tokens(kw_pos)%kind == TK_KEYWORD) then
-                select case (tokens(kw_pos)%text)
+                select case (trim(to_lower(tokens(kw_pos)%text)))
                 case ("do")
                     call try_close_construct(tokens, stmt_start, "do", kw_pos, &
                         nesting_level, stmt_end, &
@@ -479,7 +480,7 @@ contains
 
         if (idx + 1 <= size(tokens)) then
             if (tokens(idx + 1)%kind == TK_KEYWORD) then
-                select case (tokens(idx + 1)%text)
+                select case (trim(to_lower(tokens(idx + 1)%text)))
                 case ("do")
                     call try_close_construct(tokens, stmt_start, "do", idx + 1, &
                         nesting_level, stmt_end, &
@@ -577,7 +578,7 @@ contains
                 stmt_end = i - 1
                 exit
             case (TK_OPERATOR)
-                select case (tokens(i)%text)
+                select case (trim(to_lower(tokens(i)%text)))
                 case ("[")
                     bracket_depth = bracket_depth + 1
                 case ("]")

--- a/src/parser/core/parser_utils.f90
+++ b/src/parser/core/parser_utils.f90
@@ -1,6 +1,6 @@
 module parser_utils
     use lexer_core, only: token_t, TK_OPERATOR, TK_KEYWORD, TK_IDENTIFIER, TK_EOF, &
-        TK_COMMENT, TK_NEWLINE, TK_WHITESPACE
+        TK_COMMENT, TK_NEWLINE, TK_WHITESPACE, to_lower
     use parser_state_module, only: parser_state_t
     implicit none
     private
@@ -148,16 +148,23 @@ contains
     ! Check if keyword is an attribute or type modifier (not statement-ending)
     logical function is_attribute_keyword(keyword)
         character(len=*), intent(in) :: keyword
-        is_attribute_keyword = (keyword == "parameter" .or. &
-            keyword == "intent" .or. &
-            keyword == "optional" .or. &
-            keyword == "allocatable" .or. &
-            keyword == "pointer" .or. &
-            keyword == "target" .or. &
-            keyword == "save" .or. &
-            keyword == "public" .or. &
-            keyword == "private" .or. &
-            keyword == "precision") ! For double precision
+        character(len=:), allocatable :: lowered
+
+        ! Fortran keywords are case-insensitive: comparing the raw source
+        ! spelling here truncated the entity list of any declaration written
+        ! in upper case (issue #2974).
+        lowered = to_lower(trim(keyword))
+        is_attribute_keyword = (lowered == "parameter" .or. &
+            lowered == "intent" .or. &
+            lowered == "optional" .or. &
+            lowered == "allocatable" .or. &
+            lowered == "pointer" .or. &
+            lowered == "target" .or. &
+            lowered == "save" .or. &
+            lowered == "public" .or. &
+            lowered == "private" .or. &
+            lowered == "complex" .or. &
+            lowered == "precision") ! For double precision
     end function is_attribute_keyword
 
     logical function is_line_continued(tokens, newline_idx)

--- a/src/parser/declarations/parser_declarations_derived_module.f90
+++ b/src/parser/declarations/parser_declarations_derived_module.f90
@@ -592,7 +592,7 @@ contains
 
         token = parser%peek()
         if ((token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) .and. &
-            token%text == "end") then
+            to_lower(trim(token%text)) == "end") then
             return
         end if
 
@@ -1237,14 +1237,15 @@ contains
 
         ! Handle end of type definition
         if ((token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) .and. &
-            token%text &
-            == "end") then
+            to_lower(trim(adjustl(token%text))) == "end") then
             return
         end if
 
-        ! Check for type declaration keywords
+        ! Check for type declaration keywords. Fortran keywords are
+        ! case-insensitive: matching the raw source spelling dropped every
+        ! component written in upper case (issue #2966).
         if (token%kind == TK_IDENTIFIER .or. token%kind == TK_KEYWORD) then
-            select case (trim(adjustl(token%text)))
+            select case (to_lower(trim(adjustl(token%text))))
             case ("integer", "real", "complex", "logical", "character", &
                     "type", "class", "double", "procedure")
                 comp_index = parse_declaration(parser, arena)

--- a/src/parser/procedures/parser_block_statement_utils.f90
+++ b/src/parser/procedures/parser_block_statement_utils.f90
@@ -1,182 +1,92 @@
 module parser_block_statement_utils_module
     use string_utils_mod, only: to_lower
-    use lexer_core, only: token_t, TK_OPERATOR, TK_KEYWORD, TK_NEWLINE, &
-        TK_WHITESPACE, TK_COMMENT
+    use lexer_core, only: token_t, TK_OPERATOR, TK_KEYWORD, TK_IDENTIFIER, &
+        TK_NEWLINE, TK_WHITESPACE, TK_COMMENT
     implicit none
     private
 
     public :: is_if_statement_start
+    public :: is_block_construct_keyword
+    public :: block_construct_start
     public :: locate_block_statement_end
     public :: locate_single_line_end
 
 contains
 
-    logical function is_if_statement_start(first_token) result(is_if_start)
-        type(token_t), intent(in) :: first_token
+    ! True when the token opens a multi-line construct whose token span has to
+    ! be located by matching its terminator rather than by end of line.
+    logical function is_block_construct_keyword(tok) result(is_construct)
+        type(token_t), intent(in) :: tok
         character(len=:), allocatable :: token_lower
 
-        is_if_start = first_token%kind == TK_KEYWORD
-        if (is_if_start) then
-            token_lower = to_lower(first_token%text)
-            is_if_start = trim(token_lower) == "if" .or. &
-                trim(token_lower) == "do" .or. &
-                trim(token_lower) == "select" .or. &
-                trim(token_lower) == "associate" .or. &
-                trim(token_lower) == "block"
-        end if
+        is_construct = tok%kind == TK_KEYWORD
+        if (.not. is_construct) return
+        token_lower = trim(to_lower(tok%text))
+        select case (token_lower)
+        case ("if", "do", "select", "associate", "block")
+            is_construct = .true.
+        case default
+            is_construct = .false.
+        end select
+    end function is_block_construct_keyword
+
+    ! Retained name for the historical caller: a statement starts a block
+    ! construct when its first token is one of the construct keywords.
+    logical function is_if_statement_start(first_token) result(is_if_start)
+        type(token_t), intent(in) :: first_token
+
+        is_if_start = is_block_construct_keyword(first_token)
     end function is_if_statement_start
 
-    logical function handle_if_block_keyword(all_tokens, pos, depth, stmt_end) &
-            result(completed)
+    ! Index of the token that opens the construct of the statement beginning at
+    ! stmt_start, skipping a leading construct name ("check: if (...) then").
+    ! Returns 0 when the statement does not open a block construct.
+    integer function block_construct_start(all_tokens, stmt_start) result(kw_pos)
         type(token_t), intent(in) :: all_tokens(:)
-        integer, intent(in) :: pos
-        integer, intent(inout) :: depth
-        integer, intent(inout) :: stmt_end
+        integer, intent(in) :: stmt_start
+        integer :: colon_pos, candidate
 
-        logical :: preceded_by_end
-        logical :: preceded_by_else
+        kw_pos = 0
+        if (stmt_start < 1 .or. stmt_start > size(all_tokens)) return
 
-        completed = .false.
-        select case (all_tokens(pos)%text)
-        case ("if")
-            preceded_by_end = .false.
-            preceded_by_else = .false.
-            if (pos > 1) then
-                if (all_tokens(pos - 1)%kind == TK_KEYWORD) then
-                    preceded_by_end = all_tokens(pos - 1)%text == "end"
-                    preceded_by_else = all_tokens(pos - 1)%text == "else"
-                end if
-            end if
-            if (.not. preceded_by_end .and. .not. preceded_by_else) then
-                depth = depth + 1
-            end if
-        case ("end")
-            if (pos < size(all_tokens)) then
-                if (all_tokens(pos + 1)%kind == TK_KEYWORD) then
-                    if (all_tokens(pos + 1)%text == "if") then
-                        depth = depth - 1
-                        if (depth <= 0) then
-                            stmt_end = min(size(all_tokens), pos + 1)
-                            completed = .true.
-                        end if
-                    end if
-                end if
-            end if
-        end select
-    end function handle_if_block_keyword
+        if (is_block_construct_keyword(all_tokens(stmt_start))) then
+            kw_pos = stmt_start
+            return
+        end if
 
-    logical function handle_do_block_keyword(all_tokens, pos, depth, stmt_end) &
-            result(completed)
+        if (all_tokens(stmt_start)%kind /= TK_IDENTIFIER) return
+        colon_pos = next_significant(all_tokens, stmt_start + 1)
+        if (colon_pos > size(all_tokens)) return
+        if (all_tokens(colon_pos)%kind /= TK_OPERATOR) return
+        if (trim(all_tokens(colon_pos)%text) /= ":") return
+        candidate = next_significant(all_tokens, colon_pos + 1)
+        if (candidate > size(all_tokens)) return
+        if (.not. is_block_construct_keyword(all_tokens(candidate))) return
+        kw_pos = candidate
+    end function block_construct_start
+
+    integer function next_significant(all_tokens, start_pos) result(pos)
         type(token_t), intent(in) :: all_tokens(:)
-        integer, intent(in) :: pos
-        integer, intent(inout) :: depth
-        integer, intent(inout) :: stmt_end
+        integer, intent(in) :: start_pos
 
-        completed = .false.
-        select case (all_tokens(pos)%text)
-        case ("do")
-            depth = depth + 1
-        case ("enddo", "end do")
-            depth = depth - 1
-            if (depth <= 0) then
-                stmt_end = min(size(all_tokens), pos)
-                completed = .true.
-            end if
-        case ("end")
-            if (pos + 1 <= size(all_tokens)) then
-                if (all_tokens(pos + 1)%kind == TK_KEYWORD .and. &
-                    all_tokens(pos + 1)%text == "do") then
-                    depth = depth - 1
-                    if (depth <= 0) then
-                        stmt_end = min(size(all_tokens), pos + 1)
-                        completed = .true.
-                    end if
-                end if
-            end if
-        end select
-    end function handle_do_block_keyword
+        pos = start_pos
+        do while (pos <= size(all_tokens))
+            select case (all_tokens(pos)%kind)
+            case (TK_WHITESPACE, TK_NEWLINE, TK_COMMENT)
+                pos = pos + 1
+            case default
+                return
+            end select
+        end do
+    end function next_significant
 
-    logical function handle_select_block_keyword(all_tokens, pos, depth, stmt_end) &
-            result(completed)
-        type(token_t), intent(in) :: all_tokens(:)
-        integer, intent(in) :: pos
-        integer, intent(inout) :: depth
-        integer, intent(inout) :: stmt_end
-
-        completed = .false.
-        select case (to_lower(all_tokens(pos)%text))
-        case ("select")
-            depth = depth + 1
-        case ("end")
-            if (pos + 1 <= size(all_tokens)) then
-                if (all_tokens(pos + 1)%kind == TK_KEYWORD .and. &
-                    to_lower(all_tokens(pos + 1)%text) == "select") then
-                    depth = depth - 1
-                    if (depth <= 0) then
-                        stmt_end = min(size(all_tokens), pos + 1)
-                        completed = .true.
-                    end if
-                end if
-            end if
-        end select
-    end function handle_select_block_keyword
-
-    logical function handle_associate_block_keyword(all_tokens, pos, depth, &
-            stmt_end) result(completed)
-        type(token_t), intent(in) :: all_tokens(:)
-        integer, intent(in) :: pos
-        integer, intent(inout) :: depth
-        integer, intent(inout) :: stmt_end
-
-        completed = .false.
-        select case (to_lower(all_tokens(pos)%text))
-        case ("associate")
-            depth = depth + 1
-        case ("end")
-            if (pos + 1 <= size(all_tokens)) then
-                if (all_tokens(pos + 1)%kind == TK_KEYWORD .and. &
-                    to_lower(all_tokens(pos + 1)%text) == "associate") then
-                    depth = depth - 1
-                    if (depth <= 0) then
-                        stmt_end = min(size(all_tokens), pos + 1)
-                        completed = .true.
-                    end if
-                end if
-            end if
-        end select
-    end function handle_associate_block_keyword
-
-    logical function handle_block_construct_keyword(all_tokens, pos, depth, &
-            stmt_end) result(completed)
-        type(token_t), intent(in) :: all_tokens(:)
-        integer, intent(in) :: pos
-        integer, intent(inout) :: depth
-        integer, intent(inout) :: stmt_end
-
-        completed = .false.
-        select case (to_lower(all_tokens(pos)%text))
-        case ("block")
-            depth = depth + 1
-        case ("endblock")
-            depth = depth - 1
-            if (depth <= 0) then
-                stmt_end = min(size(all_tokens), pos)
-                completed = .true.
-            end if
-        case ("end")
-            if (pos + 1 <= size(all_tokens)) then
-                if (all_tokens(pos + 1)%kind == TK_KEYWORD .and. &
-                    to_lower(all_tokens(pos + 1)%text) == "block") then
-                    depth = depth - 1
-                    if (depth <= 0) then
-                        stmt_end = min(size(all_tokens), pos + 1)
-                        completed = .true.
-                    end if
-                end if
-            end if
-        end select
-    end function handle_block_construct_keyword
-
+    ! Index of the last token of the construct opened at stmt_start.
+    !
+    ! One scan serves every construct: the terminator of the construct named by
+    ! stmt_type closes a nesting level, any other occurrence of the construct
+    ! keyword opens one. Keyword text is compared case-insensitively, and the
+    ! second token of a two-word terminator ("end do") is skipped so that it
+    ! cannot be miscounted as a fresh opening (issue #2972).
     integer function locate_block_statement_end(all_tokens, stmt_start, &
             stmt_type) result(stmt_end)
         type(token_t), intent(in) :: all_tokens(:)
@@ -185,11 +95,14 @@ contains
 
         integer :: pos
         integer :: depth
+        integer :: closer_end
+        character(len=:), allocatable :: construct
+        character(len=:), allocatable :: token_lower
 
+        construct = trim(to_lower(stmt_type))
         stmt_end = stmt_start
-        pos = stmt_start
 
-        if (stmt_type == "if") then
+        if (construct == "if") then
             if (is_single_line_if_statement(all_tokens, stmt_start)) then
                 stmt_end = locate_single_line_end(all_tokens, stmt_start, &
                     all_tokens(stmt_start)%line)
@@ -197,40 +110,73 @@ contains
             end if
         end if
 
-        if (stmt_type == "do" .or. to_lower(stmt_type) == "select" .or. &
-            to_lower(stmt_type) == "associate" .or. &
-            to_lower(stmt_type) == "block") then
-            depth = 1
-            pos = stmt_start + 1
-        else
-            depth = 0
-            pos = stmt_start
-        end if
+        depth = 1
+        pos = stmt_start + 1
 
         do while (pos <= size(all_tokens))
             if (all_tokens(pos)%kind == TK_KEYWORD) then
-                select case (to_lower(stmt_type))
-                case ("if")
-                    if (handle_if_block_keyword(all_tokens, pos, depth, stmt_end)) &
-                        return
-                case ("do")
-                    if (handle_do_block_keyword(all_tokens, pos, depth, stmt_end)) &
-                        return
-                case ("select")
-                    if (handle_select_block_keyword(all_tokens, pos, depth, &
-                        stmt_end)) return
-                case ("associate")
-                    if (handle_associate_block_keyword(all_tokens, pos, depth, &
-                        stmt_end)) return
-                case ("block")
-                    if (handle_block_construct_keyword(all_tokens, pos, depth, &
-                        stmt_end)) return
-                end select
+                token_lower = trim(to_lower(all_tokens(pos)%text))
+                closer_end = construct_terminator_end(all_tokens, pos, construct)
+                if (closer_end > 0) then
+                    depth = depth - 1
+                    stmt_end = closer_end
+                    if (depth <= 0) return
+                    pos = closer_end + 1
+                    cycle
+                else if (token_lower == construct) then
+                    if (.not. opens_nested_construct(all_tokens, pos, construct)) &
+                        then
+                        stmt_end = pos
+                        pos = pos + 1
+                        cycle
+                    end if
+                    depth = depth + 1
+                end if
             end if
             stmt_end = pos
             pos = pos + 1
         end do
     end function locate_block_statement_end
+
+    ! Index of the last token of the terminator of `construct` starting at pos,
+    ! or 0 when the token at pos does not start one. Handles both the one-word
+    ! ("enddo") and two-word ("end do") spellings, case-insensitively.
+    integer function construct_terminator_end(all_tokens, pos, construct) &
+            result(closer_end)
+        type(token_t), intent(in) :: all_tokens(:)
+        integer, intent(in) :: pos
+        character(len=*), intent(in) :: construct
+        character(len=:), allocatable :: token_lower
+
+        closer_end = 0
+        token_lower = trim(to_lower(all_tokens(pos)%text))
+
+        if (token_lower == "end"//construct) then
+            closer_end = pos
+            return
+        end if
+
+        if (token_lower /= "end") return
+        if (pos + 1 > size(all_tokens)) return
+        if (all_tokens(pos + 1)%kind /= TK_KEYWORD) return
+        if (trim(to_lower(all_tokens(pos + 1)%text)) /= construct) return
+        closer_end = pos + 1
+    end function construct_terminator_end
+
+    ! An occurrence of the construct keyword that does not actually open a
+    ! nested construct: "else if" continues the current IF construct.
+    logical function opens_nested_construct(all_tokens, pos, construct) &
+            result(opens)
+        type(token_t), intent(in) :: all_tokens(:)
+        integer, intent(in) :: pos
+        character(len=*), intent(in) :: construct
+
+        opens = .true.
+        if (construct /= "if") return
+        if (pos <= 1) return
+        if (all_tokens(pos - 1)%kind /= TK_KEYWORD) return
+        if (trim(to_lower(all_tokens(pos - 1)%text)) == "else") opens = .false.
+    end function opens_nested_construct
 
     logical function is_single_line_if_statement(all_tokens, stmt_start) &
             result(is_single_line)
@@ -263,14 +209,10 @@ contains
                 end if
             case (TK_KEYWORD)
                 if (paren_depth == 0) then
-                    token_text = all_tokens(pos)%text
-                    select case (token_text)
-                    case ("then")
+                    if (trim(to_lower(all_tokens(pos)%text)) == "then") then
                         is_single_line = .false.
                         return
-                    case ("if")
-                    case default
-                    end select
+                    end if
                 end if
             case (TK_NEWLINE, TK_COMMENT)
                 if (paren_depth == 0 .and. .not. pending_continuation) then

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -9,7 +9,8 @@ module parser_procedure_definition_bodies_module
     use parser_select_constructs_module, only: parse_select_case, parse_select_type, &
         parse_select_rank
     use parser_array_constructs_module, only: parse_associate, parse_block_construct
-    use parser_block_statement_utils_module, only: is_if_statement_start, &
+    use parser_block_statement_utils_module, only: block_construct_start, &
+        is_block_construct_keyword, &
         locate_block_statement_end, &
         locate_single_line_end
     use parser_statement_utilities_module, only: parse_statement_in_if_block, &
@@ -486,13 +487,18 @@ contains
         integer, intent(out) :: stmt_end
 
         integer :: stmt_start
+        integer :: construct_pos
 
         ! Performance: work directly with parser%tokens instead of copying
         ! the entire token array for every statement
         stmt_start = parser%current_token
-        if (is_if_statement_start(first_token)) then
-            stmt_end = locate_block_statement_end(parser%tokens, stmt_start, &
-                first_token%text)
+        ! A construct name ("check: if (...) then") precedes the construct
+        ! keyword; the span still has to be located from the terminator of the
+        ! construct, not from the end of the first line (issue #2967).
+        construct_pos = block_construct_start(parser%tokens, stmt_start)
+        if (construct_pos > 0) then
+            stmt_end = locate_block_statement_end(parser%tokens, construct_pos, &
+                parser%tokens(construct_pos)%text)
         else
             stmt_end = locate_single_line_end(parser%tokens, stmt_start, &
                 first_token%line)
@@ -562,6 +568,7 @@ contains
         integer :: first_token
         integer :: keyword_token
         character(len=:), allocatable :: token_lower, stmt_label
+        type(token_t), allocatable, target :: construct_tokens(:)
         type(parser_state_t) :: block_parser
         type(token_t) :: token
 
@@ -596,28 +603,38 @@ contains
         if (keyword_token <= stmt_size) then
             if (stmt_tokens(keyword_token)%kind == TK_KEYWORD) then
                 token_lower = to_lower(stmt_tokens(keyword_token)%text)
+                ! The DO parser consumes a leading construct name itself; the
+                ! other construct parsers are handed the slice that starts at
+                ! the construct keyword (issue #2967).
+                if (trim(token_lower) == "do") then
+                    allocate (construct_tokens, source=stmt_tokens)
+                else
+                    allocate (construct_tokens, &
+                        source=stmt_tokens(keyword_token:size(stmt_tokens)))
+                end if
                 if (trim(token_lower) == "if") then
                     if (associated(parent_parser%diagnostic_sink)) then
-                        stmt_index = parse_if_statement_tokens(stmt_tokens, arena, &
-                            parent_parser%diagnostic_sink)
+                        stmt_index = parse_if_statement_tokens(construct_tokens, &
+                            arena, parent_parser%diagnostic_sink)
                     else
-                        stmt_index = parse_if_statement_tokens(stmt_tokens, arena)
+                        stmt_index = parse_if_statement_tokens(construct_tokens, &
+                            arena)
                     end if
                 else if (trim(token_lower) == "do") then
-                    stmt_index = parse_do_statement_tokens(stmt_tokens, arena, &
+                    stmt_index = parse_do_statement_tokens(construct_tokens, arena, &
                         parent_parser)
                 else if (trim(token_lower) == "select") then
-                    stmt_index = parse_select_statement_tokens(stmt_tokens, arena, &
-                        parent_parser)
+                    stmt_index = parse_select_statement_tokens(construct_tokens, &
+                        arena, parent_parser)
                 else if (trim(token_lower) == "associate") then
-                    block_parser = create_parser_state(stmt_tokens)
+                    block_parser = create_parser_state(construct_tokens)
                     if (associated(parent_parser%diagnostic_sink)) then
                         block_parser%diagnostic_sink => &
                             parent_parser%diagnostic_sink
                     end if
                     stmt_index = parse_associate(block_parser, arena)
                 else if (trim(token_lower) == "block") then
-                    block_parser = create_parser_state(stmt_tokens)
+                    block_parser = create_parser_state(construct_tokens)
                     if (associated(parent_parser%diagnostic_sink)) then
                         block_parser%diagnostic_sink => &
                             parent_parser%diagnostic_sink
@@ -672,8 +689,7 @@ contains
         if (trim(stmt_tokens(colon_token)%text) /= ":") return
         candidate = next_significant_token(stmt_tokens, stmt_size, colon_token + 1)
         if (candidate > stmt_size) return
-        if (stmt_tokens(candidate)%kind /= TK_KEYWORD) return
-        if (to_lower(trim(stmt_tokens(candidate)%text)) /= "do") return
+        if (.not. is_block_construct_keyword(stmt_tokens(candidate))) return
         keyword_token = candidate
     end function construct_keyword_position
 

--- a/src/parser/statements/parser_statement_utilities.f90
+++ b/src/parser/statements/parser_statement_utilities.f90
@@ -37,6 +37,8 @@ module parser_statement_utilities_module
     use ast_nodes_misc, only: directive_node, comment_node
     use parser_legacy_statements_module, only: parse_legacy_statement
     use parser_common_statement_module, only: parse_common_statement
+    use parser_external_statements_module, only: parse_external_statement
+    use parser_intrinsic_statements_module, only: parse_intrinsic_statement
     use uid_generator, only: generate_uid
     implicit none
     private
@@ -189,6 +191,10 @@ contains
                     parser, arena)
             case ("common")
                 stmt_index = parse_common_statement(parser, arena)
+            case ("external")
+                stmt_index = parse_external_statement(parser, arena)
+            case ("intrinsic")
+                stmt_index = parse_intrinsic_statement(parser, arena)
             case default
                 ! Check if this might be an assignment with a keyword as target
                 ! (e.g., "double = 5" where "double" is both a keyword and a variable)

--- a/test/parser/test_issue_2966_silent_statement_drops.f90
+++ b/test/parser/test_issue_2966_silent_statement_drops.f90
@@ -1,0 +1,271 @@
+program test_issue_2966_silent_statement_drops
+    ! Regression test for the family of silent source-drop defects
+    ! fortfront #2966, #2967, #2972, #2974 and #2977.
+    !
+    ! Every one of them made the frontend emit a *shorter* AST than the
+    ! source: a construct, a declaration or a whole procedure vanished
+    ! without any diagnostic, so no rejection test and no pass count could
+    ! catch it. All five share one mechanism: a token-span or dispatch
+    ! scanner comparing a keyword against its raw source spelling, or
+    ! mis-counting the nesting level of a construct terminator.
+    !
+    ! The oracle here is the source itself: every input below is accepted
+    ! by "gfortran -fsyntax-only", and each check asserts that a construct
+    ! written in the source is present in the arena.
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_data, only: declaration_node
+    use ast_nodes_conditional, only: if_node
+    use ast_nodes_io, only: print_statement_node
+    use ast_nodes_procedure, only: subroutine_def_node
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    call check_2966_uppercase_derived_type(failures)
+    call check_2967_named_if_construct(failures)
+    call check_2972_statement_after_nested_do(failures)
+    call check_2974_multi_entity_declaration(failures)
+    call check_2977_external_statement(failures)
+
+    if (failures > 0) then
+        print *, 'FAIL: ', failures, ' silent statement-drop regressions'
+        error stop 1
+    end if
+    print *, 'PASS: no silent statement drops'
+
+contains
+
+    subroutine parse_source(src, arena)
+        character(len=*), intent(in) :: src
+        type(ast_arena_t), intent(out) :: arena
+        character(:), allocatable :: error_msg
+        type(token_t), allocatable :: tokens(:)
+        integer :: prog_index
+
+        arena = create_ast_arena()
+        call lex_source(src, tokens, error_msg)
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'Lex error: ', trim(error_msg)
+                error stop 1
+            end if
+        end if
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        if (allocated(error_msg)) then
+            if (len_trim(error_msg) > 0) then
+                print *, 'Parse error: ', trim(error_msg)
+                error stop 1
+            end if
+        end if
+    end subroutine parse_source
+
+    integer function count_declaration(arena, name) result(hits)
+        type(ast_arena_t), intent(in) :: arena
+        character(len=*), intent(in) :: name
+        integer :: i, j
+
+        hits = 0
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            select type (n => arena%entries(i)%node)
+            type is (declaration_node)
+                if (allocated(n%var_name)) then
+                    if (trim(n%var_name) == name) hits = hits + 1
+                end if
+                if (allocated(n%var_names)) then
+                    do j = 1, size(n%var_names)
+                        if (trim(n%var_names(j)) == name) hits = hits + 1
+                    end do
+                end if
+            end select
+        end do
+    end function count_declaration
+
+    subroutine expect(condition, label, failures)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: label
+        integer, intent(inout) :: failures
+
+        if (.not. condition) then
+            print *, 'FAIL: ', label
+            failures = failures + 1
+        end if
+    end subroutine expect
+
+    ! #2966: an upper-case component declaration and an upper-case END TYPE
+    ! made the derived-type body swallow the rest of the module.
+    subroutine check_2966_uppercase_derived_type(failures)
+        integer, intent(inout) :: failures
+        type(ast_arena_t) :: arena
+        character(:), allocatable :: src
+        logical :: found_sub
+        integer :: i
+
+        src = 'module test'//new_line('a')// &
+            '    type vertex'//new_line('a')// &
+            '        INTEGER :: k'//new_line('a')// &
+            '    END TYPE'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    subroutine s1()'//new_line('a')// &
+            '        integer :: i'//new_line('a')// &
+            '    end subroutine'//new_line('a')// &
+            'end module test'
+        call parse_source(src, arena)
+
+        found_sub = .false.
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            select type (n => arena%entries(i)%node)
+            type is (subroutine_def_node)
+                if (allocated(n%name)) then
+                    if (trim(n%name) == 's1') found_sub = .true.
+                end if
+            end select
+        end do
+
+        call expect(found_sub, '#2966: contained subroutine s1 dropped', failures)
+        call expect(count_declaration(arena, 'k') >= 1, &
+            '#2966: upper-case component k dropped', failures)
+    end subroutine check_2966_uppercase_derived_type
+
+    ! #2967: a named IF construct inside a contained procedure was dropped
+    ! whole, because the construct name hid the construct keyword from the
+    ! span scanner and from the statement dispatcher.
+    subroutine check_2967_named_if_construct(failures)
+        integer, intent(inout) :: failures
+        type(ast_arena_t) :: arena
+        character(:), allocatable :: src
+        logical :: found_if
+        integer :: i
+
+        src = 'module m'//new_line('a')// &
+            '    implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    subroutine s1()'//new_line('a')// &
+            '        integer :: i'//new_line('a')// &
+            '        i = 0'//new_line('a')// &
+            '        check: if (i == 0) then'//new_line('a')// &
+            '            i = 1'//new_line('a')// &
+            '        end if check'//new_line('a')// &
+            '    end subroutine s1'//new_line('a')// &
+            'end module m'
+        call parse_source(src, arena)
+
+        found_if = .false.
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            select type (n => arena%entries(i)%node)
+            type is (if_node)
+                if (allocated(n%then_body_indices)) then
+                    if (size(n%then_body_indices) >= 1) found_if = .true.
+                end if
+            end select
+        end do
+
+        call expect(found_if, '#2967: named IF construct dropped', failures)
+    end subroutine check_2967_named_if_construct
+
+    ! #2972: the second token of "end do" was counted as opening a fresh DO,
+    ! so the span of a nested nest never closed and every statement after it
+    ! was absorbed into the loop's token span.
+    subroutine check_2972_statement_after_nested_do(failures)
+        integer, intent(inout) :: failures
+        type(ast_arena_t) :: arena
+        character(:), allocatable :: src
+        logical :: found_print
+        integer :: i
+
+        src = 'module m'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '   subroutine work()'//new_line('a')// &
+            '      integer :: i, j'//new_line('a')// &
+            '      do j = 1, 2'//new_line('a')// &
+            '         do i = 1, 3'//new_line('a')// &
+            '         end do'//new_line('a')// &
+            '      end do'//new_line('a')// &
+            "      print *, 'a'"//new_line('a')// &
+            '   end subroutine work'//new_line('a')// &
+            'end module m'
+        call parse_source(src, arena)
+
+        found_print = .false.
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            select type (n => arena%entries(i)%node)
+            type is (print_statement_node)
+                found_print = .true.
+            end select
+        end do
+
+        call expect(found_print, &
+            '#2972: statement after nested DO nest dropped', failures)
+    end subroutine check_2972_statement_after_nested_do
+
+    ! #2974: an upper-case declaration truncated its entity list, because the
+    ! attribute-keyword test compared the raw source spelling.
+    subroutine check_2974_multi_entity_declaration(failures)
+        integer, intent(inout) :: failures
+        type(ast_arena_t) :: arena
+        character(:), allocatable :: src
+
+        src = 'SUBROUTINE s (n, a)'//new_line('a')// &
+            'INTEGER n'//new_line('a')// &
+            'DOUBLE PRECISION a(n+1), res'//new_line('a')// &
+            'res = 2.0d0'//new_line('a')// &
+            'print *, res'//new_line('a')// &
+            'END'
+        call parse_source(src, arena)
+
+        call expect(count_declaration(arena, 'a') >= 1, &
+            '#2974: declaration of a dropped', failures)
+        call expect(count_declaration(arena, 'res') >= 1, &
+            '#2974: trailing entity res dropped from entity list', failures)
+    end subroutine check_2974_multi_entity_declaration
+
+    ! #2977: EXTERNAL was absent from the statement dispatch table used for
+    ! procedure bodies, so the statement produced no node at all.
+    subroutine check_2977_external_statement(failures)
+        integer, intent(inout) :: failures
+        type(ast_arena_t) :: arena
+        character(:), allocatable :: src
+        logical :: found_external
+        integer :: i, j
+
+        src = 'module m_ext_min'//new_line('a')// &
+            '    implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '    subroutine s()'//new_line('a')// &
+            '        external :: foo'//new_line('a')// &
+            '        call foo(1)'//new_line('a')// &
+            '    end subroutine s'//new_line('a')// &
+            'end module m_ext_min'
+        call parse_source(src, arena)
+
+        found_external = .false.
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            select type (n => arena%entries(i)%node)
+            type is (declaration_node)
+                if (.not. n%is_external) cycle
+                if (allocated(n%var_name)) then
+                    if (trim(n%var_name) == 'foo') found_external = .true.
+                end if
+                if (allocated(n%var_names)) then
+                    do j = 1, size(n%var_names)
+                        if (trim(n%var_names(j)) == 'foo') found_external = .true.
+                    end do
+                end if
+            end select
+        end do
+
+        call expect(found_external, &
+            '#2977: EXTERNAL statement in contained procedure dropped', failures)
+    end subroutine check_2977_external_statement
+
+end program test_issue_2966_silent_statement_drops


### PR DESCRIPTION
All five issues are one defect class: a token-span or dispatch scanner that
decides where a construct ends, or which parser handles a statement, by
comparing a keyword against its **raw source spelling** or by mis-counting a
construct terminator. When such a scanner is wrong it does not reject the
program -- it produces a shorter AST. The program compiles clean, runs, and
does less than it says. Same mechanism as the already-fixed #2928 (END
INTERFACE counted as opening a block) and the bare-END procedure span bug.

Fixed sites, one convention each:

* `parser_block_statement_utils` rewritten around a single generic span
  scanner. Previously each construct had its own handler with its own bugs:
  IF/DO compared raw text, and only IF guarded against re-reading the second
  token of a two-word terminator. `end do` therefore decremented the depth on
  `end` and then incremented it again on `do`, so a nested DO nest never
  closed and every following statement was absorbed into its span (#2972).
  There is now one scan: `construct_terminator_end` recognises both the
  one-word (`enddo`) and two-word (`end do`) spellings case-insensitively and
  returns the index of the terminator's last token, which the scan skips past.
  The per-construct handlers are retired, not left as a fallback.

* `collect_statement_tokens` / `construct_keyword_position` now find the
  construct keyword behind a leading construct name for every construct, not
  just DO. A named `check: if (...) then` previously looked like a one-line
  statement to the span scanner and matched no dispatch entry, so the whole
  construct vanished (#2967). Construct parsers that do not accept a leading
  name are handed the slice starting at the construct keyword.

* `frontend_statement_boundary` compares keyword text case-insensitively
  throughout. An upper-case `END TYPE` was not recognised as closing the type
  body (#2966).

* `parse_derived_type_component` matches the component type keyword and `end`
  case-insensitively; an upper-case `INTEGER :: k` component was dropped
  (#2966).

* `is_attribute_keyword` (parser_utils) lowercases before matching, so an
  upper-case declaration no longer truncates its entity list. `DOUBLE
  PRECISION a(n+1), res` produced no node for `res` (#2974).

* EXTERNAL and INTRINSIC are added to the statement dispatch table used for
  procedure bodies; they were reachable only at unit scope, so `external ::
  foo` inside a module-contained procedure produced no node at all (#2977).

Oracle: `test/parser/test_issue_2966_silent_statement_drops.f90` asserts, for
each of the five reduced cases (all accepted by `gfortran -fsyntax-only`),
that the construct written in the source is present in the arena. Recorded on
unmodified main: 6 of 6 assertions fail. On this branch all pass.

No rejection is added or tightened; every change makes the parser accept and
retain more. `make check-rejection-gate`: 822 files, accepted=750
rejected=72, no newly rejected file versus baseline.

Known remaining gap, not a drop: the construct name of a named IF/SELECT/
BLOCK is not stored on the node, so `check: if` round-trips as `if`. The
construct itself is preserved. Tracked separately.

Closes #2966
Closes #2967
Closes #2972
Closes #2974
Closes #2977