### PR TITLE
fix: recognize interface and ENTRY procedure names

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,10 @@ backend-neutral.
 
 ## Current truth
 
-The implementation baseline is `39bac6c2` (explicit semantic-context mode
-initialization for GCC14, separate module-procedure dummy resolution, implicit
-`DIMENSION` dummy preservation, the #2993 `IMPLICIT NONE`
+The implementation baseline is `f46a0059` (the #2980 result-inference
+standardizer fix on top of explicit semantic-context mode initialization for
+GCC14, separate module-procedure dummy resolution, implicit `DIMENSION` dummy
+preservation, and the #2993 `IMPLICIT NONE`
 undeclared-reference pass, full-line continuation comments, fixed-form
 comment normalization, and the #2255 follow-up). The #2993, #2996,
 nested-binding, implicit-DIMENSION, and separate-module-dummy focused oracles
@@ -90,6 +91,18 @@ line, the case that previously tokenized `C` as code. The normalizer is also
 available through the compatibility facade for source-aware downstream file
 drivers. This is one source-form fix, not a claim of complete fixed-form or
 preprocessor support.
+
+### Procedure-name semantic boundary (2026-08-07)
+
+Specific procedure names declared in an explicit interface body and names
+introduced by `ENTRY` are procedure identifiers in their enclosing scoping
+unit. The strict `IMPLICIT NONE` pass now recognizes both forms before data
+name resolution, so downstream ffc can issue its precise procedure-assignment
+diagnostic instead of receiving a misleading "not declared" error. The
+focused `test_interface_procedure_reference` oracle covers both forms, and
+ffc's `test_session_reject_result_01_compiler` rejection suite passes against
+this FortFront revision. Keep the interface checker helper shared with the
+undefined-name pass; do not reintroduce source-text heuristics in ffc.
 
 ## Required public architecture
 

--- a/src/semantic/analyzers/semantic_explicit_interface_checker.f90
+++ b/src/semantic/analyzers/semantic_explicit_interface_checker.f90
@@ -29,6 +29,7 @@ module semantic_explicit_interface_checker
     public :: validate_whole_file_explicit_interface
     public :: build_explicit_interface_name_cache
     public :: is_part_reference
+    public :: interface_declares_subroutine
 
 contains
 

--- a/src/semantic/analyzers/semantic_undefined_variable_checker.f90
+++ b/src/semantic/analyzers/semantic_undefined_variable_checker.f90
@@ -12,11 +12,13 @@ module semantic_undefined_variable_checker
     use ast_nodes_associate, only: associate_node, block_construct_node
     use ast_nodes_data, only: declaration_node, multi_unit_container_node
     use ast_nodes_misc, only: implicit_statement_node, use_statement_node, &
-        statement_function_node, namelist_statement_node
+        statement_function_node, namelist_statement_node, interface_block_node
+    use ast_nodes_transfer, only: entry_node
     use ast_nodes_procedure, only: function_def_node, subroutine_def_node, &
         subroutine_call_node
     use intrinsic_registry, only: is_intrinsic_subroutine
-    use semantic_explicit_interface_checker, only: is_part_reference
+    use semantic_explicit_interface_checker, only: is_part_reference, &
+        interface_declares_subroutine
     use semantic_external_declaration_names, only: collect_declared_procedures
     use frontend_compiler_resolution, only: declaration_binding_t, &
         find_enclosing_scope, find_host_scope, get_scope_statement_indices, &
@@ -63,17 +65,17 @@ contains
             select type (node => arena%entries(i)%node)
                 type is (assignment_node)
                 if (node%is_keyword_argument .or. &
-                        is_call_keyword_assignment(arena, i)) then
+                    is_call_keyword_assignment(arena, i)) then
                     if (node%target_index > 0 .and. &
-                            node%target_index <= arena%size) then
+                        node%target_index <= arena%size) then
                         keyword_targets(node%target_index) = .true.
                     end if
                 end if
                 type is (pointer_assignment_node)
                 if (node%pointer_index > 0 .and. &
-                        node%pointer_index <= arena%size) then
+                    node%pointer_index <= arena%size) then
                     if (node%target_index > 0 .and. &
-                            node%target_index <= arena%size) then
+                        node%target_index <= arena%size) then
                         if (is_select_type_selector(arena, i)) then
                             construct_targets(node%pointer_index) = .true.
                         end if
@@ -117,10 +119,10 @@ contains
             if (is_part_reference(trim(name))) return
             if (is_component_name_reference(arena, reference_index, trim(name))) return
             if (is_component_designator_reference(arena, reference_index, &
-                    trim(name))) return
+                trim(name))) return
             if (is_keyword_argument_name(reference_index)) return
             if (reference_index > 0 .and. reference_index <= &
-                    size(construct_targets)) then
+                size(construct_targets)) then
                 if (construct_targets(reference_index)) return
             end if
 
@@ -139,6 +141,8 @@ contains
             if (is_select_type_associate_name(arena, scope_index, trim(name))) return
             if (is_use_associated_name(arena, scope_index, trim(name))) return
             if (is_namelist_name(arena, scope_index, trim(name))) return
+            if (is_interface_procedure_name(arena, scope_index, trim(name))) return
+            if (is_entry_procedure_name(arena, scope_index, trim(name))) return
 
             call resolve_name_at_node(arena, reference_index, trim(name), &
                 binding, resolver_error)
@@ -150,7 +154,7 @@ contains
                 component="semantic_undefined_variable_checker", &
                 context="check_implicit_none_references", &
                 suggestion="Declare the name before using it, or provide an "// &
-                    "explicit interface for the procedure", &
+                "explicit interface for the procedure", &
                 line=line, column=column, end_line=line, end_column=column + 1))
         end subroutine check_reference
 
@@ -344,7 +348,7 @@ contains
                     if (.not. is_select_type_selector(arena, i)) cycle
                     pointer_index = selector%pointer_index
                     if (pointer_index <= 0 .or. &
-                            pointer_index > arena%size) cycle
+                        pointer_index > arena%size) cycle
                     if (.not. arena%has_node_at(pointer_index)) cycle
                     select type (pointer => arena%entries(pointer_index)%node)
                         type is (identifier_node)
@@ -471,6 +475,69 @@ contains
                 current = find_host_scope(arena, current)
             end do
         end function is_namelist_name
+
+        ! Specific procedure names declared inside an explicit interface body
+        ! are procedure names in the enclosing scoping unit.  They are not
+        ! data objects subject to implicit typing (Fortran 2018 19.6.7).
+        logical function is_interface_procedure_name(arena, scope_index, name) &
+                result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: scope_index
+            character(len=*), intent(in) :: name
+            integer :: current, i
+            integer, allocatable :: indices(:)
+
+            found = .false.
+            current = scope_index
+            do while (current > 0)
+                if (.not. is_scope_node(arena, current)) exit
+                call get_scope_statement_indices(arena, current, indices)
+                do i = 1, size(indices)
+                    if (.not. arena%has_node_at(indices(i))) cycle
+                    select type (block => arena%entries(indices(i))%node)
+                        type is (interface_block_node)
+                        if (allocated(block%name)) then
+                            if (same_name(block%name, name)) then
+                                found = .true.
+                                return
+                            end if
+                        end if
+                        if (interface_declares_subroutine(arena, block, name)) then
+                            found = .true.
+                            return
+                        end if
+                    end select
+                end do
+                current = find_host_scope(arena, current)
+            end do
+        end function is_interface_procedure_name
+
+        ! ENTRY introduces another procedure name in the enclosing procedure
+        ! body.  It must not be diagnosed as an undeclared implicitly typed
+        ! variable; the result/assignment validator owns its legality.
+        logical function is_entry_procedure_name(arena, scope_index, name) &
+                result(found)
+            type(ast_arena_t), intent(in) :: arena
+            integer, intent(in) :: scope_index
+            character(len=*), intent(in) :: name
+            integer :: i
+            integer, allocatable :: indices(:)
+
+            found = .false.
+            call get_scope_statement_indices(arena, scope_index, indices)
+            do i = 1, size(indices)
+                if (.not. arena%has_node_at(indices(i))) cycle
+                select type (entry => arena%entries(indices(i))%node)
+                    type is (entry_node)
+                    if (allocated(entry%name)) then
+                        if (same_name(entry%name, name)) then
+                            found = .true.
+                            return
+                        end if
+                    end if
+                end select
+            end do
+        end function is_entry_procedure_name
 
         logical function same_name(left, right) result(equal)
             character(len=*), intent(in) :: left, right

--- a/test/api/test_interface_procedure_reference.f90
+++ b/test/api/test_interface_procedure_reference.f90
@@ -1,0 +1,56 @@
+program test_interface_procedure_reference
+    ! Specific names in an explicit interface and ENTRY names are procedure
+    ! names in the enclosing scope, not implicitly typed data references.
+    use frontend_compiler_api, only: compiler_frontend_options_t, &
+        compiler_frontend_result_t, compile_frontend_from_string
+    use semantic_input_mode, only: INPUT_MODE_STANDARD
+    implicit none
+
+    type(compiler_frontend_options_t) :: options
+    type(compiler_frontend_result_t) :: result
+    character(len=:), allocatable :: source
+
+    options%run_semantics = .true.
+    options%input_mode = INPUT_MODE_STANDARD
+    options%standardize = .false.
+
+    source = 'subroutine host()'//new_line('a')// &
+        '  implicit none'//new_line('a')// &
+        '  interface'//new_line('a')// &
+        '    subroutine external_proc()'//new_line('a')// &
+        '    end subroutine external_proc'//new_line('a')// &
+        '  end interface'//new_line('a')// &
+        '  external_proc = 1'//new_line('a')// &
+        'end subroutine host'
+    call compile_frontend_from_string(source, result, options)
+    call assert_not_implicit_name(result, 'external_proc')
+
+    source = 'function host(x) result(r)'//new_line('a')// &
+        '  implicit none'//new_line('a')// &
+        '  integer :: x, r'//new_line('a')// &
+        '  r = x'//new_line('a')// &
+        '  entry alternate(x) result(r2)'//new_line('a')// &
+        '  alternate = x + 1'//new_line('a')// &
+        'end function host'
+    call compile_frontend_from_string(source, result, options)
+    call assert_not_implicit_name(result, 'alternate')
+
+    print *, 'PASS: interface and ENTRY procedure names bypass implicit-variable checks'
+
+contains
+
+    subroutine assert_not_implicit_name(frontend_result, name)
+        type(compiler_frontend_result_t), intent(in) :: frontend_result
+        character(len=*), intent(in) :: name
+        character(len=:), allocatable :: marker
+
+        marker = "Name '"//trim(name)//"' is not declared under IMPLICIT NONE"
+        if (frontend_result%success()) return
+        if (index(frontend_result%diagnostic_text, marker) /= 0) then
+            write (*, '(A)') 'FAIL: procedure name was treated as an implicit variable: '// &
+                trim(frontend_result%diagnostic_text)
+            error stop 1
+        end if
+    end subroutine assert_not_implicit_name
+
+end program test_interface_procedure_reference


### PR DESCRIPTION
The strict IMPLICIT NONE reference pass was misclassifying specific procedure names declared in an explicit interface and ENTRY names as undeclared data names.

Changes:
- share the explicit-interface procedure-name predicate with the undefined-name pass;
- skip interface-specific and ENTRY names before data-name resolution;
- add focused API oracle covering both forms;
- record the downstream ffc rejection-suite contract in ROADMAP.md.

Evidence (fo only):
- fo build (381 targets);
- fo test test_interface_procedure_reference (PASS);
- fo test test_issue_2950_procedure_actual_argument (PASS);
- ffc with this FortFront dependency: fo test test_session_reject_result_01_compiler (PASS).

No XFAIL or expected-failure changes.