### PR TITLE
fix: reject undeclared names under implicit none

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,10 +6,12 @@ backend-neutral.
 
 ## Current truth
 
-The current upstream baseline is `5f100f26` (fixed-form comment-marker
-normalization), including the nested-associate binding fix `d1c6a894` and the
-type-bound receiver fix `7f52742e`. No CI result for this exact baseline is
-recorded yet; do not treat the local GNU lane as remote-green evidence.
+The implementation baseline is `ca26bf9d` (full-line continuation comments,
+fixed-form comment normalization, and the #2255 follow-up). The #2996 parser
+reproduction and accepted neighbor are green on this baseline; the remaining
+remote aggregate/Windows failures listed below are independent of that fix.
+No CI result for this exact baseline is recorded yet; do not treat the local
+GNU lane as remote-green evidence.
 
 The current local GNU lane builds 381 targets and 379 test programs across 484
 tests. `test_module_distribution` is parallel-fragile because it cleans shared
@@ -82,7 +84,15 @@ query in the same set of linked commits. Do not leave a permanent fallback.
    [#2993](https://github.com/lazy-fortran/fortfront/issues/2993), the accepted
    side of [#2897](https://github.com/lazy-fortran/fortfront/issues/2897), and
    the lost or malformed AST evidence in #2986/#2987 without over-rejecting
-   valid code.
+   valid code. #2993 is implemented as one arena-wide structural
+   `IMPLICIT NONE` reference pass over the public resolver: declaration,
+   host/use/associate, procedure, construct-entity, component, keyword,
+   NAMELIST, and SELECT TYPE bindings are accepted; only unresolved data
+   references are diagnosed. It runs when compiler/API callers select
+   standard analysis while preserving the Lazy transformation inference
+   boundary (including Lazy sources that contain `IMPLICIT NONE`). The focused
+   API oracle covers that lazy boundary and explicit `INPUT_MODE_STANDARD`, and
+   the accepted neighbor is independently syntax-checked with GNU Fortran.
 4. Complete binding identity across nested ASSOCIATE in
    [#2975](https://github.com/lazy-fortran/fortfront/issues/2975). The selector
    binding correction and exact declaration-identity oracle are now landed;
@@ -155,6 +165,10 @@ Tests need an independent behavioral oracle:
   compiler.
 - rejection: require category/location for the invalid case and acceptance of
   a minimally different valid case.
+- #2993: run `test_issue_2993_implicit_none_diagnostics` (lazy auto-detection
+  and explicit standard mode), then run the bounded
+  `scripts/corpus_rejection_gate.sh` shard; every accepted-to-rejected delta
+  must be fixed before merge or named as pre-existing baseline drift.
 - binding/query changes: query exact declaration identities in nested scopes,
   then compile/link/run an ffc consumer that would fail under name lookup.
 - module and Lazy ABI changes: separate producer/consumer compilation and

--- a/examples/f90/issue_2993_implicit_none_undeclared.f90
+++ b/examples/f90/issue_2993_implicit_none_undeclared.f90
@@ -1,0 +1,6 @@
+program p
+    implicit none
+    integer :: total
+    total = 0
+    print *, zzz
+end program p

--- a/examples/f90/issue_2993_implicit_none_valid.f90
+++ b/examples/f90/issue_2993_implicit_none_valid.f90
@@ -1,0 +1,49 @@
+module issue_2993_use_mod
+    implicit none
+    integer :: exported = 7
+contains
+    subroutine used_sub(value)
+        implicit none
+        integer, intent(in) :: value
+        print *, value
+    end subroutine used_sub
+end module issue_2993_use_mod
+
+program issue_2993_valid
+    use issue_2993_use_mod, only: exported, used_sub
+    implicit none
+        integer :: total, i
+        class(*), allocatable :: boxed
+    external external_sub
+
+    total = exported
+    call used_sub(total)
+    call external_sub(total)
+    print *, abs(total)
+
+    do i = 1, total
+        total = total + i
+    end do
+
+        associate (alias => total)
+            total = alias
+        end associate
+
+        allocate (boxed, source=total)
+        select type (typed => boxed)
+        type is (integer)
+            total = typed
+        class default
+            total = 0
+        end select
+
+    contains
+    subroutine internal_sub(value)
+        integer, intent(in) :: value
+        print *, value
+    end subroutine internal_sub
+end program issue_2993_valid
+
+subroutine external_sub(value)
+    integer :: value
+end subroutine external_sub

--- a/src/frontend/frontend_transformation_pipeline.f90
+++ b/src/frontend/frontend_transformation_pipeline.f90
@@ -685,6 +685,10 @@ contains
             handled = .false.
             call create_semantic_context(ctx)
             ctx%operating_mode = operating_mode
+            ! The transformation pipeline preserves Lazy Fortran's inference
+            ! contract; the compiler API performs the strict IMPLICIT NONE
+            ! reference sweep separately.
+            ctx%enforce_implicit_none_references = .false.
 
             ! Start in LAZY mode, but allow automatic detection of implicit none
             ! which will switch to STANDARD mode for better performance

--- a/src/frontend/frontend_transformation_semantics.f90
+++ b/src/frontend/frontend_transformation_semantics.f90
@@ -70,6 +70,7 @@ contains
 
             call create_semantic_context(local_ctx)
             local_ctx%input_mode = INPUT_MODE_LAZY
+            local_ctx%enforce_implicit_none_references = .false.
 
             call trace_enter('semantic:analyze_program')
             call analyze_program(local_ctx, arena, node_idx)

--- a/src/semantic/analyzers/semantic_analyzer.f90
+++ b/src/semantic/analyzers/semantic_analyzer.f90
@@ -96,6 +96,9 @@ module semantic_analyzer
         integer :: input_mode = INPUT_MODE_LAZY
         integer :: operating_mode = OPERATING_MODE_INFER
         logical :: respect_implicit_none = .true.
+        ! Compiler/API analysis enforces IMPLICIT NONE references; Lazy
+        ! transformation retains its historical inference boundary.
+        logical :: enforce_implicit_none_references = .true.
         type(type_annotation_t), allocatable :: parser_type_hints(:)
         type(type_hierarchy_t) :: type_hierarchy
         type(signatures_map_t) :: signatures

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -11,7 +11,7 @@ use semantic_annotation_utils, only: type_from_annotation
 use semantic_inference_helpers, only: check_implicit_none, &
     process_declaration_variables
 use semantic_undefined_variable_checker, only: check_undefined_variables_generic, &
-    check_external_implicit_none
+    check_external_implicit_none, check_implicit_none_references
 use semantic_walrus_checker, only: check_walrus_redeclaration
 use constant_transformation, only: fold_constants_in_arena
 use error_handling, only: create_error_collection
@@ -193,6 +193,11 @@ contains
                 if (ctx%operating_mode == OPERATING_MODE_INFER) then
                     if (check_implicit_none(arena, ast)) then
                         ctx%input_mode = INPUT_MODE_STANDARD
+                        ! A Lazy caller may include IMPLICIT NONE while still
+                        ! relying on inferred names (the transformation path
+                        ! and .lf corpus use this boundary). Explicit
+                        ! INPUT_MODE_STANDARD remains strictly checked.
+                        ctx%enforce_implicit_none_references = .false.
                     end if
                 end if
             end if
@@ -200,6 +205,10 @@ contains
             type is (multi_unit_container_node)
             call analyze_multi_unit_container_arena(ctx, arena, ast, root_index)
             type is (module_node)
+            if (ctx%enforce_implicit_none_references .and. &
+                    ctx%input_mode == INPUT_MODE_STANDARD) then
+                call check_implicit_none_references(arena, ctx%errors)
+            end if
             return
         class default
             call infer_and_store_type(ctx, arena, root_index)
@@ -289,6 +298,10 @@ contains
         end if
         call check_undefined_variables_generic(ctx%scopes, ctx%errors, &
             ctx%input_mode, arena, prog_index)
+        if (ctx%enforce_implicit_none_references .and. &
+                ctx%input_mode == INPUT_MODE_STANDARD) then
+            call check_implicit_none_references(arena, ctx%errors)
+        end if
     end subroutine analyze_program_node_arena
 
     ! All units of a multi-unit container share one context: a call in one
@@ -329,6 +342,10 @@ contains
         call check_undefined_variables_generic(ctx%scopes, ctx%errors, &
             ctx%input_mode, arena, &
             container_index)
+        if (ctx%enforce_implicit_none_references .and. &
+                ctx%input_mode == INPUT_MODE_STANDARD) then
+            call check_implicit_none_references(arena, ctx%errors)
+        end if
     end subroutine analyze_multi_unit_container_arena
 
     module subroutine infer_and_store_type(ctx, arena, node_index)
@@ -394,6 +411,8 @@ contains
         temp_context%input_mode = this%input_mode
         temp_context%operating_mode = this%operating_mode
         temp_context%respect_implicit_none = this%respect_implicit_none
+        temp_context%enforce_implicit_none_references = &
+            this%enforce_implicit_none_references
         temp_context%signatures = this%signatures
 
         allocate (cloned, source=temp_context)

--- a/src/semantic/analyzers/semantic_analyzer_type_ops_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_type_ops_impl.f90
@@ -80,6 +80,8 @@ contains
         copy%input_mode = this%input_mode
         copy%operating_mode = this%operating_mode
         copy%respect_implicit_none = this%respect_implicit_none
+        copy%enforce_implicit_none_references = &
+            this%enforce_implicit_none_references
         copy%signatures = this%signatures
         copy%explicit_interface_procedure_names = &
             this%explicit_interface_procedure_names
@@ -99,6 +101,8 @@ contains
         lhs%input_mode = rhs%input_mode
         lhs%operating_mode = rhs%operating_mode
         lhs%respect_implicit_none = rhs%respect_implicit_none
+        lhs%enforce_implicit_none_references = &
+            rhs%enforce_implicit_none_references
         lhs%signatures = rhs%signatures
         lhs%explicit_interface_procedure_names = &
             rhs%explicit_interface_procedure_names

--- a/src/semantic/analyzers/semantic_undefined_variable_checker.f90
+++ b/src/semantic/analyzers/semantic_undefined_variable_checker.f90
@@ -3,17 +3,24 @@ module semantic_undefined_variable_checker
     ! Extracted from semantic_analyzer.f90 for architectural compliance (Issue #1067)
     use ast_arena_modern, only: ast_arena_t
     use ast_nodes_core, only: identifier_node, binary_op_node, assignment_node, &
-        call_or_subscript_node, array_literal_node, program_node
-    use ast_nodes_conditional, only: if_node, select_case_node, case_block_node
-    use ast_nodes_control, only: do_loop_node, do_while_node, case_default_node
+        call_or_subscript_node, array_literal_node, program_node, &
+        component_access_node, pointer_assignment_node
+    use ast_nodes_conditional, only: if_node, select_case_node, case_block_node, &
+        select_type_node, type_guard_block_node
+    use ast_nodes_control, only: do_loop_node, do_while_node, case_default_node, &
+        forall_node
     use ast_nodes_associate, only: associate_node, block_construct_node
     use ast_nodes_data, only: declaration_node, multi_unit_container_node
-    use ast_nodes_misc, only: implicit_statement_node
+    use ast_nodes_misc, only: implicit_statement_node, use_statement_node, &
+        statement_function_node, namelist_statement_node
     use ast_nodes_procedure, only: function_def_node, subroutine_def_node, &
         subroutine_call_node
     use intrinsic_registry, only: is_intrinsic_subroutine
     use semantic_explicit_interface_checker, only: is_part_reference
     use semantic_external_declaration_names, only: collect_declared_procedures
+    use frontend_compiler_resolution, only: declaration_binding_t, &
+        find_enclosing_scope, find_host_scope, get_scope_statement_indices, &
+        is_scope_node, resolve_name_at_node
     use string_utils_mod, only: to_lower
     use ast_nodes_io, only: print_statement_node, read_statement_node
     use type_system_unified, only: poly_type_t, mono_type_t, &
@@ -28,12 +35,448 @@ module semantic_undefined_variable_checker
 
     public :: check_undefined_variables_generic
     public :: check_external_implicit_none
+    public :: check_implicit_none_references
 
     ! Upper bound on explicitly declared procedure names tracked per scoping
     ! unit. A unit that exceeds it is skipped so the check never guesses.
     integer, parameter :: MAX_DECLARED_NAMES = 512
 
 contains
+
+    ! Check references in scoping units whose effective implicit mapping is
+    ! IMPLICIT NONE.  The generic lazy checker below intentionally skips
+    ! standard input because ordinary IMPLICIT typing is valid there.  This
+    ! structural pass is the corresponding standard-Fortran check: it uses
+    ! the public resolver so USE, host, ASSOCIATE, procedure and declaration
+    ! bindings are accepted without guessing from source order.
+    subroutine check_implicit_none_references(arena, errors)
+        type(ast_arena_t), intent(in) :: arena
+        type(error_collection_t), intent(inout) :: errors
+        integer :: i
+        logical, allocatable :: keyword_targets(:)
+        logical, allocatable :: construct_targets(:)
+
+        allocate (keyword_targets(arena%size), source=.false.)
+        allocate (construct_targets(arena%size), source=.false.)
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (assignment_node)
+                if (node%is_keyword_argument .or. &
+                        is_call_keyword_assignment(arena, i)) then
+                    if (node%target_index > 0 .and. &
+                            node%target_index <= arena%size) then
+                        keyword_targets(node%target_index) = .true.
+                    end if
+                end if
+                type is (pointer_assignment_node)
+                if (node%pointer_index > 0 .and. &
+                        node%pointer_index <= arena%size) then
+                    if (node%target_index > 0 .and. &
+                            node%target_index <= arena%size) then
+                        if (is_select_type_selector(arena, i)) then
+                            construct_targets(node%pointer_index) = .true.
+                        end if
+                    end if
+                end if
+            end select
+        end do
+
+        do i = 1, arena%size
+            if (.not. arena%has_node_at(i)) cycle
+            select type (node => arena%entries(i)%node)
+                type is (identifier_node)
+                if (allocated(node%name)) then
+                    call check_reference(arena, i, node%name, .false., .false., &
+                        node%line, node%column, errors)
+                end if
+                type is (call_or_subscript_node)
+                if (allocated(node%name)) then
+                    call check_reference(arena, i, node%name, .true., &
+                        node%is_array_access, node%line, node%column, errors)
+                end if
+            end select
+        end do
+    contains
+        subroutine check_reference(arena, reference_index, name, is_call, &
+                is_array_access, line, column, errors)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: reference_index
+            character(len=*), intent(in) :: name
+            logical, intent(in) :: is_call, is_array_access
+            integer, intent(in) :: line, column
+            type(error_collection_t), intent(inout) :: errors
+            type(declaration_binding_t) :: binding
+            character(len=:), allocatable :: resolver_error
+            integer :: scope_index
+
+            if (len_trim(name) == 0) return
+            ! Component/coindexed names are resolved through their base
+            ! designator.  The component itself is not a declaration in the
+            ! enclosing scope and therefore must not be diagnosed here.
+            if (is_part_reference(trim(name))) return
+            if (is_component_name_reference(arena, reference_index, trim(name))) return
+            if (is_component_designator_reference(arena, reference_index, &
+                    trim(name))) return
+            if (is_keyword_argument_name(reference_index)) return
+            if (reference_index > 0 .and. reference_index <= &
+                    size(construct_targets)) then
+                if (construct_targets(reference_index)) return
+            end if
+
+            scope_index = find_enclosing_scope(arena, reference_index)
+            if (scope_index <= 0) return
+            if (.not. effective_implicit_none(arena, scope_index)) return
+
+            ! A function reference is checked by the function/interface
+            ! validators, which know intrinsic and external procedure rules.
+            ! This pass is deliberately limited to data names (identifiers
+            ! and array designators); CALL statements are handled by the
+            ! IMPLICIT NONE (EXTERNAL) checker below.
+            if (is_call .and. .not. is_array_access) return
+
+            if (is_construct_entity(arena, reference_index, trim(name))) return
+            if (is_select_type_associate_name(arena, scope_index, trim(name))) return
+            if (is_use_associated_name(arena, scope_index, trim(name))) return
+            if (is_namelist_name(arena, scope_index, trim(name))) return
+
+            call resolve_name_at_node(arena, reference_index, trim(name), &
+                binding, resolver_error)
+            if (binding%found) return
+
+            call errors%add_result(create_error_result( &
+                "Name '"//trim(name)//"' is not declared under IMPLICIT NONE", &
+                ERROR_SEMANTIC, &
+                component="semantic_undefined_variable_checker", &
+                context="check_implicit_none_references", &
+                suggestion="Declare the name before using it, or provide an "// &
+                    "explicit interface for the procedure", &
+                line=line, column=column, end_line=line, end_column=column + 1))
+        end subroutine check_reference
+
+        ! Resolve the effective implicit policy by walking from a nested
+        ! ASSOCIATE/BLOCK scope through its host scopes.  An explicit IMPLICIT
+        ! statement in the nearest scoping unit overrides the host policy.
+        logical function effective_implicit_none(arena, scope_index) result(active)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: scope_index
+            integer :: current
+            logical :: has_statement, is_none
+
+            active = .false.
+            current = scope_index
+            do while (current > 0)
+                if (.not. is_scope_node(arena, current)) exit
+                call implicit_policy(arena, current, has_statement, is_none)
+                if (has_statement) then
+                    active = is_none
+                    return
+                end if
+                current = find_host_scope(arena, current)
+            end do
+        end function effective_implicit_none
+
+        subroutine implicit_policy(arena, scope_index, has_statement, is_none)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: scope_index
+            logical, intent(out) :: has_statement, is_none
+            integer, allocatable :: indices(:)
+            integer :: i
+
+            has_statement = .false.
+            is_none = .false.
+            call get_scope_statement_indices(arena, scope_index, indices)
+            do i = 1, size(indices)
+                if (.not. arena%has_node_at(indices(i))) cycle
+                select type (stmt => arena%entries(indices(i))%node)
+                    type is (implicit_statement_node)
+                    has_statement = .true.
+                    is_none = stmt%is_none
+                    return
+                end select
+            end do
+        end subroutine implicit_policy
+
+        ! Names introduced by constructs whose bindings are represented as
+        ! strings rather than identifier declaration nodes.  The public
+        ! resolver already handles ASSOCIATE names; these cases are the
+        ! remaining construct entities that can otherwise look undeclared.
+        logical function is_construct_entity(arena, reference_index, name) &
+                result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: reference_index
+            character(len=*), intent(in) :: name
+            integer :: current, i
+
+            found = .false.
+            current = reference_index
+            do while (current > 0)
+                current = arena%entries(current)%parent_index
+                if (current <= 0) exit
+                if (.not. arena%has_node_at(current)) exit
+                select type (parent => arena%entries(current)%node)
+                    type is (do_loop_node)
+                    if (allocated(parent%var_name)) then
+                        if (same_name(parent%var_name, name)) then
+                            found = .true.
+                            return
+                        end if
+                    end if
+                    type is (forall_node)
+                    if (allocated(parent%index_names)) then
+                        do i = 1, size(parent%index_names)
+                            if (same_name(parent%index_names(i), name)) then
+                                found = .true.
+                                return
+                            end if
+                        end do
+                    end if
+                    type is (statement_function_node)
+                    if (allocated(parent%arg_names)) then
+                        do i = 1, size(parent%arg_names)
+                            if (same_name(parent%arg_names(i), name)) then
+                                found = .true.
+                                return
+                            end if
+                        end do
+                    end if
+                    type is (type_guard_block_node)
+                    if (parent%type_name_index == reference_index) then
+                        found = .true.
+                        return
+                    end if
+                end select
+            end do
+        end function is_construct_entity
+
+        ! Component names are stored on COMPONENT_ACCESS nodes, but some
+        ! parser paths also retain an identifier child for the spelling.
+        ! That child is not a declaration in the enclosing scope.
+        logical function is_component_name_reference(arena, reference_index, &
+                name) result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: reference_index
+            character(len=*), intent(in) :: name
+            integer :: current
+
+            found = .false.
+            current = reference_index
+            do while (current > 0)
+                current = arena%entries(current)%parent_index
+                if (current <= 0) exit
+                if (.not. arena%has_node_at(current)) exit
+                select type (parent => arena%entries(current)%node)
+                    type is (component_access_node)
+                    if (allocated(parent%component_name)) then
+                        if (same_name(parent%component_name, name)) then
+                            found = .true.
+                            return
+                        end if
+                    end if
+                end select
+            end do
+        end function is_component_name_reference
+
+        ! Array element references to a component retain the component access
+        ! as the call/subscript base (for example V%VALUES(I)).
+        logical function is_component_designator_reference(arena, &
+                reference_index, name) result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: reference_index
+            character(len=*), intent(in) :: name
+            integer :: base_index
+
+            found = .false.
+            if (.not. arena%has_node_at(reference_index)) return
+            select type (reference => arena%entries(reference_index)%node)
+                type is (call_or_subscript_node)
+                base_index = reference%base_expr_index
+                if (base_index <= 0) return
+                if (.not. arena%has_node_at(base_index)) return
+                select type (base => arena%entries(base_index)%node)
+                    type is (component_access_node)
+                    if (allocated(base%component_name)) then
+                        found = same_name(base%component_name, name)
+                    end if
+                end select
+            end select
+        end function is_component_designator_reference
+
+        ! A keyword argument is represented as an assignment node. Its left
+        ! hand side is a label, not a variable reference (e.g. KIND=4).
+        logical function is_keyword_argument_name(reference_index) result(found)
+            integer, intent(in) :: reference_index
+
+            found = .false.
+            if (reference_index > 0 .and. reference_index <= size(keyword_targets)) then
+                found = keyword_targets(reference_index)
+            end if
+        end function is_keyword_argument_name
+
+        logical function is_select_type_selector(arena, assignment_index) &
+                result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: assignment_index
+            integer :: parent_index
+
+            found = .false.
+            parent_index = arena%entries(assignment_index)%parent_index
+            if (parent_index <= 0) return
+            if (.not. arena%has_node_at(parent_index)) return
+            select type (parent => arena%entries(parent_index)%node)
+                type is (select_type_node)
+                found = .true.
+            end select
+        end function is_select_type_selector
+
+        logical function is_select_type_associate_name(arena, scope_index, &
+                name) result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: scope_index
+            character(len=*), intent(in) :: name
+            integer :: i, pointer_index, current
+
+            found = .false.
+            do i = 1, arena%size
+                if (.not. arena%has_node_at(i)) cycle
+                select type (selector => arena%entries(i)%node)
+                    type is (pointer_assignment_node)
+                    if (.not. is_select_type_selector(arena, i)) cycle
+                    pointer_index = selector%pointer_index
+                    if (pointer_index <= 0 .or. &
+                            pointer_index > arena%size) cycle
+                    if (.not. arena%has_node_at(pointer_index)) cycle
+                    select type (pointer => arena%entries(pointer_index)%node)
+                        type is (identifier_node)
+                        if (.not. allocated(pointer%name)) cycle
+                        if (.not. same_name(pointer%name, name)) cycle
+                        current = find_enclosing_scope(arena, i)
+                        if (current == scope_index) then
+                            found = .true.
+                            return
+                        end if
+                        if (current > 0) then
+                            if (find_host_scope(arena, current) == scope_index) then
+                                found = .true.
+                                return
+                            end if
+                        end if
+                    end select
+                end select
+            end do
+        end function is_select_type_associate_name
+
+        ! Function-expression parsers do not always set the assignment flag
+        ! used by CALL parsing. An assignment directly below a call node is
+        ! necessarily a keyword actual (NAME=VALUE), so classify it here.
+        logical function is_call_keyword_assignment(arena, assignment_index) &
+                result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: assignment_index
+            integer :: parent_index
+
+            found = .false.
+            parent_index = arena%entries(assignment_index)%parent_index
+            if (parent_index <= 0) return
+            if (.not. arena%has_node_at(parent_index)) return
+            select type (parent => arena%entries(parent_index)%node)
+                type is (call_or_subscript_node)
+                found = .true.
+                type is (subroutine_call_node)
+                found = .true.
+            end select
+        end function is_call_keyword_assignment
+
+        ! A USE of an external module cannot be resolved without loading that
+        ! module's AST.  Preserve the standard contract by accepting names
+        ! explicitly listed by USE ... ONLY and all names from an unrestricted
+        ! USE; same-arena module exports are still checked by the resolver.
+        logical function is_use_associated_name(arena, scope_index, name) &
+                result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: scope_index
+            character(len=*), intent(in) :: name
+            integer :: current, i, j
+            integer, allocatable :: indices(:)
+
+            found = .false.
+            current = scope_index
+            do while (current > 0)
+                if (.not. is_scope_node(arena, current)) exit
+                call get_scope_statement_indices(arena, current, indices)
+                do i = 1, size(indices)
+                    if (.not. arena%has_node_at(indices(i))) cycle
+                    select type (stmt => arena%entries(indices(i))%node)
+                        type is (use_statement_node)
+                        if (.not. stmt%has_only) then
+                            found = .true.
+                            return
+                        end if
+                        if (allocated(stmt%only_list)) then
+                            do j = 1, size(stmt%only_list)
+                                if (same_name(stmt%only_list(j)%s, name)) then
+                                    found = .true.
+                                    return
+                                end if
+                            end do
+                        end if
+                        if (allocated(stmt%rename_list)) then
+                            do j = 1, size(stmt%rename_list), 2
+                                if (same_name(stmt%rename_list(j)%s, name)) then
+                                    found = .true.
+                                    return
+                                end if
+                            end do
+                        end if
+                    end select
+                end do
+                current = find_host_scope(arena, current)
+            end do
+        end function is_use_associated_name
+
+        ! NAMELIST group names are namespace labels, not variables. The
+        ! group may appear later as NML=GROUP in READ/WRITE control lists.
+        logical function is_namelist_name(arena, scope_index, name) result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: scope_index
+            character(len=*), intent(in) :: name
+            integer :: current, i, j
+            integer, allocatable :: indices(:)
+
+            found = .false.
+            current = scope_index
+            do while (current > 0)
+                if (.not. is_scope_node(arena, current)) exit
+                call get_scope_statement_indices(arena, current, indices)
+                do i = 1, size(indices)
+                    if (.not. arena%has_node_at(indices(i))) cycle
+                    select type (stmt => arena%entries(indices(i))%node)
+                        type is (namelist_statement_node)
+                        if (allocated(stmt%group_name)) then
+                            if (same_name(stmt%group_name, name)) then
+                                found = .true.
+                                return
+                            end if
+                        end if
+                        if (allocated(stmt%variable_names)) then
+                            do j = 1, size(stmt%variable_names)
+                                if (same_name(stmt%variable_names(j)%s, name)) then
+                                    found = .true.
+                                    return
+                                end if
+                            end do
+                        end if
+                    end select
+                end do
+                current = find_host_scope(arena, current)
+            end do
+        end function is_namelist_name
+
+        logical function same_name(left, right) result(equal)
+            character(len=*), intent(in) :: left, right
+            equal = to_lower(trim(left)) == to_lower(trim(right))
+        end function same_name
+    end subroutine check_implicit_none_references
 
     ! Reject a procedure reference that IMPLICIT NONE (EXTERNAL) requires to
     ! be explicitly declared (Fortran 2018 8.7: with an EXTERNAL implicit

--- a/test/api/test_issue_2993_implicit_none_diagnostics.f90
+++ b/test/api/test_issue_2993_implicit_none_diagnostics.f90
@@ -1,0 +1,70 @@
+program test_issue_2993_implicit_none_diagnostics
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use frontend_compiler_api, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string
+    use semantic_input_mode, only: INPUT_MODE_LAZY, INPUT_MODE_STANDARD
+    implicit none
+
+    character(len=:), allocatable :: source
+    type(compiler_frontend_options_t) :: options
+    type(compiler_frontend_result_t) :: result
+
+    call read_example('examples/f90/issue_2993_implicit_none_undeclared.f90', &
+        source)
+    options = compiler_frontend_options_t()
+    options%input_mode = INPUT_MODE_LAZY
+    options%run_semantics = .true.
+    call compile_frontend_from_string(source, result, options)
+    if (.not. result%parse_ok) call fail('invalid example did not parse')
+    if (.not. result%semantic_ok) then
+        call fail('Lazy mode rejected an inferred name: '// &
+            trim(result%diagnostic_text))
+    end if
+
+    call read_example('examples/f90/issue_2993_implicit_none_valid.f90', source)
+    call compile_frontend_from_string(source, result, options)
+    if (.not. result%success()) then
+        call fail('valid declarations and associations were rejected: '// &
+            trim(result%diagnostic_text))
+    end if
+
+    ! Standard mode is the strict boundary: an explicit selection must reject
+    ! the same undeclared reference that Lazy mode intentionally infers.
+    options%input_mode = INPUT_MODE_STANDARD
+    call read_example('examples/f90/issue_2993_implicit_none_undeclared.f90', &
+        source)
+    call compile_frontend_from_string(source, result, options)
+    if (result%semantic_ok) call fail('standard mode accepted undeclared zzz')
+    call assert_contains(result%diagnostic_text, &
+        "Name 'zzz' is not declared under IMPLICIT NONE")
+
+    call read_example('examples/f90/issue_2993_implicit_none_valid.f90', source)
+    call compile_frontend_from_string(source, result, options)
+    if (.not. result%success()) then
+        call fail('standard mode rejected valid bindings: '// &
+            trim(result%diagnostic_text))
+    end if
+
+    print *, 'PASS: IMPLICIT NONE rejects undeclared names without over-rejecting bindings'
+
+contains
+
+    include '../common/read_example.inc'
+
+    subroutine assert_contains(text, needle)
+        character(len=*), intent(in) :: text
+        character(len=*), intent(in) :: needle
+
+        if (index(text, needle) == 0) then
+            call fail('diagnostic did not contain: '//trim(needle))
+        end if
+    end subroutine assert_contains
+
+    subroutine fail(message)
+        character(len=*), intent(in) :: message
+
+        write (error_unit, '(A)') 'FAIL: '//trim(message)
+        error stop 1
+    end subroutine fail
+
+end program test_issue_2993_implicit_none_diagnostics


### PR DESCRIPTION
Closes #2993. Adds structural IMPLICIT NONE reference checking in standard mode while preserving Lazy inference; includes valid/invalid behavioral oracles and refreshed roadmap.