### PR TITLE
Fix untyped function result inference from RHS expressions

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -39,6 +39,33 @@ parse/semantic drops. GNU and NVIDIA `nvfortran` 26.5 cold builds cover the
 381-target lane; the downstream FortAD nvfortran gate still needs a fresh run
 against this revision and is not evidence of a FortFront failure until then.
 
+### CI evidence and #2980 result-inference tranche (2026-08-07)
+
+Run [31138641474](https://github.com/lazy-fortran/fortfront/actions/runs/31138641474)
+has a green Ubuntu job (`92743669803`), including build, tests, rejection
+gate, and cleanliness.  Its aggregate is not green: the Windows job
+(`92743669828`) fails these ten concrete executables and they remain release
+gates until reproduced and fixed on Windows:
+
+`test_alternate_return_frontend.exe`, `test_compiler_facing_queries.exe`,
+`test_fixed_form_comment_oracle.exe`,
+`test_fixed_form_implicit_dimension_oracle.exe`,
+`test_type_bound_call_base_oracle.exe`,
+`test_reject_bind_01_diagnostics.exe`,
+`test_reject_placement_01_diagnostics.exe`,
+`test_reject_value_scope_01_diagnostics.exe`, `test_all_examples_slow.exe`,
+and `test_elemental_validation.exe`.  No expected-failure or XFAIL baseline
+was changed to mask this platform drift.
+
+Issue [#2980](https://github.com/lazy-fortran/fortfront/issues/2980) now has a
+minimal differential oracle in `test/standardizer/test_issue_2980_result_inference.f90`.
+It standardizes an untyped `twice(x)` whose body assigns `2*x`, requires the
+public code generator to emit a `real` result (not the I–N implicit-name
+`integer` fallback), then compiles and runs that output with an independent
+GNU Fortran oracle.  The focused test passes locally with GCC; preserve the
+same source/behavior check on the Windows and downstream ffc lanes before
+reclassifying the issue as closed.
+
 The canonical downstream plan and current corpus counts live in the
 [ffc roadmap](https://github.com/lazy-fortran/ffc/blob/main/ROADMAP.md).
 FortFront does not duplicate its parity dashboard.

--- a/src/standardizers/ast_monomorphization_part3.inc
+++ b/src/standardizers/ast_monomorphization_part3.inc
@@ -370,9 +370,11 @@
         type(mono_type_t) :: inferred_type
         logical :: has_value
         logical :: return_is_array_kind
+        logical :: implicit_result
 
         type_str = ""
         return_is_array_kind = .false.
+        implicit_result = function_result_is_implicit(arena, orig_func)
 
         if (allocated(signature%return_type_string)) then
             if (len_trim(signature%return_type_string) > 0) then
@@ -439,6 +441,18 @@
             if (len_trim(type_str) == 0) then
                 return_is_array_kind = .true.
             end if
+        end if
+
+        ! An untyped Lazy function has no authoritative result spelling in the
+        ! original AST.  The call signature is the specialization contract;
+        ! prefer it over the pre-specialization call node, whose result was
+        ! historically inferred from the function name (I-N => INTEGER).
+        ! Without this override `twice(2.5)` produced a real parameter but an
+        ! INTEGER result (issue #2980).  Explicit result declarations and
+        ! typed function headers remain authoritative.
+        if (implicit_result .and. signature%return_kind > 0 .and. &
+            signature%return_kind /= TARRAY) then
+            type_str = get_kind_type_string(signature%return_kind)
         end if
 
                 if (allocated(signature%param_kinds)) then
@@ -566,6 +580,46 @@
         call update_call_result_type(arena, signature%call_site_node, &
                                      signature%return_kind, type_str)
     end function determine_return_type_string
+
+    logical function function_result_is_implicit(arena, func) result(is_implicit)
+        type(ast_arena_t), intent(in) :: arena
+        type(function_def_node), pointer, intent(in) :: func
+        integer :: i, body_index
+        character(len=:), allocatable :: result_name
+
+        is_implicit = .true.
+        if (.not. associated(func)) return
+        if (allocated(func%return_type)) then
+            if (len_trim(func%return_type) > 0) then
+                is_implicit = .false.
+                return
+            end if
+        end if
+        if (.not. allocated(func%body_indices)) return
+        if (allocated(func%result_variable)) then
+            result_name = trim(func%result_variable)
+        else if (allocated(func%name)) then
+            result_name = trim(func%name)
+        else
+            return
+        end if
+        if (len_trim(result_name) == 0) return
+
+        do i = 1, size(func%body_indices)
+            body_index = func%body_indices(i)
+            if (.not. arena%has_node_at(body_index)) cycle
+            select type (decl => arena%entries(body_index)%node)
+                type is (declaration_node)
+                if (.not. allocated(decl%var_name)) cycle
+                if (to_lower(trim(decl%var_name)) /= to_lower(result_name)) cycle
+                if (allocated(decl%type_name) .and. &
+                    len_trim(decl%type_name) > 0) then
+                    is_implicit = .false.
+                end if
+                return
+            end select
+        end do
+    end function function_result_is_implicit
 
     subroutine update_call_result_type(arena, call_index, return_kind, type_str)
         type(ast_arena_t), intent(inout) :: arena

--- a/src/standardizers/standardizer_declarations_collection.f90
+++ b/src/standardizers/standardizer_declarations_collection.f90
@@ -36,6 +36,7 @@ module standardizer_declarations_collection
 
     public :: collect_statement_vars
     public :: collect_assignment_vars
+    public :: infer_assignment_type
     public :: handle_string_concatenation
     public :: infer_type_from_binary_operation
     public :: get_string_length_from_node

--- a/src/standardizers/standardizer_function_result_utils.f90
+++ b/src/standardizers/standardizer_function_result_utils.f90
@@ -8,6 +8,7 @@ module standardizer_function_result_utils
     use standardizer_parameter, only: infer_parameter_type, is_type_variable_str, &
         reset_declaration_node
     use standardizer_declarations_array, only: set_array_properties_from_type
+    use standardizer_declarations_collection, only: infer_assignment_type
     use type_string_utils, only: is_character_type_string, mono_type_to_string
     implicit none
     private
@@ -319,7 +320,10 @@ contains
 
         call reset_declaration_node(decl)
         result_inferred = .false.
-        if (.not. fill_decl_from_return_type(func_def, decl)) then
+        if (.not. func_def%has_return_type_in_header .and. &
+            (.not. fill_decl_from_return_type(func_def, decl) .or. &
+             is_type_variable_str(decl%type_name) .or. &
+             trim(decl%type_name) == "function")) then
             call infer_result_type(func_def%result_variable, decl)
             result_inferred = .true.
         end if
@@ -378,9 +382,11 @@ contains
         end if
 
         result_inferred = .false.
-        if (.not. fill_decl_from_return_type(func_def, decl)) then
+        if (.not. func_def%has_return_type_in_header .and. &
+            .not. fill_decl_from_return_type(func_def, decl)) then
             call infer_result_type(func_def%result_variable, decl)
             result_inferred = .true.
+            call infer_result_type_from_body(arena, func_def, decl)
         end if
 
         if (decl%type_name == "real" .and. type_std_enabled .and. &
@@ -480,6 +486,49 @@ contains
         decl%type_name = trim(inferred_type)
 
     end subroutine infer_result_type
+
+    ! An explicit RESULT variable has no implicit type declaration in the
+    ! source. Infer it from its assignment expression when the header carries
+    ! no result type (issue #2980). Named-result functions whose result is the
+    ! function name retain the standard I-N implicit rule.
+    subroutine infer_result_type_from_body(arena, func_def, decl)
+        use ast_nodes_core, only: assignment_node, identifier_node
+        type(ast_arena_t), intent(in) :: arena
+        type(function_def_node), intent(in) :: func_def
+        type(declaration_node), intent(inout) :: decl
+        character(len=:), allocatable :: result_name
+        character(len=64) :: inferred_type
+        integer :: i, body_index, value_index
+
+        if (func_def%has_return_type_in_header) return
+        if (.not. allocated(func_def%body_indices)) return
+        if (.not. allocated(func_def%result_variable)) return
+        result_name = trim(func_def%result_variable)
+        if (len_trim(result_name) == 0) return
+
+        do i = 1, size(func_def%body_indices)
+            body_index = func_def%body_indices(i)
+            if (.not. arena%has_node_at(body_index)) cycle
+            select type (stmt => arena%entries(body_index)%node)
+                type is (assignment_node)
+                if (stmt%target_index <= 0 .or. stmt%value_index <= 0) cycle
+                if (.not. arena%has_node_at(stmt%target_index)) cycle
+                select type (target => arena%entries(stmt%target_index)%node)
+                    type is (identifier_node)
+                    if (.not. allocated(target%name)) cycle
+                    if (to_lower(trim(target%name)) /= to_lower(result_name)) cycle
+                    value_index = stmt%value_index
+                    inferred_type = infer_assignment_type(arena, value_index)
+                    if (len_trim(inferred_type) == 0) cycle
+                    decl%type_name = trim(inferred_type)
+                    decl%has_kind = .false.
+                    decl%kind_value = 0
+                    return
+                end select
+            end select
+        end do
+    end subroutine infer_result_type_from_body
+
     subroutine ensure_function_return_type(func_def, decl)
         use ast_nodes_data, only: declaration_node
         type(function_def_node), intent(inout) :: func_def

--- a/test/standardizer/test_issue_2980_result_inference.f90
+++ b/test/standardizer/test_issue_2980_result_inference.f90
@@ -1,0 +1,87 @@
+program test_issue_2980_result_inference
+    use, intrinsic :: iso_fortran_env, only: error_unit
+    use frontend_core, only: lex_source
+    use frontend_parsing, only: parse_tokens
+    use standardizer, only: standardize_ast
+    use codegen_core, only: codegen_core_generate_arena, initialize_codegen
+    use ast_arena_modern, only: ast_arena_t
+    use lexer_core, only: token_t
+    implicit none
+    character(len=:), allocatable :: source, code, error_msg
+    character(len=:), allocatable :: temp_dir, source_path, exe_path
+    character(len=:), allocatable :: compile_command, run_command
+    character(len=1) :: separator
+    type(token_t), allocatable :: tokens(:)
+    type(ast_arena_t) :: arena
+    integer :: root_index, unit, exit_code
+    logical :: is_windows
+
+    source = 'program issue_2980'//new_line('a')// &
+        '  if (abs(twice(2.5) - 5.0) > 1.0e-6) error stop 1'//new_line('a')// &
+        'contains'//new_line('a')// &
+        '  function twice(x)'//new_line('a')// &
+        '    twice = 2 * x'//new_line('a')// &
+        '  end function twice'//new_line('a')// &
+        'end program issue_2980'//new_line('a')
+
+    call initialize_codegen()
+    call lex_source(source, tokens, error_msg)
+    call assert_empty(error_msg, 'lexer rejected issue #2980 source')
+    call parse_tokens(tokens, arena, root_index, error_msg)
+    call assert_empty(error_msg, 'parser rejected issue #2980 source')
+    call standardize_ast(arena, root_index)
+    code = codegen_core_generate_arena(arena, root_index)
+
+    if (index(code, 'real function twice') <= 0 .or. &
+        index(code, 'integer function twice') > 0) then
+        write (error_unit, '(A)') &
+            'FAIL: result type was not inferred from real RHS expression'
+        write (error_unit, '(A)') trim(code)
+        error stop 1
+    end if
+
+    is_windows = check_if_windows()
+    call create_temp_directory(temp_dir, is_windows)
+    if (len_trim(temp_dir) == 0) error stop 'FAIL: temp directory unavailable'
+    separator = path_separator_for(temp_dir)
+    source_path = join_path(temp_dir, 'issue_2980.f90', separator)
+    exe_path = join_path(temp_dir, 'issue_2980.exe', separator)
+    open (newunit=unit, file=source_path, status='replace', action='write')
+    write (unit, '(A)') trim(code)
+    close (unit)
+
+    compile_command = 'gfortran '//quote_for_shell(source_path, is_windows, &
+        escape_for_cmd=is_windows)//' -o '//quote_for_shell(exe_path, &
+        is_windows, escape_for_cmd=is_windows)
+    call execute_command_line(compile_command, exitstat=exit_code, wait=.true.)
+    if (exit_code /= 0) then
+        call cleanup_temp_directory(temp_dir, is_windows)
+        error stop 'FAIL: gfortran rejected standardized issue #2980 source'
+    end if
+
+    run_command = quote_for_shell(exe_path, is_windows, &
+        escape_for_cmd=is_windows)
+    call execute_command_line(run_command, exitstat=exit_code, wait=.true.)
+    call cleanup_temp_directory(temp_dir, is_windows)
+    if (exit_code /= 0) then
+        write (error_unit, '(A)') 'FAIL: independent gfortran oracle mismatch'
+        error stop 1
+    end if
+
+    print '(A)', 'PASS: issue #2980 result follows real RHS and gfortran output'
+
+contains
+
+    include '../common/filesystem_helpers.inc'
+    include '../common/shell_commands.inc'
+
+    subroutine assert_empty(message, context)
+        character(len=:), allocatable, intent(in) :: message
+        character(len=*), intent(in) :: context
+        if (len_trim(message) > 0) then
+            write (error_unit, '(A)') trim(context)//': '//trim(message)
+            error stop 1
+        end if
+    end subroutine assert_empty
+
+end program test_issue_2980_result_inference


### PR DESCRIPTION
## Summary
- infer untyped function result declarations from the assigned RHS expression instead of only the I–N name rule
- preserve the specialization return contract for untyped Lazy functions
- add a focused independent gfortran differential oracle for issue #2980
- document run 31138641474 Ubuntu/Windows evidence and the ten remaining Windows failures in ROADMAP.md

## Verification
- `OMP_NUM_THREADS=1 fpm test test_issue_2980_result_inference --flag '-DREBUILD2980FINAL'`
- `OMP_NUM_THREADS=1 fpm test test_issue_2142_mono_return_types --flag '-DREBUILD2980REG'`
- `OMP_NUM_THREADS=1 fpm test test_standardizer_attributes_monomorphization --flag '-DREBUILD2980ATTR'`

All three pass locally; the new test compiles and runs generated code with independent GNU Fortran.
