### PR TITLE
Restore the duplication gate to zero and stop overclaiming it (#2990)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,15 @@ end program
 - Negative control: `make check-duplication-gate` proves the gate can still fail
 - CI workflow: `.github/workflows/ci.yml`
 
+**Do not read "blocking in CI" as "cannot land".** PRs here are squash-merged
+with `--admin` without waiting for CI, so a CI gate is not a merge
+precondition: a violation can reach `main` and sit there until someone runs
+the target locally. That is exactly how #2990 happened — the gate was made
+blocking by #2910, and a new violation landed anyway three weeks later, while
+this file still said the gate was at zero. **Run `make check-duplication`
+yourself before merging anything that adds or edits a test.** Treat the
+statement above as a claim that was true when written, not as a live signal.
+
 Keep it at zero: new end-to-end tests must use `read_example()` rather than inline full programs.
 
 **How to Check Status**:

--- a/test/api/test_reject_call_01_diagnostics.f90
+++ b/test/api/test_reject_call_01_diagnostics.f90
@@ -227,18 +227,7 @@ contains
         character(len=:), allocatable :: source
 
         print *, 'Testing intrinsic actual with matching argument count (accepted)...'
-        source = 'module m'//new_line('a')// &
-            'implicit none'//new_line('a')// &
-            'contains'//new_line('a')// &
-            'subroutine sub(a)'//new_line('a')// &
-            'interface'//new_line('a')// &
-            'function a(x)'//new_line('a')// &
-            'real :: a, x'//new_line('a')// &
-            'end function a'//new_line('a')// &
-            'end interface'//new_line('a')// &
-            'print *, a(4.0)'//new_line('a')// &
-            'end subroutine sub'//new_line('a')// &
-            'end module m'//new_line('a')// &
+        source = unary_dummy_function_module()//new_line('a')// &
             'program p'//new_line('a')// &
             'use m'//new_line('a')// &
             'implicit none'//new_line('a')// &
@@ -300,6 +289,25 @@ contains
             'end subroutine sub'//new_line('a')// &
             'end module m'
     end function dummy_function_module
+
+    ! As dummy_function_module, but the dummy function takes one argument, so
+    ! an intrinsic actual with matching arity is accepted.
+    function unary_dummy_function_module() result(text)
+        character(len=:), allocatable :: text
+
+        text = 'module m'//new_line('a')// &
+            'implicit none'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine sub(a)'//new_line('a')// &
+            'interface'//new_line('a')// &
+            'function a(x)'//new_line('a')// &
+            'real :: a, x'//new_line('a')// &
+            'end function a'//new_line('a')// &
+            'end interface'//new_line('a')// &
+            'print *, a(4.0)'//new_line('a')// &
+            'end subroutine sub'//new_line('a')// &
+            'end module m'
+    end function unary_dummy_function_module
 
     ! Module whose subroutine `test` takes a dummy subroutine with one
     ! INTENT(IN), OPTIONAL integer argument.


### PR DESCRIPTION
`make check-duplication` was failing on main: `test_reject_call_01_diagnostics`
spelled out a 17-line module inline in
`test_intrinsic_actual_argument_arity_accepted`, over the threshold of 15,
while CLAUDE.md stated the gate reports 0 violations.

The file already had the right pattern for this: a `dummy_function_module()`
helper that every other test in it composes with. That helper's dummy function
takes no arguments, and this one test needs a one-argument dummy, which is why
it was written out longhand. Added `unary_dummy_function_module()` alongside
it and composed with that instead. No threshold was moved and no test was
weakened; the gate is genuinely at zero, and the negative control still proves
it can fail.

The documentation fix is the more important half. #2910 made this gate
blocking in CI, and a violation landed anyway three weeks later, because PRs
here are squash-merged with `--admin` without waiting for CI. "Blocking in CI"
therefore does not mean "cannot reach main". CLAUDE.md now says so explicitly
and tells the reader to run the target locally before merging a test change,
rather than leaving a stale "reports 0 violations" that the next person will
read as a live signal and trust.

Verification:
- `make check-duplication`: 0 violations, 8 advisory warnings (unchanged).
- `make check-duplication-gate`: clean tree accepted, deliberately added
  inline fixture rejected.
- `fo test test_reject_call_01_diagnostics`: PASS.
- Full `fo`: Static/Build/Tests/Lint OK.

Closes #2990