### PR TITLE
test: cover nested associate owner boundary

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,9 +6,10 @@ backend-neutral.
 
 ## Current truth
 
-The implementation source baseline is `c0a32743`; the current documentation
-handoff is `f3aea46d`. The source baseline is the merged procedure-name semantic
-boundary fix on top of the #2980 result-inference standardizer, explicit
+The implementation semantic source baseline remains `c0a32743`; the current
+documentation/source handoff is merged main `9c528d6b`. The handoff includes
+the typed #2974 compound-declaration regression on top of the procedure-name
+semantic boundary fix, #2980 result-inference standardizer, explicit
 semantic-context mode initialization for GCC14, separate module-procedure dummy
 resolution, implicit `DIMENSION` dummy preservation, and the #2993 `IMPLICIT NONE`
 undeclared-reference pass, full-line continuation comments, fixed-form
@@ -18,11 +19,12 @@ are green locally. The current local GNU lane is green: 1,545 static modules,
 381 build targets, 378 derivative targets, 483/483 tests, and clean lint. The
 Windows lane and remote aggregate remain open.
 
-The merge push for this head is [run 31144447791](https://github.com/lazy-fortran/fortfront/actions/runs/31144447791)
-and remains in progress. The latest procedure-name PR observation is [run
-31144062538](https://github.com/lazy-fortran/fortfront/actions/runs/31144062538):
-Ubuntu completed successfully while Windows remains in progress and retains the
-known portability failures. The local GNU gate is not remote-green evidence.
+The latest merged-handoff aggregate is [run 31146242801](https://github.com/lazy-fortran/fortfront/actions/runs/31146242801):
+Ubuntu passed; Windows retains the documented nine-test portability baseline
+(`test_compiler_facing_queries`, fixed-form comment and implicit-DIMENSION
+oracles, type-bound call base, three rejection diagnostics, all examples, and
+elemental validation). The #2974 regression is not among those failures. The
+local GNU gate is not remote-green evidence.
 
 The semantic context constructor now assigns its input-mode and strict
 `IMPLICIT NONE` policy explicitly. This is required for GCC14, where relying
@@ -75,6 +77,20 @@ public code generator to emit a `real` result (not the I–N implicit-name
 GNU Fortran oracle.  The focused test passes locally with GCC; preserve the
 same source/behavior check on the Windows and downstream ffc lanes before
 reclassifying the issue as closed.
+
+### #2975 owner-boundary evidence (2026-08-07)
+
+The resolver correction is already landed in `d1c6a894`; it restores
+`ASSOCIATION_DIRECT` only when a nested selector resolves to a declaration
+owned by the enclosing function/subroutine. It leaves a genuine host binding
+as `ASSOCIATION_HOST`. The existing nested-dummy oracle remains in
+`test_compiler_scope_resolution`; its new owner-boundary case additionally
+queries a host selector and a local-dummy selector through the public typed
+binding API and requires exact declaration-node and declaration-entity
+identity on both sides. This is a regression boundary, not a source-text
+fallback or a second resolver implementation. `fo test
+test_compiler_scope_resolution` passes locally; no production resolver change
+was needed in this tranche.
 
 The canonical downstream plan and current corpus counts live in the
 [ffc roadmap](https://github.com/lazy-fortran/ffc/blob/main/ROADMAP.md).

--- a/test/api/test_compiler_scope_resolution.f90
+++ b/test/api/test_compiler_scope_resolution.f90
@@ -21,6 +21,7 @@ program test_compiler_scope_resolution
     call test_nested_block_shadow()
     call test_use_rename()
     call test_nested_associate_selector_binding()
+    call test_nested_associate_owner_boundary()
     call test_module_accessibility()
     call test_procedure_and_generic()
     print *, 'PASS: compiler scope resolution queries'
@@ -315,6 +316,123 @@ contains
             error stop 1
         end if
     end subroutine test_nested_associate_selector_binding
+
+    subroutine test_nested_associate_owner_boundary()
+        ! A nested selector must preserve both sides of the ownership
+        ! boundary: a local dummy remains DIRECT, while a same-named host
+        ! variable remains HOST. The declaration node and entity identities
+        ! must agree with the corresponding scope query in both cases.
+        type(compiler_frontend_result_t) :: result
+        type(declaration_binding_t) :: dummy_scope_binding
+        type(declaration_binding_t) :: host_scope_binding
+        type(declaration_binding_t) :: dummy_selector_binding
+        type(declaration_binding_t) :: host_selector_binding
+        character(len=:), allocatable :: error_msg
+        integer :: outer_associate
+        integer :: inner_associate
+        integer :: outer_selector
+        integer :: inner_selector
+        integer :: function_index
+        integer :: program_index
+        integer :: i
+
+        call compile_standard( &
+            'program owner_boundary'//new_line('a')// &
+            '  implicit none'//new_line('a')// &
+            '  real :: x, y'//new_line('a')// &
+            '  y = compute(x)'//new_line('a')// &
+            '  print *, y'//new_line('a')// &
+            'contains'//new_line('a')// &
+            '  pure function compute(value) result(r)'//new_line('a')// &
+            '    real, intent(in) :: value'//new_line('a')// &
+            '    real :: r'//new_line('a')// &
+            '    associate(host_alias => x)'//new_line('a')// &
+            '      associate(sum => value + host_alias)'//new_line('a')// &
+            '        r = sum'//new_line('a')// &
+            '      end associate'//new_line('a')// &
+            '    end associate'//new_line('a')// &
+            '  end function compute'//new_line('a')// &
+            'end program owner_boundary', result)
+
+        outer_associate = 0
+        inner_associate = 0
+        do i = 1, result%arena%size
+            if (.not. result%arena%has_node_at(i)) cycle
+            select type (node => result%arena%entries(i)%node)
+                type is (associate_node)
+                if (result%arena%entries(i)%parent_index <= 0) cycle
+                select type (parent_node => result%arena%entries( &
+                        result%arena%entries(i)%parent_index)%node)
+                    type is (associate_node)
+                    inner_associate = i
+                    outer_associate = result%arena%entries(i)%parent_index
+                end select
+            end select
+        end do
+        if (outer_associate <= 0 .or. inner_associate <= 0) then
+            write (error_unit, '(A)') &
+                'FAIL: owner-boundary nested ASSOCIATE not found'
+            error stop 1
+        end if
+
+        function_index = find_function(result, 'compute')
+        program_index = find_program(result, 'owner_boundary')
+        call resolve_name_in_scope(result%arena, function_index, 'value', &
+            dummy_scope_binding, error_msg)
+        call require_found(error_msg, dummy_scope_binding, BINDING_DECLARATION, &
+            ASSOCIATION_DIRECT, 'owner-boundary local dummy')
+        call resolve_name_in_scope(result%arena, program_index, 'x', &
+            host_scope_binding, error_msg)
+        call require_found(error_msg, host_scope_binding, BINDING_DECLARATION, &
+            ASSOCIATION_DIRECT, 'owner-boundary host variable')
+
+        select type (node => result%arena%entries(outer_associate)%node)
+            type is (associate_node)
+            outer_selector = node%associations(1)%expr_index
+        class default
+            error stop 'FAIL: outer ASSOCIATE has wrong node type'
+        end select
+        select type (node => result%arena%entries(inner_associate)%node)
+            type is (associate_node)
+            inner_selector = node%associations(1)%expr_index
+        class default
+            error stop 'FAIL: inner ASSOCIATE has wrong node type'
+        end select
+
+        call resolve_name_at_node(result%arena, outer_selector, 'x', &
+            host_selector_binding, error_msg)
+        call require_binding(error_msg, host_selector_binding, &
+            host_scope_binding%declaration_node_index, BINDING_DECLARATION, &
+            ASSOCIATION_HOST, 'owner-boundary host selector')
+        if (host_selector_binding%scope_node_index /= program_index) then
+            write (error_unit, '(A)') &
+                'FAIL: host selector owner escaped the host program'
+            error stop 1
+        end if
+
+        call resolve_name_at_node(result%arena, inner_selector, 'value', &
+            dummy_selector_binding, error_msg)
+        call require_binding(error_msg, dummy_selector_binding, &
+            dummy_scope_binding%declaration_node_index, BINDING_DECLARATION, &
+            ASSOCIATION_DIRECT, 'owner-boundary local selector')
+        if (dummy_selector_binding%scope_node_index /= function_index) then
+            write (error_unit, '(A)') &
+                'FAIL: local selector owner escaped its function'
+            error stop 1
+        end if
+        if (dummy_selector_binding%declaration_entity_index /= &
+            dummy_scope_binding%declaration_entity_index) then
+            write (error_unit, '(A)') &
+                'FAIL: local selector changed declaration entity identity'
+            error stop 1
+        end if
+        if (host_selector_binding%declaration_entity_index /= &
+            host_scope_binding%declaration_entity_index) then
+            write (error_unit, '(A)') &
+                'FAIL: host selector changed declaration entity identity'
+            error stop 1
+        end if
+    end subroutine test_nested_associate_owner_boundary
 
     subroutine test_use_rename()
         type(compiler_frontend_result_t) :: result


### PR DESCRIPTION
## Summary

- extend the public typed binding-query oracle for FortFront issue #2975
- assert exact declaration-node and declaration-entity identity for a local dummy selector through two nested ASSOCIATE constructs
- assert a genuine host selector remains `ASSOCIATION_HOST` and owned by the host program
- refresh `ROADMAP.md` to merged handoff `9c528d6b`, including #2974 and run 31146242801 evidence

The resolver fix itself is already merged as `d1c6a894`; this is a boundary
regression that prevents an over-broad DIRECT relabeling from hiding real host
association. No source-text fallback or production resolver change is added.

## Verification

- `fo test test_compiler_scope_resolution` — PASS
- `fo check --json=compact` — PASS, 483/483 tests
- `git diff --check` — PASS
- `fo fmt --check test/api/test_compiler_scope_resolution.f90` still reports the file's pre-existing formatter drift outside this patch; added lines follow current style
