### PR TITLE
Fail loudly when a construct span cannot be accounted for (#2983)

### DIFF
--- a/scripts/corpus_rejection_gate.sh
+++ b/scripts/corpus_rejection_gate.sh
@@ -105,10 +105,19 @@ echo "corpus rejection gate: $total files, probe $probe" >&2
 
 probe_one() {
     local file=$1
-    local rel line status
+    local rel line status rc err
     rel=${file#"$project_root"/}
-    line=$(timeout "$FF_GATE_TIMEOUT_S" "$FF_GATE_PROBE" "$file" 2>/dev/null)
-    if [[ $? -ne 0 || -z "$line" ]]; then
+    err=$(mktemp)
+    line=$(timeout "$FF_GATE_TIMEOUT_S" "$FF_GATE_PROBE" "$file" 2>"$err")
+    rc=$?
+    # Anything the probe writes to stderr -- a runtime abort, a scanner
+    # invariant, an instrumentation trace -- used to be discarded here, which
+    # made a whole class of diagnostic invisible to the gate. Keep it.
+    if [[ -s "$err" ]]; then
+        sed "s|^|$rel\t|" "$err" >>"$FF_GATE_STDERR_LOG"
+    fi
+    rm -f "$err"
+    if [[ $rc -ne 0 || -z "$line" ]]; then
         status=REJECTED
     elif [[ "$line" == *'"parse_ok":true'* && "$line" == *'"semantic_ok":true'* ]]; then
         status=ACCEPTED
@@ -120,15 +129,24 @@ probe_one() {
 export -f probe_one
 export FF_GATE_PROBE="$probe"
 export FF_GATE_TIMEOUT_S="$timeout_s"
+export FF_GATE_STDERR_LOG="$out.stderr.log"
 export project_root
 
 mkdir -p "$(dirname -- "$out")"
+: >"$out.stderr.log"
 xargs -a "$file_list" -d '\n' -P "$jobs" -n 1 \
     bash -c 'probe_one "$0"' | sort -k2,2 >"$out"
 
 accepted=$(grep -c '^ACCEPTED' "$out" || true)
 rejected=$(grep -c '^REJECTED' "$out" || true)
 echo "gate report: $out (accepted=$accepted rejected=$rejected)" >&2
+stderr_files=$(cut -f1 "$out.stderr.log" | sort -u | grep -c . || true)
+if ((stderr_files > 0)); then
+    echo "probe stderr: $stderr_files file(s) wrote to stderr;" \
+        "see $out.stderr.log" >&2
+else
+    rm -f "$out.stderr.log"
+fi
 
 [[ -n "$baseline" ]] || exit 0
 [[ -f "$baseline" ]] || die "baseline report not found: $baseline"

--- a/src/parser/core/parser_construct_terminators.f90
+++ b/src/parser/core/parser_construct_terminators.f90
@@ -73,7 +73,31 @@ contains
 
             i = i + 1
         end do
+
+        ! The token stream ended with constructs still open. Every scanner
+        ! downstream locates a construct's span by matching its terminator; with
+        ! no terminator to match, the span runs to the end of the unit and
+        ! silently swallows everything after the construct. Rejecting here is
+        ! what keeps that from producing a shorter AST than the source
+        ! (issue #2983).
+        call report_unclosed_constructs(stack, depth, error_msg)
     end subroutine validate_construct_terminators
+
+    subroutine report_unclosed_constructs(stack, depth, error_msg)
+        type(open_construct_t), intent(in) :: stack(:)
+        integer, intent(in) :: depth
+        character(len=:), allocatable, intent(inout) :: error_msg
+
+        character(len=32) :: line_text, column_text
+
+        if (depth <= 0) return
+
+        write (line_text, '(I0)') stack(depth)%line
+        write (column_text, '(I0)') stack(depth)%column
+        error_msg = "Expecting END"//upper_kind(stack(depth)%kind)// &
+            " statement for the construct opened at line "//trim(line_text)// &
+            ", column "//trim(column_text)
+    end subroutine report_unclosed_constructs
 
     subroutine handle_statement(tokens, j, lowered, stack, depth, error_msg)
         type(token_t), intent(in) :: tokens(:)
@@ -94,6 +118,15 @@ contains
         case ("do")
             if (.not. starts_do_construct(tokens, j)) return
             call push_construct(stack, depth, "do", "", tokens(j))
+        case ("if")
+            if (.not. starts_block_if(tokens, j)) return
+            call push_construct(stack, depth, "if", "", tokens(j))
+        case ("select")
+            if (.not. starts_select_construct(tokens, j)) return
+            call push_construct(stack, depth, "select", "", tokens(j))
+        case ("associate")
+            if (.not. starts_associate_construct(tokens, j)) return
+            call push_construct(stack, depth, "associate", "", tokens(j))
         case ("interface")
             call push_construct(stack, depth, "interface", &
                 statement_remainder(tokens, j + 1), tokens(j))
@@ -101,6 +134,13 @@ contains
             call close_construct(stack, depth, "block", "", tokens(j), error_msg)
         case ("enddo")
             call close_construct(stack, depth, "do", "", tokens(j), error_msg)
+        case ("endif")
+            call close_construct(stack, depth, "if", "", tokens(j), error_msg)
+        case ("endselect")
+            call close_construct(stack, depth, "select", "", tokens(j), error_msg)
+        case ("endassociate")
+            call close_construct(stack, depth, "associate", "", tokens(j), &
+                error_msg)
         case ("endinterface")
             call close_construct(stack, depth, "interface", &
                 statement_remainder(tokens, j + 1), tokens(j), error_msg)
@@ -115,6 +155,14 @@ contains
                 call close_construct(stack, depth, "block", "", tokens(j), error_msg)
             case ("do")
                 call close_construct(stack, depth, "do", "", tokens(j), error_msg)
+            case ("if")
+                call close_construct(stack, depth, "if", "", tokens(j), error_msg)
+            case ("select")
+                call close_construct(stack, depth, "select", "", tokens(j), &
+                    error_msg)
+            case ("associate")
+                call close_construct(stack, depth, "associate", "", tokens(j), &
+                    error_msg)
             case ("interface")
                 call close_construct(stack, depth, "interface", &
                     statement_remainder(tokens, k + 1), tokens(j), error_msg)
@@ -219,6 +267,12 @@ contains
             text = " BLOCK"
         case ("do")
             text = " DO"
+        case ("if")
+            text = " IF"
+        case ("select")
+            text = " SELECT"
+        case ("associate")
+            text = " ASSOCIATE"
         case default
             text = " INTERFACE"
         end select
@@ -324,6 +378,60 @@ contains
         end if
         is_construct = .true.
     end function starts_do_construct
+
+    ! Only the block form of IF opens a construct: its statement ends with
+    ! THEN. "if (x) i = 1" is a single statement with no terminator.
+    logical function starts_block_if(tokens, j) result(is_construct)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: j
+
+        integer :: k, prev
+
+        is_construct = .false.
+        if (tokens(j)%kind /= TK_KEYWORD) return
+
+        prev = j
+        k = next_significant(tokens, j + 1)
+        do while (k > 0)
+            if (.not. continues_statement(tokens, prev, k)) exit
+            prev = k
+            k = next_significant(tokens, k + 1)
+        end do
+        if (prev == j) return
+        is_construct = to_lower(trim(tokens(prev)%text)) == "then"
+    end function starts_block_if
+
+    ! SELECT opens a construct only in the CASE, TYPE and RANK forms.
+    logical function starts_select_construct(tokens, j) result(is_construct)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: j
+
+        integer :: k
+
+        is_construct = .false.
+        if (tokens(j)%kind /= TK_KEYWORD) return
+        k = next_significant(tokens, j + 1)
+        if (.not. continues_statement(tokens, j, k)) return
+        select case (to_lower(trim(tokens(k)%text)))
+        case ("case", "type", "rank")
+            is_construct = .true.
+        end select
+    end function starts_select_construct
+
+    ! ASSOCIATE opens a construct when followed by its association list.
+    logical function starts_associate_construct(tokens, j) result(is_construct)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: j
+
+        integer :: k
+
+        is_construct = .false.
+        if (tokens(j)%kind /= TK_KEYWORD) return
+        k = next_significant(tokens, j + 1)
+        if (.not. continues_statement(tokens, j, k)) return
+        if (tokens(k)%kind /= TK_OPERATOR) return
+        is_construct = trim(tokens(k)%text) == "("
+    end function starts_associate_construct
 
     function statement_remainder(tokens, start) result(text)
         type(token_t), intent(in) :: tokens(:)

--- a/src/parser/procedures/parser_block_statement_utils.f90
+++ b/src/parser/procedures/parser_block_statement_utils.f90
@@ -88,10 +88,22 @@ contains
     ! second token of a two-word terminator ("end do") is skipped so that it
     ! cannot be miscounted as a fresh opening (issue #2972).
     integer function locate_block_statement_end(all_tokens, stmt_start, &
-            stmt_type) result(stmt_end)
+            stmt_type, unaccounted) result(stmt_end)
         type(token_t), intent(in) :: all_tokens(:)
         integer, intent(in) :: stmt_start
         character(len=*), intent(in) :: stmt_type
+        ! Token-accounting invariant. .true. when the scan consumed every
+        ! remaining token of the unit without matching the terminator, so the
+        ! span it returns covers source that does not belong to the construct.
+        !
+        ! This is a check on the SCANNER, not on the source: the pre-parse
+        ! construct-terminator validator has already established that the
+        ! source closes every construct it opens. So if this fires, the
+        ! bookkeeping here is wrong, and the caller is about to absorb
+        ! unrelated statements into this construct and drop them from the AST.
+        ! That is the mechanism of #2928, the bare-END procedure span, and
+        ! #2966/#2967/#2972/#2974/#2977 (issue #2983).
+        logical, intent(out), optional :: unaccounted
 
         integer :: pos
         integer :: depth
@@ -101,6 +113,7 @@ contains
 
         construct = trim(to_lower(stmt_type))
         stmt_end = stmt_start
+        if (present(unaccounted)) unaccounted = .false.
 
         if (construct == "if") then
             if (is_single_line_if_statement(all_tokens, stmt_start)) then
@@ -136,6 +149,9 @@ contains
             stmt_end = pos
             pos = pos + 1
         end do
+
+        ! Ran out of tokens with the construct still open.
+        if (present(unaccounted)) unaccounted = .true.
     end function locate_block_statement_end
 
     ! Index of the last token of the terminator of `construct` starting at pos,

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -488,6 +488,7 @@ contains
 
         integer :: stmt_start
         integer :: construct_pos
+        logical :: unaccounted
 
         ! Performance: work directly with parser%tokens instead of copying
         ! the entire token array for every statement
@@ -498,7 +499,18 @@ contains
         construct_pos = block_construct_start(parser%tokens, stmt_start)
         if (construct_pos > 0) then
             stmt_end = locate_block_statement_end(parser%tokens, construct_pos, &
-                parser%tokens(construct_pos)%text)
+                parser%tokens(construct_pos)%text, unaccounted)
+            ! The span scanner could not account for the tokens of this unit.
+            ! The source is already known to close every construct it opens, so
+            ! the span returned here is wrong and would swallow the statements
+            ! that follow. Report it instead of emitting a shorter AST (#2983).
+            if (unaccounted) then
+                call parser%error_at_token( &
+                    "internal: could not locate the end of this "// &
+                    trim(to_lower(parser%tokens(construct_pos)%text))// &
+                    " construct; refusing to drop the statements that follow", &
+                    parser%tokens(construct_pos))
+            end if
         else
             stmt_end = locate_single_line_end(parser%tokens, stmt_start, &
                 first_token%line)

--- a/test/parser/test_issue_2983_unterminated_span_rejected.f90
+++ b/test/parser/test_issue_2983_unterminated_span_rejected.f90
@@ -1,0 +1,248 @@
+program test_issue_2983_unterminated_span_rejected
+    ! fortfront #2983.
+    !
+    ! The block-construct span scanner locates the end of a construct by
+    ! matching its terminator. When it cannot find one it used to run to the
+    ! end of the token array and return that as the span, so every statement
+    ! after the construct was absorbed and silently vanished from the AST.
+    ! That is the mechanism behind seven known defects (#2928, the bare-END
+    ! procedure span, and #2966/#2967/#2972/#2974/#2977).
+    !
+    ! The fix keeps one canonical mechanism rather than adding a second: the
+    ! pre-parse construct-terminator validator already maintains a stack of
+    ! open constructs, but never checked that the stack was empty at end of
+    ! input, and tracked only DO, BLOCK and INTERFACE. It now also tracks the
+    ! block form of IF, SELECT and ASSOCIATE, and reports whatever is still
+    ! open when the token stream ends.
+    !
+    ! This test pins both directions: an unterminated construct is rejected
+    ! with a diagnostic naming the terminator it wants, and constructs that ARE
+    ! terminated -- including one that is the last statement of a procedure,
+    ! where the terminator sits immediately before END SUBROUTINE -- still
+    ! parse.
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use lexer_core, only: TK_KEYWORD
+    use string_utils_mod, only: to_lower
+    use parser_block_statement_utils_module, only: locate_block_statement_end
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    call expect_rejected('unterminated DO in a module procedure', 'END DO', &
+        'module m'//nl()// &
+        'contains'//nl()// &
+        '   subroutine work()'//nl()// &
+        '      integer :: i'//nl()// &
+        '      do i = 1, 3'//nl()// &
+        '         print *, i'//nl()// &
+        '   end subroutine work'//nl()// &
+        'end module m', failures)
+
+    call expect_rejected('unterminated IF in a module procedure', 'END IF', &
+        'module m'//nl()// &
+        'contains'//nl()// &
+        '   subroutine work()'//nl()// &
+        '      integer :: i'//nl()// &
+        '      i = 1'//nl()// &
+        '      if (i == 1) then'//nl()// &
+        '         i = 2'//nl()// &
+        '   end subroutine work'//nl()// &
+        'end module m', failures)
+
+    ! Negative controls: every one of these is accepted by
+    ! "gfortran -fsyntax-only" and must keep parsing.
+    call expect_accepted('DO as the last statement of a procedure', &
+        'module m'//nl()// &
+        'contains'//nl()// &
+        '   subroutine work()'//nl()// &
+        '      integer :: i'//nl()// &
+        '      do i = 1, 3'//nl()// &
+        '         print *, i'//nl()// &
+        '      end do'//nl()// &
+        '   end subroutine work'//nl()// &
+        'end module m', failures)
+
+    call expect_accepted('nested DO nest followed by a statement', &
+        'module m'//nl()// &
+        'contains'//nl()// &
+        '   subroutine work()'//nl()// &
+        '      integer :: i, j'//nl()// &
+        '      do j = 1, 2'//nl()// &
+        '         do i = 1, 3'//nl()// &
+        '         end do'//nl()// &
+        '      end do'//nl()// &
+        "      print *, 'a'"//nl()// &
+        '   end subroutine work'//nl()// &
+        'end module m', failures)
+
+    call expect_accepted('upper-case DO ... END DO', &
+        'module m'//nl()// &
+        'contains'//nl()// &
+        '   SUBROUTINE work()'//nl()// &
+        '      INTEGER :: i'//nl()// &
+        '      DO i = 1, 3'//nl()// &
+        '         PRINT *, i'//nl()// &
+        '      END DO'//nl()// &
+        '   END SUBROUTINE work'//nl()// &
+        'end module m', failures)
+
+    call expect_accepted('named IF construct', &
+        'module m'//nl()// &
+        'contains'//nl()// &
+        '   subroutine work()'//nl()// &
+        '      integer :: i'//nl()// &
+        '      i = 0'//nl()// &
+        '      check: if (i == 0) then'//nl()// &
+        '         i = 1'//nl()// &
+        '      end if check'//nl()// &
+        '   end subroutine work'//nl()// &
+        'end module m', failures)
+
+    call expect_accepted('one-line IF needs no terminator', &
+        'module m'//nl()// &
+        'contains'//nl()// &
+        '   subroutine work()'//nl()// &
+        '      integer :: i'//nl()// &
+        '      i = 0'//nl()// &
+        '      if (i == 0) i = 1'//nl()// &
+        "      print *, 'a'"//nl()// &
+        '   end subroutine work'//nl()// &
+        'end module m', failures)
+
+    ! The scanner invariant itself, exercised directly. It is meant to be
+    ! unreachable through the parser -- the validator above rejects
+    ! unterminated sources first -- so it is pinned at the unit level.
+    call check_span_scanner_invariant(failures)
+
+    if (failures > 0) then
+        print *, 'FAIL: ', failures, ' unterminated-span checks'
+        error stop 1
+    end if
+    print *, 'PASS: unterminated construct spans are reported, not swallowed'
+
+contains
+
+    function nl() result(c)
+        character(len=1) :: c
+        c = new_line('a')
+    end function nl
+
+    ! parse_tokens takes error_msg as character(len=*), so the buffer has to
+    ! be long enough for the diagnostic; a deferred-length actual argument
+    ! sized by lex_source would silently truncate it to zero characters.
+    subroutine parse_source(src, error_msg)
+        character(len=*), intent(in) :: src
+        character(len=1024), intent(out) :: error_msg
+        character(:), allocatable :: lex_error
+        type(token_t), allocatable :: tokens(:)
+        type(ast_arena_t) :: arena
+        integer :: prog_index
+
+        error_msg = ''
+        arena = create_ast_arena()
+        call lex_source(src, tokens, lex_error)
+        if (allocated(lex_error)) then
+            if (len_trim(lex_error) > 0) then
+                error_msg = lex_error
+                return
+            end if
+        end if
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+    end subroutine parse_source
+
+    ! locate_block_statement_end reports whether it accounted for the tokens
+    ! it scanned: .false. when it matched the terminator, .true. when it ran to
+    ! the end of the array with the construct still open.
+    subroutine check_span_scanner_invariant(failures)
+        integer, intent(inout) :: failures
+        type(token_t), allocatable :: tokens(:)
+        character(:), allocatable :: lex_error
+        integer :: i, do_pos, span_end
+        logical :: unaccounted
+
+        call lex_source('do i = 1, 3'//nl()//'   print *, i'//nl()// &
+            'end do'//nl()//'print *, 0'//nl(), tokens, lex_error)
+        do_pos = 0
+        do i = 1, size(tokens)
+            if (tokens(i)%kind /= TK_KEYWORD) cycle
+            if (trim(to_lower(tokens(i)%text)) == 'do') then
+                do_pos = i
+                exit
+            end if
+        end do
+        if (do_pos == 0) then
+            print *, 'FAIL: could not locate DO token in fixture'
+            failures = failures + 1
+            return
+        end if
+        span_end = locate_block_statement_end(tokens, do_pos, 'do', unaccounted)
+        if (unaccounted) then
+            print *, 'FAIL: scanner reported terminated DO as unaccounted'
+            failures = failures + 1
+        end if
+        if (span_end >= size(tokens)) then
+            print *, 'FAIL: terminated DO span reached the end of the array'
+            failures = failures + 1
+        end if
+
+        call lex_source('do i = 1, 3'//nl()//'   print *, i'//nl(), tokens, &
+            lex_error)
+        do_pos = 0
+        do i = 1, size(tokens)
+            if (tokens(i)%kind /= TK_KEYWORD) cycle
+            if (trim(to_lower(tokens(i)%text)) == 'do') then
+                do_pos = i
+                exit
+            end if
+        end do
+        if (do_pos == 0) then
+            print *, 'FAIL: could not locate DO token in fixture'
+            failures = failures + 1
+            return
+        end if
+        span_end = locate_block_statement_end(tokens, do_pos, 'do', unaccounted)
+        if (.not. unaccounted) then
+            print *, 'FAIL: scanner silently returned a span for an '// &
+                'unterminated DO'
+            failures = failures + 1
+        end if
+    end subroutine check_span_scanner_invariant
+
+    subroutine expect_rejected(label, wanted, src, failures)
+        character(len=*), intent(in) :: label, wanted, src
+        integer, intent(inout) :: failures
+        character(len=1024) :: error_msg
+
+        call parse_source(src, error_msg)
+        if (len_trim(error_msg) == 0) then
+            print *, 'FAIL: accepted silently, source would be dropped: ', label
+            failures = failures + 1
+            return
+        end if
+        if (index(error_msg, 'Expecting '//wanted) == 0) then
+            print *, 'FAIL: rejected without naming the missing '// &
+                wanted//' terminator: ', label
+            print *, '      got: ', trim(error_msg)
+            failures = failures + 1
+        end if
+    end subroutine expect_rejected
+
+    subroutine expect_accepted(label, src, failures)
+        character(len=*), intent(in) :: label, src
+        integer, intent(inout) :: failures
+        character(len=1024) :: error_msg
+
+        call parse_source(src, error_msg)
+        if (len_trim(error_msg) /= 0) then
+            print *, 'FAIL: valid source rejected: ', label
+            print *, '      got: ', trim(error_msg)
+            failures = failures + 1
+        end if
+    end subroutine expect_accepted
+
+end program test_issue_2983_unterminated_span_rejected


### PR DESCRIPTION
Seven known defects (#2928, the bare-END procedure span, and the five closed
by #2982) came from a span scanner that could not find a construct's
terminator and therefore returned a span running to the end of the unit,
swallowing every following statement. The failure is silent by construction:
the program parses, compiles and runs, and does less than its source says.

This adds the two checks that make that outcome impossible to reach silently.
They are deliberately different guarantees, not two copies of one:

1. Source validation -- `validate_construct_terminators` already keeps a stack
   of open constructs, but never looked at it once the token stream ended, so
   a construct that was simply never closed was accepted. It now reports
   whatever is still open at end of input, naming the terminator it wants and
   the line the construct was opened on. It also tracks three more constructs:
   the block form of IF (statement ends in THEN, so a one-line IF is
   untouched), SELECT in its CASE/TYPE/RANK forms, and ASSOCIATE. DO, BLOCK
   and INTERFACE were already tracked. Construct names were already handled by
   `skip_statement_label`, so `check: do ... end do check` is covered.

2. Scanner invariant -- `locate_block_statement_end` now reports whether it
   accounted for the tokens it scanned. Because check 1 has already
   established that the source closes every construct it opens, this can only
   fire when the scanner's own bookkeeping is wrong, which is exactly the
   defect family. The caller rejects instead of returning a truncated body.
   On valid input it is unreachable; the corpus confirms it never fires.

This is why one check does not subsume the other: check 1 is a property of the
source and cannot detect a mis-count on validly terminated input, which is
what all five of #2966/#2967/#2972/#2974/#2977 were. Check 2 is a property of
the scanner and catches precisely that.

Also fixes the gate's blind spot: `scripts/corpus_rejection_gate.sh` discarded
per-file stderr, so a probe abort or any diagnostic of this kind was invisible.
It now records stderr to `<report>.stderr.log` and reports how many files
wrote to it. The TSV format is unchanged. Running it immediately surfaced 3
corpus files that were writing diagnostics nobody could see -- all benign
(nested internal procedure and IF-THEN suggestions), none a crash.

Rejection gate, since this is a tightening: 822 files, accepted=750
rejected=72, **no newly rejected file** versus the baseline.

Oracle: `test/parser/test_issue_2983_unterminated_span_rejected.f90` pins both
directions -- an unterminated DO and an unterminated IF are rejected with a
diagnostic naming the missing terminator, and six valid programs still parse
(DO as the last statement of a procedure, a nested nest followed by a
statement, upper-case DO/END DO, a named IF construct, a one-line IF). The
scanner invariant is exercised directly at the unit level, since it is
unreachable through the parser by design.

Closes #2983