### PR TITLE
Keep BLOCK-local declarations out of the enclosing scope (#2989)

### DIFF
--- a/examples/f90/block_local_scope.f90
+++ b/examples/f90/block_local_scope.f90
@@ -1,0 +1,32 @@
+! BLOCK construct scoping (F2018 11.1.4): entities declared in a BLOCK
+! specification part are local to the construct and are not visible after
+! END BLOCK. A BLOCK-local name may shadow an outer name of a different type
+! without disturbing it.
+program block_local_scope
+    implicit none
+    integer :: total
+    integer :: shadowed
+
+    total = 0
+    shadowed = 7
+
+    block
+        integer :: k
+        k = 5
+        total = total + k
+    end block
+
+    block
+        real :: shadowed
+        shadowed = 2.5
+        total = total + int(shadowed)
+    end block
+
+    outer_block: block
+        character(len=3) :: tag
+        tag = 'abc'
+        total = total + len(tag)
+    end block outer_block
+
+    print *, total, shadowed
+end program block_local_scope

--- a/src/codegen/programs/codegen_program_variables_collect.inc
+++ b/src/codegen/programs/codegen_program_variables_collect.inc
@@ -325,9 +325,51 @@
             type is (interface_block_node)
                 if (contains_seen) cycle
                 call extract_declaration_names(arena, idx, state)
+            type is (block_construct_node)
+                ! A BLOCK construct has its own specification part. Its local
+                ! entities are not visible outside it (F2018 11.1.4), but the
+                ! identifier walk below does descend into the block body, so
+                ! without recording these names an assignment to a block-local
+                ! is mistaken for an undeclared program-scope variable and a
+                ! declaration is invented for it -- with the fallback type,
+                ! not the declared one (issue #2989).
+                if (contains_seen) cycle
+                if (allocated(decl%body_indices)) then
+                    call record_block_local_names(arena, decl%body_indices, state)
+                end if
             end select
         end do
     end subroutine collect_declared_symbols
+
+    ! Record the names a BLOCK construct declares, descending through nested
+    ! BLOCKs. Only declarations are recorded: a name merely assigned inside a
+    ! block is host-associated from the enclosing scope, so it must still reach
+    ! the program-scope collector.
+    recursive subroutine record_block_local_names(arena, body_indices, state)
+        type(ast_arena_t), intent(in) :: arena
+        integer, intent(in) :: body_indices(:)
+        type(program_decl_state_t), intent(inout) :: state
+        integer :: i, j, idx
+
+        do i = 1, size(body_indices)
+            idx = body_indices(i)
+            if (.not. arena%has_node_at(idx)) cycle
+            select type (inner => arena%entries(idx)%node)
+            type is (declaration_node)
+                if (inner%is_multi_declaration .and. allocated(inner%var_names)) then
+                    do j = 1, size(inner%var_names)
+                        call record_declared_name(state, trim(inner%var_names(j)))
+                    end do
+                else
+                    call record_declared_name(state, trim(inner%var_name))
+                end if
+            type is (block_construct_node)
+                if (allocated(inner%body_indices)) then
+                    call record_block_local_names(arena, inner%body_indices, state)
+                end if
+            end select
+        end do
+    end subroutine record_block_local_names
 
     subroutine collect_namelist_groups(arena, prog, state)
         type(ast_arena_t), intent(in) :: arena

--- a/test/standardizer/test_issue_2989_block_local_scope.f90
+++ b/test/standardizer/test_issue_2989_block_local_scope.f90
@@ -1,0 +1,108 @@
+program test_issue_2989_block_local_scope
+    ! fortfront #2989: a variable declared inside a BLOCK construct leaked a
+    ! declaration to the enclosing program scope, and the leaked declaration
+    ! carried the fallback type rather than the declared one -- an
+    ! `integer :: k` inside the block reappeared as `real :: k` outside it,
+    ! and a `character(len=3) :: tag` reappeared as `real :: tag`.
+    !
+    ! Entities declared in a BLOCK specification part are local to the
+    ! construct (F2018 11.1.4). A name that exists at the outer scope with a
+    ! type the source never wrote is a wrong-code path: anything referring to
+    ! it binds to the invented declaration.
+    !
+    ! Oracle: examples/f90/block_local_scope.f90 is accepted by
+    ! "gfortran -fsyntax-only" and prints "10 7". The emitted program must
+    ! declare, at program scope, exactly the names the source declares there.
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use transformation_api, only: transform_lazy_fortran_string
+    implicit none
+
+    integer :: failures
+    character(len=:), allocatable :: source, output, errors
+
+    failures = 0
+
+    call read_example('examples/f90/block_local_scope.f90', source)
+    call transform_lazy_fortran_string(source, output, errors)
+    if (allocated(errors)) then
+        if (len_trim(errors) > 0) then
+            write (error_unit, '(a)') 'FAIL: transform reported: '//trim(errors)
+            error stop 1
+        end if
+    end if
+
+    ! The BLOCK locals keep their own declarations, inside the block.
+    call expect_present(output, 'integer :: k', failures)
+    call expect_present(output, 'real(dp) :: shadowed', failures)
+    call expect_present(output, 'character(len=3) :: tag', failures)
+
+    ! None of them may acquire a second, invented declaration carrying the
+    ! fallback type. `k` and `tag` are declared only inside their blocks, so
+    ! they must not appear with any other type anywhere.
+    call expect_absent(output, 'real :: k', failures)
+    call expect_absent(output, 'real(dp) :: k', failures)
+    call expect_absent(output, 'real :: tag', failures)
+    call expect_absent(output, 'real(dp) :: tag', failures)
+
+    ! The outer `shadowed` is an integer and stays one. Exactly two
+    ! declarations of the name may exist: the program-scope integer and the
+    ! BLOCK-local real that shadows it -- never a third, invented one.
+    call expect_present(output, 'integer :: shadowed', failures)
+    call expect_occurrences(output, ':: shadowed', 2, failures)
+
+    if (failures > 0) then
+        write (error_unit, '(a,i0,a)') 'FAIL: ', failures, ' block-scope checks'
+        write (error_unit, '(a)') '--- emitted ---'
+        write (error_unit, '(a)') output
+        error stop 1
+    end if
+    print *, 'PASS: BLOCK-local declarations stay local'
+
+contains
+
+    include '../common/read_example.inc'
+
+    subroutine expect_present(haystack, needle, failures)
+        character(len=*), intent(in) :: haystack, needle
+        integer, intent(inout) :: failures
+
+        if (index(haystack, needle) == 0) then
+            write (error_unit, '(a)') 'FAIL: emitted code lost "'//needle//'"'
+            failures = failures + 1
+        end if
+    end subroutine expect_present
+
+    subroutine expect_absent(haystack, needle, failures)
+        character(len=*), intent(in) :: haystack, needle
+        integer, intent(inout) :: failures
+
+        if (index(haystack, needle) /= 0) then
+            write (error_unit, '(a)') 'FAIL: BLOCK-local name leaked as "'// &
+                needle//'"'
+            failures = failures + 1
+        end if
+    end subroutine expect_absent
+
+    subroutine expect_occurrences(haystack, needle, wanted, failures)
+        character(len=*), intent(in) :: haystack, needle
+        integer, intent(in) :: wanted
+        integer, intent(inout) :: failures
+        integer :: pos, hit, found
+
+        found = 0
+        pos = 1
+        do
+            if (pos > len(haystack)) exit
+            hit = index(haystack(pos:), needle)
+            if (hit == 0) exit
+            found = found + 1
+            pos = pos + hit + len(needle) - 1
+        end do
+        if (found /= wanted) then
+            write (error_unit, '(a,i0,a,i0)') 'FAIL: occurrences of "'//needle// &
+                '": expected ', wanted, ', found ', found
+            failures = failures + 1
+        end if
+    end subroutine expect_occurrences
+
+end program test_issue_2989_block_local_scope


### PR DESCRIPTION
A variable declared inside a BLOCK construct gained a second declaration at
program scope, carrying the fallback type rather than the declared one:

    block
        integer :: k
        k = 5
    end block

emitted `real :: k` at program scope. A `character(len=3) :: tag` came out as
`real :: tag`. Entities declared in a BLOCK specification part are local to
the construct (F2018 11.1.4), so the name should not exist outside it at all,
and certainly not with a type the source never wrote: anything at the outer
scope referring to it binds to the invented declaration.

Root cause is a mismatch between two walks in the codegen-time declaration
synthesizer (`src/codegen/programs/`). `collect_executable_identifier_symbols`
has a skip-list of nodes that open a new scope -- `contains_node`,
`function_def_node`, `subroutine_def_node` -- and `block_construct_node` is not
on it, so the block body falls through to the recursive identifier walk, which
does descend into it. Meanwhile `collect_declared_symbols` iterates the program
body one level deep and never enters a block, so the block's own `integer :: k`
never reaches `state%declared_names`. The identifier `k` is therefore harvested
as an undeclared program-scope variable, and since nothing type-infers inside a
BLOCK either, it gets the `real`/`real(dp)` fallback. Declaring `k` at program
scope as well made the bug vanish, which is what pointed at the declared-names
set.

The fix records what a BLOCK declares, recursing through nested BLOCKs. It
deliberately records *only* declarations, not assignments: a name merely
assigned inside a block is host-associated from the enclosing scope, so it must
still reach the program-scope collector and get its declaration synthesized as
before. Skipping block bodies wholesale would have broken that.

Oracle: `examples/f90/block_local_scope.f90` (accepted by `gfortran
-fsyntax-only`, prints "10 7") declares a block-local `integer :: k`, a
block-local `real :: shadowed` that shadows an outer `integer :: shadowed`, and
a block-local `character(len=3) :: tag` in a named block.
`test/standardizer/test_issue_2989_block_local_scope.f90` asserts each local
keeps its own declaration inside its block, that none of them reappears with a
fallback type, and that exactly two declarations of `shadowed` exist -- the
outer integer and the block-local real, never a third. Recorded failing on
unmodified main: `BLOCK-local name leaked as "real(dp) :: k"`. The emitted
program also compiles with gfortran and prints "10 7", matching the source.

Gates: rejection gate 824 files, accepted=752 rejected=72, no newly rejected
file. `make check-duplication`: 0 violations. Full `fo`: Static/Build/Tests/
Lint OK.

Not fixed here, and not BLOCK-specific: fortfront does not diagnose a
reference to an undeclared name under `implicit none` at all. With this fix
`print *, k` after `end block` no longer binds to an invented `real`, but it is
still accepted silently -- and so is `print *, zzz` in a program with no BLOCK
anywhere, which gfortran rejects with "Symbol 'zzz' has no IMPLICIT type".
That is a separate missing check; filed separately rather than bolted on here,
since a general undeclared-name rejection needs its own over-rejection
evidence.

Closes #2989