### PR TITLE
Keep the construct name of a named IF, SELECT, ASSOCIATE or BLOCK (#2984)

### DIFF
--- a/examples/f90/named_constructs.f90
+++ b/examples/f90/named_constructs.f90
@@ -1,0 +1,41 @@
+! Named constructs: every construct that may carry a construct name, plus
+! EXIT and CYCLE referring to an enclosing construct by name.
+program named_constructs
+    implicit none
+    integer :: i, j, total
+
+    total = 0
+
+    outer: do i = 1, 3
+        inner: do j = 1, 3
+            if (j == 2) cycle outer
+            if (j == 3) exit outer
+            total = total + j
+        end do inner
+    end do outer
+
+    check: if (total > 0) then
+        total = total + 1
+    else
+        total = -1
+    end if check
+
+    pick: select case (total)
+    case (1)
+        total = 2
+    case default
+        total = 3
+    end select pick
+
+    scope: block
+        integer :: k
+        k = 5
+        total = total + k
+    end block scope
+
+    link: associate (m => total)
+        m = m + 1
+    end associate link
+
+    print *, total
+end program named_constructs

--- a/src/ast/ast_base.f90
+++ b/src/ast/ast_base.f90
@@ -41,6 +41,11 @@ module ast_base
         ! Statement label (for GOTO targets, like 10  i = i + 1)
         character(len=:), allocatable :: stmt_label
 
+        ! Construct name of a named construct ("check: if (...) then ...
+        ! end if check"). EXIT and CYCLE refer to a construct by this name, so
+        ! it has to survive on the node for a consumer to resolve them.
+        character(len=:), allocatable :: construct_name
+
         ! Trailing inline comment (e.g. "x = 1  ! set x")
         character(len=:), allocatable :: trailing_comment
 
@@ -104,6 +109,11 @@ contains
             lhs%stmt_label = rhs%stmt_label
         else if (allocated(lhs%stmt_label)) then
             deallocate (lhs%stmt_label)
+        end if
+        if (allocated(rhs%construct_name)) then
+            lhs%construct_name = rhs%construct_name
+        else if (allocated(lhs%construct_name)) then
+            deallocate (lhs%construct_name)
         end if
         if (allocated(rhs%trailing_comment)) then
             lhs%trailing_comment = rhs%trailing_comment

--- a/src/ast/factory/ast_factory_control_part1.inc
+++ b/src/ast/factory/ast_factory_control_part1.inc
@@ -99,7 +99,12 @@ function push_do_loop(arena, var_name, start_index, end_index, step_index, &
         loop_node%uid = generate_uid()
 
         loop_node%var_name = var_name
-        if (present(loop_label)) loop_node%label = loop_label
+        if (present(loop_label)) then
+            loop_node%label = loop_label
+            ! Every construct reports its name through the same base field so
+            ! one query serves all of them (#2984).
+            loop_node%construct_name = loop_label
+        end if
         if (present(is_concurrent)) loop_node%is_concurrent = is_concurrent
         if (present(type_spec) .and. len_trim(type_spec) > 0) loop_node%type_spec = type_spec
 
@@ -165,7 +170,10 @@ function push_do_loop(arena, var_name, start_index, end_index, step_index, &
         while_node%uid = generate_uid()
 
         ! Set label if provided
-        if (present(loop_label)) while_node%label = loop_label
+        if (present(loop_label)) then
+            while_node%label = loop_label
+            while_node%construct_name = loop_label
+        end if
 
         ! Set condition index
         if (condition_index > 0 .and. condition_index <= arena%size) then

--- a/src/ast/nodes/ast_nodes_associate.f90
+++ b/src/ast/nodes/ast_nodes_associate.f90
@@ -1,7 +1,7 @@
 module ast_nodes_associate
     use uid_generator, only: generate_uid
     use ast_base, only: ast_node, &
-        ast_node_wrapper, ast_visitor_base_t
+        ast_node_wrapper, ast_visitor_base_t, copy_ast_node_base
     implicit none
     private
 
@@ -49,16 +49,7 @@ contains
         class(associate_node), intent(in) :: rhs
         integer :: i
 
-        ! Copy base fields
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
 
         ! Copy associations
         if (allocated(rhs%associations)) then
@@ -107,15 +98,7 @@ contains
         class(block_construct_node), intent(inout) :: lhs
         class(block_construct_node), intent(in) :: rhs
 
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
 
         if (allocated(rhs%body_indices)) then
             lhs%body_indices = rhs%body_indices

--- a/src/ast/nodes/ast_nodes_conditional.f90
+++ b/src/ast/nodes/ast_nodes_conditional.f90
@@ -1,7 +1,7 @@
 module ast_nodes_conditional
     use uid_generator, only: generate_uid
     use ast_base, only: ast_node, &
-        ast_node_wrapper, ast_visitor_base_t
+        ast_node_wrapper, ast_visitor_base_t, copy_ast_node_base
     implicit none
     private
 
@@ -140,16 +140,7 @@ contains
         class(if_node), intent(inout) :: lhs
         class(if_node), intent(in) :: rhs
         integer :: i
-        ! Copy base fields
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific fields
         lhs%condition_index = rhs%condition_index
         if (allocated(rhs%then_body_indices)) then
@@ -180,15 +171,7 @@ contains
         class(select_case_node), intent(inout) :: lhs
         class(select_case_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific components
         lhs%selector_index = rhs%selector_index
         lhs%default_index = rhs%default_index
@@ -210,15 +193,7 @@ contains
         class(case_block_node), intent(inout) :: lhs
         class(case_block_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Deep copy allocatable arrays
         if (allocated(rhs%value_indices)) then
             if (allocated(lhs%value_indices)) deallocate (lhs%value_indices)
@@ -242,15 +217,7 @@ contains
         class(case_range_node), intent(inout) :: lhs
         class(case_range_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific components
         lhs%start_value = rhs%start_value
         lhs%end_value = rhs%end_value
@@ -266,15 +233,7 @@ contains
         class(case_default_node), intent(inout) :: lhs
         class(case_default_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Deep copy allocatable array
         if (allocated(rhs%body_indices)) then
             if (allocated(lhs%body_indices)) deallocate (lhs%body_indices)
@@ -293,15 +252,7 @@ contains
         class(select_type_node), intent(inout) :: lhs
         class(select_type_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific components
         lhs%selector_index = rhs%selector_index
         lhs%default_index = rhs%default_index
@@ -323,15 +274,7 @@ contains
         class(type_guard_block_node), intent(inout) :: lhs
         class(type_guard_block_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific components
         lhs%guard_type = rhs%guard_type
         lhs%type_name_index = rhs%type_name_index
@@ -353,15 +296,7 @@ contains
         class(select_rank_node), intent(inout) :: lhs
         class(select_rank_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific components
         lhs%selector_index = rhs%selector_index
         lhs%default_index = rhs%default_index
@@ -383,15 +318,7 @@ contains
         class(rank_block_node), intent(inout) :: lhs
         class(rank_block_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific components
         lhs%rank_value = rhs%rank_value
         ! Deep copy allocatable array

--- a/src/ast/nodes/ast_nodes_loops.f90
+++ b/src/ast/nodes/ast_nodes_loops.f90
@@ -1,7 +1,7 @@
 module ast_nodes_loops
     use uid_generator, only: generate_uid
     use ast_base, only: ast_node, &
-        ast_node_wrapper, ast_visitor_base_t
+        ast_node_wrapper, ast_visitor_base_t, copy_ast_node_base
     implicit none
     private
 
@@ -89,15 +89,7 @@ contains
         class(do_loop_node), intent(inout) :: lhs
         class(do_loop_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific components
         lhs%var_name = rhs%var_name
         if (allocated(lhs%label)) deallocate (lhs%label)
@@ -126,15 +118,7 @@ contains
         class(do_while_node), intent(inout) :: lhs
         class(do_while_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific components
         if (allocated(lhs%label)) deallocate (lhs%label)
         if (allocated(rhs%label)) lhs%label = rhs%label
@@ -157,15 +141,7 @@ contains
         class(forall_node), intent(inout) :: lhs
         class(forall_node), intent(in) :: rhs
         ! Copy base class components
-        lhs%line = rhs%line
-        lhs%column = rhs%column
-        lhs%uid = rhs%uid
-        lhs%inferred_type = rhs%inferred_type
-        lhs%is_constant = rhs%is_constant
-        lhs%constant_logical = rhs%constant_logical
-        lhs%constant_integer = rhs%constant_integer
-        lhs%constant_real = rhs%constant_real
-        lhs%constant_type = rhs%constant_type
+        call copy_ast_node_base(lhs, rhs)
         ! Copy specific components
         lhs%num_indices = rhs%num_indices
         if (allocated(rhs%index_names)) then

--- a/src/codegen/statements/codegen_control_flow.f90
+++ b/src/codegen/statements/codegen_control_flow.f90
@@ -1,5 +1,6 @@
 module codegen_control_flow
     use ast_arena_modern, only: ast_arena_t
+    use ast_base, only: ast_node
     use ast_nodes_control
     use type_system_unified
     use codegen_indent
@@ -22,6 +23,29 @@ module codegen_control_flow
     public :: generate_code_block_construct
 
 contains
+
+    ! "name: " for a named construct, empty otherwise. One helper for every
+    ! construct so the spelling cannot drift between them (#2984).
+    function construct_prefix(node) result(text)
+        class(ast_node), intent(in) :: node
+        character(len=:), allocatable :: text
+
+        text = ""
+        if (.not. allocated(node%construct_name)) return
+        if (len_trim(node%construct_name) == 0) return
+        text = trim(adjustl(node%construct_name))//": "
+    end function construct_prefix
+
+    ! " name" for the END statement of a named construct, empty otherwise.
+    function construct_suffix(node) result(text)
+        class(ast_node), intent(in) :: node
+        character(len=:), allocatable :: text
+
+        text = ""
+        if (.not. allocated(node%construct_name)) return
+        if (len_trim(node%construct_name) == 0) return
+        text = " "//trim(adjustl(node%construct_name))
+    end function construct_suffix
 
     function append_header_comment(code, comment) result(out)
         character(len=:), allocatable, intent(in) :: code
@@ -110,7 +134,7 @@ contains
         end if
 
         ! Generate if statement in block form
-        code = "if ("//cond_code//") then"
+        code = construct_prefix(node)//"if ("//cond_code//") then"
         code = append_header_comment(code, node%trailing_comment)
 
         ! Generate then body
@@ -152,7 +176,8 @@ contains
         end if
 
         ! Generate end if
-        code = code//new_line('A')//repeat("    ", indent_level)//"end if"
+        code = code//new_line('A')//repeat("    ", indent_level)//"end if"// &
+            construct_suffix(node)
     end function generate_code_if
 
     ! Try to generate single-line IF statement if conditions are met
@@ -164,6 +189,11 @@ contains
         character(len=:), allocatable :: stmt_code
         integer :: stmt_index
 
+        ! A named IF must keep its block form: there is nowhere to put the
+        ! construct name on a one-line IF (#2984).
+        if (allocated(node%construct_name)) then
+            if (len_trim(node%construct_name) > 0) return
+        end if
         if (.not. allocated(node%then_body_indices)) return
         if (size(node%then_body_indices) /= 1) return
 
@@ -233,30 +263,18 @@ contains
             if (allocated(node%type_spec) .and. len_trim(node%type_spec) > 0) then
                 index_code = trim(node%type_spec)//" :: "//var_code
             end if
-            if (allocated(node%label)) then
-                code = trim(adjustl(node%label))//": do concurrent ("// &
-                    index_code// &
-                    " = "//start_code//":"//end_code
-                end_keyword = "end do "//trim(adjustl(node%label))
-            else
-                code = "do concurrent ("//index_code//" = "//start_code//":"// &
-                    end_code
-                end_keyword = "end do"
-            end if
+            code = construct_prefix(node)//"do concurrent ("//index_code// &
+                " = "//start_code//":"//end_code
+            end_keyword = "end do"//construct_suffix(node)
             if (len(step_code) > 0) then
                 code = code//":"//step_code
             end if
             code = code//")"
         else
             ! Regular DO loop syntax: do var = start, end [, step]
-            if (allocated(node%label)) then
-                code = trim(adjustl(node%label))//": do "//var_code//" = "// &
-                    start_code//", "//end_code
-                end_keyword = "end do "//trim(adjustl(node%label))
-            else
-                code = "do "//var_code//" = "//start_code//", "//end_code
-                end_keyword = "end do"
-            end if
+            code = construct_prefix(node)//"do "//var_code//" = "// &
+                start_code//", "//end_code
+            end_keyword = "end do"//construct_suffix(node)
             if (len(step_code) > 0) then
                 code = code//", "//step_code
             end if
@@ -323,7 +341,7 @@ contains
         end if
 
         ! Generate select case statement
-        code = "select case ("//expr_code//")"
+        code = construct_prefix(node)//"select case ("//expr_code//")"
 
         ! Generate case blocks
         if (allocated(node%case_indices)) then
@@ -410,7 +428,8 @@ contains
         end if
 
         ! Generate end select
-        code = code//new_line('A')//repeat("    ", indent_level)//"end select"
+        code = code//new_line('A')//repeat("    ", indent_level)//"end select"// &
+            construct_suffix(node)
     end function generate_code_select_case
 
     ! Generate code for select type statements
@@ -432,7 +451,7 @@ contains
         end if
 
         ! Generate select type statement
-        code = "select type ("//expr_code//")"
+        code = construct_prefix(node)//"select type ("//expr_code//")"
 
         ! Generate type guard blocks
         if (allocated(node%guard_indices)) then
@@ -489,7 +508,8 @@ contains
         end if
 
         ! Generate end select
-        code = code//new_line('A')//repeat("    ", indent_level)//"end select"
+        code = code//new_line('A')//repeat("    ", indent_level)//"end select"// &
+            construct_suffix(node)
     end function generate_code_select_type
 
     ! Generate code for SELECT RANK constructs
@@ -512,7 +532,7 @@ contains
         end if
 
         ! Generate select rank statement
-        code = "select rank ("//expr_code//")"
+        code = construct_prefix(node)//"select rank ("//expr_code//")"
 
         ! Generate rank blocks
         if (allocated(node%rank_indices)) then
@@ -566,7 +586,8 @@ contains
         end if
 
         ! Generate end select
-        code = code//new_line('A')//repeat("    ", indent_level)//"end select"
+        code = code//new_line('A')//repeat("    ", indent_level)//"end select"// &
+            construct_suffix(node)
     end function generate_code_select_rank
 
     ! Generate code for where constructs
@@ -692,7 +713,7 @@ contains
         indent_level = 0
 
         ! Generate associate statement
-        code = "associate ("
+        code = construct_prefix(node)//"associate ("
 
         ! Generate associations
         if (allocated(node%associations)) then
@@ -724,7 +745,7 @@ contains
 
         ! Generate end associate
         code = code//new_line('A')//repeat("    ", indent_level)
-        code = code//"end associate"
+        code = code//"end associate"//construct_suffix(node)
     end function generate_code_associate
 
     function generate_code_block_construct(arena, node, node_index) result(code)
@@ -736,7 +757,7 @@ contains
         integer :: indent_level
 
         indent_level = 0
-        code = "block"
+        code = construct_prefix(node)//"block"
 
         if (allocated(node%body_indices)) then
             body_code = generate_grouped_body_internal( &
@@ -747,7 +768,7 @@ contains
         end if
 
         code = code//new_line('A')//repeat("    ", indent_level)
-        code = code//"end block"
+        code = code//"end block"//construct_suffix(node)
     end function generate_code_block_construct
 
     ! Internal function to generate grouped body

--- a/src/fortfront.f90
+++ b/src/fortfront.f90
@@ -51,6 +51,7 @@ module fortfront
         get_select_type_info, get_type_guard_info, &
         get_dummy_allocatable_attribute, &
         get_alternate_return_label, &
+        get_construct_name, &
         get_return_selector, &
         is_alternate_return_dummy, &
         get_program_body_info, &

--- a/src/fortfront_compiler.f90
+++ b/src/fortfront_compiler.f90
@@ -22,6 +22,7 @@ module fortfront_compiler
         get_select_type_info, get_type_guard_info, &
         get_dummy_allocatable_attribute, &
         get_alternate_return_label, &
+        get_construct_name, &
         get_return_selector, &
         is_alternate_return_dummy, &
         get_program_body_info, &

--- a/src/frontend/frontend_compiler_queries.f90
+++ b/src/frontend/frontend_compiler_queries.f90
@@ -53,6 +53,7 @@ module frontend_compiler_queries
     public :: get_type_guard_info
     public :: get_dummy_allocatable_attribute
     public :: get_alternate_return_label
+    public :: get_construct_name
     public :: get_return_selector
     public :: is_alternate_return_dummy
     public :: get_program_body_info
@@ -1037,6 +1038,22 @@ contains
 
     ! Compiler-facing query: statement label of an alternate return spec
     ! (`*<label>` actual argument).  Returns 0 for any other node kind.
+    ! Compiler-facing query: the construct name of a named construct
+    ! ("check: if (...) then ... end if check"), or an empty string when the
+    ! construct is unnamed or the node is not a construct. EXIT and CYCLE name
+    ! the construct they target, so a consumer resolves them by matching their
+    ! label against this over the enclosing constructs.
+    function get_construct_name(arena, node_index) result(name)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: node_index
+        character(len=:), allocatable :: name
+
+        name = ""
+        if (.not. arena%has_node_at(node_index)) return
+        if (.not. allocated(arena%entries(node_index)%node%construct_name)) return
+        name = trim(arena%entries(node_index)%node%construct_name)
+    end function get_construct_name
+
     function get_alternate_return_label(arena, node_index) result(label)
         type(ast_arena_t), intent(in) :: arena
         integer, intent(in) :: node_index

--- a/src/parser/procedures/parser_procedure_definition_bodies.f90
+++ b/src/parser/procedures/parser_procedure_definition_bodies.f90
@@ -580,6 +580,7 @@ contains
         integer :: first_token
         integer :: keyword_token
         character(len=:), allocatable :: token_lower, stmt_label
+        character(len=:), allocatable :: construct_name
         type(token_t), allocatable, target :: construct_tokens(:)
         type(parser_state_t) :: block_parser
         type(token_t) :: token
@@ -611,6 +612,11 @@ contains
         ! moves past it here (issue #2888).
         keyword_token = construct_keyword_position(stmt_tokens, stmt_size, &
                                                    first_token)
+        ! Keep the construct name: EXIT and CYCLE refer to a construct by it,
+        ! and a consumer cannot resolve them from an anonymous node (#2984).
+        if (keyword_token > first_token) then
+            construct_name = trim(stmt_tokens(first_token)%text)
+        end if
 
         if (keyword_token <= stmt_size) then
             if (stmt_tokens(keyword_token)%kind == TK_KEYWORD) then
@@ -676,6 +682,11 @@ contains
         if (stmt_index > 0 .and. allocated(stmt_label)) then
             if (arena%has_node_at(stmt_index)) then
                 arena%entries(stmt_index)%node%stmt_label = stmt_label
+            end if
+        end if
+        if (stmt_index > 0 .and. allocated(construct_name)) then
+            if (arena%has_node_at(stmt_index)) then
+                arena%entries(stmt_index)%node%construct_name = construct_name
             end if
         end if
     end function parse_body_statement_tokens

--- a/src/parser/statements/parser_execution_statements_module.inc
+++ b/src/parser/statements/parser_execution_statements_module.inc
@@ -887,8 +887,11 @@
             type(parser_state_t), intent(inout) :: parser_ref
             type(ast_arena_t), intent(inout) :: arena_ref
             type(token_t) :: next_token
+            character(len=:), allocatable :: construct_label
 
             ! Check for labeled construct: identifier : keyword
+            next_token = parser_ref%peek()
+            construct_label = trim(next_token%text)
             next_token = parser_ref%consume()  ! Consume identifier
             next_token = parser_ref%peek()
             if (next_token%kind == TK_OPERATOR .and. next_token%text == ":") then
@@ -904,9 +907,17 @@
                             stmt_index = parse_do_loop(parser_ref, arena_ref)
                             return
                         else if (is_control_flow_keyword(keyword_text)) then
-                            ! Other control flow keywords - rewind and route
-                            parser_ref%current_token = parser_ref%current_token - 2
+                            ! Every other construct parser starts at the
+                            ! construct keyword, so route from there and record
+                            ! the construct name on the node afterwards; EXIT
+                            ! and CYCLE refer to it by name (#2984).
                             stmt_index = route_control_flow(parser_ref, arena_ref)
+                            if (stmt_index > 0) then
+                                if (arena_ref%has_node_at(stmt_index)) then
+                                    arena_ref%entries(stmt_index)%node% &
+                                        construct_name = construct_label
+                                end if
+                            end if
                             return
                         else
                             ! Not control flow, rewind and parse as assignment

--- a/test/parser/test_issue_2984_construct_names.f90
+++ b/test/parser/test_issue_2984_construct_names.f90
@@ -1,0 +1,187 @@
+program test_issue_2984_construct_names
+    ! fortfront #2984: a named IF, SELECT, ASSOCIATE or BLOCK lost its
+    ! construct name. DO already kept one, so the source round-tripped with
+    ! some constructs renamed and others not.
+    !
+    ! This is not only a fidelity problem. EXIT and CYCLE name the construct
+    ! they target, so with no name on the node a consumer cannot resolve which
+    ! construct `exit outer` leaves, nor check that it names an enclosing one.
+    !
+    ! Oracle: examples/f90/named_constructs.f90 is accepted by
+    ! "gfortran -fsyntax-only" and names every construct that may carry a name.
+    ! Round-tripping it must preserve each name on both the opening statement
+    ! and its END, and the public query must report the same names.
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use transformation_api, only: transform_lazy_fortran_string
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use fortfront, only: get_construct_name
+    use lexer_core, only: token_t
+    use ast_arena_modern, only: ast_arena_t, create_ast_arena
+    use ast_nodes_conditional, only: if_node, select_case_node
+    use ast_nodes_associate, only: associate_node, block_construct_node
+    use ast_nodes_loops, only: do_loop_node
+    use ast_nodes_transfer, only: exit_node, cycle_node
+    implicit none
+
+    integer :: failures
+
+    failures = 0
+
+    call check_round_trip(failures)
+    call check_query_and_transfer_targets(failures)
+
+    if (failures > 0) then
+        write (error_unit, '(a,i0,a)') 'FAIL: ', failures, ' construct-name checks'
+        error stop 1
+    end if
+    print *, 'PASS: construct names survive parse, codegen and the query API'
+
+contains
+
+    include '../common/read_example.inc'
+
+    ! Every named construct must round-trip with its name on both statements.
+    subroutine check_round_trip(failures)
+        integer, intent(inout) :: failures
+        character(len=:), allocatable :: source, output, errors
+
+        call read_example('examples/f90/named_constructs.f90', source)
+        call transform_lazy_fortran_string(source, output, errors)
+        if (allocated(errors)) then
+            if (len_trim(errors) > 0) then
+                write (error_unit, '(a)') 'FAIL: transform reported: '//trim(errors)
+                failures = failures + 1
+                return
+            end if
+        end if
+
+        call expect_contains(output, 'outer: do', failures)
+        call expect_contains(output, 'end do outer', failures)
+        call expect_contains(output, 'inner: do', failures)
+        call expect_contains(output, 'end do inner', failures)
+        call expect_contains(output, 'check: if', failures)
+        call expect_contains(output, 'end if check', failures)
+        call expect_contains(output, 'pick: select case', failures)
+        call expect_contains(output, 'end select pick', failures)
+        call expect_contains(output, 'scope: block', failures)
+        call expect_contains(output, 'end block scope', failures)
+        call expect_contains(output, 'link: associate', failures)
+        call expect_contains(output, 'end associate link', failures)
+        ! EXIT and CYCLE keep naming the construct they target.
+        call expect_contains(output, 'cycle outer', failures)
+        call expect_contains(output, 'exit outer', failures)
+    end subroutine check_round_trip
+
+    ! The public query reports the name for each construct kind, reports an
+    ! empty string for an unnamed one, and lets a consumer match an EXIT or
+    ! CYCLE label against an enclosing construct -- here from inside a nested
+    ! construct, where `exit outer` skips past `inner`.
+    subroutine check_query_and_transfer_targets(failures)
+        integer, intent(inout) :: failures
+        character(len=:), allocatable :: source
+        character(len=1024) :: error_msg
+        type(token_t), allocatable :: tokens(:)
+        character(len=:), allocatable :: lex_error
+        type(ast_arena_t) :: arena
+        integer :: prog_index, i
+        logical :: saw_if, saw_select, saw_block, saw_associate
+        logical :: saw_unnamed_if, resolved_exit, resolved_cycle
+        character(len=:), allocatable :: outer_name
+
+        call read_example('examples/f90/named_constructs.f90', source)
+        arena = create_ast_arena()
+        call lex_source(source, tokens, lex_error)
+        error_msg = ''
+        call parse_tokens(tokens, arena, prog_index, error_msg)
+        if (len_trim(error_msg) > 0) then
+            write (error_unit, '(a)') 'FAIL: parse reported: '//trim(error_msg)
+            failures = failures + 1
+            return
+        end if
+
+        saw_if = .false.
+        saw_select = .false.
+        saw_block = .false.
+        saw_associate = .false.
+        saw_unnamed_if = .false.
+        outer_name = ''
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            select type (n => arena%entries(i)%node)
+            type is (if_node)
+                if (get_construct_name(arena, i) == 'check') saw_if = .true.
+                if (get_construct_name(arena, i) == '') saw_unnamed_if = .true.
+            type is (select_case_node)
+                if (get_construct_name(arena, i) == 'pick') saw_select = .true.
+            type is (block_construct_node)
+                if (get_construct_name(arena, i) == 'scope') saw_block = .true.
+            type is (associate_node)
+                if (get_construct_name(arena, i) == 'link') saw_associate = .true.
+            type is (do_loop_node)
+                if (get_construct_name(arena, i) == 'outer') &
+                    outer_name = get_construct_name(arena, i)
+            end select
+        end do
+
+        call expect(saw_if, 'named IF reports its construct name', failures)
+        call expect(saw_select, 'named SELECT CASE reports its construct name', &
+            failures)
+        call expect(saw_block, 'named BLOCK reports its construct name', failures)
+        call expect(saw_associate, 'named ASSOCIATE reports its construct name', &
+            failures)
+        call expect(saw_unnamed_if, &
+            'an unnamed IF reports an empty construct name', failures)
+        call expect(outer_name == 'outer', &
+            'named DO reports its construct name through the same query', &
+            failures)
+
+        ! Resolve the EXIT and CYCLE that target the OUTER loop from inside
+        ! the nested INNER loop: their label must match a construct name that
+        ! the query reports.
+        resolved_exit = .false.
+        resolved_cycle = .false.
+        do i = 1, arena%size
+            if (.not. allocated(arena%entries(i)%node)) cycle
+            select type (n => arena%entries(i)%node)
+            type is (exit_node)
+                if (allocated(n%label)) then
+                    if (trim(n%label) == outer_name) resolved_exit = .true.
+                end if
+            type is (cycle_node)
+                if (allocated(n%label)) then
+                    if (trim(n%label) == outer_name) resolved_cycle = .true.
+                end if
+            end select
+        end do
+
+        call expect(resolved_exit, &
+            'EXIT from a nested construct resolves to the named outer DO', &
+            failures)
+        call expect(resolved_cycle, &
+            'CYCLE from a nested construct resolves to the named outer DO', &
+            failures)
+    end subroutine check_query_and_transfer_targets
+
+    subroutine expect_contains(haystack, needle, failures)
+        character(len=*), intent(in) :: haystack, needle
+        integer, intent(inout) :: failures
+
+        if (index(haystack, needle) == 0) then
+            write (error_unit, '(a)') 'FAIL: round-trip lost "'//needle//'"'
+            failures = failures + 1
+        end if
+    end subroutine expect_contains
+
+    subroutine expect(condition, label, failures)
+        logical, intent(in) :: condition
+        character(len=*), intent(in) :: label
+        integer, intent(inout) :: failures
+
+        if (.not. condition) then
+            write (error_unit, '(a)') 'FAIL: '//label
+            failures = failures + 1
+        end if
+    end subroutine expect
+
+end program test_issue_2984_construct_names


### PR DESCRIPTION
`check: if (...) then ... end if check` round-tripped as `if (...) then ...
end if`. DO kept its name and nothing else did, so the frontend silently
renamed some constructs and not others.

This is not only fidelity. EXIT and CYCLE name the construct they target, so
with no name on the node a consumer cannot resolve which construct `exit
outer` leaves, nor check that it names an enclosing one.

Rather than add a name field to each of the six construct node types and a
matching argument to each of their nine factory functions, the name lives on
the base `ast_node` as `construct_name`, next to `stmt_label`, which is
already the base-level home for a statement's leading label. One field, one
copy site, one query, and it works for every construct including the ones
nobody has thought of yet.

* `ast_base`: `construct_name`, copied by `copy_ast_node_base`.

* The construct node modules hand-rolled their base-field copies instead of
  calling `copy_ast_node_base`, and those copies were already dropping
  `stmt_label` and `trailing_comment` on every arena copy. All twelve of them
  now call the canonical helper, which fixes that latent loss as well.

* Parsers: the procedure-body dispatcher records the name it already had to
  find in order to locate the construct keyword (#2967). At program scope,
  `parse_identifier_assignment` used to rewind two tokens before routing a
  named non-DO construct, leaving the parser on the construct name; it now
  routes from the construct keyword, which is where every construct parser
  expects to start, and attaches the name afterwards.

* Codegen: one `construct_prefix`/`construct_suffix` pair emits the name for
  all six constructs, and DO now goes through it too instead of open-coding
  the same concatenation twice. A named IF is never collapsed to the one-line
  form, since there is nowhere to put the name.

* `get_construct_name(arena, node_index)` is public through `fortfront` and
  `fortfront_compiler`, returning "" for an unnamed construct or a non-
  construct node. `do_loop_node%label` stays as it was for existing consumers;
  the factory populates both.

Oracle: `examples/f90/named_constructs.f90` (accepted by `gfortran
-fsyntax-only`) names every construct that can carry a name, and cycles and
exits the outer DO by name from inside the inner one.
`test/parser/test_issue_2984_construct_names.f90` asserts each name survives
on both the opening statement and its END, that the query reports it for all
six construct kinds and "" for an unnamed IF, and that the EXIT and CYCLE
labels match the name the query reports for the enclosing DO. Recorded on
unmodified main: 8 of 8 round-trip assertions fail (the query half does not
compile there, since the query is new).

Rejection gate: 823 files, accepted=751 rejected=72, no newly rejected file.

Closes #2984