### PR TITLE
fix: parse nested procedure constructs

### DIFF
--- a/src/lexer/lexer_scanners.f90
+++ b/src/lexer/lexer_scanners.f90
@@ -443,8 +443,8 @@ contains
                     do while (pos <= len(source))
                         c = source(pos:pos)
                         if (.not. ((c >= 'a' .and. c <= 'z') .or. &
-                                   (c >= 'A' .and. c <= 'Z') .or. &
-                                   (c >= '0' .and. c <= '9') .or. c == '_')) exit
+                            (c >= 'A' .and. c <= 'Z') .or. &
+                            (c >= '0' .and. c <= '9') .or. c == '_')) exit
                         pos = pos + 1
                         col_num = col_num + 1
                     end do
@@ -761,7 +761,7 @@ contains
                 'procedure', 'interface', 'import', 'include', 'generic', &
                 'operator', &
                 'assignment', 'print', 'read', 'write', 'open', 'close', &
-                'inquire', &
+                'inquire', 'flush', &
                 'backspace', 'rewind', &
                 'call', 'format', 'allocate', 'deallocate', 'select', 'case', &
                 'default', &
@@ -797,7 +797,7 @@ contains
             is_constant = .true.
         case default
             is_constant = (index(trim(lower_text), '.true._') == 1 .or. &
-                           index(trim(lower_text), '.false._') == 1)
+                index(trim(lower_text), '.false._') == 1)
         end select
     end function is_logical_constant
 

--- a/src/parser/control_flow/parser_do_constructs.f90
+++ b/src/parser/control_flow/parser_do_constructs.f90
@@ -21,6 +21,7 @@ module parser_do_constructs_module
         statement_callbacks_t, &
         null_statement_callbacks, &
         find_statement_end, extend_block_statement_end
+    use parser_block_statement_utils_module, only: block_construct_start
     use parser_trailing_comment_module, only: capture_trailing_comment
     implicit none
     private

--- a/src/parser/control_flow/parser_do_constructs_part2.inc
+++ b/src/parser/control_flow/parser_do_constructs_part2.inc
@@ -94,6 +94,16 @@
                 ! body as siblings of that node.
                 handled_block = .false.
                 do_pos = stmt_start
+                if (parser%tokens(do_pos)%kind == TK_IDENTIFIER) then
+                    block_end = block_construct_start(parser%tokens, do_pos)
+                    if (block_end > 0) then
+                        if (to_lower(trim(parser%tokens(block_end)%text)) == &
+                            "block") then
+                            stmt_start = block_end
+                            do_pos = block_end
+                        end if
+                    end if
+                end if
                 if (parser%tokens(do_pos)%kind == TK_KEYWORD) then
                     select case (to_lower(parser%tokens(do_pos)%text))
                     case ("if")
@@ -104,6 +114,13 @@
                         end if
                     case ("do")
                         block_end = find_matching_end_do(parser%tokens, do_pos)
+                        if (block_end > do_pos) then
+                            stmt_end = block_end
+                            handled_block = .true.
+                        end if
+                    case ("block")
+                        block_end = extend_block_statement_end( &
+                            parser%tokens, do_pos, do_pos)
                         if (block_end > do_pos) then
                             stmt_end = block_end
                             handled_block = .true.

--- a/src/parser/control_flow/parser_select_constructs.f90
+++ b/src/parser/control_flow/parser_select_constructs.f90
@@ -27,6 +27,19 @@ module parser_select_constructs_module
 
     public :: parse_select_case, parse_select_type, parse_select_rank
 
+    interface
+        subroutine ensure_if_do_registration_bridge()
+        end subroutine ensure_if_do_registration_bridge
+
+        recursive function parse_block_construct_bridge(parser, arena) &
+                result(block_index)
+            import :: parser_state_t, ast_arena_t
+            type(parser_state_t), intent(inout) :: parser
+            type(ast_arena_t), intent(inout) :: arena
+            integer :: block_index
+        end function parse_block_construct_bridge
+    end interface
+
 contains
 
     include 'parser_select_constructs_helpers.inc'

--- a/src/parser/control_flow/parser_select_constructs_type.inc
+++ b/src/parser/control_flow/parser_select_constructs_type.inc
@@ -201,6 +201,8 @@
         type(statement_callbacks_t) :: callbacks
         logical :: arm_ok, header_ok
 
+        call ensure_if_do_registration_bridge()
+
         ! Header selector may include associate_name => selector syntax
         call parse_select_header(parser, arena, "type", .true., line, column, &
                                  selector_index, header_ok)
@@ -226,6 +228,7 @@
         callbacks%parse_select_case => parse_select_case
         callbacks%parse_select_type => parse_select_type
         callbacks%parse_select_rank => parse_select_rank
+        callbacks%parse_block => parse_block_construct_bridge
 
         do while (parser%current_token <= size(parser%tokens))
             guard_token = parser%peek()

--- a/src/parser/core/ensure_if_do_registration_bridge.f90
+++ b/src/parser/core/ensure_if_do_registration_bridge.f90
@@ -7,3 +7,16 @@ subroutine ensure_if_do_registration_bridge()
     call ensure_if_do_registration()
 
 end subroutine ensure_if_do_registration_bridge
+
+recursive function parse_block_construct_bridge(parser, arena) result(block_index)
+    use parser_state_module, only: parser_state_t
+    use ast_arena_modern, only: ast_arena_t
+    use parser_array_constructs_module, only: parse_block_construct
+    implicit none
+
+    type(parser_state_t), intent(inout) :: parser
+    type(ast_arena_t), intent(inout) :: arena
+    integer :: block_index
+
+    block_index = parse_block_construct(parser, arena)
+end function parse_block_construct_bridge

--- a/src/parser/expressions/parser_array_constructs.f90
+++ b/src/parser/expressions/parser_array_constructs.f90
@@ -634,6 +634,12 @@ contains
             token = parser%peek()
             if (token%kind == TK_KEYWORD .and. to_lower(token%text) == "block") then
                 token = parser%consume()
+                token = parser%peek()
+                do while (token%kind == TK_WHITESPACE .or. &
+                        token%kind == TK_COMMENT)
+                    token = parser%consume()
+                end do
+                if (token%kind == TK_IDENTIFIER) token = parser%consume()
             end if
         end if
 

--- a/src/parser/procedures/parser_block_statement_utils.f90
+++ b/src/parser/procedures/parser_block_statement_utils.f90
@@ -146,7 +146,13 @@ contains
                 if (closer_end > 0) then
                     depth = depth - 1
                     stmt_end = closer_end
-                    if (depth <= 0) return
+                    if (depth <= 0) then
+                        if (construct == "block") then
+                            stmt_end = include_block_construct_name(all_tokens, &
+                                stmt_end)
+                        end if
+                        return
+                    end if
                     pos = closer_end + 1
                     cycle
                 else if (token_lower == construct) then
@@ -173,6 +179,30 @@ contains
         ! Ran out of tokens with the construct still open.
         if (present(unaccounted)) unaccounted = .true.
     end function locate_block_statement_end
+
+    integer function include_block_construct_name(all_tokens, end_index) &
+            result(extended_end)
+        type(token_t), intent(in) :: all_tokens(:)
+        integer, intent(in) :: end_index
+        integer :: name_index
+
+        extended_end = end_index
+        name_index = end_index + 1
+        do while (name_index <= size(all_tokens))
+            select case (all_tokens(name_index)%kind)
+            case (TK_WHITESPACE, TK_COMMENT)
+                name_index = name_index + 1
+            case default
+                exit
+            end select
+        end do
+
+        if (name_index <= size(all_tokens)) then
+            if (all_tokens(name_index)%kind == TK_IDENTIFIER) then
+                extended_end = name_index
+            end if
+        end if
+    end function include_block_construct_name
 
     ! Index of the last token of the terminator of `construct` starting at pos,
     ! or 0 when the token at pos does not start one. Handles both the one-word

--- a/src/parser/statements/parser_basic_statement_module.f90
+++ b/src/parser/statements/parser_basic_statement_module.f90
@@ -1,6 +1,6 @@
 module parser_basic_statement_module
     ! Parser module for basic statement parsing and utilities
-    use lexer_core, only: token_t, TK_EOF, TK_KEYWORD, TK_OPERATOR, TK_NEWLINE, &
+    use lexer_core, only: token_t, TK_EOF, TK_KEYWORD, TK_IDENTIFIER, TK_OPERATOR, TK_NEWLINE, &
         TK_COMMENT, TK_WHITESPACE, to_lower
     use parser_state_module, only: parser_state_t
     use parser_expressions_module, only: parse_range
@@ -10,12 +10,23 @@ module parser_basic_statement_module
         find_statement_end, &
         extend_if_statement_end, extend_do_statement_end, &
         extend_block_statement_end
+    use parser_block_statement_utils_module, only: block_construct_start
     use ast_arena_modern, only: ast_arena_t
     implicit none
     private
 
     public :: parse_basic_statement_multi, parse_statement_body
     public :: parse_expression_length
+
+    interface
+        recursive function parse_block_construct_bridge(parser, arena) &
+                result(block_index)
+            import :: parser_state_t, ast_arena_t
+            type(parser_state_t), intent(inout) :: parser
+            type(ast_arena_t), intent(inout) :: arena
+            integer :: block_index
+        end function parse_block_construct_bridge
+    end interface
 
 contains
 
@@ -77,6 +88,8 @@ contains
         type(statement_callbacks_t) :: local_callbacks
         logical :: has_meaningful
         integer :: nested_block_index
+        integer :: construct_start
+        integer :: direct_block_index
         integer :: stmt_count
 
         allocate (body_indices(0))
@@ -108,6 +121,24 @@ contains
                 end if
 
                 stmt_start = parser%current_token
+                if (parser%tokens(stmt_start)%kind == TK_IDENTIFIER) then
+                    construct_start = block_construct_start(parser%tokens, &
+                        stmt_start)
+                    if (construct_start > 0) then
+                        if (to_lower(trim(parser%tokens(construct_start)%text)) == &
+                            "block") then
+                            parser%current_token = construct_start
+                            direct_block_index = parse_block_construct_bridge( &
+                                parser, arena)
+                            if (direct_block_index > 0) then
+                                body_indices = [body_indices, direct_block_index]
+                                stmt_count = stmt_count + 1
+                                cycle
+                            end if
+                            stmt_start = construct_start
+                        end if
+                    end if
+                end if
                 stmt_end = find_statement_end(parser%tokens, stmt_start)
                 ! Hand a whole construct over, not just its header. This body
                 ! parser serves case arms and other block bodies, and an `if`

--- a/src/parser/statements/parser_keyword_disambiguation.f90
+++ b/src/parser/statements/parser_keyword_disambiguation.f90
@@ -59,7 +59,7 @@ contains
                 "program", "module", "submodule", "if", "data", &
                 "read", "write", "print", "open", "close", &
                 "inquire", "backspace", "rewind", "endfile", "format", &
-                "parameter", "rank", "block")
+                "parameter", "rank", "block", "operator")
             is_supported = .true.
         case default
             is_supported = .false.

--- a/src/parser/statements/parser_statement_core.f90
+++ b/src/parser/statements/parser_statement_core.f90
@@ -87,7 +87,7 @@ contains
         handled = try_handle_declaration(parser, arena, first_token, stmt_indices)
         if (handled) then
             if (size(stmt_indices) > 0 .and. stmt_indices(1) > 0 .and. &
-                    .not. parser%has_errors()) then
+                .not. parser%has_errors()) then
                 call reject_unconsumed_tokens(parser)
             end if
             if (present(consumed_count)) consumed_count = parser%current_token - 1
@@ -202,11 +202,24 @@ contains
         stmt_index = 0
         block
             character(len=:), allocatable :: lowered
+            type(token_t) :: ignored_token
             lowered = to_lower(first_token%text)
 
             stmt_index = handle_control_keyword(lowered, parser, arena, &
                 parent_index, callbacks)
             if (stmt_index /= 0) return
+
+            ! FLUSH has no AST node yet, but it is a valid executable
+            ! statement. Consume the complete statement so it does not become
+            ! an unparsed-statement diagnostic while preserving the rest of
+            ! the procedure body.
+            if (lowered == "flush") then
+                do while (.not. parser%is_at_end())
+                    ignored_token = parser%consume()
+                end do
+                stmt_index = STATEMENT_NO_NODE
+                return
+            end if
 
             stmt_index = handle_io_keyword(lowered, parser, arena)
             if (stmt_index /= 0) return
@@ -309,7 +322,7 @@ contains
                     ! populated no callback - `select case` sets only its own
                     ! entry, so a nested if in a case arm lands here.
                     stmt_index = call_fallback_if_parser(parser, arena, &
-                                                        parent_index)
+                        parent_index)
                     if (stmt_index /= 0) return
                     ! Fallback to simple IF parser if callback not set
                     stmt_index = parse_if_from_definition(parser, arena)

--- a/src/parser/statements/parser_statement_detection.f90
+++ b/src/parser/statements/parser_statement_detection.f90
@@ -27,8 +27,10 @@ contains
         type(token_t), intent(in) :: tokens(:)
         integer, intent(in) :: start_index
         integer :: i
+        logical :: continuation_pending
 
         is_block = .false.
+        continuation_pending = .false.
         do i = start_index + 1, size(tokens)
             select case (tokens(i)%kind)
             case (TK_KEYWORD)
@@ -36,15 +38,22 @@ contains
                     is_block = .true.
                     return
                 else
-                    return
+                    continuation_pending = .false.
+                    cycle
                 end if
             case (TK_OPERATOR)
                 if (tokens(i)%text == ";") return
+                continuation_pending = trim(tokens(i)%text) == "&"
             case (TK_NEWLINE, TK_EOF)
+                if (tokens(i)%kind == TK_NEWLINE .and. continuation_pending) then
+                    continuation_pending = .false.
+                    cycle
+                end if
                 return
             case (TK_COMMENT, TK_WHITESPACE)
                 cycle
             case default
+                continuation_pending = .false.
                 cycle
             end select
         end do
@@ -611,14 +620,14 @@ contains
                 case ("endblock")
                     depth = depth - 1
                     if (depth <= 0) then
-                        end_index = idx
+                        end_index = include_block_construct_name(tokens, idx)
                         return
                     end if
                 case ("end")
                     if (next_keyword_is(tokens, idx, "block")) then
                         depth = depth - 1
                         if (depth <= 0) then
-                            end_index = idx + 1
+                            end_index = include_block_construct_name(tokens, idx + 1)
                             return
                         end if
                         idx = idx + 1
@@ -628,6 +637,30 @@ contains
             idx = idx + 1
         end do
     end function extend_block_statement_end
+
+    integer function include_block_construct_name(tokens, end_index) &
+            result(extended_end)
+        type(token_t), intent(in) :: tokens(:)
+        integer, intent(in) :: end_index
+        integer :: name_index
+
+        extended_end = end_index
+        name_index = end_index + 1
+        do while (name_index <= size(tokens))
+            select case (tokens(name_index)%kind)
+            case (TK_WHITESPACE, TK_COMMENT)
+                name_index = name_index + 1
+            case default
+                exit
+            end select
+        end do
+
+        if (name_index <= size(tokens)) then
+            if (tokens(name_index)%kind == TK_IDENTIFIER) then
+                extended_end = name_index
+            end if
+        end if
+    end function include_block_construct_name
 
     logical function next_keyword_is(tokens, idx, word) result(matches)
         !! Whether the next token, skipping trivia, is the given keyword.

--- a/src/semantic/analyzers/semantic_external_declaration_names.f90
+++ b/src/semantic/analyzers/semantic_external_declaration_names.f90
@@ -135,34 +135,35 @@ contains
                 type is (subroutine_def_node)
                 call add_declared(declared, declared_count, proc%name, usable)
                 type is (module_procedure_node)
-                block_names: block
-                integer :: k
-                if (.not. allocated(proc%procedure_names)) exit block_names
-                do k = 1, size(proc%procedure_names)
-                    if (.not. allocated(proc%procedure_names(k)%s)) cycle
-                    call add_declared(declared, declared_count, &
-                        proc%procedure_names(k)%s, usable)
-                end do
-            end block block_names
-        end select
-        if (.not. usable) return
-    end do
-end subroutine add_interface_names
+                block
+                    integer :: k
+                    if (allocated(proc%procedure_names)) then
+                        do k = 1, size(proc%procedure_names)
+                            if (.not. allocated(proc%procedure_names(k)%s)) cycle
+                            call add_declared(declared, declared_count, &
+                                proc%procedure_names(k)%s, usable)
+                        end do
+                    end if
+                end block
+            end select
+            if (.not. usable) return
+        end do
+    end subroutine add_interface_names
 
-subroutine add_declared(declared, declared_count, name, usable)
-    character(len=64), intent(inout) :: declared(:)
-    integer, intent(inout) :: declared_count
-    character(len=*), intent(in) :: name
-    logical, intent(inout) :: usable
+    subroutine add_declared(declared, declared_count, name, usable)
+        character(len=64), intent(inout) :: declared(:)
+        integer, intent(inout) :: declared_count
+        character(len=*), intent(in) :: name
+        logical, intent(inout) :: usable
 
-    if (len_trim(name) == 0) return
-    if (len_trim(name) > len(declared)) return
-    if (declared_count >= size(declared)) then
-        usable = .false.
-        return
-    end if
-    declared_count = declared_count + 1
-    declared(declared_count) = to_lower(trim(name))
-end subroutine add_declared
+        if (len_trim(name) == 0) return
+        if (len_trim(name) > len(declared)) return
+        if (declared_count >= size(declared)) then
+            usable = .false.
+            return
+        end if
+        declared_count = declared_count + 1
+        declared(declared_count) = to_lower(trim(name))
+    end subroutine add_declared
 
 end module semantic_external_declaration_names

--- a/src/utilities/path_validation.f90
+++ b/src/utilities/path_validation.f90
@@ -293,7 +293,7 @@ contains
                     exit
                 end if
                 ! Stop at directory separators
-                if (path(i:i) == '/' .or. path(i:i) == '\') exit
+                if (path(i:i) == '/' .or. path(i:i) == achar(92)) exit
             end do
         end block
 

--- a/test/test_nested_procedure_constructs.f90
+++ b/test/test_nested_procedure_constructs.f90
@@ -1,0 +1,81 @@
+program test_nested_procedure_constructs
+    use fortfront, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    implicit none
+
+    type(compiler_frontend_options_t) :: options
+    type(compiler_frontend_result_t) :: result
+
+    options = compiler_frontend_options_t()
+    call compile_frontend_from_string(source_text(), result, options)
+    if (.not. result%success()) then
+        write (error_unit, '(a)') 'FAIL: nested procedure constructs rejected: '// &
+            trim(result%diagnostic_text)
+        error stop 1
+    end if
+
+    print '(a)', 'PASS: nested procedure constructs parsed'
+
+contains
+
+    function source_text() result(source)
+        character(len=:), allocatable :: source
+
+        source = 'module nested_procedure_constructs'//new_line('a')// &
+            'contains'//new_line('a')// &
+            'subroutine check(value)'//new_line('a')// &
+            '    integer, intent(in) :: value'//new_line('a')// &
+            '    integer :: i'//new_line('a')// &
+            '    type :: holder'//new_line('a')// &
+            '        class(*), allocatable :: node'//new_line('a')// &
+            '    end type holder'//new_line('a')// &
+            '    type(holder) :: arena'//new_line('a')// &
+            '    type(holder), allocatable :: entries(:)'//new_line('a')// &
+            '    class(*), allocatable :: obj'//new_line('a')// &
+            '    character(len=:), allocatable :: current_type'//new_line('a')// &
+            '    allocate (integer :: obj)'//new_line('a')// &
+            '    allocate (entries(1))'//new_line('a')// &
+            '    select type (node => entries(1)%node)'//new_line('a')// &
+            '        type is (integer)'//new_line('a')// &
+            '        if (value < 0 .and. &'//new_line('a')// &
+            '            allocated(entries)) then'//new_line('a')// &
+            '            if (value == -1) then'//new_line('a')// &
+            '                return'//new_line('a')// &
+            '            end if'//new_line('a')// &
+            '        end if'//new_line('a')// &
+            '        type_names: block'//new_line('a')// &
+            '            integer :: block_value'//new_line('a')// &
+            '            block_value = 1'//new_line('a')// &
+            '            value = value'//new_line('a')// &
+            '        end block type_names'//new_line('a')// &
+            '        type is (holder)'//new_line('a')// &
+            '        if (value > 0) then'//new_line('a')// &
+            '            return'//new_line('a')// &
+            '        end if'//new_line('a')// &
+            '    class default'//new_line('a')// &
+            '        return'//new_line('a')// &
+            '    end select'//new_line('a')// &
+            '    deallocate (obj)'//new_line('a')// &
+            '    current_type = "child"'//new_line('a')// &
+            '    flush (1)'//new_line('a')// &
+            '    i = 1'//new_line('a')// &
+            '    do while (i <= 2)'//new_line('a')// &
+            '        if (value < 0) then'//new_line('a')// &
+            '            return'//new_line('a')// &
+            '        end if'//new_line('a')// &
+            '        body_names: block'//new_line('a')// &
+            '            character(len=:), allocatable :: next_type'//new_line('a')// &
+            '            call find_parent(current_type, next_type)'//new_line('a')// &
+            '            call move_alloc(next_type, current_type)'//new_line('a')// &
+            '            if (value > 0) then'//new_line('a')// &
+            '                current_type = "parent"'//new_line('a')// &
+            '            end if'//new_line('a')// &
+            '        end block body_names'//new_line('a')// &
+            '        i = i + 1'//new_line('a')// &
+            '    end do'//new_line('a')// &
+            'end subroutine check'//new_line('a')// &
+            'end module nested_procedure_constructs'//new_line('a')
+    end function source_text
+
+end program test_nested_procedure_constructs


### PR DESCRIPTION
Fix parser/source compatibility for nested procedure constructs and related statement-span cases.

Verified on TU Graz acluster:
- full `fo build` passed (380/380 library sources, 674/674 test objects)
- focused nested-procedure regression passed
- 15 previously failing source probes passed parse and semantic checks
- `fo fmt --check` passed