### PR TITLE
docs: record separate module dummy resolution

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,13 +6,14 @@ backend-neutral.
 
 ## Current truth
 
-The implementation baseline is `193457a9` (implicit `DIMENSION` dummy
-preservation, the #2993 `IMPLICIT NONE` undeclared-reference pass, full-line
-continuation comments, fixed-form comment normalization, and the #2255
-follow-up). The #2993, #2996, nested-binding, and implicit-DIMENSION focused
-oracles are green locally; the remaining remote aggregate/Windows failures
-listed below are independent of those fixes. Merge CI is [run
-31136187566](https://github.com/lazy-fortran/fortfront/actions/runs/31136187566)
+The implementation baseline is `704cd27f` (separate module-procedure dummy
+resolution, implicit `DIMENSION` dummy preservation, the #2993 `IMPLICIT NONE`
+undeclared-reference pass, full-line continuation comments, fixed-form
+comment normalization, and the #2255 follow-up). The #2993, #2996,
+nested-binding, implicit-DIMENSION, and separate-module-dummy focused oracles
+are green locally; the remaining remote aggregate/Windows failures listed
+below are independent of those fixes. Merge CI is [run
+31136782260](https://github.com/lazy-fortran/fortfront/actions/runs/31136782260)
 and is still in progress; do not treat the local GNU lane as remote-green
 evidence.
 
@@ -99,25 +100,31 @@ query in the same set of linked commits. Do not leave a permanent fallback.
    `DIMENSION` dummy path is landed in `e5e8157b` with a compiled source-vs-
    transformed behavior oracle; extend this pattern to the remaining fixed-
    form and declaration-shape cases before reclassifying corpus rows.
-5. Complete binding identity across nested ASSOCIATE in
+5. Resolve separate module-procedure dummies by interface identity. The
+   implementation is landed in `8d3e5a8a`; the three-test focused oracle
+   (`test_compiler_scope_resolution`, `test_compiler_facing_queries`, and
+   `test_f2008_submodule_constructs`) passes on the current head. Preserve the
+   rule that the resolver consumes the parent module interface rather than
+   guessing from source spelling.
+6. Complete binding identity across nested ASSOCIATE in
    [#2975](https://github.com/lazy-fortran/fortfront/issues/2975). The selector
    binding correction and exact declaration-identity oracle are now landed;
    this remains the frontend prerequisite for ffc #584 and removal of
    text-name lookup.
-6. Fix parser representation defects #2973 and the remaining explicit-
+7. Fix parser representation defects #2973 and the remaining explicit-
    interface representation work #2970. Then rebaseline stale umbrellas
    #2883/#2924/#2951 and close or split them by live signature.
-7. Establish Lazy result/specialization identity in #2980/#2994 before ffc
+8. Establish Lazy result/specialization identity in #2980/#2994 before ffc
    serializes or emits it.
-8. Fix the full-line-comment-inside-continuation lexer defect in
+9. Fix the full-line-comment-inside-continuation lexer defect in
    [#2996](https://github.com/lazy-fortran/fortfront/issues/2996) with its
    parser reproduction, token/position oracle, gfortran accepted neighbor, and
    a malformed-continuation rejection control. The implementation keeps the
    lexer continuation state alive across comment/blank trivia while preserving
    character-literal state separately; the focused tests pass locally.
-9. Keep the nested character-array substring AST contract green for downstream
+10. Keep the nested character-array substring AST contract green for downstream
    ffc #669 and run its read/write/overlap/actual-argument differential oracle.
-10. Run downstream ffc binding, rejection, module-consumer, and Lazy ABI gates
+11. Run downstream ffc binding, rejection, module-consumer, and Lazy ABI gates
    against the exact FortFront revision before release.
 
 Parser, semantic, query, and portability work may proceed in isolated


### PR DESCRIPTION
Records the current separate-module-procedure resolver fix, focused oracle, and current CI head.