### PR TITLE
fix: initialize semantic mode policy explicitly

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,6 +15,12 @@ are green locally. The current local GNU lane is green: 1,545 static modules,
 381 build targets, 378 derivative targets, 483/483 tests, and clean lint. The
 Windows lane and remote aggregate remain open.
 
+The semantic context constructor now assigns its input-mode and strict
+`IMPLICIT NONE` policy explicitly. This is required for GCC14, where relying
+on default initialization of an `INTENT(OUT)` derived context left the strict
+gate disabled. The `test_issue_2993_implicit_none_diagnostics` oracle passes
+with both local GCC16 and remote GCC14.2 after the explicit initialization.
+
 `test_module_distribution` was previously parallel-fragile because it cleans
 shared Makefile artifacts; isolate its outputs before treating the full suite as a
 parallel gate. The last-known Windows failures are

--- a/src/semantic/analyzers/semantic_analyzer_context_impl.f90
+++ b/src/semantic/analyzers/semantic_analyzer_context_impl.f90
@@ -67,8 +67,14 @@ contains
         allocate (ctx%subst%types(ctx%subst%capacity))
         ctx%errors = create_error_collection()
         ctx%next_var_id = 1
+        ! Set mode policy explicitly.  Relying on derived-type default
+        ! initialization here is not portable across supported gfortran
+        ! versions when the context is an INTENT(OUT) dummy; GCC14 otherwise
+        ! leaves the strict IMPLICIT NONE gate disabled.
+        ctx%input_mode = INPUT_MODE_LAZY
         ctx%operating_mode = OPERATING_MODE_INFER
         ctx%respect_implicit_none = .true.
+        ctx%enforce_implicit_none_references = .true.
         ctx%type_hierarchy = create_type_hierarchy()
         ctx%signatures = create_signatures_map()
         ctx%explicit_interface_procedure_names%count = 0_int32


### PR DESCRIPTION
Fixes GCC14 strict IMPLICIT NONE regression: explicit context initialization prevents default-initialization differences for INTENT(OUT) derived contexts. Closes the current CI failure in test_issue_2993_implicit_none_diagnostics; focused oracle passes with GCC16 locally and GCC14.2 on faepkub4.